### PR TITLE
Update WinRMSecurity.md

### DIFF
--- a/scripting/setup/WinRMSecurity.md
+++ b/scripting/setup/WinRMSecurity.md
@@ -103,11 +103,6 @@ This is known as the "Double-Hop" problem.
 
 There are several ways to avoid this problem:
 
-### Kerberos Constrained Delegation
-
-For highly trusted servers, you can enable [Kerberos Constrained Delegation](https://technet.microsoft.com/en-us/library/cc995228.aspx). This allows the remote server to impersonate the
-authenticated user to a specified list of computers and services.
-
 ### Trust between remote computers
 
 If you trust users connected remotely to *Server1* to resources on *Server2*, you can explicitly grant *Server1* access to those resources.


### PR DESCRIPTION
Removed Kerberos Constrained Delegation which doesn't work for PowerShell remoting using WinRM as host process WinRM creates is under the user identity which doesn't have permission to obtain a ticket.