### PR TITLE
Change EKU/KU in SecureMOF examples to be minimum required for cred encryption

### DIFF
--- a/dsc/secureMOF.md
+++ b/dsc/secureMOF.md
@@ -92,8 +92,8 @@ An alternate method is to [download the New-SelfSignedCertificateEx.ps1 script f
 . .\New-SelfSignedCertificateEx.ps1
 New-SelfsignedCertificateEx `
     -Subject "CN=${ENV:ComputerName}" `
-    -EKU 'Document Encryption','Server Authentication','Client Authentication' `
-    -KeyUsage 'DigitalSignature, KeyEncipherment, DataEncipherment' `
+    -EKU 'Document Encryption' `
+    -KeyUsage 'KeyEncipherment, DataEncipherment' `
     -SAN ${ENV:ComputerName} `
     -FriendlyName 'DSC Credential Encryption certificate' `
     -Exportable `
@@ -159,8 +159,8 @@ An alternate method is to [download the New-SelfSignedCertificateEx.ps1 script f
 . .\New-SelfSignedCertificateEx.ps1
 New-SelfsignedCertificateEx `
     -Subject "CN=${ENV:ComputerName}" `
-    -EKU 'Document Encryption','Server Authentication','Client Authentication' `
-    -KeyUsage 'DigitalSignature, KeyEncipherment, DataEncipherment' `
+    -EKU 'Document Encryption' `
+    -KeyUsage 'KeyEncipherment, DataEncipherment' `
     -SAN ${ENV:ComputerName} `
     -FriendlyName 'DSC Credential Encryption certificate' `
     -Exportable `


### PR DESCRIPTION
- Change EKU/KU in SecureMOF examples to be minimum required for cred encryption.

The EKU and KU in the Secure MOF examples for generating Self Signed certs for Windows Server 2012 R2 and earlier had EKU and KU's that aren't actually required. This change removes the unnecessary ones.

Thanks @megamorf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell-docs/305)
<!-- Reviewable:end -->
