### PR TITLE
Update scripting/core-powershell/ise/How-to-Create-a-PowerShell-Tab-i…

### DIFF
--- a/scripting/core-powershell/ise/How-to-Create-a-PowerShell-Tab-in-Windows-PowerShell-ISE.md
+++ b/scripting/core-powershell/ise/How-to-Create-a-PowerShell-Tab-in-Windows-PowerShell-ISE.md
@@ -11,12 +11,12 @@ ms.assetid:  c10c18c7-9ece-4fd0-83dc-a19c53d4fd83
 ---
 
 # How to Create a PowerShell Tab in Windows PowerShell ISE
-Tabs in the Windows PowerShellÂ® Integrated Scripting Environment (ISE) allow you to simultaneously create and use several execution environments within the same application. Each PowerShell tab corresponds to a separate execution environment or session.
+Tabs in the Windows PowerShell® Integrated Scripting Environment (ISE) allow you to simultaneously create and use several execution environments within the same application. Each PowerShell tab corresponds to a separate execution environment or session.
 
 > [!NOTE]
 > Variables, functions, and aliases that you create in one tab do not carry over to another. They are different Windows PowerShell sessions.
 
-Use the following steps to open or close a tab in Windows PowerShell. To rename a tab, set the [DisplayName](https://technet.microsoft.com/en-us/library/a9b58556-951b-4f48-b3ae-b351b7564360#Displayname) property on the Windows PowerShell Tab scripting object.
+Use the following steps to open or close a tab in Windows PowerShell. To rename a tab, set the [DisplayName](The-PowerShellTab-Object.md#Displayname) property on the Windows PowerShell Tab scripting object.
 
 ## To create and use a new PowerShell Tab
 On the **File** menu, click **New PowerShell Tab**. The new PowerShell tab always opens as the active window. PowerShell tabs are incrementally numbered in the order that they are opened. Each tab is associated with its own Windows PowerShell console window. You can have up to 32 PowerShell tabs with their own session open at a time (this is limited to 8 on Windows PowerShell ISE 2.0.)
@@ -35,9 +35,9 @@ To close a tab, you can use any of the following techniques:
 
 -   On the **File** menu, click **Close PowerShell Tab**, or click  the Close button  (**X**) on an active tab to close the tab.
 
-If you have unsaved files open in the PowerShell tab that you are closing, you are prompted to save or discard them. For more information about how to save a script, see [How to Save a Script](https://technet.microsoft.com/en-us/library/162f594d-efd3-4234-9960-45e56e6eadc8).
+If you have unsaved files open in the PowerShell tab that you are closing, you are prompted to save or discard them. For more information about how to save a script, see [How to Save a Script](https://technet.microsoft.com/library/162f594d-efd3-4234-9960-45e56e6eadc8).
 
 ## See Also
-[Using the Windows PowerShell ISE](Using-the-Windows-PowerShell-ISE.md)
-[How to Use the Console Pane in the Windows PowerShell ISE](How-to-Use-the-Console-Pane-in-the-Windows-PowerShell-ISE.md)
+- [Using the Windows PowerShell ISE](Using-the-Windows-PowerShell-ISE.md)
+- [How to Use the Console Pane in the Windows PowerShell ISE](How-to-Use-the-Console-Pane-in-the-Windows-PowerShell-ISE.md)
 


### PR DESCRIPTION
…n-Windows-PowerShell-ISE.md

- Invalid character removed before copyright symbol.
- DisplayName link updated because the page has been moved to the new documentation.
- "How to Save a Script"link updated to remove the preference for "en-us".
- "See Also" section updated to fix links being displayed on the same line.