### PR TITLE
Updated GetReport Cmdlet Example

### DIFF
--- a/dsc/reportServer.md
+++ b/dsc/reportServer.md
@@ -112,8 +112,8 @@ The following script returns the reports for the node on which it is run:
 ```powershell
 function GetReport
 {
-    param($AgentId = "$((glcm).AgentId)", $serviceURL = "http://CONTOSO-REPORT:8080/PSDSCReportServer.svc")
-    $requestUri = "$serviceURL/Nodes(AgentId= '$AgentId')/Reports"
+    param($AgentId = "$((glcm).AgentId)", $serviceURL = "http://CONTOSO-REPORT:8080/PSDSCPullServer.svc")
+    $requestUri = "$serviceURL/Node(ConfigurationId= '$AgentId')/StatusReports"
     $request = Invoke-WebRequest -Uri $requestUri  -ContentType "application/json;odata=minimalmetadata;streaming=true;charset=utf-8" `
                -UseBasicParsing -Headers @{Accept = "application/json";ProtocolVersion = "2.0"} `
                -ErrorAction SilentlyContinue -ErrorVariable ev


### PR DESCRIPTION
The GetReport cmdlet example is out of date and no longer works.

Place see the comment @NarineM posted [here](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/97#issuecomment-209115354) detailing the changes required to work with the new report server.