### PR TITLE
Fixed typo in dsc_waitfor.md

### DIFF
--- a/wmf/dsc_waitfor.md
+++ b/wmf/dsc_waitfor.md
@@ -33,4 +33,4 @@ Configuration JoinDomain
 	}
 }
 ```
-**Hint:** By default the WaitFor\* resources try one time and then fail so although it is not required, you will typically want to specify a regry interval and count.
+**Hint:** By default the WaitFor\* resources try one time and then fail so although it is not required, you will typically want to specify a retry interval and count.


### PR DESCRIPTION
Fixed a minor typo in the hint at the bottom of the file (line 36).