### PR TITLE
Get cert directly from CERT:\LocalMachine\MY

### DIFF
--- a/dsc/pullServer.md
+++ b/dsc/pullServer.md
@@ -63,7 +63,7 @@ configuration Sample_xDscWebService
 1. Run the configuration, passing the thumbprint of the self-signed certificate you created as the **certificateThumbPrint** parameter:
 
 ```powershell
-PS:\>$myCert = Get-ChildItem CERT: | Where-Object {$_.Subject -eq 'CN=PSDSCPullServerCert'}
+PS:\>$myCert = Get-ChildItem CERT:\LocalMachine\MY | Where-Object {$_.Subject -eq 'CN=PSDSCPullServerCert'}
 PS:\>Sample_xDSCService -certificateThumbprint $myCert.Thumbprint 
 ```
 


### PR DESCRIPTION
On Server 2016 TP4, "Get-ChildItem CERT: | Where-Object {$_.Subject -eq 'CN=PSDSCPullServerCert'}" did not get the cert we need. 
After changing to CERT:\LocalMachine\MY, it get the right cert we need

Rocky@DataON