### PR TITLE
Adding additional info about certificate creation on Windows Server 2012 R2 to SecureMOF.md - Fixes #300

### DIFF
--- a/dsc/secureMOF.md
+++ b/dsc/secureMOF.md
@@ -70,13 +70,48 @@ The following example:
  3. imports the public key certificate into the **my** certificate store on the **Authoring node**.
 
 #### On the Target Node: create and export the certificate
+>Authoring Node: Windows Server 2016 and Windows 10
+
 ```powershell
 # note: These steps need to be performed in an Administrator PowerShell session
 $cert = New-SelfSignedCertificate -Type DocumentEncryptionCertLegacyCsp -DnsName 'DscEncryptionCert' 
 # export the public key certificate
 $cert | Export-Certificate -FilePath "$env:temp\DscPublicKey.cer" -Force
 ```
+Once exported, the ```DscPublicKey.cer``` would need to be copied to the **Authoring Node**.
 
+>Authoring Node: Windows Server 2012 R2/Windows 8.1 and earlier
+
+Because the New-SelfSignedCertificate cmdlet on Windows Operating Systems prior to Windows 10 and Windows Server 2016 do not support the **Type** parameter, an alternate method of creating this certificate is required on these operating systems.
+In this case you can use ```makecert.exe``` or ```certutil.exe``` to create the certificate.
+
+An alternate method is to [download the New-SelfSignedCertificateEx.ps1 script from Microsoft Script Center](https://gallery.technet.microsoft.com/scriptcenter/Self-signed-certificate-5920a7c6) and use it to create the certificate instead:
+```powershell
+# note: These steps need to be performed in an Administrator PowerShell session
+# and in the folder that contains New-SelfSignedCertificateEx.ps1
+. .\New-SelfSignedCertificateEx.ps1
+New-SelfsignedCertificateEx `
+    -Subject "CN=${ENV:ComputerName}" `
+    -EKU 'Document Encryption','Server Authentication','Client Authentication' `
+    -KeyUsage 'DigitalSignature, KeyEncipherment, DataEncipherment' `
+    -SAN ${ENV:ComputerName} `
+    -FriendlyName 'DSC Credential Encryption certificate' `
+    -Exportable `
+    -StoreLocation 'LocalMachine' `
+    -StoreName 'My' `
+    -KeyLength 2048 `
+    -ProviderName 'Microsoft Enhanced Cryptographic Provider v1.0' `
+    -AlgorithmName 'RSA' `
+    -SignatureAlgorithm 'SHA256'
+# Locate the newly created certificate
+$Cert = Get-ChildItem -Path cert:\LocalMachine\My `
+    | Where-Object {
+        ($_.FriendlyName -eq 'DSC Credential Encryption certificate') `
+        -and ($_.Subject -eq "CN=${ENV:ComputerName}")
+    } | Select-Object -First 1
+# export the public key certificate
+$cert | Export-Certificate -FilePath "$env:temp\DscPublicKey.cer" -Force
+```
 Once exported, the ```DscPublicKey.cer``` would need to be copied to the **Authoring Node**.
 
 #### On the Authoring Node: import the cert’s public key
@@ -97,6 +132,8 @@ The following example:
    - it must be added to the root store so that it will be trusted by the **Target node**.
 
 #### On the Authoring Node: create and export the certificate
+>Target Node: Windows Server 2016 and Windows 10
+
 ```powershell
 # note: These steps need to be performed in an Administrator PowerShell session
 $cert = New-SelfSignedCertificate -Type DocumentEncryptionCertLegacyCsp -DnsName 'DscEncryptionCert'
@@ -108,8 +145,45 @@ $cert | Export-Certificate -FilePath "$env:temp\DscPublicKey.cer" -Force
 $cert | Remove-Item -Force
 Import-Certificate -FilePath "$env:temp\DscPublicKey.cer" -CertStoreLocation Cert:\LocalMachine\My
 ```
-
 Once exported, the ```DscPrivateKey.cer``` would need to be copied to the **Target Node**.
+
+>Target Node: Windows Server 2012 R2/Windows 8.1 and earlier
+
+Because the New-SelfSignedCertificate cmdlet on Windows Operating Systems prior to Windows 10 and Windows Server 2016 do not support the **Type** parameter, an alternate method of creating this certificate is required on these operating systems.
+In this case you can use ```makecert.exe``` or ```certutil.exe``` to create the certificate.
+
+An alternate method is to [download the New-SelfSignedCertificateEx.ps1 script from Microsoft Script Center](https://gallery.technet.microsoft.com/scriptcenter/Self-signed-certificate-5920a7c6) and use it to create the certificate instead:
+```powershell
+# note: These steps need to be performed in an Administrator PowerShell session
+# and in the folder that contains New-SelfSignedCertificateEx.ps1
+. .\New-SelfSignedCertificateEx.ps1
+New-SelfsignedCertificateEx `
+    -Subject "CN=${ENV:ComputerName}" `
+    -EKU 'Document Encryption','Server Authentication','Client Authentication' `
+    -KeyUsage 'DigitalSignature, KeyEncipherment, DataEncipherment' `
+    -SAN ${ENV:ComputerName} `
+    -FriendlyName 'DSC Credential Encryption certificate' `
+    -Exportable `
+    -StoreLocation 'LocalMachine' `
+    -StoreName 'My' `
+    -KeyLength 2048 `
+    -ProviderName 'Microsoft Enhanced Cryptographic Provider v1.0' `
+    -AlgorithmName 'RSA' `
+    -SignatureAlgorithm 'SHA256'
+# Locate the newly created certificate
+$Cert = Get-ChildItem -Path cert:\LocalMachine\My `
+    | Where-Object {
+        ($_.FriendlyName -eq 'DSC Credential Encryption certificate') `
+        -and ($_.Subject -eq "CN=${ENV:ComputerName}")
+    } | Select-Object -First 1
+# export the public key certificate
+$mypwd = ConvertTo-SecureString -String "YOUR_PFX_PASSWD" -Force -AsPlainText
+$cert | Export-PfxCertificate -FilePath "$env:temp\DscPrivateKey.pfx" -Password $mypwd -Force
+# remove the private key certificate from the node but keep the public key certificate
+$cert | Export-Certificate -FilePath "$env:temp\DscPublicKey.cer" -Force
+$cert | Remove-Item -Force
+Import-Certificate -FilePath "$env:temp\DscPublicKey.cer" -CertStoreLocation Cert:\LocalMachine\My
+```
 
 #### On the Target Node: import the cert’s private key as a trusted root
 ```powershell
@@ -123,7 +197,6 @@ Note: If your target node is a _Nano Server_, you should use the CertOC.exe appl
 # Import to the root store so that it is trusted
 certoc.exe -ImportPFX -p YOUR_PFX_PASSWD Root c:\temp\DscPrivateKey.pfx
 ```
-
 
 ## Configuration data
 


### PR DESCRIPTION
@gigi81 pointed out that the script samples will only work on Windows 10/Windows Server 2016.

I have added examples on how to perform the process on earlier version OS's.

@megamorf - could you possibly take a look and let me know if you think anything else should be changed?

@TravisEz13 - In the examples I added I've used a script available on [Script Center](https://gallery.technet.microsoft.com/scriptcenter/Self-signed-certificate-5920a7c6) - is it acceptable to do this in the DSC documentation? I used to use this method prior to Windows 10 so it was the one I was most familiar with and no works (I still use it in my LabBuilder project).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell-docs/302)
<!-- Reviewable:end -->
