### PR TITLE
no support for SMA 2012 R2

### DIFF
--- a/wmf/productincompat.md
+++ b/wmf/productincompat.md
@@ -7,6 +7,7 @@
 - Microsoft SharePoint Server 2013
 - Microsoft SharePoint Server 2010
 - System Center 2012 Virtual Machine Manager
+- System Center 2012 R2 Service Management Automation
 
 **Servers that are running the following applications can now run WMF 5.0:**
 


### PR DESCRIPTION
As we don't support WFM 5.0 with SMA 2012 R2, we need to document this as we already found 2 incompatibility bugs and customers should not upgrade to WFM 5.0 anymore in the SMA 2012 R2 environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell-docs/295)
<!-- Reviewable:end -->
