### PR TITLE
Fix misspelled cmdlets

### DIFF
--- a/scripting/core-powershell/ise/How-to-Debug-Scripts-in-Windows-PowerShell-ISE.md
+++ b/scripting/core-powershell/ise/How-to-Debug-Scripts-in-Windows-PowerShell-ISE.md
@@ -66,7 +66,7 @@ The following script is an example of how to remove all breakpoints from the Con
 
 ```
 # This command deletes all of the breakpoints in the current session.
-get-breakpoint | remove-breakpoint
+get-psbreakpoint | remove-psbreakpoint
 ```
 
 ### <a name="bkmk_disable"></a>Disable a Breakpoint


### PR DESCRIPTION
Line 69 is missing the PS-prefix:
get-breakpoint | remove-breakpoint

It should be:
get-psbreakpoint | remove-psbreakpoint

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell-docs/508)
<!-- Reviewable:end -->
