### PR TITLE
Change in markdown formatting of the table

### DIFF
--- a/wmf/5.1/engine-improvements.md
+++ b/wmf/5.1/engine-improvements.md
@@ -29,7 +29,7 @@ Some example improvements (your results may vary depending your your hardware):
 | `powershell -command "echo 1"` | 900 | 250 |
 | First ever PowerShell run: `powershell -command "Unknown-Command"` | 30000 | 13000 |
 | Command analysis cache built: `powershell -command "Unknown-Command"` | 7000 | 520 |
-| `1..1000000 | % { }` | 1400 | 750 |
+| <code>1..1000000 &#124; % { }</code> | 1400 | 750 |
   
 > Note 
 > One change related to startup might impact some unsupported scenarios. PowerShell no longer


### PR DESCRIPTION
The table used a pipe symbol within a code block. When this document is used to generate content for MSDN, that causes the table to render incorrectly. Using <code></code> to identify the code block instead of backticks and replacing the internal pipe with &#124; (ascii pipe) should resolve this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell-docs/536)
<!-- Reviewable:end -->
