### PR TITLE
Added additional Group example for working with AD user into Local Group

### DIFF
--- a/dsc/groupResource.md
+++ b/dsc/groupResource.md
@@ -62,7 +62,7 @@ The following example shows how to add an Active Directory User to the local adm
     )
 }
                   
-$domain = $node.domainname.split('.')[0]
+$domain = $node.DomainName.split('.')[0]
 $DCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList ("$domain\$($credential.Username)", $Credential.Password)
 
 Group AddADUserToLocalAdminGroup

--- a/dsc/groupResource.md
+++ b/dsc/groupResource.md
@@ -32,7 +32,7 @@ Group [string] #ResourceName
 | MembersToInclude| Indicates the users who you want to ensure are members of the group.| 
 | DependsOn | Indicates that the configuration of another resource must run before this resource is configured. For example, if the ID of the resource configuration script block that you want to run first is __ResourceName__ and its type is __ResourceType__, the syntax for using this property is `DependsOn = "[ResourceType]ResourceName"``.| 
 
-## Example
+## Example 1
 
 The following example shows how to ensure that a group called TestGroup is absent. 
 
@@ -44,4 +44,33 @@ Group GroupExample
     Ensure = "Absent"
     GroupName = "TestGroup"
 }
+```
+## Example 2
+The following example shows how to add an Active Directory User to the local administrators group as part of a Multi-Machine Lab build where you are already using a PSCredential for the Local Adminstrator account. As this is also used for the Domain Admin Account (after Domain promotion) we then need to convert this existing PSCredential to a Domain Friendly credential to enable us to add a Domain User to the Local Administrators Group on the Member server.
+
+```powershell
+@{
+    AllNodes = @(
+        @{
+            NodeName = '*';
+            DomainName = 'SubTest.contoso.com';
+         }
+     @{
+            NodeName = 'Box2';
+            AdminAccount = 'Admin-Dave_Alexanderson'   
+      }    
+    )
+}
+                  
+$domain = $node.domainname.split('.')[0]
+$DCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList ("$domain\$($credential.Username)", $Credential.Password)
+
+Group AddADUserToLocalAdminGroup
+        {
+            GroupName='Administrators'   
+            Ensure= 'Present'             
+            MembersToInclude= "$domain\$($Node.AdminAccount)"
+            Credential = $dCredential    
+            PsDscRunAsCredential = $DCredential
+        }
 ```


### PR DESCRIPTION
Hopefully this makes it clearer as to the requirements for the Credential usage when adding AD Users to the Local Administrators Group on a machine

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell-docs/304)
<!-- Reviewable:end -->
