### PR TITLE
Fix for long word in H2 tag

### DIFF
--- a/dsc/configDataCredentials.md
+++ b/dsc/configDataCredentials.md
@@ -108,7 +108,7 @@ This example has two issues:
 1.  An error explains that plain text passwords are not recommended
 2.  A warning advises against using a domain credential
 
-## PsDscAllowPlainTextPassword
+##` PsDscAllowPlainTextPassword`
 
 The first error message has a URL with documentation.
 This link explains how to encrypt passwords using a [ConfigurationData](https://msdn.microsoft.com/en-us/powershell/dsc/configdata) structure and a certificate.
@@ -162,7 +162,7 @@ Using a local account eliminates potential exposure of domain credentials that c
 If there is a '\' or '@' in the `Username` property of the credential, then DSC will treat it as a domain account.
 An exception is made for "localhost", "127.0.0.1", and "::1" in the domain portion of the user name.
 
-## PSDscAllowDomainUser
+##` PSDscAllowDomainUser`
 
 In the DSC `Group` resource example above, querying an Active Directory domain *requires* the use of a domain account.
 In this case add the `PSDscAllowDomainUser` property to the `ConfigurationData` block as follows:


### PR DESCRIPTION
Received this email instructing to make the change:

From: Junning Liu 
Sent: Wednesday, January 13, 2016 8:40 PM
To: Ashley McGlone (GOATEEPFE) <Ashley.McGlone@microsoft.com>
Cc: Yajun Lu (Pactera Technologies Inc) <v-yajlu@microsoft.com>
Subject: 487828: OPS: The long continuous topic title is truncated in one column

Hi, Ashley,

We have a bug for the open publishing document not display properly when header 2 contains long continuous word. We have fixed the rendering engine, though which requires some update for the content:

“content owner need to update the content, for the long continuous title (in header2), need to wrap the word with <code>, the syntax in markdown file would be:

##`yourlongcontinouswordherelongtobreakinmobileview`
”

In your document, following word: PsDscAllowPlainTextPassword was too long, get truncated in mobile view, can you please update the content:

## PsDscAllowPlainTextPassword

=>

##` PsDscAllowPlainTextPassword`

Thanks
-Junning