### PR TITLE
Fix PSScriptAnalyzer module file example

### DIFF
--- a/gallery/psget/module/modulewithpseditionsupport.md
+++ b/gallery/psget/module/modulewithpseditionsupport.md
@@ -109,9 +109,6 @@ Below logic loads the required assemblies depending on the current edition or ve
 #
 # Script module for module 'PSScriptAnalyzer'
 #
-
-# Clear PSDefaultParameterValues in the module scope and enable strict mode
-$PSDefaultParameterValues.Clear()
 Set-StrictMode -Version Latest
 
 # Set up some helper variables to make it easier to work with the module


### PR DESCRIPTION
$PSDefaultParameterValues.Clear() is not needed  at each module gets its own copy