### PR TITLE
Query Parameter in Example 2 is corrected

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Management/Register-WmiEvent.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Register-WmiEvent.md
@@ -21,8 +21,7 @@ Subscribes to a Windows Management Instrumentation (WMI) event.
 ## SYNTAX
 
 ### class (Default)
-```
-Register-WmiEvent [-Namespace <String>] [-Credential <PSCredential>] [-ComputerName <String>] [-Class] <String>
+```Register-WmiEvent [-Namespace <String>] [-Credential <PSCredential>] [-ComputerName <String>] [-Class] <String>
  [-Timeout <Int64>] [[-SourceIdentifier] <String>] [[-Action] <ScriptBlock>] [-MessageData <PSObject>]
  [-SupportEvent] [-Forward] [-MaxTriggerCount <Int32>] [<CommonParameters>]
 ```
@@ -63,7 +62,7 @@ This class raises an event whenever a process starts.
 
 ### Example 2: Subscribe to creation events for a process
 ```
-PS C:\>Register-WmiEvent -Auery "select * from __instancecreationevent within 5 where targetinstance isa 'win32_process'" -SourceIdentifier "WMIProcess" -MessageData "Test 01" -TimeOut 500
+PS C:\>Register-WmiEvent -query "select * from __instancecreationevent within 5 where targetinstance isa 'win32_process'" -SourceIdentifier "WMIProcess" -MessageData "Test 01" -TimeOut 500
 ```
 
 This command uses a query to subscribe to Win32_process instance creation events.

--- a/reference/5.0/Microsoft.PowerShell.Management/Register-WmiEvent.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Register-WmiEvent.md
@@ -21,7 +21,8 @@ Subscribes to a Windows Management Instrumentation (WMI) event.
 ## SYNTAX
 
 ### class (Default)
-```Register-WmiEvent [-Namespace <String>] [-Credential <PSCredential>] [-ComputerName <String>] [-Class] <String>
+```
+Register-WmiEvent [-Namespace <String>] [-Credential <PSCredential>] [-ComputerName <String>] [-Class] <String>
  [-Timeout <Int64>] [[-SourceIdentifier] <String>] [[-Action] <ScriptBlock>] [-MessageData <PSObject>]
  [-SupportEvent] [-Forward] [-MaxTriggerCount <Int32>] [<CommonParameters>]
 ```


### PR DESCRIPTION
-Query parameter was having a typo as -Auery