### PR TITLE
Fix missing list item for nxScript

### DIFF
--- a/dsc/lnxBuiltInResources.md
+++ b/dsc/lnxBuiltInResources.md
@@ -11,7 +11,8 @@ The following table provides a list of these resources and links to topics that 
 * [nxFile Resource](lnxFileResource.md)--Manages Linux files and directories. 
 * [nxFileLine Resource](lnxFileLineResource.md)--Manages individual lines in a Linux file. 
 * [nxGroup Resource](lnxGroupResource.md)--Manages local Linux groups. 
-* [nxPackage Resource](lnxPackageResource.md)--Manages packages on Linux nodes.- [nxScript Resource](lnxScriptResource.md)--Runs scripts on target nodes.
+* [nxPackage Resource](lnxPackageResource.md)--Manages packages on Linux nodes.
+* [nxScript Resource](lnxScriptResource.md)--Runs scripts on target nodes.
 * [nxService Resource](lnxServiceResource.md)--Manages Linux services (daemons).
 * [nxSshAuthorizedKeys Resource](lnxSshAuthorizedKeysResource.md)--Manages public ssh keys for a Linux user. 
 * [nxUser Resource](lnxUserResource.md)--Manages local Linux users. 


### PR DESCRIPTION
Asterisk missing in markdown means the nxScript link isn't in the list on https://msdn.microsoft.com/en-us/powershell/dsc/lnxbuiltinresources