### PR TITLE
Fix platyPS errors in ConvertFrom-String.md

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Utility/ConvertFrom-String.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/ConvertFrom-String.md
@@ -415,7 +415,10 @@ For more information, see [about_CommonParameters](../Microsoft.PowerShell.Core/
 
 ## RELATED LINKS
 
--  [ConvertFrom-String: Example-based text parsing](http://blogs.msdn.com/b/powershell/archive/2014/10/31/convertfrom-string-example-based-text-parsing.aspx)
--  [ConvertFrom-StringData](ConvertFrom-StringData.md)
--  [ConvertFrom-Csv](ConvertFrom-Csv.md)
--  [ConvertTo-Xml](ConvertTo-Xml.md)
+[ConvertFrom-String: Example-based text parsing](http://blogs.msdn.com/b/powershell/archive/2014/10/31/convertfrom-string-example-based-text-parsing.aspx)
+
+[ConvertFrom-StringData](ConvertFrom-StringData.md)
+
+[ConvertFrom-Csv](ConvertFrom-Csv.md)
+
+[ConvertTo-Xml](ConvertTo-Xml.md)

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-String.md
@@ -415,7 +415,10 @@ For more information, see [about_CommonParameters](../Microsoft.PowerShell.Core/
 
 ## RELATED LINKS
 
--  [ConvertFrom-String: Example-based text parsing](http://blogs.msdn.com/b/powershell/archive/2014/10/31/convertfrom-string-example-based-text-parsing.aspx)
--  [ConvertFrom-StringData](ConvertFrom-StringData.md)
--  [ConvertFrom-Csv](ConvertFrom-Csv.md)
--  [ConvertTo-Xml](ConvertTo-Xml.md)
+[ConvertFrom-String: Example-based text parsing](http://blogs.msdn.com/b/powershell/archive/2014/10/31/convertfrom-string-example-based-text-parsing.aspx)
+
+[ConvertFrom-StringData](ConvertFrom-StringData.md)
+
+[ConvertFrom-Csv](ConvertFrom-Csv.md)
+
+[ConvertTo-Xml](ConvertTo-Xml.md)


### PR DESCRIPTION
Fix these errors

```
Exception calling "NodeModelToMamlModel" with "1" argument(s):
"F:\dev\PowerShell-Docs\reference\5.0\Microsoft.PowerShell.Utility\ConvertFrom-String.md:402:(1505) '-  '
 Expect hyperlink, but got -"
At F:\dev\platyPS\out\platyPS\platyPS.psm1:1224 char:9
+         $maml = $t.NodeModelToMamlModel($model)
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : HelpSchemaException

Exception calling "NodeModelToMamlModel" with "1" argument(s):
"F:\dev\PowerShell-Docs\reference\5.1\Microsoft.PowerShell.Utility\ConvertFrom-String.md:402:(1505) '-  '
 Expect hyperlink, but got -"
At F:\dev\platyPS\out\platyPS\platyPS.psm1:1224 char:9
+         $maml = $t.NodeModelToMamlModel($model)
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : HelpSchemaException
```