### PR TITLE
Fixed headers and semantic line feeds on Gallery content

### DIFF
--- a/gallery/psgallery/Deleting-Items.md
+++ b/gallery/psgallery/Deleting-Items.md
@@ -1,7 +1,11 @@
-## Deleting items
+# Deleting items
 
-PowerShellGallery.com does not support permanent deletion of items, because that would break anyone who is depending on it remaining available.
+The PowerShell Gallery does not support permanent deletion of items, because that would break anyone who is depending on it remaining available.
 
-Instead, PowerShellGallery.com supports a way to 'unlist' an item, which can be done in the item management page on the web site. When an item is unlisted, it no longer shows up in search and in any item listing, both on PowerShellGallery.com and using PowerShellGet commands. However, it remains downloadable by specifying its exact version, which is what allows the automated scripts to continue working.
+Instead, the PowerShell Gallery supports a way to 'unlist' an item, which can be done in the item management page on the web site. 
+When an item is unlisted, it no longer shows up in search and in any item listing, both on the PowerShell Gallery and using PowerShellGet commands. 
+However, it remains downloadable by specifying its exact version, which is what allows the automated scripts to continue working.
 
-If you run into an exceptional situation where you think one of your items must be deleted, this can be handled manually by the PowerShell Gallery team. e.g. if there is a copyright infringement issue, or potentially harmful content, that could be a valid reason to delete it. You should submit a support request through [PowerShell Gallery] (http://www.PowerShellGallery.com) in that case.
+If you run into an exceptional situation where you think one of your items must be deleted, this can be handled manually by the PowerShell Gallery team. 
+For example, if there is a copyright infringement issue, or potentially harmful content, that could be a valid reason to delete it. 
+You should submit a support request through [PowerShell Gallery] (http://www.PowerShellGallery.com) in that case.

--- a/gallery/psgallery/Managing-Item-Owners.md
+++ b/gallery/psgallery/Managing-Item-Owners.md
@@ -1,16 +1,18 @@
 # Managing Item Owners
 
-Ownership of an item in the PowerShell Gallery is defined by who published the item to the gallery. Sometimes this metadata needs to be managed beyond the initial item publishing, which means the owner metadata needs to be mutable while the item itself is not.
+Ownership of an item in the PowerShell Gallery is defined by who published the item to the gallery.
+Sometimes this metadata needs to be managed beyond the initial item publishing, which means the owner metadata needs to be mutable while the item itself is not.
 
-All item owners are peers. This means any item owner can publish a new version of an item. It also means that any item owner can remove any other item owner. No owner has more authority than other owners.  
+All item owners are peers. 
+This means any item owner can publish a new version of an item. It also means that any item owner can remove any other item owner. 
+No owner has more authority than other owners.  
 
-
-## Setting an Item's Initial Owner ##
+## Setting an Item's Initial Owner 
 
 When a new item is published to PowerShell Gallery, the initial owner is defined by the user that published the item. This is determined by whose API key was used in the Publish-Module cmdlet.
 
-
 ## Adding Owners
+
 Once an item has been published to the PowerShell Gallery, it's easy to invite additional users to become owners of an item.
 
 1. [Log on](https://powershellgallery.com/users/account/LogOn) to the PowerShell Gallery with the account that is the current owner of an item.
@@ -20,7 +22,10 @@ Once an item has been published to the PowerShell Gallery, it's easy to invite a
 5. An email is then sent to the new co-owner, as an invitation to become an owner of an item.
 6. Once that user clicks the link, they are a full co-owner with full control over an item, including the ability to remove other users as owners.
 
-**NOTE**: Until the new owner confirms ownership, they *will not* be listed as an owner of an item. When viewing the **Manage Owners** page, you will see a "pending approval" entry in the current owners. That invitation can be removed; just as other owners can be removed. This process of invitations prevents users from falsely adding other users as owners of their items.
+**NOTE**: Until the new owner confirms ownership, they *will not* be listed as an owner of an item.
+When viewing the **Manage Owners** page, you will see a "pending approval" entry in the current owners.
+That invitation can be removed; just as other owners can be removed.
+This process of invitations prevents users from falsely adding other users as owners of their items.
 
 Note that the "Authors" metadata is purely freeform text; only "Owners" are controlled.
 
@@ -36,7 +41,8 @@ When an item has multiple owners and one needs to be removed, the process is sim
 
 
 ## Transferring Item Ownership
-We sometimes get support requests to transfer item ownership from one user to another, but you can almost always accomplish this yourself.  Transferring ownership from one user to another is simply a combination of the two features above.
+We sometimes get support requests to transfer item ownership from one user to another, but you can almost always accomplish this yourself.
+Transferring ownership from one user to another is simply a combination of the two features above.
 
 1. The current owner invites the new user to become a co-owner and the new user accepts the invite;
 2. The new user removes the old user from the list of owners.
@@ -48,10 +54,17 @@ This request has come in under a couple forms but the process works the same.
 
 
 ## Orphaned Items
-One last scenario has occurred, but not many times.  Items have become orphans and the only item owner account cannot be used to add new owners.  Here are some examples of this scenario:
+One last scenario has occurred, but not many times.
+Items have become orphans and the only item owner account cannot be used to add new owners.
+Here are some examples of this scenario:
 
 * The owner's account is associated with an email address that no longer exists and the user has forgotten their password
 * The registered owner has left the company that produces the item and cannot be reached to update the item ownership
 * Due to a bug that has only affected a handful of items, the item is somehow ownerless on the gallery
 
-The PowerShell Gallery Administrators can access the 'Manage Owners' link for any item.  If you are the rightful owner of a item and cannot reach the current owner to gain ownership permissions, then use the 'Report Abuse' link on the gallery to reach the PowerShell Gallery Administrators.  We will then follow a process to verify your ownership of the item.  If we determine you should be an owner of the item, we will use the 'Manage Owners' link for the item ourselves and send you the invite to become an owner.  We will only do this after verifying that you should be an owner and the process for this varies by circumstances.  Often times, we will use the item's Project URL to find a way to contact the project owner, but we may also use Twitter, Email, or other means for contacting the project owner.
+The PowerShell Gallery Administrators can access the 'Manage Owners' link for any item.
+If you are the rightful owner of a item and cannot reach the current owner to gain ownership permissions, then use the 'Report Abuse' link on the gallery to reach the PowerShell Gallery Administrators.
+We will then follow a process to verify your ownership of the item.
+If we determine you should be an owner of the item, we will use the 'Manage Owners' link for the item ourselves and send you the invite to become an owner.
+We will only do this after verifying that you should be an owner and the process for this varies by circumstances.
+Often times, we will use the item's Project URL to find a way to contact the project owner, but we may also use Twitter, Email, or other means for contacting the project owner.

--- a/gallery/psgallery/psgallery_contacting_administrators.md
+++ b/gallery/psgallery/psgallery_contacting_administrators.md
@@ -1,6 +1,7 @@
-##Contact Gallery Administrators
+# Contact Gallery Administrators
 
-###When to Contact Gallery Administrators
+## When to Contact Gallery Administrators
+
 You should contact gallery administrators when:
 
 1. You need to delete an item that you published.
@@ -9,7 +10,8 @@ You should contact gallery administrators when:
 4. You have item name dispute with other users and you are not able to resolve it by contacting the users.
 5. You were contacted by Gallery Administrators, regarding your items in the gallery and you want to respond.
 
-###How to Contact Gallery Administrators
+## How to Contact Gallery Administrators
+
 1. Send us an email: cgadmin@microsoft.com.
 2. If you are reporting abuse of an item, you can find Report Abuse link below the item information on the left panel.
 3. For any other general questions regarding the Gallery, please submit your question to [UserVoice](http://windowsserver.uservoice.com/forums/301869-powershell)

--- a/gallery/psgallery/psgallery_contacting_item_owners.md
+++ b/gallery/psgallery/psgallery_contacting_item_owners.md
@@ -1,4 +1,7 @@
-#Contacting Item Owners
+# Contacting Item Owners
 
-To contact owner of a particular item, navigate to the item detail page. There is a contact Owners link in the left menu bar. Clicking on the link will take you to a new page. You can send a message from here.
+To contact owner of a particular item, navigate to the item detail page.
+There is a contact Owners link in the left menu bar.
+Clicking on the link will take you to a new page.
+You can send a message from here.
 

--- a/gallery/psgallery/psgallery_dispute_resolution.md
+++ b/gallery/psgallery/psgallery_dispute_resolution.md
@@ -1,12 +1,14 @@
-# PowerShell Gallery Dispute Resolution
+# Dispute Resolution
 
 This document is a recommended dispute resolution process for community members to help resolve disputes with other PowerShell Gallery publishers.
 
 ## Process
 
-1. Contact the owners of the item you have the dispute with using the **Contact Owners** link on the item details page.  Explain your issue in a kind and direct manner.
+1. Contact the owners of the item you have the dispute with using the **Contact Owners** link on the item details page.
+Explain your issue in a kind and direct manner.
 2. Send a copy of your message to [cgadmin@microsoft.com](mailto:cgadmin@microsoft.com) so that PowerShell Gallery Administrators are aware of your dispute.
-3. Wait a maximum of 30 days and if you don’t have resolution notify [cgadmin@microsoft.com](mailto:cgadmin@microsoft.com) again.  The PowerShellGallery.com support team will get involved and try to work this out.
+3. Wait a maximum of 30 days and if you don’t have resolution notify [cgadmin@microsoft.com](mailto:cgadmin@microsoft.com) again.
+The PowerShellGallery.com support team will get involved and try to work this out.
 
 
 ## Prohibited Use
@@ -17,7 +19,8 @@ The following things are not allowed on the public PowerShell Gallery and will b
 - Items that are designed to harm the user systems;
 - Copyright infringement or license violation;
 - Illegal content;
-- "Squatting" on item names that you plan to use but are not actually using. This also includes publishing items that have zero productive content. Either publish code and get going or concede the name to someone who actually has a product to ship; and
+- "Squatting" on item names that you plan to use but are not actually using. This also includes publishing items that have zero productive content.
+Either publish code and get going or concede the name to someone who actually has a product to ship; and
 - Attempting to make the gallery do something that it is not explicitly designed to do.
 
 

--- a/gallery/psgallery/psgallery_filelist_feature.md
+++ b/gallery/psgallery/psgallery_filelist_feature.md
@@ -1,9 +1,10 @@
-##FileList Feature in the Gallery
+# FileList Feature in the Gallery
+
 You are able to view the contents in all items published in the gallery. 
 
 This feature includes two parts: listing the files within the item, and displaying file contents for supported file types. Currently we support displaying the contents of the following file extensions: .ps1, .psm1, .psd1, .ps1xml, .xml and .txt. We will be supporting more file extensions in the next releases. 
 
-###Where to Find FileList
+## Where to Find FileList
 On each individual item page, you will be able to find FileList section and a **Show** link. Click on the Show and you will find a complete list of items contained in the item.
 
 Each supported file type is displayed as a hyperlink, and clicking it will take you to a new page with file contents displayed in PowerShell syntax highlighting. Clicking on the title or the version of the item, which is displayed at the top of the screen, will bring you back to item detail page.

--- a/gallery/psgallery/psgallery_unlist_items.md
+++ b/gallery/psgallery/psgallery_unlist_items.md
@@ -1,17 +1,23 @@
-#### 1. Why is removing an item from PowerShell Gallery not exposed as an option?
+# Unlisting items
 
-The PowerShell Gallery does not support users permanently deleting their items. This enables others to take dependencies on your items without worrying about possible breaks in the future. For example, if the Pester module depends on the Azure module and the Azure module is removed from the gallery, then user can no longer uses the Pester module.
+**Why is removing an item from PowerShell Gallery not exposed as an option?**
+
+The PowerShell Gallery does not support users permanently deleting their items. 
+This enables others to take dependencies on your items without worrying about possible breaks in the future. 
+For example, if the Pester module depends on the Azure module and the Azure module is removed from the gallery, then user can no longer uses the Pester module.
 
 Instead of removing an item, however, you can unlist it instead.
 
-#### 2. What does unlisting an item on PowerShell Gallery do?
+**What does unlisting an item on PowerShell Gallery do?**
 
-Unlisting an item such as module or script on PowerShell Gallery will remove it from the Items tab. In addition, unlisted items will not be discoverable using the search bar. The only way to download an unlisted item is to specify the exact name and version of the item.
+Unlisting an item such as module or script on PowerShell Gallery will remove it from the Items tab.
+In addition, unlisted items will not be discoverable using the search bar.
+The only way to download an unlisted item is to specify the exact name and version of the item.
 Because of this, the unlisting of an item will not break other modules or scripts that depend on it.
 
 To unlist your item, visit the item details page and select 'Delete Item'. Uncheck the 'Listed' checkbox, and click Save.
 
-#### 3. How can I remove an item?
+**How can I remove an item?**
 
 If you experience a scenario where item deletion is necessary, contact the PowerShell Gallery Administrators.
 Valid deletion scenarios are:


### PR DESCRIPTION
Just did a quick pass at lunch on the new Gallery content. A couple of the headers were missing, H2s that should have been H1s, etc. Just small stuff.

In addition, remember to use [semantic line feeds](http://rhodesmill.org/brandon/2012/one-sentence-per-line/) so that `git diff` is easy to read.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell-docs/554)
<!-- Reviewable:end -->
