### PR TITLE
Replace references to PSDSCReportServer.svc with PSDSCPullServer.svc

### DIFF
--- a/dsc/reportServer.md
+++ b/dsc/reportServer.md
@@ -54,7 +54,7 @@ configuration ReportClientConfig
 
         ReportServerWeb CONTOSO-ReportSrv
         {
-            ServerURL               = 'http://CONTOSO-REPORT:8080/PSDSCReportServer.svc'
+            ServerURL               = 'http://CONTOSO-REPORT:8080/PSDSCPullServer.svc'
             RegistrationKey         = 'ba39daaa-96c5-4f2f-9149-f95c46460faa'
             AllowUnsecureConnection = $true
         }
@@ -101,7 +101,7 @@ PullClientConfig
 
 Reports sent to the pull server are entered into a database on the server. The reports are available through calls to the web service. To retrieve reports for a specific node, 
 send an HTTP request to the report web service in the following form:
-`http://CONTOSO-REPORT:8080/PSDSCReportServer.svc/Nodes(AgentID = MyNodeAgentId)/Reports` 
+`http://CONTOSO-REPORT:8080/PSDSCPullServer.svc/Nodes(AgentID = MyNodeAgentId)/Reports` 
 where `MyNodeAgentId` is the AgentId of the node for which you want to get reports. You can get the AgentID for a node by calling [Get-DscLocalConfigurationManager](https://technet.microsoft.com/en-us/library/dn407378.aspx)
 on that node.
 
@@ -112,7 +112,7 @@ The following script returns the reports for the node on which it is run:
 ```powershell
 function GetReport
 {
-    param($AgentId = "$((glcm).AgentId)", $serviceURL = "http://CONTOSO-REPORT:8080/PSDSCReportServer.svc")
+    param($AgentId = "$((glcm).AgentId)", $serviceURL = "http://CONTOSO-REPORT:8080/PSDSCPullServer.svc")
     $requestUri = "$serviceURL/Nodes(AgentId= '$AgentId')/Reports"
     $request = Invoke-WebRequest -Uri $requestUri  -ContentType "application/json;odata=minimalmetadata;streaming=true;charset=utf-8" `
                -UseBasicParsing -Headers @{Accept = "application/json";ProtocolVersion = "2.0"} `


### PR DESCRIPTION
There is a typo in the DSC reportServer.md page (See https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/98#issuecomment-202639297)

PSDSCReportServer.svc is not a valid service in [xPSDesiredStateConfiguration](
https://github.com/PowerShell/xPSDesiredStateConfiguration/tree/dev/DSCResources/MSFT_xDSCWebService), only PSDSCPullServer.svc.