### PR TITLE
-Store param removed from self-signed script

### DIFF
--- a/dsc/secureMOF.md
+++ b/dsc/secureMOF.md
@@ -176,7 +176,6 @@ New-SelfsignedCertificateEx `
     -FriendlyName 'DSC Credential Encryption certificate' `
     -Exportable `
     -StoreLocation 'LocalMachine' `
-    -StoreName 'My' `
     -KeyLength 2048 `
     -ProviderName 'Microsoft Enhanced Cryptographic Provider v1.0' `
     -AlgorithmName 'RSA' `


### PR DESCRIPTION
Vadims Podans updated his self-signed certificate generator script on 9/11/2016 and removed the parameter '-Store'.