### PR TITLE
Updating loc config to include upper case ".MD"

### DIFF
--- a/.localization-config
+++ b/.localization-config
@@ -1,6 +1,6 @@
 {
 	"locales": ["ja-jp", "de-de", "fr-fr", "zh-cn", "zh-tw", "ko-kr", "es-es", "it-it", "ru-ru", "pt-br"],
-	"files": ["!/*.md", "**/**/*.md", "**/*.md"],
+	"files": ["!/*.md", "**/**/*.md", "**/*.md", "!/*.MD", "**/**/*.MD", "**/*.MD"],
 	"includeDependencies": false,
 	"autoPush": true,
 	"useJavascriptMarkdownTransformer": true


### PR DESCRIPTION
Updating loc config to include upper case ".MD" due to source file "jea/TOC.MD".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell-docs/584)
<!-- Reviewable:end -->
