### PR TITLE
Fixed typo, updated casing, used PS variables.

### DIFF
--- a/dsc/lnxGettingStarted.md
+++ b/dsc/lnxGettingStarted.md
@@ -12,7 +12,7 @@ The following Linux operating system versions are supported for DSC for Linux.
 - SUSE Linux Enterprise Server 10, 11 and 12 (x86/x64)
 - Ubuntu Server 12.04 LTS and 14.04 LTS (x86/x64)
 
-The following table describes the required ackage dependencies for DSC for Linux.
+The following table describes the required package dependencies for DSC for Linux.
 
 |  Required package |  Description |  Minimum version | 
 |---|---|---|
@@ -60,7 +60,7 @@ The Windows PowerShell Configuration keyword is used to create a configuration f
 
 1. Import the nx module. The nx Windows PowerShell module contains the schema for Built-In resources for DSC for Linux, and must be installed to your local computer and imported in the configuration.
 
-    -To install the nx module, copy the nx module directory to either `%UserProfile%\Documents\WindowsPowerShell\Modules\` or `C:\windows\system32\WindowsPowerShell\v1.0\Modules`. The nx module is included in the DSC for Linux installation package (MSI). To import the nx module in your configuration, use the __Import-DSCResource__ command:
+    -To install the nx module, copy the nx module directory to either `$env:USERPROFILE\Documents\WindowsPowerShell\Modules\` or `$PSHOME\Modules`. The nx module is included in the DSC for Linux installation package (MSI). To import the nx module in your configuration, use the __Import-DSCResource__ command:
     
 ```powershell
 Configuration ExampleConfiguration{
@@ -74,7 +74,7 @@ Configuration ExampleConfiguration{
 ```powershell
 Configuration ExampleConfiguration{
    
-    Import-DSCResource -Module nx
+    Import-DscResource -Module nx
  
     Node  "linuxhost.contoso.com"{
     nxFile ExampleFile {
@@ -116,7 +116,7 @@ If this certificate is not trusted by the Windows computer that you are running 
 
 Run the following command to push the DSC configuration to the Linux node.
 
-`Start-DSCConfiguration -Path:"C:\temp" -cimsession:$sess -wait -verbose`
+`Start-DscConfiguration -Path:"C:\temp" -CimSession:$Sess -Wait -Verbose`
 
 ### Distribute the configuration with a pull server
 


### PR DESCRIPTION
- small typo (ackage instaed of package)
- $env:USERPROFILE and $PSHOME instead of cmd-style variables
- case for -Parameters, $Variables and CommandNames

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell-docs/273)
<!-- Reviewable:end -->
