### PR TITLE
Added UseSecurityBestPractices

### DIFF
--- a/dsc/pullServer.md
+++ b/dsc/pullServer.md
@@ -61,15 +61,16 @@ configuration Sample_xDscPullServer
  
          xDscWebService PSDSCPullServer 
          { 
-             Ensure                  = 'Present' 
-             EndpointName            = 'PSDSCPullServer' 
-             Port                    = 8080 
-             PhysicalPath            = "$env:SystemDrive\inetpub\PSDSCPullServer" 
-             CertificateThumbPrint   = $certificateThumbPrint          
-             ModulePath              = "$env:PROGRAMFILES\WindowsPowerShell\DscService\Modules" 
-             ConfigurationPath       = "$env:PROGRAMFILES\WindowsPowerShell\DscService\Configuration" 
-             State                   = 'Started'
-             DependsOn               = '[WindowsFeature]DSCServiceFeature'                         
+             Ensure                   = 'Present' 
+             EndpointName             = 'PSDSCPullServer' 
+             Port                     = 8080 
+             PhysicalPath             = "$env:SystemDrive\inetpub\PSDSCPullServer" 
+             CertificateThumbPrint    = $certificateThumbPrint          
+             ModulePath               = "$env:PROGRAMFILES\WindowsPowerShell\DscService\Modules" 
+             ConfigurationPath        = "$env:PROGRAMFILES\WindowsPowerShell\DscService\Configuration" 
+             State                    = 'Started'
+             DependsOn                = '[WindowsFeature]DSCServiceFeature'     
+             UseSecurityBestPractices = $true
          } 
 
         File RegistrationKeyFile


### PR DESCRIPTION
Prevents:

xPSDesiredStateConfiguration\xDscWebService : Class 'xDSCWebService' requires that a value of type 'Boolean' be
provided for property 'UseSecurityBestPractices'.
At line:25 char:9
+         xDscWebService PSDSCPullServer
+         ~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Write-Error], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : MissingValueForMandatoryProperty,xPSDesiredStateConfiguration\xDSCWebService