### PR TITLE
Default UseSecurityBestPractices to False

### DIFF
--- a/dsc/pullServer.md
+++ b/dsc/pullServer.md
@@ -70,7 +70,7 @@ configuration Sample_xDscPullServer
              ConfigurationPath        = "$env:PROGRAMFILES\WindowsPowerShell\DscService\Configuration" 
              State                    = 'Started'
              DependsOn                = '[WindowsFeature]DSCServiceFeature'     
-             UseSecurityBestPractices = $true
+             UseSecurityBestPractices = $false
          } 
 
         File RegistrationKeyFile


### PR DESCRIPTION
Looks like the best practices include killing SSL, which I believe will cause some issues with DSC communication such as:

SocketException: An existing connection was forcibly closed by the remote host