### PR TITLE
Replacing <pre> tags with code fencing in Using-Familiar-Command-Name…

### DIFF
--- a/scripting/getting-started/fundamental/Using-Familiar-Command-Names.md
+++ b/scripting/getting-started/fundamental/Using-Familiar-Command-Names.md
@@ -62,8 +62,10 @@ Set-Alias -Name gcm -Value Get-Command
 
 Internally, Windows PowerShell uses commands like these during startup, but these aliases are not changeable. If you attempt to actually execute one of these commands, you will get an error explaining that the alias cannot be modified. For example:
 
-<pre>PS> Set-Alias -Name gi -Value Get-Item
+```
+PS> Set-Alias -Name gi -Value Get-Item
 Set-Alias : Alias is not writeable because alias gi is read-only or constant and cannot be written to.
 At line:1 char:10
-+ Set-Alias  <<<< -Name gi -Value Get-Item</pre>
++ Set-Alias  <<<< -Name gi -Value Get-Item
+```
 


### PR DESCRIPTION
…s.md

Hi @juanpablojofre,
We have a localization bug where formatting was lost only for the two code blocks fixed in this PR.
We found it was due to \<pre\> tags used instead of code fencing like others.
The MD transformer used for localization will not treat the text within \<pre\> tags as code block, so formatting will be lost.
If you agree, could you please help to merge this PR?
Thank you
Jason