### PR TITLE
Made the resource names as single word because that's how it is used in configurations

### DIFF
--- a/dsc/TOC.md
+++ b/dsc/TOC.md
@@ -18,7 +18,7 @@
 ### [Script Resource](scriptResource.md)
 ### [Service Resource](serviceResource.md)
 ### [User Resource](userResource.md)
-### [Windows Feature Resource](windowsfeatureResource.md)
+### [WindowsFeature Resource](windowsfeatureResource.md)
 ### [WindowsProcess Resource](windowsProcessResource.md)
 ## [Authoring custom resources](authoringResource.md) 
 ### [MOF-based custom resources](authoringResourceMOF.md)

--- a/dsc/builtInResource.md
+++ b/dsc/builtInResource.md
@@ -14,5 +14,5 @@ Windows PowerShell Desired State Configuration (DSC) comes with a set of built-i
 * [Script Resource](scriptResource.md)
 * [Service Resource](serviceResource.md)
 * [User Resource](userResource.md)
-* [Windows Feature Resource](windowsFeatureResource.md)
-* [Windows Process Resource](windowsProcessResource.md)
+* [WindowsFeature Resource](windowsFeatureResource.md)
+* [WindowsProcess Resource](windowsProcessResource.md)


### PR DESCRIPTION
@eslesar Should they be single word? Either way TOC and builtinResource.md should use the same style.