### PR TITLE
Remove BOM from md files

### DIFF
--- a/reference/3.0/ISE/Get-IseSnippet.md
+++ b/reference/3.0/ISE/Get-IseSnippet.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: ISE-help.xml

--- a/reference/3.0/ISE/ISE.md
+++ b/reference/3.0/ISE/ISE.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: ISE
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/ISE/Import-IseSnippet.md
+++ b/reference/3.0/ISE/Import-IseSnippet.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: ISE-help.xml

--- a/reference/3.0/ISE/New-IseSnippet.md
+++ b/reference/3.0/ISE/New-IseSnippet.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: ISE-help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Aliases.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Aliases.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Aliases
 description:
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Arithmetic_Operators
 description:
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Arrays
 description:
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Assignment_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Automatic_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Break.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Break.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Break
 description:
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Command_Precedence
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Command_Syntax
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Comment_Based_Help
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_CommonParameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Comparison_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Continue.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Continue.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Continue
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Core_Commands.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Core_Commands.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Core_Commands
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Data_Sections
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Debuggers
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Do.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Do.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Do
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Environment_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Escape_Characters
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Eventlogs.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Eventlogs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Eventlogs
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Execution_Policies
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_For.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_For.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_For
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Foreach.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Foreach.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Foreach
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Format.ps1xml
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_Advanced
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_Advanced_Methods
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_Advanced_Parameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_CmdletBindingAttribute
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_OutputTypeAttribute
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Group_Policy_Settings
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Hash_Tables
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_History.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_History
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_If.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_If
 description:
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Job_Details
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Jobs.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Jobs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Jobs
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Join.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Join.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Join
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Language_Modes
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Line_Editing
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Methods.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Methods.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Methods
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Modules
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Object_Creation.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Object_Creation.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Object_Creation
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Objects.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Objects.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Objects
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Operator_Precedence
 description:
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PSSession_Details
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_PSSessions.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_PSSessions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PSSessions
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_PSSnapins.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_PSSnapins.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PSSnapins
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Parameters.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Parameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Parameters_Default_Values.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Parameters_Default_Values.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parameters_Default_Values
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Parsing.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Parsing.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parsing
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Path_Syntax.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Path_Syntax.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Path_Syntax
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_PowerShell.exe.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_PowerShell.exe.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PowerShell.exe
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_PowerShell_Ise.exe.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_PowerShell_Ise.exe.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PowerShell_Ise.exe
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Preference_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Prompts
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Properties
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Providers
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Quoting_Rules
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Redirection
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Ref.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Ref.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Ref
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Regular_Expressions
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Disconnected_Sessions
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_FAQ
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Jobs
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Output.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Output.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Output
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Requirements
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Troubleshooting
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Requires
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Reserved_Words
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Return.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Return.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Return
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Run_With_PowerShell.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Run_With_PowerShell.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Run_With_PowerShell
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Script_Blocks
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Script_Internationalization
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Scripts.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Scripts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scripts
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Session_Configuration_Files
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Session_Configurations
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Signing
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Special_Characters
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Splatting
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Split.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Split
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Switch
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Throw.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Throw.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Throw
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Transactions.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Transactions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Transactions
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Trap.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Trap.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Trap
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Try_Catch_Finally
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Type_Operators.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Type_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Type_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Types.ps1xml
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Updatable_Help
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Variables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_WMI.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_WMI.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WMI
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_WMI_Cmdlets.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_WMI_Cmdlets.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WMI_Cmdlets
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_WQL.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_WQL.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WQL
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_While.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_While.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_While
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Wildcards
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Windows_PowerShell_ISE.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Windows_PowerShell_ISE.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Windows_PowerShell_ISE
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Windows_RT.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Windows_RT.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Windows_RT
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_packagemanagement.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_packagemanagement.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PackageManagement
 ms.custom: na
 ms.reviewer: na

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_pipelines
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_profiles.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_profiles.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Profiles
 ms.custom: na
 ms.reviewer: na

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_scopes.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_scopes.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scopes
 ms.custom: na
 ms.reviewer: na

--- a/reference/3.0/Microsoft.PowerShell.Core/Add-History.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Add-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Clear-History.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Clear-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Exit-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Exit-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Export-Console.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Export-Console.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Export-ModuleMember.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Export-ModuleMember.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Functions/Clear-Host.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Functions/Clear-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 external help file: System.Management.Automation.dll-help.xml
 online version: http://technet.microsoft.com/library/hh852689(v=wps.630).aspx
 schema: 2.0.0

--- a/reference/3.0/Microsoft.PowerShell.Core/Functions/Get-Verb.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Functions/Get-Verb.md
@@ -1,4 +1,4 @@
-﻿---
+---
 external help file: System.Management.Automation.dll-help.xml
 online version: http://technet.microsoft.com/library/hh852690(v=wps.630).aspx
 schema: 2.0.0

--- a/reference/3.0/Microsoft.PowerShell.Core/Get-History.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Get-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Get-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Get-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Get-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Get-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Get-PSSnapin.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Get-PSSnapin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Invoke-History.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Invoke-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Core
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Core/New-Module.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/New-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/New-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/New-PSSessionOption.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/New-PSSessionOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/New-PSTransportOption.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/New-PSTransportOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Out-Default.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Out-Default.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Out-Host.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Out-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Out-Null.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Out-Null.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Providers/Alias-Provider.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Providers/Alias-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Alias Provider
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Core/Providers/Environment-Provider.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Providers/Environment-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Environment Provider
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: FileSystem Provider
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Add-Content-for-FileSystem.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Add-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Add-Content for FileSystem
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Clear-Content-for-FileSystem.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Clear-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Clear-Content for FileSystem
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-ChildItem-for-FileSystem.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-ChildItem-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Get-ChildItem for FileSystem
 ms.custom: na
 ms.date: 07/31/2015

--- a/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Content-for-FileSystem.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Get-Content for FileSystem
 ms.custom: na
 ms.date: 07/31/2015

--- a/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Item-for-FileSystem.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Item-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Get-Item for FileSystem
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Remove-Item-for-FileSystem.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Remove-Item-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Remove-Item for FileSystem
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Set-Content-for-FileSystem.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Set-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Set-Content for FileSystem
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Test-Path-for-FileSystem.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Test-Path-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Test-Path for FileSystem
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Core/Providers/Function-Provider.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Providers/Function-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Function Provider
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Core/Providers/Registry-Provider.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Providers/Registry-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Registry Provider
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Core/Providers/Variable-Provider.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Providers/Variable-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Variable Provider
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Core/Receive-Job.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Receive-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Remove-Job.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Remove-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Remove-Module.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Remove-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Remove-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Remove-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Resume-Job.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Resume-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Save-Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Start-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Suspend-Job.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Suspend-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Test-ModuleManifest.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Test-ModuleManifest.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Wait-Job.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Wait-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Where-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Diagnostics/Export-Counter.md
+++ b/reference/3.0/Microsoft.PowerShell.Diagnostics/Export-Counter.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Diagnostics/Get-Counter.md
+++ b/reference/3.0/Microsoft.PowerShell.Diagnostics/Get-Counter.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
+++ b/reference/3.0/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Diagnostics/Import-Counter.md
+++ b/reference/3.0/Microsoft.PowerShell.Diagnostics/Import-Counter.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Diagnostics/Microsoft.PowerShell.Diagnostics.md
+++ b/reference/3.0/Microsoft.PowerShell.Diagnostics/Microsoft.PowerShell.Diagnostics.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Diagnostics
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Diagnostics/New-WinEvent.md
+++ b/reference/3.0/Microsoft.PowerShell.Diagnostics/New-WinEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Host/Microsoft.PowerShell.Host.md
+++ b/reference/3.0/Microsoft.PowerShell.Host/Microsoft.PowerShell.Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Host
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/3.0/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ConsoleHost.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Host/Stop-Transcript.md
+++ b/reference/3.0/Microsoft.PowerShell.Host/Stop-Transcript.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ConsoleHost.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Add-Computer.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Add-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Add-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Checkpoint-Computer.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Checkpoint-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Clear-Content.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Clear-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Clear-EventLog.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Clear-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Clear-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Clear-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Clear-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Clear-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Complete-Transaction.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Complete-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Convert-Path.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Convert-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Copy-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Copy-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Copy-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Debug-Process.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Debug-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-ComputerRestorePoint.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-ComputerRestorePoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-Content.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-EventLog.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-HotFix.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-HotFix.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-PSProvider.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-PSProvider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-Service.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-Transaction.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-WmiObject.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-WmiObject.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Invoke-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Invoke-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Join-Path.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Join-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Limit-EventLog.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Limit-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Management
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Management/Move-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Move-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Move-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Move-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/New-EventLog.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/New-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/New-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/New-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/New-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/New-PSDrive.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/New-PSDrive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/New-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/New-WebServiceProxy.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/New-WebServiceProxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Pop-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Push-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Register-WmiEvent.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Register-WmiEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Remove-Computer.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Remove-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Remove-EventLog.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Remove-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Remove-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Remove-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Remove-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Remove-PSDrive.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Remove-PSDrive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Remove-WmiObject.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Remove-WmiObject.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Rename-Computer.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Rename-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Rename-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Rename-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Rename-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Resolve-Path.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Resolve-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Restart-Service.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Restart-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Restore-Computer.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Restore-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Resume-Service.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Resume-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Set-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Set-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Set-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Set-Service.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Set-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Show-ControlPanelItem.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Show-ControlPanelItem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Show-EventLog.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Show-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Split-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Start-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Start-Service.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Start-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Start-Transaction.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Start-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Stop-Computer.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Stop-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Stop-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Stop-Service.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Stop-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Suspend-Service.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Suspend-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Test-Connection.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Test-Path.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Test-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Undo-Transaction.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Undo-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Use-Transaction.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Use-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Wait-Process.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Wait-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Management/Write-EventLog.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Write-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Security/ConvertTo-SecureString.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/ConvertTo-SecureString.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Security/Get-Acl.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Get-Acl.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Security/Get-Credential.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Get-Credential.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Security/Get-PfxCertificate.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Get-PfxCertificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Security
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Security/Providers/Get-ChildItem-for-Certificate.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Providers/Get-ChildItem-for-Certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Get-ChildItem for Certificate
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Security/Providers/Move-Item-for-Certificate.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Providers/Move-Item-for-Certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Move-Item for Certificate
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Security/Providers/New-Item-for-Certificate.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Providers/New-Item-for-Certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: New-Item for Certificate
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Security/Providers/Remove-Item-for-Certificate.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Providers/Remove-Item-for-Certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Remove-Item for Certificate
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Security/Providers/certificate-provider.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Providers/certificate-provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Certificate Provider"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.PowerShell.Security/Set-Acl.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Set-Acl.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Add-Member.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Add-Type.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Clear-Variable.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Clear-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/ConvertTo-Json.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/ConvertTo-Json.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Format-Custom.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Format-Custom.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Format-List.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Format-Table.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Culture.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Culture.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Date.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Event.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Host.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-PSCallStack.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-PSCallStack.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Random.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Random.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-TraceSource.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-TraceSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-TypeData.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-TypeData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-UICulture.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-UICulture.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Unique.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Unique.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Variable.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Group-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Import-Alias.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Import-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Import-Csv.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Import-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Import-LocalizedData.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Import-LocalizedData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Import-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Import-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Invoke-Expression.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Invoke-Expression.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Measure-Object.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Measure-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Utility
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/New-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/New-Event.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/New-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/New-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/New-TimeSpan.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/New-TimeSpan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/New-Variable.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/New-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Out-File.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Out-GridView.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Out-GridView.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Out-Printer.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Out-Printer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Out-String.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Remove-Event.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Remove-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Remove-TypeData.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Remove-TypeData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Select-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Select-Xml.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Select-Xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Send-MailMessage.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Send-MailMessage.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Set-Date.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Set-Date.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Show-Command.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Show-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Start-Sleep.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Start-Sleep.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Unregister-Event.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Unregister-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Update-List.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Update-List.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Wait-Event.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Wait-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Write-Debug.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Write-Debug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Write-Error.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Write-Host.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Write-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Write-Output.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Write-Verbose.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Write-Verbose.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Write-Warning.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Write-Warning.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/3.0/Microsoft.WsMan.Management/About/about_WS-Management_Cmdlets.md
+++ b/reference/3.0/Microsoft.WsMan.Management/About/about_WS-Management_Cmdlets.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WS-Management_Cmdlets
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.WsMan.Management/Connect-WSMan.md
+++ b/reference/3.0/Microsoft.WsMan.Management/Connect-WSMan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.WsMan.Management/Disable-WSManCredSSP.md
+++ b/reference/3.0/Microsoft.WsMan.Management/Disable-WSManCredSSP.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.WsMan.Management/Disconnect-WSMan.md
+++ b/reference/3.0/Microsoft.WsMan.Management/Disconnect-WSMan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.WsMan.Management/Enable-WSManCredSSP.md
+++ b/reference/3.0/Microsoft.WsMan.Management/Enable-WSManCredSSP.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.WsMan.Management/Get-WSManCredSSP.md
+++ b/reference/3.0/Microsoft.WsMan.Management/Get-WSManCredSSP.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.WsMan.Management/Get-WSManInstance.md
+++ b/reference/3.0/Microsoft.WsMan.Management/Get-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.WsMan.Management/Invoke-WSManAction.md
+++ b/reference/3.0/Microsoft.WsMan.Management/Invoke-WSManAction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.WsMan.Management/Microsoft.WsMan.Management.md
+++ b/reference/3.0/Microsoft.WsMan.Management/Microsoft.WsMan.Management.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.WsMan.Management
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/Microsoft.WsMan.Management/New-WSManInstance.md
+++ b/reference/3.0/Microsoft.WsMan.Management/New-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.WsMan.Management/New-WSManSessionOption.md
+++ b/reference/3.0/Microsoft.WsMan.Management/New-WSManSessionOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.WsMan.Management/Remove-WSManInstance.md
+++ b/reference/3.0/Microsoft.WsMan.Management/Remove-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.WsMan.Management/Set-WSManInstance.md
+++ b/reference/3.0/Microsoft.WsMan.Management/Set-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.WsMan.Management/Set-WSManQuickConfig.md
+++ b/reference/3.0/Microsoft.WsMan.Management/Set-WSManQuickConfig.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.WsMan.Management/Test-WSMan.md
+++ b/reference/3.0/Microsoft.WsMan.Management/Test-WSMan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/3.0/Microsoft.WsMan.Management/provider/new-item-for-clientcertificate.md
+++ b/reference/3.0/Microsoft.WsMan.Management/provider/new-item-for-clientcertificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for ClientCertificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.WsMan.Management/provider/new-item-for-initializationparameters.md
+++ b/reference/3.0/Microsoft.WsMan.Management/provider/new-item-for-initializationparameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for InitializationParameters"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.WsMan.Management/provider/new-item-for-listener.md
+++ b/reference/3.0/Microsoft.WsMan.Management/provider/new-item-for-listener.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Listener"
 ms.custom: na
 ms.date: 07/31/2015

--- a/reference/3.0/Microsoft.WsMan.Management/provider/new-item-for-plugin.md
+++ b/reference/3.0/Microsoft.WsMan.Management/provider/new-item-for-plugin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Plugin"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.WsMan.Management/provider/new-item-for-resources.md
+++ b/reference/3.0/Microsoft.WsMan.Management/provider/new-item-for-resources.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Resources"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.WsMan.Management/provider/new-item-for-security.md
+++ b/reference/3.0/Microsoft.WsMan.Management/provider/new-item-for-security.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Security"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/3.0/Microsoft.WsMan.Management/provider/wsman-provider.md
+++ b/reference/3.0/Microsoft.WsMan.Management/provider/wsman-provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "WSMan Provider"
 ms.custom: na
 ms.date: 07/31/2015

--- a/reference/3.0/PSScheduledJob/About/about_Scheduled_Jobs.md
+++ b/reference/3.0/PSScheduledJob/About/about_Scheduled_Jobs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSScheduledJob/About/about_Scheduled_Jobs_Advanced.md
+++ b/reference/3.0/PSScheduledJob/About/about_Scheduled_Jobs_Advanced.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs_Advanced
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSScheduledJob/About/about_Scheduled_Jobs_Basics.md
+++ b/reference/3.0/PSScheduledJob/About/about_Scheduled_Jobs_Basics.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs_Basics
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSScheduledJob/About/about_Scheduled_Jobs_Troubleshooting.md
+++ b/reference/3.0/PSScheduledJob/About/about_Scheduled_Jobs_Troubleshooting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs_Troubleshooting
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSScheduledJob/Add-JobTrigger.md
+++ b/reference/3.0/PSScheduledJob/Add-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/Disable-JobTrigger.md
+++ b/reference/3.0/PSScheduledJob/Disable-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/Disable-ScheduledJob.md
+++ b/reference/3.0/PSScheduledJob/Disable-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/Enable-JobTrigger.md
+++ b/reference/3.0/PSScheduledJob/Enable-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/Enable-ScheduledJob.md
+++ b/reference/3.0/PSScheduledJob/Enable-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/Get-JobTrigger.md
+++ b/reference/3.0/PSScheduledJob/Get-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/Get-ScheduledJob.md
+++ b/reference/3.0/PSScheduledJob/Get-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/Get-ScheduledJobOption.md
+++ b/reference/3.0/PSScheduledJob/Get-ScheduledJobOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/New-JobTrigger.md
+++ b/reference/3.0/PSScheduledJob/New-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/New-ScheduledJobOption.md
+++ b/reference/3.0/PSScheduledJob/New-ScheduledJobOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/PSScheduledJob.md
+++ b/reference/3.0/PSScheduledJob/PSScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSScheduledJob
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSScheduledJob/Register-ScheduledJob.md
+++ b/reference/3.0/PSScheduledJob/Register-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/Remove-JobTrigger.md
+++ b/reference/3.0/PSScheduledJob/Remove-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/Set-JobTrigger.md
+++ b/reference/3.0/PSScheduledJob/Set-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/Set-ScheduledJob.md
+++ b/reference/3.0/PSScheduledJob/Set-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/Set-ScheduledJobOption.md
+++ b/reference/3.0/PSScheduledJob/Set-ScheduledJobOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSScheduledJob/Unregister-ScheduledJob.md
+++ b/reference/3.0/PSScheduledJob/Unregister-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/3.0/PSWorkflow/About/about_ActivityCommonParameters.md
+++ b/reference/3.0/PSWorkflow/About/about_ActivityCommonParameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_ActivityCommonParameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSWorkflow/About/about_Checkpoint-Workflow.md
+++ b/reference/3.0/PSWorkflow/About/about_Checkpoint-Workflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Checkpoint-Workflow
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSWorkflow/About/about_Foreach-Parallel.md
+++ b/reference/3.0/PSWorkflow/About/about_Foreach-Parallel.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Foreach-Parallel
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSWorkflow/About/about_InlineScript.md
+++ b/reference/3.0/PSWorkflow/About/about_InlineScript.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_InlineScript
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSWorkflow/About/about_Parallel.md
+++ b/reference/3.0/PSWorkflow/About/about_Parallel.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parallel
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSWorkflow/About/about_Sequence.md
+++ b/reference/3.0/PSWorkflow/About/about_Sequence.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Sequence
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSWorkflow/About/about_Suspend-Workflow.md
+++ b/reference/3.0/PSWorkflow/About/about_Suspend-Workflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Suspend-Workflow
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSWorkflow/About/about_WorkflowCommonParameters.md
+++ b/reference/3.0/PSWorkflow/About/about_WorkflowCommonParameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WorkflowCommonParameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSWorkflow/About/about_Workflows.md
+++ b/reference/3.0/PSWorkflow/About/about_Workflows.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Workflows
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSWorkflow/New-PSWorkflowExecutionOption.md
+++ b/reference/3.0/PSWorkflow/New-PSWorkflowExecutionOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.Workflow.ServiceCore.dll-Help.xml

--- a/reference/3.0/PSWorkflow/New-PSWorkflowSession.md
+++ b/reference/3.0/PSWorkflow/New-PSWorkflowSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSWorkflow-help.xml

--- a/reference/3.0/PSWorkflow/PSWorkflow.md
+++ b/reference/3.0/PSWorkflow/PSWorkflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSWorkflow
 description: 
 keywords: powershell, cmdlet

--- a/reference/3.0/PSWorkflowUtility/PSWorkflowUtility.md
+++ b/reference/3.0/PSWorkflowUtility/PSWorkflowUtility.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSWorkflowUtility
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/ISE/Get-IseSnippet.md
+++ b/reference/4.0/ISE/Get-IseSnippet.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: ISE-help.xml

--- a/reference/4.0/ISE/ISE.md
+++ b/reference/4.0/ISE/ISE.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: ISE
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/ISE/Import-IseSnippet.md
+++ b/reference/4.0/ISE/Import-IseSnippet.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: ISE-help.xml

--- a/reference/4.0/ISE/New-IseSnippet.md
+++ b/reference/4.0/ISE/New-IseSnippet.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: ISE-help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Aliases.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Aliases.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Aliases
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Arithmetic_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Arrays
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Assignment_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Automatic_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Break.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Break.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Break
 description:
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Command_Precedence
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Command_Syntax
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Comment_Based_Help
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_CommonParameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Comparison_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Continue.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Continue.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Continue
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Core_Commands.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Core_Commands.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Core_Commands
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Data_Sections
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Debuggers
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Do.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Do.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Do
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Environment_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Escape_Characters
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Eventlogs.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Eventlogs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Eventlogs
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Execution_Policies
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_For.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_For.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_For
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Foreach.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Foreach.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Foreach
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Format.ps1xml
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_Advanced
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_Advanced_Methods
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_Advanced_Parameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_CmdletBindingAttribute
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_OutputTypeAttribute
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Group_Policy_Settings
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Hash_Tables
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_History.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_History
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_If.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_If
 description:
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Job_Details
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Jobs.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Jobs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Jobs
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Join.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Join.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Join
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Language_Modes
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Line_Editing
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Methods.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Methods.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Methods
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Modules
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Object_Creation.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Object_Creation.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Object_Creation
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Objects.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Objects.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Objects
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Operator_Precedence
 description:
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PSSession_Details
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_PSSessions.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_PSSessions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PSSessions
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_PSSnapins.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_PSSnapins.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PSSnapins
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Parameters.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Parameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Parameters_Default_Values.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Parameters_Default_Values.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parameters_Default_Values
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Parsing.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Parsing.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parsing
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Path_Syntax.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Path_Syntax.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Path_Syntax
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_PowerShell.exe.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_PowerShell.exe.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PowerShell.exe
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_PowerShell_Ise.exe.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_PowerShell_Ise.exe.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PowerShell_Ise.exe
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Preference_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Prompts
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Properties
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Providers
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Quoting_Rules
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Redirection
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Ref.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Ref.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Ref
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Regular_Expressions
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Disconnected_Sessions
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_FAQ
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Jobs
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Output.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Output.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Output
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Requirements
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Troubleshooting
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Requires
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Reserved_Words
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Return.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Return.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Return
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Run_With_PowerShell.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Run_With_PowerShell.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Run_With_PowerShell
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Script_Blocks
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Script_Internationalization
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Scripts.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Scripts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scripts
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Session_Configuration_Files
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Session_Configurations
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Signing
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Special_Characters
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Splatting
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Split.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Split
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Switch
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Throw.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Throw.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Throw
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Transactions.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Transactions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Transactions
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Trap.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Trap.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Trap
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Try_Catch_Finally
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Type_Operators.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Type_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Type_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Types.ps1xml
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Updatable_Help
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Variables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_WMI.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_WMI.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WMI
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_WMI_Cmdlets.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_WMI_Cmdlets.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WMI_Cmdlets
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_WQL.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_WQL.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WQL
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_While.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_While.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_While
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Wildcards
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Windows_PowerShell_ISE.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Windows_PowerShell_ISE.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Windows_PowerShell_ISE
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Windows_RT.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Windows_RT.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Windows_RT
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_packagemanagement.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_packagemanagement.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PackageManagement
 ms.custom: na
 ms.reviewer: na

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_pipelines
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_profiles.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_profiles.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Profiles
 ms.custom: na
 ms.reviewer: na

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_scopes.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_scopes.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scopes
 ms.custom: na
 ms.reviewer: na

--- a/reference/4.0/Microsoft.PowerShell.Core/Add-History.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Add-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Clear-History.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Clear-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Exit-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Exit-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Export-Console.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Export-Console.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Export-ModuleMember.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Export-ModuleMember.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Functions/Clear-Host.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Functions/Clear-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 external help file: System.Management.Automation.dll-help.xml
 online version: http://technet.microsoft.com/library/hh852689(v=wps.630).aspx
 schema: 2.0.0

--- a/reference/4.0/Microsoft.PowerShell.Core/Functions/Get-Verb.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Functions/Get-Verb.md
@@ -1,4 +1,4 @@
-﻿---
+---
 external help file: System.Management.Automation.dll-help.xml
 online version: http://technet.microsoft.com/library/hh852690(v=wps.630).aspx
 schema: 2.0.0

--- a/reference/4.0/Microsoft.PowerShell.Core/Get-Help.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Get-Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Get-History.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Get-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Get-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Get-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Get-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Get-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Get-PSSnapin.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Get-PSSnapin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Invoke-History.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Invoke-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Core
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Core/New-Module.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/New-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/New-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/New-PSSessionOption.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/New-PSSessionOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/New-PSTransportOption.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/New-PSTransportOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Out-Default.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Out-Default.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Out-Host.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Out-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Out-Null.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Out-Null.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Providers/Alias-Provider.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Providers/Alias-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Alias Provider
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Core/Providers/Environment-Provider.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Providers/Environment-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Environment Provider
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: FileSystem Provider
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Add-Content-for-FileSystem.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Add-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Add-Content for FileSystem
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Clear-Content-for-FileSystem.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Clear-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Clear-Content for FileSystem
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-ChildItem-for-FileSystem.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-ChildItem-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Get-ChildItem for FileSystem
 ms.custom: na
 ms.date: 07/31/2015

--- a/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Content-for-FileSystem.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Get-Content for FileSystem
 ms.custom: na
 ms.date: 07/31/2015

--- a/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Item-for-FileSystem.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Item-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Get-Item for FileSystem
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Remove-Item-for-FileSystem.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Remove-Item-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Remove-Item for FileSystem
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Set-Content-for-FileSystem.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Set-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Set-Content for FileSystem
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Test-Path-for-FileSystem.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Test-Path-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Test-Path for FileSystem
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Core/Providers/Function-Provider.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Providers/Function-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Function Provider
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Core/Providers/Registry-Provider.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Providers/Registry-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Registry Provider
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Core/Providers/Variable-Provider.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Providers/Variable-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Variable Provider
 ms.custom: na
 ms.reviewer: na

--- a/reference/4.0/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Remove-Job.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Remove-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Remove-Module.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Remove-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Remove-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Remove-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Resume-Job.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Resume-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Save-Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Set-StrictMode.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Set-StrictMode.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Start-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Stop-Job.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Stop-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Suspend-Job.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Suspend-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Test-ModuleManifest.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Test-ModuleManifest.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Update-Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Core/Wait-Job.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Wait-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Diagnostics/Export-Counter.md
+++ b/reference/4.0/Microsoft.PowerShell.Diagnostics/Export-Counter.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Diagnostics/Get-Counter.md
+++ b/reference/4.0/Microsoft.PowerShell.Diagnostics/Get-Counter.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
+++ b/reference/4.0/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Diagnostics/Import-Counter.md
+++ b/reference/4.0/Microsoft.PowerShell.Diagnostics/Import-Counter.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Diagnostics/Microsoft.PowerShell.Diagnostics.md
+++ b/reference/4.0/Microsoft.PowerShell.Diagnostics/Microsoft.PowerShell.Diagnostics.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Diagnostics
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Diagnostics/New-WinEvent.md
+++ b/reference/4.0/Microsoft.PowerShell.Diagnostics/New-WinEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Host/Microsoft.PowerShell.Host.md
+++ b/reference/4.0/Microsoft.PowerShell.Host/Microsoft.PowerShell.Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Host
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/4.0/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ConsoleHost.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Host/Stop-Transcript.md
+++ b/reference/4.0/Microsoft.PowerShell.Host/Stop-Transcript.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ConsoleHost.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Add-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Add-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Add-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Checkpoint-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Checkpoint-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Clear-Content.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Clear-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Clear-EventLog.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Clear-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Clear-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Clear-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Clear-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Clear-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Complete-Transaction.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Complete-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Convert-Path.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Convert-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Copy-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Copy-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Copy-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Debug-Process.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Debug-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-ComputerRestorePoint.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-ComputerRestorePoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-Content.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-EventLog.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-HotFix.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-HotFix.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-PSProvider.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-PSProvider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-Service.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-Transaction.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-WmiObject.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-WmiObject.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Invoke-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Invoke-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Join-Path.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Join-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Limit-EventLog.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Limit-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Management
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Management/Move-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Move-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Move-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Move-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/New-EventLog.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/New-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/New-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/New-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/New-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/New-PSDrive.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/New-PSDrive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/New-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/New-WebServiceProxy.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/New-WebServiceProxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Pop-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Push-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Register-WmiEvent.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Register-WmiEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Remove-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Remove-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Remove-EventLog.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Remove-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Remove-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Remove-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Remove-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Remove-PSDrive.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Remove-PSDrive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Remove-WmiObject.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Remove-WmiObject.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Rename-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Rename-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Rename-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Rename-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Rename-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Resolve-Path.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Resolve-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Restart-Service.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Restart-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Restore-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Restore-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Resume-Service.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Resume-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Set-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Set-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Set-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Set-Service.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Set-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Show-ControlPanelItem.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Show-ControlPanelItem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Show-EventLog.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Show-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Split-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Start-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Start-Service.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Start-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Start-Transaction.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Start-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Stop-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Stop-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Stop-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Stop-Service.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Stop-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Suspend-Service.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Suspend-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Test-Connection.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Test-Path.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Test-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Undo-Transaction.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Undo-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Use-Transaction.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Use-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Wait-Process.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Wait-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Management/Write-EventLog.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Write-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Security/ConvertTo-SecureString.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/ConvertTo-SecureString.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Security/Get-Acl.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/Get-Acl.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Security/Get-Credential.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/Get-Credential.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Security/Get-PfxCertificate.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/Get-PfxCertificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Security
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Security/Set-Acl.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/Set-Acl.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Security/providers/certificate-provider.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/providers/certificate-provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Certificate Provider"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Security/providers/get-childitem-for-certificate.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/providers/get-childitem-for-certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Get-ChildItem for Certificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Security/providers/move-item-for-certificate.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/providers/move-item-for-certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Move-Item for Certificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Security/providers/new-item-for-certificate.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/providers/new-item-for-certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Certificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Security/providers/remove-item-for-certificate.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/providers/remove-item-for-certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Remove-Item for Certificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Add-Member.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Add-Member
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Add-Type.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Clear-Variable.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Clear-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/ConvertTo-Json.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/ConvertTo-Json.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Format-Custom.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Format-Custom.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Format-List.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Format-Table.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Culture.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Culture.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Date.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Event.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-FileHash.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-FileHash.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Utility-help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Host.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-PSCallStack.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-PSCallStack.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Random.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Random.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-TraceSource.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-TraceSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-TypeData.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-TypeData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-UICulture.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-UICulture.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Unique.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Unique.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Variable.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Group-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Import-Alias.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Import-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Import-Csv.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Import-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Import-LocalizedData.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Import-LocalizedData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Import-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Import-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Invoke-Expression.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Invoke-Expression.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Measure-Object.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Measure-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Utility
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/New-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/New-Event.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/New-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/New-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/New-TimeSpan.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/New-TimeSpan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/New-Variable.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/New-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Out-File.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Out-GridView.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Out-GridView.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Out-Printer.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Out-Printer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Out-String.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Read-Host.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Read-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Remove-Event.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Remove-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Remove-TypeData.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Remove-TypeData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Remove-Variable.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Remove-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Select-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Select-Xml.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Select-Xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Send-MailMessage.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Send-MailMessage.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Set-Date.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Set-Date.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Show-Command.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Show-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Start-Sleep.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Start-Sleep.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Unblock-File.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Unblock-File.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Unregister-Event.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Unregister-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Update-List.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Update-List.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Wait-Event.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Wait-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Write-Debug.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Write-Debug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Write-Error.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Write-Host.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Write-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Write-Output.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Write-Verbose.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Write-Verbose.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Write-Warning.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Write-Warning.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/4.0/Microsoft.WsMan.Management/About/about_WS-Management_Cmdlets.md
+++ b/reference/4.0/Microsoft.WsMan.Management/About/about_WS-Management_Cmdlets.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WS-Management_Cmdlets
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.WsMan.Management/Connect-WSMan.md
+++ b/reference/4.0/Microsoft.WsMan.Management/Connect-WSMan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.WsMan.Management/Disable-WSManCredSSP.md
+++ b/reference/4.0/Microsoft.WsMan.Management/Disable-WSManCredSSP.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.WsMan.Management/Disconnect-WSMan.md
+++ b/reference/4.0/Microsoft.WsMan.Management/Disconnect-WSMan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.WsMan.Management/Enable-WSManCredSSP.md
+++ b/reference/4.0/Microsoft.WsMan.Management/Enable-WSManCredSSP.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.WsMan.Management/Get-WSManCredSSP.md
+++ b/reference/4.0/Microsoft.WsMan.Management/Get-WSManCredSSP.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.WsMan.Management/Get-WSManInstance.md
+++ b/reference/4.0/Microsoft.WsMan.Management/Get-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.WsMan.Management/Invoke-WSManAction.md
+++ b/reference/4.0/Microsoft.WsMan.Management/Invoke-WSManAction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.WsMan.Management/Microsoft.WsMan.Management.md
+++ b/reference/4.0/Microsoft.WsMan.Management/Microsoft.WsMan.Management.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.WsMan.Management
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/Microsoft.WsMan.Management/New-WSManInstance.md
+++ b/reference/4.0/Microsoft.WsMan.Management/New-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.WsMan.Management/New-WSManSessionOption.md
+++ b/reference/4.0/Microsoft.WsMan.Management/New-WSManSessionOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.WsMan.Management/Remove-WSManInstance.md
+++ b/reference/4.0/Microsoft.WsMan.Management/Remove-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.WsMan.Management/Set-WSManInstance.md
+++ b/reference/4.0/Microsoft.WsMan.Management/Set-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.WsMan.Management/Set-WSManQuickConfig.md
+++ b/reference/4.0/Microsoft.WsMan.Management/Set-WSManQuickConfig.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.WsMan.Management/Test-WSMan.md
+++ b/reference/4.0/Microsoft.WsMan.Management/Test-WSMan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/4.0/Microsoft.WsMan.Management/provider/new-item-for-clientcertificate.md
+++ b/reference/4.0/Microsoft.WsMan.Management/provider/new-item-for-clientcertificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for ClientCertificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.WsMan.Management/provider/new-item-for-initializationparameters.md
+++ b/reference/4.0/Microsoft.WsMan.Management/provider/new-item-for-initializationparameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for InitializationParameters"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.WsMan.Management/provider/new-item-for-listener.md
+++ b/reference/4.0/Microsoft.WsMan.Management/provider/new-item-for-listener.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Listener"
 ms.custom: na
 ms.date: 07/31/2015

--- a/reference/4.0/Microsoft.WsMan.Management/provider/new-item-for-plugin.md
+++ b/reference/4.0/Microsoft.WsMan.Management/provider/new-item-for-plugin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Plugin"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.WsMan.Management/provider/new-item-for-resources.md
+++ b/reference/4.0/Microsoft.WsMan.Management/provider/new-item-for-resources.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Resources"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.WsMan.Management/provider/new-item-for-security.md
+++ b/reference/4.0/Microsoft.WsMan.Management/provider/new-item-for-security.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Security"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/4.0/Microsoft.WsMan.Management/provider/wsman-provider.md
+++ b/reference/4.0/Microsoft.WsMan.Management/provider/wsman-provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "WSMan Provider"
 ms.custom: na
 ms.date: 07/31/2015

--- a/reference/4.0/PSDesiredStateConfiguration/Get-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Get-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Get-DSCConfiguration.cdxml-help.xml

--- a/reference/4.0/PSDesiredStateConfiguration/Get-DscLocalConfigurationManager.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Get-DscLocalConfigurationManager.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Get-DSCLocalConfigurationManager.cdxml-help.xml

--- a/reference/4.0/PSDesiredStateConfiguration/Get-DscResource.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Get-DscResource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSDesiredStateConfiguration-help.xml

--- a/reference/4.0/PSDesiredStateConfiguration/New-DSCCheckSum.md
+++ b/reference/4.0/PSDesiredStateConfiguration/New-DSCCheckSum.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSDesiredStateConfiguration-help.xml

--- a/reference/4.0/PSDesiredStateConfiguration/PSDesiredStateConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/PSDesiredStateConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSDesiredStateConfiguration
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSDesiredStateConfiguration/Remove-DscConfigurationDocument.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Remove-DscConfigurationDocument.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Remove-DscConfigurationDocument.cdxml-help.xml

--- a/reference/4.0/PSDesiredStateConfiguration/Restore-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Restore-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Restore-DSCConfiguration.cdxml-help.xml

--- a/reference/4.0/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/4.0/PSDesiredStateConfiguration/Start-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Start-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/4.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Stop-DscConfiguration.cdxml-help.xml

--- a/reference/4.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Test-DSCConfiguration.cdxml-help.xml

--- a/reference/4.0/PSDesiredStateConfiguration/Update-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Update-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/About/about_Scheduled_Jobs.md
+++ b/reference/4.0/PSScheduledJob/About/about_Scheduled_Jobs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSScheduledJob/About/about_Scheduled_Jobs_Advanced.md
+++ b/reference/4.0/PSScheduledJob/About/about_Scheduled_Jobs_Advanced.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs_Advanced
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSScheduledJob/About/about_Scheduled_Jobs_Basics.md
+++ b/reference/4.0/PSScheduledJob/About/about_Scheduled_Jobs_Basics.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs_Basics
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSScheduledJob/About/about_Scheduled_Jobs_Troubleshooting.md
+++ b/reference/4.0/PSScheduledJob/About/about_Scheduled_Jobs_Troubleshooting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs_Troubleshooting
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSScheduledJob/Add-JobTrigger.md
+++ b/reference/4.0/PSScheduledJob/Add-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/Disable-JobTrigger.md
+++ b/reference/4.0/PSScheduledJob/Disable-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/Disable-ScheduledJob.md
+++ b/reference/4.0/PSScheduledJob/Disable-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/Enable-JobTrigger.md
+++ b/reference/4.0/PSScheduledJob/Enable-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/Enable-ScheduledJob.md
+++ b/reference/4.0/PSScheduledJob/Enable-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/Get-JobTrigger.md
+++ b/reference/4.0/PSScheduledJob/Get-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/Get-ScheduledJob.md
+++ b/reference/4.0/PSScheduledJob/Get-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/Get-ScheduledJobOption.md
+++ b/reference/4.0/PSScheduledJob/Get-ScheduledJobOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/New-JobTrigger.md
+++ b/reference/4.0/PSScheduledJob/New-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/New-ScheduledJobOption.md
+++ b/reference/4.0/PSScheduledJob/New-ScheduledJobOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/PSScheduledJob.md
+++ b/reference/4.0/PSScheduledJob/PSScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSScheduledJob
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSScheduledJob/Register-ScheduledJob.md
+++ b/reference/4.0/PSScheduledJob/Register-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/Remove-JobTrigger.md
+++ b/reference/4.0/PSScheduledJob/Remove-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/Set-JobTrigger.md
+++ b/reference/4.0/PSScheduledJob/Set-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/Set-ScheduledJob.md
+++ b/reference/4.0/PSScheduledJob/Set-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/Set-ScheduledJobOption.md
+++ b/reference/4.0/PSScheduledJob/Set-ScheduledJobOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSScheduledJob/Unregister-ScheduledJob.md
+++ b/reference/4.0/PSScheduledJob/Unregister-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/4.0/PSWorkflow/About/about_ActivityCommonParameters.md
+++ b/reference/4.0/PSWorkflow/About/about_ActivityCommonParameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_ActivityCommonParameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSWorkflow/About/about_Checkpoint-Workflow.md
+++ b/reference/4.0/PSWorkflow/About/about_Checkpoint-Workflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Checkpoint-Workflow
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSWorkflow/About/about_Foreach-Parallel.md
+++ b/reference/4.0/PSWorkflow/About/about_Foreach-Parallel.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Foreach-Parallel
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSWorkflow/About/about_InlineScript.md
+++ b/reference/4.0/PSWorkflow/About/about_InlineScript.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_InlineScript
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSWorkflow/About/about_Parallel.md
+++ b/reference/4.0/PSWorkflow/About/about_Parallel.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parallel
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSWorkflow/About/about_Sequence.md
+++ b/reference/4.0/PSWorkflow/About/about_Sequence.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Sequence
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSWorkflow/About/about_Suspend-Workflow.md
+++ b/reference/4.0/PSWorkflow/About/about_Suspend-Workflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Suspend-Workflow
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSWorkflow/About/about_WorkflowCommonParameters.md
+++ b/reference/4.0/PSWorkflow/About/about_WorkflowCommonParameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WorkflowCommonParameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSWorkflow/About/about_Workflows.md
+++ b/reference/4.0/PSWorkflow/About/about_Workflows.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Workflows
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSWorkflow/New-PSWorkflowExecutionOption.md
+++ b/reference/4.0/PSWorkflow/New-PSWorkflowExecutionOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Workflow.ServiceCore.dll-Help.xml

--- a/reference/4.0/PSWorkflow/New-PSWorkflowSession.md
+++ b/reference/4.0/PSWorkflow/New-PSWorkflowSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSWorkflow-help.xml

--- a/reference/4.0/PSWorkflow/PSWorkflow.md
+++ b/reference/4.0/PSWorkflow/PSWorkflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSWorkflow
 description: 
 keywords: powershell, cmdlet

--- a/reference/4.0/PSWorkflowUtility/Invoke-AsWorkflow.md
+++ b/reference/4.0/PSWorkflowUtility/Invoke-AsWorkflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSWorkflowUtility-help.xml

--- a/reference/4.0/PSWorkflowUtility/PSWorkflowUtility.md
+++ b/reference/4.0/PSWorkflowUtility/PSWorkflowUtility.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSWorkflowUtility
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/ISE/Get-IseSnippet.md
+++ b/reference/5.0/ISE/Get-IseSnippet.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: ISE-help.xml

--- a/reference/5.0/ISE/ISE.md
+++ b/reference/5.0/ISE/ISE.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: ISE
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/ISE/Import-IseSnippet.md
+++ b/reference/5.0/ISE/Import-IseSnippet.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: ISE-help.xml

--- a/reference/5.0/ISE/New-IseSnippet.md
+++ b/reference/5.0/ISE/New-IseSnippet.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: ISE-help.xml

--- a/reference/5.0/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/5.0/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Archive-help.xml

--- a/reference/5.0/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/5.0/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Archive-help.xml

--- a/reference/5.0/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.md
+++ b/reference/5.0/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Archive
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Aliases.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Aliases.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Aliases
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Arithmetic_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Arrays
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Assignment_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Automatic_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Break.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Break.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Break
 description:
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Command_Precedence
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Command_Syntax
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Comment_Based_Help
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_CommonParameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Comparison_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Continue.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Continue.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Continue
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Core_Commands.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Core_Commands.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Core_Commands
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Data_Sections
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Debuggers
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Do.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Do.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Do
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Environment_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Escape_Characters
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Eventlogs.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Eventlogs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Eventlogs
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Execution_Policies
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_For.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_For.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_For
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Foreach.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Foreach.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Foreach
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Format.ps1xml
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_Advanced
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_Advanced_Methods
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_Advanced_Parameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_CmdletBindingAttribute
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_OutputTypeAttribute
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Group_Policy_Settings
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Hash_Tables
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_History.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_History
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_If.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_If
 description:
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Job_Details
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Jobs.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Jobs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Jobs
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Join.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Join.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Join
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Language_Modes
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Line_Editing.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Line_Editing
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Methods.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Methods.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Methods
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Modules
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Object_Creation.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Object_Creation.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Object_Creation
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Objects.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Objects.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Objects
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Operator_Precedence
 description:
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PSSession_Details
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_PSSessions.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_PSSessions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PSSessions
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_PSSnapins.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_PSSnapins.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PSSnapins
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Parameters.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Parameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Parameters_Default_Values.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Parameters_Default_Values.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parameters_Default_Values
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Parsing.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Parsing.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parsing
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Path_Syntax.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Path_Syntax.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Path_Syntax
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_PowerShell.exe.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_PowerShell.exe.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PowerShell.exe
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_PowerShell_Ise.exe.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_PowerShell_Ise.exe.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PowerShell_Ise.exe
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Preference_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Prompts
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Properties
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Providers
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Quoting_Rules
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Redirection
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Ref.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Ref.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Ref
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Regular_Expressions
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Disconnected_Sessions
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_FAQ
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Jobs
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Output.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Output.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Output
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Requirements
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Troubleshooting
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Requires
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Reserved_Words
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Return.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Return.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Return
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Run_With_PowerShell.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Run_With_PowerShell.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Run_With_PowerShell
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Script_Blocks
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Script_Internationalization
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Scripts.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Scripts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scripts
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Session_Configuration_Files
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Session_Configurations
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Signing
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Special_Characters
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Splatting
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Split.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Split
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Switch
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Throw.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Throw.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Throw
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Transactions.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Transactions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Transactions
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Trap.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Trap.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Trap
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Try_Catch_Finally
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Type_Operators.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Type_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Type_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Types.ps1xml
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Updatable_Help
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Variables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_WMI.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_WMI.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WMI
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_WMI_Cmdlets.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_WMI_Cmdlets.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WMI_Cmdlets
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_WQL.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_WQL.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WQL
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_While.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_While.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_While
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Wildcards
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Windows_PowerShell_ISE.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Windows_PowerShell_ISE.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Windows_PowerShell_ISE
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Windows_RT.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Windows_RT.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Windows_RT
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_packagemanagement.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_packagemanagement.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PackageManagement
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_pipelines
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_profiles.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_profiles.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Profiles
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_scopes.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_scopes.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scopes
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Add-History.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Add-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Add-PSSnapin.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Add-PSSnapin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Clear-History.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Clear-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Debug-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Debug-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Disable-PSRemoting.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Disable-PSRemoting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Disable-PSSessionConfiguration.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Disable-PSSessionConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Enable-PSRemoting.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Enable-PSRemoting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Enable-PSSessionConfiguration.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Enable-PSSessionConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Exit-PSHostProcess.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Exit-PSHostProcess.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Exit-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Exit-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Export-Console.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Export-Console.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Export-ModuleMember.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Export-ModuleMember.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Functions/Clear-Host.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Functions/Clear-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 external help file: System.Management.Automation.dll-help.xml
 online version: http://technet.microsoft.com/library/hh852689(v=wps.630).aspx
 schema: 2.0.0

--- a/reference/5.0/Microsoft.PowerShell.Core/Functions/Get-Verb.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Functions/Get-Verb.md
@@ -1,4 +1,4 @@
-﻿---
+---
 external help file: System.Management.Automation.dll-help.xml
 online version: http://go.microsoft.com/fwlink/?LinkId=834942
 schema: 2.0.0

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-Help.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-History.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-PSHostProcessInfo.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-PSHostProcessInfo.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-PSSessionConfiguration.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-PSSessionConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-PSSnapin.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-PSSnapin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Import-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Invoke-History.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Invoke-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Core
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Core/New-Module.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/New-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/New-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/New-PSSessionOption.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/New-PSSessionOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/New-PSTransportOption.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/New-PSTransportOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Out-Default.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Out-Default.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Out-Host.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Out-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Out-Null.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Out-Null.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Providers/Alias-Provider.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Providers/Alias-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Alias Provider
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Providers/Environment-Provider.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Providers/Environment-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Environment Provider
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: FileSystem Provider
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Add-Content-for-FileSystem.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Add-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Add-Content for FileSystem
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Clear-Content-for-FileSystem.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Clear-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Clear-Content for FileSystem
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-ChildItem-for-FileSystem.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-ChildItem-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Get-ChildItem for FileSystem
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Content-for-FileSystem.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Get-Content for FileSystem
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Item-for-FileSystem.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Item-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Get-Item for FileSystem
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Remove-Item-for-FileSystem.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Remove-Item-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Remove-Item for FileSystem
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Set-Content-for-FileSystem.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Set-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Set-Content for FileSystem
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Test-Path-for-FileSystem.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Test-Path-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Test-Path for FileSystem
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Providers/Function-Provider.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Providers/Function-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Function Provider
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Providers/Registry-Provider.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Providers/Registry-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Registry Provider
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Providers/Variable-Provider.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Providers/Variable-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Variable Provider
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.0/Microsoft.PowerShell.Core/Receive-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Receive-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description:
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Register-PSSessionConfiguration.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Register-PSSessionConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Remove-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Remove-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Remove-Module.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Remove-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Remove-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Remove-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Remove-PSSnapin.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Remove-PSSnapin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Resume-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Resume-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Save-Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Set-PSDebug.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Set-PSDebug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Start-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Suspend-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Suspend-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Test-ModuleManifest.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Test-ModuleManifest.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Unregister-PSSessionConfiguration.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Unregister-PSSessionConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Update-Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Wait-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Wait-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Where-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/get-pssessioncapability.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/get-pssessioncapability.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Core/new-psrolecapabilityfile.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/new-psrolecapabilityfile.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Diagnostics/Export-Counter.md
+++ b/reference/5.0/Microsoft.PowerShell.Diagnostics/Export-Counter.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Diagnostics/Get-Counter.md
+++ b/reference/5.0/Microsoft.PowerShell.Diagnostics/Get-Counter.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
+++ b/reference/5.0/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Diagnostics/Import-Counter.md
+++ b/reference/5.0/Microsoft.PowerShell.Diagnostics/Import-Counter.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Diagnostics/Microsoft.PowerShell.Diagnostics.md
+++ b/reference/5.0/Microsoft.PowerShell.Diagnostics/Microsoft.PowerShell.Diagnostics.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Diagnostics
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Diagnostics/New-WinEvent.md
+++ b/reference/5.0/Microsoft.PowerShell.Diagnostics/New-WinEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Host/Microsoft.PowerShell.Host.md
+++ b/reference/5.0/Microsoft.PowerShell.Host/Microsoft.PowerShell.Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Host
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/5.0/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ConsoleHost.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Host/Stop-Transcript.md
+++ b/reference/5.0/Microsoft.PowerShell.Host/Stop-Transcript.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ConsoleHost.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Add-Computer.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Add-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Add-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Checkpoint-Computer.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Checkpoint-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Clear-Content.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Clear-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Clear-EventLog.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Clear-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Clear-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Clear-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Clear-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Clear-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Clear-RecycleBin.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Clear-RecycleBin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Complete-Transaction.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Complete-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Convert-Path.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Convert-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Copy-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Copy-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Copy-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Debug-Process.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Debug-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-Clipboard.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-Clipboard.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-ComputerRestorePoint.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-ComputerRestorePoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-Content.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-EventLog.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-HotFix.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-HotFix.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-ItemPropertyValue.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-ItemPropertyValue.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-PSProvider.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-PSProvider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-Transaction.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-WmiObject.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-WmiObject.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Invoke-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Invoke-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description:
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Join-Path.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Join-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Limit-EventLog.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Limit-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Management
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Management/Move-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Move-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Move-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Move-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/New-EventLog.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/New-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/New-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/New-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/New-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/New-PSDrive.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/New-PSDrive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/New-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/New-WebServiceProxy.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/New-WebServiceProxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Pop-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Push-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Register-WmiEvent.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Register-WmiEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Remove-Computer.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Remove-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Remove-EventLog.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Remove-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Remove-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Remove-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Remove-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Remove-PSDrive.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Remove-PSDrive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Remove-WmiObject.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Remove-WmiObject.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Rename-Computer.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Rename-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Rename-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Rename-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Rename-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Resolve-Path.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Resolve-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Restart-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Restart-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Restore-Computer.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Restore-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Resume-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Resume-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Show-ControlPanelItem.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Show-ControlPanelItem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Show-EventLog.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Show-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Split-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Start-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Start-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Start-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Start-Transaction.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Start-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Stop-Computer.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Stop-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Stop-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Stop-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Stop-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Suspend-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Suspend-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Test-Connection.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Test-Path.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Test-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Undo-Transaction.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Undo-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Use-Transaction.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Use-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Wait-Process.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Wait-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Management/Write-EventLog.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Write-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.ODataUtils/Export-ODataEndpointProxy.md
+++ b/reference/5.0/Microsoft.PowerShell.ODataUtils/Export-ODataEndpointProxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ODataUtils-help.xml

--- a/reference/5.0/Microsoft.PowerShell.ODataUtils/Microsoft.PowerShell.ODataUtils.md
+++ b/reference/5.0/Microsoft.PowerShell.ODataUtils/Microsoft.PowerShell.ODataUtils.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.ODataUtils
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Security/ConvertTo-SecureString.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/ConvertTo-SecureString.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Security/Get-Acl.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Get-Acl.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Security/Get-CmsMessage.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Get-CmsMessage.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Security/Get-Credential.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Get-Credential.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Security/Get-PfxCertificate.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Get-PfxCertificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Security
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Security/Protect-CmsMessage.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Protect-CmsMessage.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Security/Set-Acl.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Set-Acl.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Security/Unprotect-CmsMessage.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Unprotect-CmsMessage.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Security/providers/certificate-provider.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/providers/certificate-provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Certificate Provider"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.0/Microsoft.PowerShell.Security/providers/get-childitem-for-certificate.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/providers/get-childitem-for-certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Get-ChildItem for Certificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.0/Microsoft.PowerShell.Security/providers/move-item-for-certificate.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/providers/move-item-for-certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Move-Item for Certificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.0/Microsoft.PowerShell.Security/providers/new-item-for-certificate.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/providers/new-item-for-certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Certificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.0/Microsoft.PowerShell.Security/providers/remove-item-for-certificate.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/providers/remove-item-for-certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Remove-Item for Certificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.0/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Add-Member.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Add-Type.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Clear-Variable.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Clear-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Convert-String.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Convert-String.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/ConvertFrom-String.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/ConvertFrom-String.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description:
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/ConvertTo-Json.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/ConvertTo-Json.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Debug-Runspace.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Debug-Runspace.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Disable-RunspaceDebug.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Disable-RunspaceDebug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Enable-RunspaceDebug.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Enable-RunspaceDebug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-Custom.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-Custom.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Utility-help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-List.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-Table.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Culture.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Culture.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Date.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Event.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-FileHash.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-FileHash.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Utility-help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Host.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Member.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-PSCallStack.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-PSCallStack.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Random.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Random.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Runspace.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Runspace.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-RunspaceDebug.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-RunspaceDebug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-TraceSource.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-TraceSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-TypeData.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-TypeData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-UICulture.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-UICulture.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Unique.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Unique.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Variable.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Group-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Import-Alias.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Import-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Import-Csv.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Import-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Import-LocalizedData.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Import-LocalizedData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Import-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Import-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Invoke-Expression.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Invoke-Expression.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Measure-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Measure-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Utility
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/New-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/New-Event.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/New-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/New-Guid.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/New-Guid.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Utility-help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/New-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/New-TemporaryFile.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/New-TemporaryFile.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Utility-help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/New-TimeSpan.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/New-TimeSpan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/New-Variable.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/New-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Out-File.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Out-GridView.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Out-GridView.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Out-Printer.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Out-Printer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Out-String.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Read-Host.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Read-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Register-EngineEvent.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Register-EngineEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Remove-Event.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Remove-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Remove-TypeData.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Remove-TypeData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Remove-Variable.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Remove-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Select-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Select-Xml.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Select-Xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Send-MailMessage.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Send-MailMessage.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Set-Date.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Set-Date.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Show-Command.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Show-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Start-Sleep.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Start-Sleep.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Unblock-File.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Unblock-File.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Unregister-Event.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Unregister-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Update-List.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Update-List.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Wait-Debugger.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Wait-Debugger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Wait-Event.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Wait-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Write-Debug.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Write-Debug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Write-Error.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Write-Host.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Write-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Write-Information.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Write-Output.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Write-Verbose.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Write-Verbose.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Write-Warning.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Write-Warning.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/convertfrom-sddlstring.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/convertfrom-sddlstring.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Utility-help.xml

--- a/reference/5.0/Microsoft.PowerShell.Utility/import-powershelldatafile.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/import-powershelldatafile.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Utility-help.xml

--- a/reference/5.0/Microsoft.WsMan.Management/About/about_WS-Management_Cmdlets.md
+++ b/reference/5.0/Microsoft.WsMan.Management/About/about_WS-Management_Cmdlets.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WS-Management_Cmdlets
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.WsMan.Management/Connect-WSMan.md
+++ b/reference/5.0/Microsoft.WsMan.Management/Connect-WSMan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.WsMan.Management/Disable-WSManCredSSP.md
+++ b/reference/5.0/Microsoft.WsMan.Management/Disable-WSManCredSSP.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.WsMan.Management/Disconnect-WSMan.md
+++ b/reference/5.0/Microsoft.WsMan.Management/Disconnect-WSMan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.WsMan.Management/Enable-WSManCredSSP.md
+++ b/reference/5.0/Microsoft.WsMan.Management/Enable-WSManCredSSP.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.WsMan.Management/Get-WSManCredSSP.md
+++ b/reference/5.0/Microsoft.WsMan.Management/Get-WSManCredSSP.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.WsMan.Management/Get-WSManInstance.md
+++ b/reference/5.0/Microsoft.WsMan.Management/Get-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.WsMan.Management/Invoke-WSManAction.md
+++ b/reference/5.0/Microsoft.WsMan.Management/Invoke-WSManAction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.WsMan.Management/Microsoft.WsMan.Management.md
+++ b/reference/5.0/Microsoft.WsMan.Management/Microsoft.WsMan.Management.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.WsMan.Management
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/Microsoft.WsMan.Management/New-WSManInstance.md
+++ b/reference/5.0/Microsoft.WsMan.Management/New-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.WsMan.Management/New-WSManSessionOption.md
+++ b/reference/5.0/Microsoft.WsMan.Management/New-WSManSessionOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.WsMan.Management/Remove-WSManInstance.md
+++ b/reference/5.0/Microsoft.WsMan.Management/Remove-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.WsMan.Management/Set-WSManInstance.md
+++ b/reference/5.0/Microsoft.WsMan.Management/Set-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.WsMan.Management/Set-WSManQuickConfig.md
+++ b/reference/5.0/Microsoft.WsMan.Management/Set-WSManQuickConfig.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description:
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.WsMan.Management/Test-WSMan.md
+++ b/reference/5.0/Microsoft.WsMan.Management/Test-WSMan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.0/Microsoft.WsMan.Management/providers/new-item-for-clientcertificate.md
+++ b/reference/5.0/Microsoft.WsMan.Management/providers/new-item-for-clientcertificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for ClientCertificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.0/Microsoft.WsMan.Management/providers/new-item-for-initializationparameters.md
+++ b/reference/5.0/Microsoft.WsMan.Management/providers/new-item-for-initializationparameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for InitializationParameters"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.0/Microsoft.WsMan.Management/providers/new-item-for-listener.md
+++ b/reference/5.0/Microsoft.WsMan.Management/providers/new-item-for-listener.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Listener"
 ms.custom: na
 ms.date: 07/31/2015

--- a/reference/5.0/Microsoft.WsMan.Management/providers/new-item-for-plugin.md
+++ b/reference/5.0/Microsoft.WsMan.Management/providers/new-item-for-plugin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Plugin"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.0/Microsoft.WsMan.Management/providers/new-item-for-resources.md
+++ b/reference/5.0/Microsoft.WsMan.Management/providers/new-item-for-resources.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Resources"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.0/Microsoft.WsMan.Management/providers/new-item-for-security.md
+++ b/reference/5.0/Microsoft.WsMan.Management/providers/new-item-for-security.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Security"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.0/Microsoft.WsMan.Management/providers/wsman-provider.md
+++ b/reference/5.0/Microsoft.WsMan.Management/providers/wsman-provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "WSMan Provider"
 ms.custom: na
 ms.date: 07/31/2015

--- a/reference/5.0/PSDesiredStateConfiguration/Disable-DscDebug.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Disable-DscDebug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Disable-DscDebug.cdxml-help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/Enable-DscDebug.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Enable-DscDebug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Enable-DscDebug.cdxml-help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/Find-DscResource.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Find-DscResource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSDesiredStateConfiguration-help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/Get-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Get-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Get-DSCConfiguration.cdxml-help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/Get-DscConfigurationStatus.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Get-DscConfigurationStatus.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Get-DscConfigurationStatus.cdxml-help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/Get-DscLocalConfigurationManager.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Get-DscLocalConfigurationManager.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Get-DSCLocalConfigurationManager.cdxml-help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/Get-DscResource.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Get-DscResource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSDesiredStateConfiguration-help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/Invoke-DscResource.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Invoke-DscResource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/New-DSCCheckSum.md
+++ b/reference/5.0/PSDesiredStateConfiguration/New-DSCCheckSum.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSDesiredStateConfiguration-help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/PSDesiredStateConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/PSDesiredStateConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSDesiredStateConfiguration
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSDesiredStateConfiguration/Publish-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Publish-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/Remove-DscConfigurationDocument.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Remove-DscConfigurationDocument.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Remove-DscConfigurationDocument.cdxml-help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/Restore-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Restore-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Restore-DSCConfiguration.cdxml-help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/Start-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Start-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Stop-DscConfiguration.cdxml-help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/5.0/PSDesiredStateConfiguration/Update-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Update-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/5.0/PSReadline/Get-PSReadlineKeyHandler.md
+++ b/reference/5.0/PSReadline/Get-PSReadlineKeyHandler.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml

--- a/reference/5.0/PSReadline/Get-PSReadlineOption.md
+++ b/reference/5.0/PSReadline/Get-PSReadlineOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml

--- a/reference/5.0/PSReadline/PSReadline.md
+++ b/reference/5.0/PSReadline/PSReadline.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSReadline
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSReadline/Remove-PSReadlineKeyHandler.md
+++ b/reference/5.0/PSReadline/Remove-PSReadlineKeyHandler.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml

--- a/reference/5.0/PSReadline/Set-PSReadlineKeyHandler.md
+++ b/reference/5.0/PSReadline/Set-PSReadlineKeyHandler.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml

--- a/reference/5.0/PSReadline/Set-PSReadlineOption.md
+++ b/reference/5.0/PSReadline/Set-PSReadlineOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/About/about_Scheduled_Jobs.md
+++ b/reference/5.0/PSScheduledJob/About/about_Scheduled_Jobs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSScheduledJob/About/about_Scheduled_Jobs_Advanced.md
+++ b/reference/5.0/PSScheduledJob/About/about_Scheduled_Jobs_Advanced.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs_Advanced
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSScheduledJob/About/about_Scheduled_Jobs_Basics.md
+++ b/reference/5.0/PSScheduledJob/About/about_Scheduled_Jobs_Basics.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs_Basics
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSScheduledJob/About/about_Scheduled_Jobs_Troubleshooting.md
+++ b/reference/5.0/PSScheduledJob/About/about_Scheduled_Jobs_Troubleshooting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs_Troubleshooting
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSScheduledJob/Add-JobTrigger.md
+++ b/reference/5.0/PSScheduledJob/Add-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/Disable-JobTrigger.md
+++ b/reference/5.0/PSScheduledJob/Disable-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/Disable-ScheduledJob.md
+++ b/reference/5.0/PSScheduledJob/Disable-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/Enable-JobTrigger.md
+++ b/reference/5.0/PSScheduledJob/Enable-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/Enable-ScheduledJob.md
+++ b/reference/5.0/PSScheduledJob/Enable-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/Get-JobTrigger.md
+++ b/reference/5.0/PSScheduledJob/Get-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/Get-ScheduledJob.md
+++ b/reference/5.0/PSScheduledJob/Get-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/Get-ScheduledJobOption.md
+++ b/reference/5.0/PSScheduledJob/Get-ScheduledJobOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/New-JobTrigger.md
+++ b/reference/5.0/PSScheduledJob/New-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/New-ScheduledJobOption.md
+++ b/reference/5.0/PSScheduledJob/New-ScheduledJobOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/PSScheduledJob.md
+++ b/reference/5.0/PSScheduledJob/PSScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSScheduledJob
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSScheduledJob/Register-ScheduledJob.md
+++ b/reference/5.0/PSScheduledJob/Register-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/Remove-JobTrigger.md
+++ b/reference/5.0/PSScheduledJob/Remove-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/Set-JobTrigger.md
+++ b/reference/5.0/PSScheduledJob/Set-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/Set-ScheduledJob.md
+++ b/reference/5.0/PSScheduledJob/Set-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/Set-ScheduledJobOption.md
+++ b/reference/5.0/PSScheduledJob/Set-ScheduledJobOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSScheduledJob/Unregister-ScheduledJob.md
+++ b/reference/5.0/PSScheduledJob/Unregister-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.0/PSWorkflow/About/about_ActivityCommonParameters.md
+++ b/reference/5.0/PSWorkflow/About/about_ActivityCommonParameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_ActivityCommonParameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSWorkflow/About/about_Checkpoint-Workflow.md
+++ b/reference/5.0/PSWorkflow/About/about_Checkpoint-Workflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Checkpoint-Workflow
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSWorkflow/About/about_Foreach-Parallel.md
+++ b/reference/5.0/PSWorkflow/About/about_Foreach-Parallel.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Foreach-Parallel
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSWorkflow/About/about_InlineScript.md
+++ b/reference/5.0/PSWorkflow/About/about_InlineScript.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_InlineScript
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSWorkflow/About/about_Parallel.md
+++ b/reference/5.0/PSWorkflow/About/about_Parallel.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parallel
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSWorkflow/About/about_Sequence.md
+++ b/reference/5.0/PSWorkflow/About/about_Sequence.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Sequence
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSWorkflow/About/about_Suspend-Workflow.md
+++ b/reference/5.0/PSWorkflow/About/about_Suspend-Workflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Suspend-Workflow
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSWorkflow/About/about_WorkflowCommonParameters.md
+++ b/reference/5.0/PSWorkflow/About/about_WorkflowCommonParameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WorkflowCommonParameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSWorkflow/About/about_Workflows.md
+++ b/reference/5.0/PSWorkflow/About/about_Workflows.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Workflows
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSWorkflow/New-PSWorkflowExecutionOption.md
+++ b/reference/5.0/PSWorkflow/New-PSWorkflowExecutionOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Workflow.ServiceCore.dll-Help.xml

--- a/reference/5.0/PSWorkflow/New-PSWorkflowSession.md
+++ b/reference/5.0/PSWorkflow/New-PSWorkflowSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSWorkflow-help.xml

--- a/reference/5.0/PSWorkflow/PSWorkflow.md
+++ b/reference/5.0/PSWorkflow/PSWorkflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSWorkflow
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PSWorkflowUtility/Invoke-AsWorkflow.md
+++ b/reference/5.0/PSWorkflowUtility/Invoke-AsWorkflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSWorkflowUtility-help.xml

--- a/reference/5.0/PSWorkflowUtility/PSWorkflowUtility.md
+++ b/reference/5.0/PSWorkflowUtility/PSWorkflowUtility.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSWorkflowUtility
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PackageManagement/Find-Package.md
+++ b/reference/5.0/PackageManagement/Find-Package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.0/PackageManagement/Get-Package.md
+++ b/reference/5.0/PackageManagement/Get-Package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.0/PackageManagement/Get-PackageProvider.md
+++ b/reference/5.0/PackageManagement/Get-PackageProvider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.0/PackageManagement/Get-PackageSource.md
+++ b/reference/5.0/PackageManagement/Get-PackageSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.0/PackageManagement/Install-Package.md
+++ b/reference/5.0/PackageManagement/Install-Package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.0/PackageManagement/PackageManagement.md
+++ b/reference/5.0/PackageManagement/PackageManagement.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PackageManagement
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PackageManagement/Register-PackageSource.md
+++ b/reference/5.0/PackageManagement/Register-PackageSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.0/PackageManagement/Save-Package.md
+++ b/reference/5.0/PackageManagement/Save-Package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.0/PackageManagement/Set-PackageSource.md
+++ b/reference/5.0/PackageManagement/Set-PackageSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.0/PackageManagement/Uninstall-Package.md
+++ b/reference/5.0/PackageManagement/Uninstall-Package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.0/PackageManagement/Unregister-PackageSource.md
+++ b/reference/5.0/PackageManagement/Unregister-PackageSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.0/PowershellGet/Find-Command.md
+++ b/reference/5.0/PowershellGet/Find-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.0/PowershellGet/Find-DscResource.md
+++ b/reference/5.0/PowershellGet/Find-DscResource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSGet-help.xml

--- a/reference/5.0/PowershellGet/Find-Module.md
+++ b/reference/5.0/PowershellGet/Find-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSGet-help.xml

--- a/reference/5.0/PowershellGet/Get-InstalledModule.md
+++ b/reference/5.0/PowershellGet/Get-InstalledModule.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSGet-help.xml

--- a/reference/5.0/PowershellGet/Get-PSRepository.md
+++ b/reference/5.0/PowershellGet/Get-PSRepository.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSGet-help.xml

--- a/reference/5.0/PowershellGet/Install-Module.md
+++ b/reference/5.0/PowershellGet/Install-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSGet-help.xml

--- a/reference/5.0/PowershellGet/PowershellGet.md
+++ b/reference/5.0/PowershellGet/PowershellGet.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PowershellGet
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.0/PowershellGet/Publish-Module.md
+++ b/reference/5.0/PowershellGet/Publish-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSGet-help.xml

--- a/reference/5.0/PowershellGet/Register-PSRepository.md
+++ b/reference/5.0/PowershellGet/Register-PSRepository.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSGet-help.xml

--- a/reference/5.0/PowershellGet/Save-Module.md
+++ b/reference/5.0/PowershellGet/Save-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSGet-help.xml

--- a/reference/5.0/PowershellGet/Set-PSRepository.md
+++ b/reference/5.0/PowershellGet/Set-PSRepository.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSGet-help.xml

--- a/reference/5.0/PowershellGet/Uninstall-Module.md
+++ b/reference/5.0/PowershellGet/Uninstall-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSGet-help.xml

--- a/reference/5.0/PowershellGet/Unregister-PSRepository.md
+++ b/reference/5.0/PowershellGet/Unregister-PSRepository.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSGet-help.xml

--- a/reference/5.0/PowershellGet/Update-Module.md
+++ b/reference/5.0/PowershellGet/Update-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSGet-help.xml

--- a/reference/5.1/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/5.1/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Archive-help.xml

--- a/reference/5.1/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/5.1/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Archive-help.xml

--- a/reference/5.1/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.md
+++ b/reference/5.1/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Archive
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Aliases.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Aliases.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Aliases
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Arithmetic_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Arrays
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Assignment_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Automatic_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Break.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Break.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Break
 description:
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Precedence.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Command_Precedence
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Command_Syntax
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comment_Based_Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Comment_Based_Help
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_CommonParameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Comparison_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Continue.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Continue.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Continue
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Core_Commands.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Core_Commands.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Core_Commands
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Data_Sections
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Debuggers
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Do.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Do.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Do
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Environment_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Escape_Characters
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Eventlogs.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Eventlogs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Eventlogs
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Execution_Policies.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Execution_Policies
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_For.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_For.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_For
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Foreach.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Foreach.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Foreach
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Format.ps1xml
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_Advanced
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_Advanced_Methods
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_Advanced_Parameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_CmdletBindingAttribute.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_CmdletBindingAttribute
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_OutputTypeAttribute.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Functions_OutputTypeAttribute
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Group_Policy_Settings.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Group_Policy_Settings
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Hash_Tables
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_History.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_History
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_If.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_If.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_If
 description:
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Job_Details
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Jobs.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Jobs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Jobs
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Join.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Join.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Join
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Language_Modes
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Line_Editing.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Line_Editing.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Line_Editing
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Methods.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Methods.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Methods
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Modules
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Object_Creation.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Object_Creation.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Object_Creation
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Objects.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Objects.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Objects
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Operator_Precedence
 description:
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PSSession_Details.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PSSession_Details
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PSSessions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PSSessions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PSSessions
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PSSnapins.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PSSnapins.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PSSnapins
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PackageManagement.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PackageManagement.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PackageManagement
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameters_Default_Values.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameters_Default_Values.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parameters_Default_Values
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Parsing.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Parsing.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parsing
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Path_Syntax.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Path_Syntax.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Path_Syntax
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PowerShell.exe.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PowerShell.exe.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PowerShell.exe
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PowerShell_Ise.exe.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PowerShell_Ise.exe.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_PowerShell_Ise.exe
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Preference_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Preference_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Profiles.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Profiles.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Profiles
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Prompts
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Properties
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Providers
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Quoting_Rules
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Redirection
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Ref.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Ref.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Ref
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Regular_Expressions
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Disconnected_Sessions
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_FAQ
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Jobs
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Output.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Output.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Output
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Requirements
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Troubleshooting
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Remote_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Requires
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Reserved_Words.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Reserved_Words
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Return.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Return.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Return
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Run_With_PowerShell.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Run_With_PowerShell.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Run_With_PowerShell
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Scopes.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scopes
 ms.custom: na
 ms.reviewer: na

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Blocks.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Script_Blocks
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Script_Internationalization
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Scripts.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Scripts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scripts
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Session_Configuration_Files.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Session_Configuration_Files
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Session_Configurations
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Signing
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Special_Characters
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Splatting
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Split.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Split
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Switch
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Throw.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Throw.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Throw
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Transactions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Transactions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Transactions
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Trap.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Trap.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Trap
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Try_Catch_Finally
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Type_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Type_Operators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Type_Operators
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Types.ps1xml
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Updatable_Help
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Variables
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_WMI.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_WMI.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WMI
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_WMI_Cmdlets.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_WMI_Cmdlets.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WMI_Cmdlets
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_WQL.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_WQL.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WQL
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_While.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_While.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_While
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Wildcards
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Windows_PowerShell_ISE.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Windows_PowerShell_ISE.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Windows_PowerShell_ISE
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Windows_RT.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Windows_RT.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Windows_RT
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_pipelines
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/Add-History.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Add-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Add-PSSnapin.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Add-PSSnapin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Clear-History.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Clear-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Debug-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Debug-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Disable-PSRemoting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Disable-PSRemoting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Disable-PSSessionConfiguration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Disable-PSSessionConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Enable-PSRemoting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Enable-PSRemoting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Enable-PSSessionConfiguration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Enable-PSSessionConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Enter-PSHostProcess.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Exit-PSHostProcess.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Exit-PSHostProcess.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Exit-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Exit-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Export-Console.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Export-Console.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Export-ModuleMember.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Export-ModuleMember.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Functions/Clear-Host.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Functions/Clear-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 external help file: System.Management.Automation.dll-help.xml
 online version: http://go.microsoft.com/fwlink/?LinkId=834941
 schema: 2.0.0

--- a/reference/5.1/Microsoft.PowerShell.Core/Functions/Get-Verb.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Functions/Get-Verb.md
@@ -1,4 +1,4 @@
-﻿---
+---
 external help file: System.Management.Automation.dll-help.xml
 online version: http://go.microsoft.com/fwlink/?LinkId=834942
 schema: 2.0.0

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-History.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-PSHostProcessInfo.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-PSHostProcessInfo.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-PSSessionCapability.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-PSSessionCapability.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-PSSessionConfiguration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-PSSessionConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-PSSnapin.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-PSSnapin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Invoke-History.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Invoke-History.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Core
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Core/New-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/New-PSRoleCapabilityFile.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-PSRoleCapabilityFile.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-PSSessionConfigurationFile.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/New-PSSessionOption.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-PSSessionOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/New-PSTransportOption.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-PSTransportOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Out-Default.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Out-Default.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Out-Host.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Out-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Out-Null.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Out-Null.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Providers/Environment-Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Providers/Environment-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Environment Provider"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "FileSystem Provider"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Add-Content-for-FileSystem.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Add-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Add-Content for FileSystem"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Clear-Content-for-FileSystem.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Clear-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Clear-Content for FileSystem"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-ChildItem-for-FileSystem.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-ChildItem-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Get-ChildItem for FileSystem"
 ms.custom: na
 ms.date: 07/31/2015

--- a/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Content-for-FileSystem.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Get-Content for FileSystem"
 ms.custom: na
 ms.date: 07/31/2015

--- a/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Item-for-FileSystem.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Get-Item-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Get-Item for FileSystem"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Remove-Item-for-FileSystem.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Remove-Item-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Remove-Item for FileSystem"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Set-Content-for-FileSystem.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Set-Content-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Set-Content for FileSystem"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Test-Path-for-FileSystem.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Providers/FileSystem-Provider/Test-Path-for-FileSystem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Test-Path for FileSystem"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Core/Providers/Function-Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Providers/Function-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Function Provider"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Core/Providers/Registry-Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Providers/Registry-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Registry Provider"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Core/Providers/Variable-Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Providers/Variable-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Variable Provider"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Core/Receive-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Receive-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Register-PSSessionConfiguration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Register-PSSessionConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Remove-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Remove-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Remove-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Remove-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Remove-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Remove-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Remove-PSSnapin.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Remove-PSSnapin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Resume-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Resume-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Save-Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Set-PSDebug.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Set-PSDebug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Set-StrictMode.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Set-StrictMode.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Start-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Start-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Stop-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Stop-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Suspend-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Suspend-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Test-ModuleManifest.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Test-ModuleManifest.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Test-PSSessionConfigurationFile.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Unregister-PSSessionConfiguration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Unregister-PSSessionConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Update-Help.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Wait-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Wait-Job.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: System.Management.Automation.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Diagnostics/Export-Counter.md
+++ b/reference/5.1/Microsoft.PowerShell.Diagnostics/Export-Counter.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Diagnostics/Get-Counter.md
+++ b/reference/5.1/Microsoft.PowerShell.Diagnostics/Get-Counter.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Diagnostics/Get-WinEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Diagnostics/Import-Counter.md
+++ b/reference/5.1/Microsoft.PowerShell.Diagnostics/Import-Counter.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Diagnostics/Microsoft.PowerShell.Diagnostics.md
+++ b/reference/5.1/Microsoft.PowerShell.Diagnostics/Microsoft.PowerShell.Diagnostics.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Diagnostics
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Diagnostics/New-WinEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Diagnostics/New-WinEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Host/Microsoft.PowerShell.Host.md
+++ b/reference/5.1/Microsoft.PowerShell.Host/Microsoft.PowerShell.Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Host
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ConsoleHost.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Host/Stop-Transcript.md
+++ b/reference/5.1/Microsoft.PowerShell.Host/Stop-Transcript.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ConsoleHost.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Add-LocalGroupMember.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Add-LocalGroupMember.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Disable-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Disable-LocalUser.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Enable-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Enable-LocalUser.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Get-LocalGroup.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Get-LocalGroup.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Get-LocalGroupMember.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Get-LocalGroupMember.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Get-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Get-LocalUser.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Microsoft.PowerShell.LocalAccounts.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Microsoft.PowerShell.LocalAccounts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.LocalAccounts
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalGroup.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalGroup.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalGroup.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalGroup.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalGroupMember.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalGroupMember.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalUser.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Rename-LocalGroup.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Rename-LocalGroup.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Rename-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Rename-LocalUser.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Set-LocalGroup.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Set-LocalGroup.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Set-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Set-LocalUser.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Powershell.LocalAccounts.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Add-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Add-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Add-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Checkpoint-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Checkpoint-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Clear-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Clear-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Clear-EventLog.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Clear-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Clear-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Clear-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Clear-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Clear-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Clear-RecycleBin.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Clear-RecycleBin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Complete-Transaction.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Complete-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Convert-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Convert-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Copy-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Copy-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Copy-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Debug-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Debug-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Clipboard.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Clipboard.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ComputerInfo.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ComputerInfo.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ComputerRestorePoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ComputerRestorePoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-EventLog.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-HotFix.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-HotFix.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ItemPropertyValue.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ItemPropertyValue.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description:
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-PSProvider.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-PSProvider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description:
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description:
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-TimeZone.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-TimeZone.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Transaction.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-WmiObject.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-WmiObject.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Invoke-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Invoke-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Join-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Join-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Limit-EventLog.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Limit-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Management
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Management/Move-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Move-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Move-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Move-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/New-EventLog.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/New-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/New-PSDrive.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-PSDrive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/New-WebServiceProxy.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-WebServiceProxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Pop-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Push-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Register-WmiEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Register-WmiEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Remove-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Remove-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Remove-EventLog.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Remove-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Remove-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Remove-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Remove-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Remove-PSDrive.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Remove-PSDrive.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Remove-WmiObject.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Remove-WmiObject.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Rename-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Rename-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Rename-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Rename-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Rename-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Resolve-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Resolve-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Restart-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Restart-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Restore-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Restore-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Resume-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Resume-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Content.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Item.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Location.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-TimeZone.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-TimeZone.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-WmiInstance.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-WmiInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Show-ControlPanelItem.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Show-ControlPanelItem.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Show-EventLog.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Show-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Split-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Split-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Start-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Start-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Start-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Start-Transaction.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Start-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Stop-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Stop-Computer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Stop-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Stop-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Stop-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Suspend-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Suspend-Service.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Test-Connection.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Test-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Test-Path.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Undo-Transaction.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Undo-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Use-Transaction.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Use-Transaction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Wait-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Wait-Process.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Management/Write-EventLog.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Write-EventLog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.ODataUtils/Export-ODataEndpointProxy.md
+++ b/reference/5.1/Microsoft.PowerShell.ODataUtils/Export-ODataEndpointProxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ODataUtils-help.xml

--- a/reference/5.1/Microsoft.PowerShell.ODataUtils/Microsoft.PowerShell.ODataUtils.md
+++ b/reference/5.1/Microsoft.PowerShell.ODataUtils/Microsoft.PowerShell.ODataUtils.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.ODataUtils
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Security/ConvertTo-SecureString.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/ConvertTo-SecureString.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Security/Get-Acl.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Get-Acl.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Get-AuthenticodeSignature.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Security/Get-CmsMessage.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Get-CmsMessage.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Security/Get-Credential.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Get-Credential.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Security/Get-PfxCertificate.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Get-PfxCertificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Security
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Security/New-FileCatalog.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/New-FileCatalog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Security/Protect-CmsMessage.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Protect-CmsMessage.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Security/Providers/Certificate-Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Providers/Certificate-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Certificate Provider"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Security/Providers/get-childitem-for-certificate.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Providers/get-childitem-for-certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Get-ChildItem for Certificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Security/Providers/move-item-for-certificate.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Providers/move-item-for-certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Move-Item for Certificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Security/Providers/new-item-for-certificate.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Providers/new-item-for-certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Certificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Security/Providers/remove-item-for-certificate.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Providers/remove-item-for-certificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Remove-Item for Certificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.PowerShell.Security/Set-Acl.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Set-Acl.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Security/Test-FileCatalog.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Test-FileCatalog.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Security/Unprotect-CmsMessage.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Unprotect-CmsMessage.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Security.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Add-Member.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Add-Member.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Add-Type.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Clear-Variable.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Clear-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Compare-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Compare-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Convert-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Convert-String.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-SddlString.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-SddlString.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Utility-help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-String.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description:
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-StringData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Json.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Json.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Debug-Runspace.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Debug-Runspace.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Disable-RunspaceDebug.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Disable-RunspaceDebug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Enable-RunspaceDebug.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Enable-RunspaceDebug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-FormatData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-FormatData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Custom.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Custom.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Hex.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Hex.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Utility-help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-List.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Table.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Culture.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Culture.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Event.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-FileHash.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-FileHash.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description:
 external help file: Microsoft.PowerShell.Utility-help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-FormatData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-FormatData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Host.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-PSCallStack.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-PSCallStack.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Random.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Random.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Runspace.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Runspace.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-RunspaceDebug.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-RunspaceDebug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-TraceSource.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-TraceSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-TypeData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-TypeData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-UICulture.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-UICulture.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Unique.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Unique.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Variable.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Group-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-Clixml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-Clixml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-Csv.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-LocalizedData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-LocalizedData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-PSSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-PowerShellDataFile.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-PowerShellDataFile.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Utility-help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Invoke-Expression.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Invoke-Expression.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Measure-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Measure-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.PowerShell.Utility
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Event.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Guid.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Guid.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Utility-help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-TemporaryFile.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-TemporaryFile.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Utility-help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-TimeSpan.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-TimeSpan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Variable.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-File.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-GridView.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-GridView.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-Printer.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-Printer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Read-Host.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Read-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Register-EngineEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Register-EngineEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Register-ObjectEvent.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Remove-Event.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Remove-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Remove-TypeData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Remove-TypeData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Remove-Variable.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Remove-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-String.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-Xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-Xml.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Send-MailMessage.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Send-MailMessage.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-Date.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-Date.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-PSBreakpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description:
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Show-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Show-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Start-Sleep.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Start-Sleep.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Unblock-File.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Unblock-File.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Unregister-Event.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Unregister-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Update-List.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Update-List.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Wait-Debugger.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Wait-Debugger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Wait-Event.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Wait-Event.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Debug.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Debug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Error.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Host.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Host.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Information.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Output.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Output.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Verbose.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Verbose.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Warning.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Warning.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml

--- a/reference/5.1/Microsoft.WsMan.Management/About/about_WS-Management_Cmdlets.md
+++ b/reference/5.1/Microsoft.WsMan.Management/About/about_WS-Management_Cmdlets.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WS-Management_Cmdlets
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.WsMan.Management/Connect-WSMan.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Connect-WSMan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.WsMan.Management/Disable-WSManCredSSP.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Disable-WSManCredSSP.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.WsMan.Management/Disconnect-WSMan.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Disconnect-WSMan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.WsMan.Management/Enable-WSManCredSSP.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Enable-WSManCredSSP.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.WsMan.Management/Get-WSManCredSSP.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Get-WSManCredSSP.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.WsMan.Management/Get-WSManInstance.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Get-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.WsMan.Management/Invoke-WSManAction.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Invoke-WSManAction.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.WsMan.Management/Microsoft.WsMan.Management.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Microsoft.WsMan.Management.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Microsoft.WsMan.Management
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/Microsoft.WsMan.Management/New-WSManInstance.md
+++ b/reference/5.1/Microsoft.WsMan.Management/New-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.WsMan.Management/New-WSManSessionOption.md
+++ b/reference/5.1/Microsoft.WsMan.Management/New-WSManSessionOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.WsMan.Management/Providers/New-Item-for-ClientCertificate.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Providers/New-Item-for-ClientCertificate.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for ClientCertificate"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.WsMan.Management/Providers/New-Item-for-InitializationParameters.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Providers/New-Item-for-InitializationParameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for InitializationParameters"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.WsMan.Management/Providers/New-Item-for-Listener.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Providers/New-Item-for-Listener.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Listener"
 ms.custom: na
 ms.date: 07/31/2015

--- a/reference/5.1/Microsoft.WsMan.Management/Providers/New-Item-for-Plugin.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Providers/New-Item-for-Plugin.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Plugin"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.WsMan.Management/Providers/New-Item-for-Resources.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Providers/New-Item-for-Resources.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Resources"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.WsMan.Management/Providers/New-Item-for-Security.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Providers/New-Item-for-Security.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "New-Item for Security"
 ms.custom: na
 ms.date: 09/30/2014

--- a/reference/5.1/Microsoft.WsMan.Management/Providers/WSMan-Provider.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Providers/WSMan-Provider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "WSMan Provider"
 ms.custom: na
 ms.date: 07/31/2015

--- a/reference/5.1/Microsoft.WsMan.Management/Remove-WSManInstance.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Remove-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.WsMan.Management/Set-WSManInstance.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Set-WSManInstance.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.WsMan.Management/Set-WSManQuickConfig.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Set-WSManQuickConfig.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.1/Microsoft.WsMan.Management/Test-WSMan.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Test-WSMan.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.WSMan.Management.dll-Help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/Disable-DscDebug.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Disable-DscDebug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Disable-DscDebug.cdxml-help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/Enable-DscDebug.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Enable-DscDebug.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Enable-DscDebug.cdxml-help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/Get-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Get-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Get-DSCConfiguration.cdxml-help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/Get-DscConfigurationStatus.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Get-DscConfigurationStatus.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Get-DscConfigurationStatus.cdxml-help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/Get-DscLocalConfigurationManager.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Get-DscLocalConfigurationManager.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Get-DSCLocalConfigurationManager.cdxml-help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/Get-DscResource.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Get-DscResource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSDesiredStateConfiguration-help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/Invoke-DscResource.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Invoke-DscResource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/New-DSCCheckSum.md
+++ b/reference/5.1/PSDesiredStateConfiguration/New-DSCCheckSum.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSDesiredStateConfiguration-help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/PSDesiredStateConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/PSDesiredStateConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSDesiredStateConfiguration
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSDesiredStateConfiguration/Publish-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Publish-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/Remove-DscConfigurationDocument.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Remove-DscConfigurationDocument.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Remove-DscConfigurationDocument.cdxml-help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/Restore-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Restore-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Restore-DSCConfiguration.cdxml-help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/Start-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Start-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/Stop-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Stop-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Stop-DscConfiguration.cdxml-help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/5.1/PSDesiredStateConfiguration/Update-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Update-DscConfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml

--- a/reference/5.1/PSReadline/Get-PSReadlineKeyHandler.md
+++ b/reference/5.1/PSReadline/Get-PSReadlineKeyHandler.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml

--- a/reference/5.1/PSReadline/Get-PSReadlineOption.md
+++ b/reference/5.1/PSReadline/Get-PSReadlineOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml

--- a/reference/5.1/PSReadline/PSReadline.md
+++ b/reference/5.1/PSReadline/PSReadline.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSReadline
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSReadline/Remove-PSReadlineKeyHandler.md
+++ b/reference/5.1/PSReadline/Remove-PSReadlineKeyHandler.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml

--- a/reference/5.1/PSReadline/Set-PSReadlineKeyHandler.md
+++ b/reference/5.1/PSReadline/Set-PSReadlineKeyHandler.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml

--- a/reference/5.1/PSReadline/Set-PSReadlineOption.md
+++ b/reference/5.1/PSReadline/Set-PSReadlineOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/About/about_Scheduled_Jobs.md
+++ b/reference/5.1/PSScheduledJob/About/about_Scheduled_Jobs.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSScheduledJob/About/about_Scheduled_Jobs_Advanced.md
+++ b/reference/5.1/PSScheduledJob/About/about_Scheduled_Jobs_Advanced.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs_Advanced
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSScheduledJob/About/about_Scheduled_Jobs_Basics.md
+++ b/reference/5.1/PSScheduledJob/About/about_Scheduled_Jobs_Basics.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs_Basics
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSScheduledJob/About/about_Scheduled_Jobs_Troubleshooting.md
+++ b/reference/5.1/PSScheduledJob/About/about_Scheduled_Jobs_Troubleshooting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Scheduled_Jobs_Troubleshooting
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSScheduledJob/Add-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Add-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/Disable-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Disable-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/Disable-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Disable-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/Enable-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Enable-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/Enable-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Enable-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/Get-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Get-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/Get-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Get-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/Get-ScheduledJobOption.md
+++ b/reference/5.1/PSScheduledJob/Get-ScheduledJobOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/New-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/New-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/New-ScheduledJobOption.md
+++ b/reference/5.1/PSScheduledJob/New-ScheduledJobOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/PSScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/PSScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSScheduledJob
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSScheduledJob/Register-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Register-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/Remove-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Remove-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/Set-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Set-JobTrigger.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/Set-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Set-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/Set-ScheduledJobOption.md
+++ b/reference/5.1/PSScheduledJob/Set-ScheduledJobOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSScheduledJob/Unregister-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Unregister-ScheduledJob.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.ScheduledJob.dll-Help.xml

--- a/reference/5.1/PSWorkflow/About/about_ActivityCommonParameters.md
+++ b/reference/5.1/PSWorkflow/About/about_ActivityCommonParameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_ActivityCommonParameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSWorkflow/About/about_Checkpoint-Workflow.md
+++ b/reference/5.1/PSWorkflow/About/about_Checkpoint-Workflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Checkpoint-Workflow
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSWorkflow/About/about_Foreach-Parallel.md
+++ b/reference/5.1/PSWorkflow/About/about_Foreach-Parallel.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Foreach-Parallel
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSWorkflow/About/about_InlineScript.md
+++ b/reference/5.1/PSWorkflow/About/about_InlineScript.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_InlineScript
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSWorkflow/About/about_Parallel.md
+++ b/reference/5.1/PSWorkflow/About/about_Parallel.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Parallel
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSWorkflow/About/about_Sequence.md
+++ b/reference/5.1/PSWorkflow/About/about_Sequence.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Sequence
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSWorkflow/About/about_Suspend-Workflow.md
+++ b/reference/5.1/PSWorkflow/About/about_Suspend-Workflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Suspend-Workflow
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSWorkflow/About/about_WorkflowCommonParameters.md
+++ b/reference/5.1/PSWorkflow/About/about_WorkflowCommonParameters.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_WorkflowCommonParameters
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSWorkflow/About/about_Workflows.md
+++ b/reference/5.1/PSWorkflow/About/about_Workflows.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: about_Workflows
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSWorkflow/New-PSWorkflowExecutionOption.md
+++ b/reference/5.1/PSWorkflow/New-PSWorkflowExecutionOption.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.Workflow.ServiceCore.dll-Help.xml

--- a/reference/5.1/PSWorkflow/New-PSWorkflowSession.md
+++ b/reference/5.1/PSWorkflow/New-PSWorkflowSession.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSWorkflow-help.xml

--- a/reference/5.1/PSWorkflow/PSWorkflow.md
+++ b/reference/5.1/PSWorkflow/PSWorkflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSWorkflow
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PSWorkflowUtility/Invoke-AsWorkflow.md
+++ b/reference/5.1/PSWorkflowUtility/Invoke-AsWorkflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSWorkflowUtility-help.xml

--- a/reference/5.1/PSWorkflowUtility/PSWorkflowUtility.md
+++ b/reference/5.1/PSWorkflowUtility/PSWorkflowUtility.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PSWorkflowUtility
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PackageManagement/Find-Package.md
+++ b/reference/5.1/PackageManagement/Find-Package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.1/PackageManagement/Find-PackageProvider.md
+++ b/reference/5.1/PackageManagement/Find-PackageProvider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.1/PackageManagement/Get-Package.md
+++ b/reference/5.1/PackageManagement/Get-Package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.1/PackageManagement/Get-PackageProvider.md
+++ b/reference/5.1/PackageManagement/Get-PackageProvider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.1/PackageManagement/Get-PackageSource.md
+++ b/reference/5.1/PackageManagement/Get-PackageSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.1/PackageManagement/Import-PackageProvider.md
+++ b/reference/5.1/PackageManagement/Import-PackageProvider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.1/PackageManagement/Install-Package.md
+++ b/reference/5.1/PackageManagement/Install-Package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.1/PackageManagement/Install-PackageProvider.md
+++ b/reference/5.1/PackageManagement/Install-PackageProvider.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.1/PackageManagement/PackageManagement.md
+++ b/reference/5.1/PackageManagement/PackageManagement.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PackageManagement
 description: 
 keywords: powershell, cmdlet

--- a/reference/5.1/PackageManagement/Register-PackageSource.md
+++ b/reference/5.1/PackageManagement/Register-PackageSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.1/PackageManagement/Save-Package.md
+++ b/reference/5.1/PackageManagement/Save-Package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.1/PackageManagement/Set-PackageSource.md
+++ b/reference/5.1/PackageManagement/Set-PackageSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.1/PackageManagement/Uninstall-Package.md
+++ b/reference/5.1/PackageManagement/Uninstall-Package.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.1/PackageManagement/Unregister-PackageSource.md
+++ b/reference/5.1/PackageManagement/Unregister-PackageSource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: Microsoft.PowerShell.PackageManagement.dll-Help.xml

--- a/reference/5.1/PowershellGet/Find-Command.md
+++ b/reference/5.1/PowershellGet/Find-Command.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Find-DscResource.md
+++ b/reference/5.1/PowershellGet/Find-DscResource.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Find-Module.md
+++ b/reference/5.1/PowershellGet/Find-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Find-RoleCapability.md
+++ b/reference/5.1/PowershellGet/Find-RoleCapability.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Find-Script.md
+++ b/reference/5.1/PowershellGet/Find-Script.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Get-InstalledModule.md
+++ b/reference/5.1/PowershellGet/Get-InstalledModule.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Get-InstalledScript.md
+++ b/reference/5.1/PowershellGet/Get-InstalledScript.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Get-PSRepository.md
+++ b/reference/5.1/PowershellGet/Get-PSRepository.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Install-Module.md
+++ b/reference/5.1/PowershellGet/Install-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Install-Script.md
+++ b/reference/5.1/PowershellGet/Install-Script.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/New-ScriptFileInfo.md
+++ b/reference/5.1/PowershellGet/New-ScriptFileInfo.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/PowerShellGet.md
+++ b/reference/5.1/PowershellGet/PowerShellGet.md
@@ -1,5 +1,5 @@
 ---
-title: PowerShellGet
+title: PowershellGet
 description: 
 keywords: powershell, cmdlet
 author: jpjofre

--- a/reference/5.1/PowershellGet/Publish-Module.md
+++ b/reference/5.1/PowershellGet/Publish-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Publish-Script.md
+++ b/reference/5.1/PowershellGet/Publish-Script.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Register-PSRepository.md
+++ b/reference/5.1/PowershellGet/Register-PSRepository.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Save-Module.md
+++ b/reference/5.1/PowershellGet/Save-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Save-Script.md
+++ b/reference/5.1/PowershellGet/Save-Script.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Set-PSRepository.md
+++ b/reference/5.1/PowershellGet/Set-PSRepository.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Test-ScriptFileInfo.md
+++ b/reference/5.1/PowershellGet/Test-ScriptFileInfo.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Uninstall-Module.md
+++ b/reference/5.1/PowershellGet/Uninstall-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Uninstall-Script.md
+++ b/reference/5.1/PowershellGet/Uninstall-Script.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Unregister-PSRepository.md
+++ b/reference/5.1/PowershellGet/Unregister-PSRepository.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Update-Module.md
+++ b/reference/5.1/PowershellGet/Update-Module.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Update-ModuleManifest.md
+++ b/reference/5.1/PowershellGet/Update-ModuleManifest.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Update-Script.md
+++ b/reference/5.1/PowershellGet/Update-Script.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml

--- a/reference/5.1/PowershellGet/Update-ScriptFileInfo.md
+++ b/reference/5.1/PowershellGet/Update-ScriptFileInfo.md
@@ -1,4 +1,4 @@
-﻿---
+---
 author: jpjofre
 description: 
 external help file: PSModule-help.xml


### PR DESCRIPTION
GitHub cannot handle BOM and YML metadata together correctly.

Example:
![image](https://cloud.githubusercontent.com/assets/816680/20244413/a2176330-a935-11e6-9ca3-3a152462c9cb.png)

https://github.com/PowerShell/PowerShell-Docs/blob/417fff809b74d68e5674befa32828f388afe66a4/reference/5.1/ISE/ISE.md

This is a follow-up from #788

Script used for re-encoding

```powershell
ls -Recurse -Filter *.md | % { bash -c "/usr/local/Cellar/icu4c/55.1/bin/uconv -t UTF8 --remove-signature < $($_.FullName) > t"; cp -Force t $_.FullName }
```