### PR TITLE
Removing the release notes reference

### DIFF
--- a/gallery/psget/overview.md
+++ b/gallery/psget/overview.md
@@ -3,5 +3,3 @@
 PowerShellGet module contains cmdlets for discovering, installing, updating and publishing the PowerShell artifacts like Modules, DSC Resources, Role Capabilities and Scripts from the https://www.PowerShellGallery.com and other private repositories.
 
 ## [PowerShellGet cmdlet reference](./psget_cmdlets_reference.md)
-
-## [PowerShellGet module release notes](./psget_release_notes.md)


### PR DESCRIPTION
Release notes document will be created while publishing the PowerShellGet module to the PowerShellGallery.com.