### PR TITLE
only run appveyor if ref is changed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,3 +19,8 @@ build_script:
 
 artifacts:
   - path: out_cab
+
+only_commits:
+  files:
+    - reference/**/*
+    - appveyor.*


### PR DESCRIPTION
This should make it so that we only run the Appveyor CI if something in a PR or commit to `staging` or `live` changes a file inside of the `reference` folder (or the Appveyor script itself). 