### PR TITLE
Removing duplicate sentences in a description for the -Confirm and -WhatIf parameters

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/Clear-History.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Clear-History.md
@@ -136,7 +136,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -152,7 +152,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -552,7 +552,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -568,7 +568,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Disable-PSRemoting.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Disable-PSRemoting.md
@@ -242,7 +242,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -258,7 +258,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Disable-PSSessionConfiguration.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Disable-PSSessionConfiguration.md
@@ -147,7 +147,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -163,7 +163,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -398,7 +398,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -414,7 +414,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Enable-PSRemoting.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Enable-PSRemoting.md
@@ -130,7 +130,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -146,7 +146,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Enable-PSSessionConfiguration.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Enable-PSSessionConfiguration.md
@@ -151,7 +151,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -167,7 +167,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Export-Console.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Export-Console.md
@@ -164,7 +164,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -180,7 +180,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -282,7 +282,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -298,7 +298,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Invoke-History.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Invoke-History.md
@@ -89,7 +89,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -105,7 +105,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -796,7 +796,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -812,7 +812,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -651,7 +651,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -667,7 +667,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Register-PSSessionConfiguration.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Register-PSSessionConfiguration.md
@@ -659,7 +659,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -675,7 +675,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Remove-Job.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Remove-Job.md
@@ -309,7 +309,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -325,7 +325,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Remove-Module.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Remove-Module.md
@@ -139,7 +139,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -155,7 +155,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Remove-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Remove-PSSession.md
@@ -218,7 +218,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -234,7 +234,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Remove-PSSnapin.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Remove-PSSnapin.md
@@ -90,7 +90,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -106,7 +106,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Resume-Job.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Resume-Job.md
@@ -300,7 +300,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -316,7 +316,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
@@ -577,7 +577,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -593,7 +593,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Stop-Job.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Stop-Job.md
@@ -298,7 +298,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -314,7 +314,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Suspend-Job.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Suspend-Job.md
@@ -297,7 +297,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -313,7 +313,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Core/Unregister-PSSessionConfiguration.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Unregister-PSSessionConfiguration.md
@@ -156,7 +156,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -172,7 +172,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/3.0/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -141,7 +141,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -157,7 +157,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Add-Computer.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Add-Computer.md
@@ -402,7 +402,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -418,7 +418,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Add-Content.md
@@ -141,7 +141,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -157,7 +157,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Clear-Content.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Clear-Content.md
@@ -214,7 +214,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -230,7 +230,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Clear-EventLog.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Clear-EventLog.md
@@ -120,7 +120,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -136,7 +136,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Clear-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Clear-Item.md
@@ -201,7 +201,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -217,7 +217,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Clear-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Clear-ItemProperty.md
@@ -208,7 +208,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -224,7 +224,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Complete-Transaction.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Complete-Transaction.md
@@ -170,7 +170,7 @@ However, when you add the UseTransaction parameter to the "dir" command, the com
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -186,7 +186,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Copy-Item.md
@@ -259,7 +259,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -275,7 +275,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Copy-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Copy-ItemProperty.md
@@ -211,7 +211,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -227,7 +227,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Debug-Process.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Debug-Process.md
@@ -161,7 +161,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -177,7 +177,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
@@ -71,7 +71,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -87,7 +87,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
@@ -69,7 +69,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -85,7 +85,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Invoke-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Invoke-Item.md
@@ -163,7 +163,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -179,7 +179,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
@@ -456,7 +456,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -472,7 +472,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Limit-EventLog.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Limit-EventLog.md
@@ -170,7 +170,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -186,7 +186,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Move-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Move-Item.md
@@ -268,7 +268,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -284,7 +284,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Move-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Move-ItemProperty.md
@@ -221,7 +221,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -237,7 +237,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/New-Item.md
@@ -209,7 +209,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -225,7 +225,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/New-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/New-ItemProperty.md
@@ -259,7 +259,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -275,7 +275,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/New-PSDrive.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/New-PSDrive.md
@@ -313,7 +313,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -329,7 +329,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Remove-EventLog.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Remove-EventLog.md
@@ -174,7 +174,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -190,7 +190,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Remove-Item.md
@@ -255,7 +255,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -271,7 +271,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Remove-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Remove-ItemProperty.md
@@ -215,7 +215,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -231,7 +231,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Remove-PSDrive.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Remove-PSDrive.md
@@ -140,7 +140,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -156,7 +156,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Remove-WmiObject.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Remove-WmiObject.md
@@ -358,7 +358,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -374,7 +374,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Rename-Computer.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Rename-Computer.md
@@ -194,7 +194,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -210,7 +210,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Rename-Item.md
@@ -212,7 +212,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -228,7 +228,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Rename-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Rename-ItemProperty.md
@@ -214,7 +214,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -230,7 +230,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
@@ -92,7 +92,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -108,7 +108,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -400,7 +400,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -416,7 +416,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Restore-Computer.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Restore-Computer.md
@@ -86,7 +86,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -102,7 +102,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Set-Content.md
@@ -137,7 +137,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -153,7 +153,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Set-Item.md
@@ -224,7 +224,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -240,7 +240,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -310,7 +310,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -326,7 +326,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
@@ -497,7 +497,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -513,7 +513,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Start-Transaction.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Start-Transaction.md
@@ -335,7 +335,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -351,7 +351,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Stop-Computer.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Stop-Computer.md
@@ -248,7 +248,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -264,7 +264,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Stop-Process.md
@@ -204,7 +204,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -220,7 +220,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Stop-Service.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Stop-Service.md
@@ -193,7 +193,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -209,7 +209,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Suspend-Service.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Suspend-Service.md
@@ -178,7 +178,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -194,7 +194,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
@@ -136,7 +136,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -152,7 +152,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Management/Undo-Transaction.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Undo-Transaction.md
@@ -104,7 +104,7 @@ The results show that the transaction is rolled back, and that the subscriber co
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -120,7 +120,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Security/Set-Acl.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Set-Acl.md
@@ -290,7 +290,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -306,7 +306,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
@@ -211,7 +211,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -227,7 +227,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -199,7 +199,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -215,7 +215,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Clear-Variable.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Clear-Variable.md
@@ -161,7 +161,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -177,7 +177,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
@@ -137,7 +137,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -153,7 +153,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -281,7 +281,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -297,7 +297,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -200,7 +200,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -216,7 +216,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -300,7 +300,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -316,7 +316,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Import-Alias.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Import-Alias.md
@@ -134,7 +134,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -150,7 +150,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/New-Alias.md
@@ -170,7 +170,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -186,7 +186,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/New-Variable.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/New-Variable.md
@@ -251,7 +251,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -267,7 +267,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Out-File.md
@@ -228,7 +228,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -244,7 +244,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Remove-Event.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Remove-Event.md
@@ -89,7 +89,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -105,7 +105,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
@@ -114,7 +114,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -130,7 +130,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Remove-TypeData.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Remove-TypeData.md
@@ -158,7 +158,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -174,7 +174,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Remove-Variable.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Remove-Variable.md
@@ -123,7 +123,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -139,7 +139,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -213,7 +213,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -229,7 +229,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Set-Date.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Set-Date.md
@@ -149,7 +149,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -165,7 +165,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -273,7 +273,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -289,7 +289,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Unblock-File.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Unblock-File.md
@@ -120,7 +120,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -136,7 +136,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Unregister-Event.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Unregister-Event.md
@@ -118,7 +118,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -134,7 +134,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -119,7 +119,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -135,7 +135,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -571,7 +571,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -587,7 +587,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/PSScheduledJob/Disable-JobTrigger.md
+++ b/reference/3.0/PSScheduledJob/Disable-JobTrigger.md
@@ -99,7 +99,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -115,7 +115,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/PSScheduledJob/Disable-ScheduledJob.md
+++ b/reference/3.0/PSScheduledJob/Disable-ScheduledJob.md
@@ -186,7 +186,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -202,7 +202,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/PSScheduledJob/Enable-JobTrigger.md
+++ b/reference/3.0/PSScheduledJob/Enable-JobTrigger.md
@@ -107,7 +107,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -123,7 +123,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/PSScheduledJob/Enable-ScheduledJob.md
+++ b/reference/3.0/PSScheduledJob/Enable-ScheduledJob.md
@@ -165,7 +165,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -181,7 +181,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/PSScheduledJob/Register-ScheduledJob.md
+++ b/reference/3.0/PSScheduledJob/Register-ScheduledJob.md
@@ -357,7 +357,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -373,7 +373,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/3.0/PSScheduledJob/Unregister-ScheduledJob.md
+++ b/reference/3.0/PSScheduledJob/Unregister-ScheduledJob.md
@@ -151,7 +151,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -167,7 +167,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Clear-History.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Clear-History.md
@@ -91,7 +91,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -160,7 +160,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -334,7 +334,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -575,7 +575,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Disable-PSRemoting.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Disable-PSRemoting.md
@@ -235,7 +235,7 @@ The output shows that the AccessDenied security descriptor for all network users
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -267,7 +267,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Disable-PSSessionConfiguration.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Disable-PSSessionConfiguration.md
@@ -119,7 +119,7 @@ This example shows the effect of disabling a session configuration.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -171,7 +171,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -249,7 +249,7 @@ Values set for the session take precedence over values set in the session config
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -422,7 +422,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Enable-PSRemoting.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Enable-PSRemoting.md
@@ -96,7 +96,7 @@ The command uses the **Set-NetFirewallRule** cmdlet in the **NetSecurity** modul
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -152,7 +152,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Enable-PSSessionConfiguration.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Enable-PSSessionConfiguration.md
@@ -76,7 +76,7 @@ This command re-enables the MaintenanceShell session configuration and specifies
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -174,7 +174,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Export-Console.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Export-Console.md
@@ -114,7 +114,7 @@ This command exports the names of all the Windows PowerShell snap-ins in the cur
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -188,7 +188,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -205,7 +205,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -307,7 +307,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Invoke-History.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Invoke-History.md
@@ -76,7 +76,7 @@ The pipeline operator (|) passes the commands to **Invoke-History**, which execu
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -113,7 +113,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -318,7 +318,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -821,7 +821,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -391,7 +391,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -678,7 +678,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Register-PSSessionConfiguration.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Register-PSSessionConfiguration.md
@@ -298,7 +298,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -689,7 +689,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Remove-Job.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Remove-Job.md
@@ -191,7 +191,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -336,7 +336,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Remove-Module.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Remove-Module.md
@@ -94,7 +94,7 @@ This command uses the ModuleInfo parameter to remove the BitsTransfer module.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -162,7 +162,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Remove-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Remove-PSSession.md
@@ -151,7 +151,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -243,7 +243,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Remove-PSSnapin.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Remove-PSSnapin.md
@@ -64,7 +64,7 @@ This command specifies the "Name" parameter name, but the parameter name can be 
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -112,7 +112,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Resume-Job.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Resume-Job.md
@@ -186,7 +186,7 @@ For information about the Suspend-Workflow, see about_Suspend-Workflow.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -326,7 +326,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
@@ -244,7 +244,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -603,7 +603,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Stop-Job.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Stop-Job.md
@@ -175,7 +175,7 @@ For more information about remote background jobs, see about_Remote_Jobs.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -325,7 +325,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Suspend-Job.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Suspend-Job.md
@@ -161,7 +161,7 @@ The Maintenance job does not have checkpoints, so it cannot be suspended correct
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -322,7 +322,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Unregister-PSSessionConfiguration.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Unregister-PSSessionConfiguration.md
@@ -104,7 +104,7 @@ This time, the session fails because the MaintenanceShell configuration has been
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -179,7 +179,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/4.0/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -153,7 +153,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -169,7 +169,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Add-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Add-Computer.md
@@ -414,7 +414,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -430,7 +430,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Add-Content.md
@@ -249,7 +249,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -265,7 +265,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Clear-Content.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Clear-Content.md
@@ -201,7 +201,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -217,7 +217,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Clear-EventLog.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Clear-EventLog.md
@@ -127,7 +127,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -143,7 +143,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Clear-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Clear-Item.md
@@ -207,7 +207,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -223,7 +223,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Clear-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Clear-ItemProperty.md
@@ -212,7 +212,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -228,7 +228,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Complete-Transaction.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Complete-Transaction.md
@@ -176,7 +176,7 @@ However, when you add the UseTransaction parameter to the "dir" command, the com
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -192,7 +192,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Copy-Item.md
@@ -266,7 +266,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -282,7 +282,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Copy-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Copy-ItemProperty.md
@@ -215,7 +215,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -231,7 +231,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Debug-Process.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Debug-Process.md
@@ -172,7 +172,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -188,7 +188,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
@@ -76,7 +76,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -92,7 +92,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
@@ -74,7 +74,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -90,7 +90,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Invoke-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Invoke-Item.md
@@ -168,7 +168,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -184,7 +184,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
@@ -464,7 +464,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -480,7 +480,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Limit-EventLog.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Limit-EventLog.md
@@ -176,7 +176,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -192,7 +192,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Move-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Move-Item.md
@@ -277,7 +277,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -293,7 +293,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Move-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Move-ItemProperty.md
@@ -225,7 +225,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -241,7 +241,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/New-Item.md
@@ -217,7 +217,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -233,7 +233,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/New-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/New-ItemProperty.md
@@ -264,7 +264,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -280,7 +280,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/New-PSDrive.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/New-PSDrive.md
@@ -321,7 +321,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -337,7 +337,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Remove-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Remove-Computer.md
@@ -236,7 +236,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -252,7 +252,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Remove-EventLog.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Remove-EventLog.md
@@ -182,7 +182,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -198,7 +198,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Remove-Item.md
@@ -244,7 +244,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -260,7 +260,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Remove-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Remove-ItemProperty.md
@@ -221,7 +221,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -237,7 +237,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Remove-PSDrive.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Remove-PSDrive.md
@@ -145,7 +145,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -161,7 +161,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Remove-WmiObject.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Remove-WmiObject.md
@@ -362,7 +362,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -378,7 +378,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Rename-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Rename-Computer.md
@@ -200,7 +200,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -216,7 +216,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Rename-Item.md
@@ -219,7 +219,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -235,7 +235,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Rename-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Rename-ItemProperty.md
@@ -218,7 +218,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -234,7 +234,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
@@ -98,7 +98,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -114,7 +114,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -410,7 +410,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -426,7 +426,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Restore-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Restore-Computer.md
@@ -92,7 +92,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -108,7 +108,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Set-Content.md
@@ -238,7 +238,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -254,7 +254,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Set-Item.md
@@ -231,7 +231,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -247,7 +247,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -316,7 +316,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -332,7 +332,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
@@ -506,7 +506,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -522,7 +522,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Start-Transaction.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Start-Transaction.md
@@ -345,7 +345,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -361,7 +361,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Stop-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Stop-Computer.md
@@ -256,7 +256,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -272,7 +272,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Stop-Process.md
@@ -211,7 +211,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -227,7 +227,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Stop-Service.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Stop-Service.md
@@ -199,7 +199,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -215,7 +215,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Suspend-Service.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Suspend-Service.md
@@ -185,7 +185,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -201,7 +201,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
@@ -144,7 +144,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -160,7 +160,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Management/Undo-Transaction.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Undo-Transaction.md
@@ -110,7 +110,7 @@ The results show that the transaction is rolled back, and that the subscriber co
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -126,7 +126,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Security/Set-Acl.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/Set-Acl.md
@@ -296,7 +296,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -312,7 +312,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
@@ -217,7 +217,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -233,7 +233,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -209,7 +209,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -225,7 +225,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Clear-Variable.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Clear-Variable.md
@@ -167,7 +167,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -183,7 +183,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
@@ -144,7 +144,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -160,7 +160,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -288,7 +288,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -304,7 +304,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -206,7 +206,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -222,7 +222,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -310,7 +310,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -326,7 +326,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Import-Alias.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Import-Alias.md
@@ -138,7 +138,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -154,7 +154,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/New-Alias.md
@@ -175,7 +175,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -191,7 +191,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/New-Variable.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/New-Variable.md
@@ -258,7 +258,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -274,7 +274,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Out-File.md
@@ -235,7 +235,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -251,7 +251,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Remove-Event.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Remove-Event.md
@@ -95,7 +95,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -111,7 +111,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
@@ -121,7 +121,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -137,7 +137,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Remove-TypeData.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Remove-TypeData.md
@@ -166,7 +166,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -182,7 +182,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Remove-Variable.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Remove-Variable.md
@@ -127,7 +127,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -143,7 +143,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -221,7 +221,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -237,7 +237,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Set-Date.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Set-Date.md
@@ -156,7 +156,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -172,7 +172,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -279,7 +279,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -295,7 +295,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Unblock-File.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Unblock-File.md
@@ -126,7 +126,7 @@ Accept wildcard characters: True
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -142,7 +142,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Unregister-Event.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Unregister-Event.md
@@ -124,7 +124,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -140,7 +140,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -125,7 +125,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -141,7 +141,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -579,7 +579,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -595,7 +595,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/PSDesiredStateConfiguration/Restore-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Restore-DscConfiguration.md
@@ -92,7 +92,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -108,7 +108,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
@@ -152,7 +152,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -168,7 +168,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/PSDesiredStateConfiguration/Start-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Start-DscConfiguration.md
@@ -250,7 +250,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -266,7 +266,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/PSScheduledJob/Disable-JobTrigger.md
+++ b/reference/4.0/PSScheduledJob/Disable-JobTrigger.md
@@ -120,7 +120,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -136,7 +136,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/PSScheduledJob/Disable-ScheduledJob.md
+++ b/reference/4.0/PSScheduledJob/Disable-ScheduledJob.md
@@ -194,7 +194,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -210,7 +210,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/PSScheduledJob/Enable-JobTrigger.md
+++ b/reference/4.0/PSScheduledJob/Enable-JobTrigger.md
@@ -129,7 +129,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -145,7 +145,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/PSScheduledJob/Enable-ScheduledJob.md
+++ b/reference/4.0/PSScheduledJob/Enable-ScheduledJob.md
@@ -172,7 +172,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -188,7 +188,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/PSScheduledJob/Register-ScheduledJob.md
+++ b/reference/4.0/PSScheduledJob/Register-ScheduledJob.md
@@ -381,7 +381,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -397,7 +397,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/4.0/PSScheduledJob/Unregister-ScheduledJob.md
+++ b/reference/4.0/PSScheduledJob/Unregister-ScheduledJob.md
@@ -157,7 +157,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -173,7 +173,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/5.0/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -130,7 +130,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -232,7 +232,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/5.0/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -55,7 +55,7 @@ This command extracts the contents of an existing archive file in the current fo
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -136,7 +136,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Clear-History.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Clear-History.md
@@ -91,7 +91,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -160,7 +160,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -346,7 +346,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -587,7 +587,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Debug-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Debug-Job.md
@@ -87,7 +87,7 @@ This command breaks into a running job with an ID of 3.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -169,7 +169,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Disable-PSRemoting.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Disable-PSRemoting.md
@@ -235,7 +235,7 @@ The output shows that the AccessDenied security descriptor for all network users
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -266,7 +266,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Disable-PSSessionConfiguration.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Disable-PSSessionConfiguration.md
@@ -120,7 +120,7 @@ This example shows the effect of disabling a session configuration.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -186,7 +186,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -250,7 +250,7 @@ Values set for the session take precedence over values set in the session config
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -424,7 +424,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Enable-PSRemoting.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Enable-PSRemoting.md
@@ -96,7 +96,7 @@ This includes locations in different subnets.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -150,7 +150,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Enable-PSSessionConfiguration.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Enable-PSSessionConfiguration.md
@@ -77,7 +77,7 @@ This command re-enables the MaintenanceShell session configuration and specifies
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -190,7 +190,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Export-Console.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Export-Console.md
@@ -115,7 +115,7 @@ This command exports the names of all the Windows PowerShell snap-ins in the cur
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -189,7 +189,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -207,7 +207,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -312,7 +312,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Invoke-History.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Invoke-History.md
@@ -75,7 +75,7 @@ The pipeline operator (|) passes the commands to **Invoke-History**, which runs 
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -111,7 +111,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -321,7 +321,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -916,7 +916,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -404,7 +404,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -696,7 +696,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Register-PSSessionConfiguration.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Register-PSSessionConfiguration.md
@@ -298,7 +298,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -705,7 +705,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Remove-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Remove-Job.md
@@ -196,7 +196,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -354,7 +354,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Remove-Module.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Remove-Module.md
@@ -99,7 +99,7 @@ This command uses the *ModuleInfo* parameter to remove the BitsTransfer module.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -182,7 +182,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Remove-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Remove-PSSession.md
@@ -149,7 +149,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -244,7 +244,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Remove-PSSnapin.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Remove-PSSnapin.md
@@ -63,7 +63,7 @@ This command removes all Windows PowerShell snap-ins that have names that includ
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -111,7 +111,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Resume-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Resume-Job.md
@@ -174,7 +174,7 @@ For information about the Suspend-Workflow, see about_Suspend-Workflow.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -328,7 +328,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
@@ -245,7 +245,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -612,7 +612,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Stop-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Stop-Job.md
@@ -177,7 +177,7 @@ For more information about remote background jobs, see about_Remote_Jobs.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -340,7 +340,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Suspend-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Suspend-Job.md
@@ -162,7 +162,7 @@ It cannot be suspended correctly and might not resume correctly.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -338,7 +338,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Unregister-PSSessionConfiguration.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Unregister-PSSessionConfiguration.md
@@ -104,7 +104,7 @@ This time, the session fails because the MaintenanceShell configuration has been
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -179,7 +179,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Update-Help.md
@@ -208,7 +208,7 @@ The script uses the **PSCustomObject** class and a hash table to create a custom
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -418,7 +418,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/5.0/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -85,7 +85,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -206,7 +206,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Add-Computer.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Add-Computer.md
@@ -143,7 +143,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -414,7 +414,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Add-Content.md
@@ -88,7 +88,7 @@ The *Force* parameter is not required for this command.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -357,7 +357,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Clear-Content.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Clear-Content.md
@@ -60,7 +60,7 @@ Using a filter to restrict the command to files with the .log file name extensio
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -242,7 +242,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Clear-EventLog.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Clear-EventLog.md
@@ -102,7 +102,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -134,7 +134,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Clear-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Clear-Item.md
@@ -68,7 +68,7 @@ To delete the value of a registry entry, use the Clear-ItemPropertycmdlet.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -233,7 +233,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Clear-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Clear-ItemProperty.md
@@ -53,7 +53,7 @@ It uses the *Name* parameter to specify the Options value.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -247,7 +247,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Clear-RecycleBin.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Clear-RecycleBin.md
@@ -35,7 +35,7 @@ PS C:\>
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -81,7 +81,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Complete-Transaction.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Complete-Transaction.md
@@ -176,7 +176,7 @@ However, when you add the *UseTransaction* parameter to the dir command, the com
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -192,7 +192,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Copy-Item.md
@@ -164,7 +164,7 @@ Since this command uses the *Recurse* parameter, the operation will create the s
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -412,7 +412,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Copy-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Copy-ItemProperty.md
@@ -50,7 +50,7 @@ This command copies the property named MyProperty from the MyApplication registr
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -250,7 +250,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Debug-Process.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Debug-Process.md
@@ -120,7 +120,7 @@ The second command uses the *InputObject* parameter of the **Debug-Process** cmd
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -188,7 +188,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
@@ -55,7 +55,7 @@ The command uses the *Drive* parameter, but it omits the Drive parameter name.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -92,7 +92,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
@@ -53,7 +53,7 @@ This command enables System Restore on the C: and D: drives of the local compute
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -90,7 +90,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Invoke-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Invoke-Item.md
@@ -59,7 +59,7 @@ In this case, opening in Excel is the default action for .xls files.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -203,7 +203,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
@@ -308,7 +308,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -481,7 +481,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Limit-EventLog.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Limit-EventLog.md
@@ -99,7 +99,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -191,7 +191,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Move-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Move-Item.md
@@ -113,7 +113,7 @@ The *Destination* parameter does not require a literal path, because the Destina
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -309,7 +309,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Move-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Move-ItemProperty.md
@@ -51,7 +51,7 @@ This command moves the Version registry value, and its data, from the MyApp subk
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -257,7 +257,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/New-Item.md
@@ -101,7 +101,7 @@ Because *Path* takes multiple strings, you can use it to create multiple items.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -254,7 +254,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/New-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/New-ItemProperty.md
@@ -82,7 +82,7 @@ For more information, see about_Pipelines.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -312,7 +312,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/New-PSDrive.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/New-PSDrive.md
@@ -186,7 +186,7 @@ This example shows the difference between a persistent mapped network drive and 
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -371,7 +371,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/New-Service.md
@@ -93,7 +93,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -216,7 +216,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Remove-Computer.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Remove-Computer.md
@@ -109,7 +109,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -234,7 +234,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Remove-EventLog.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Remove-EventLog.md
@@ -145,7 +145,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -195,7 +195,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Remove-Item.md
@@ -96,7 +96,7 @@ If the key contains subkeys and you omit the *Recurse* parameter, you are prompt
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -308,7 +308,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Remove-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Remove-ItemProperty.md
@@ -79,7 +79,7 @@ Then, it uses the *Name* parameter of **Remove-ItemProperty** to specify the nam
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -256,7 +256,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Remove-PSDrive.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Remove-PSDrive.md
@@ -64,7 +64,7 @@ The command uses the Get-PSDrive cmdlet to get the drives and **Remove-PSDrive**
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -181,7 +181,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Remove-WmiObject.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Remove-WmiObject.md
@@ -221,7 +221,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -378,7 +378,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Rename-Computer.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Rename-Computer.md
@@ -94,7 +94,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -236,7 +236,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Rename-Item.md
@@ -99,7 +99,7 @@ The backslash character is not required in .log because it is a string, not a re
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -248,7 +248,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Rename-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Rename-ItemProperty.md
@@ -51,7 +51,7 @@ This command renames the config registry entry that is contained in the HKEY_LOC
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -253,7 +253,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
@@ -59,7 +59,7 @@ For more information about remote commands in Windows PowerShell, see about_Remo
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -114,7 +114,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -169,7 +169,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -420,7 +420,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Restart-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Restart-Service.md
@@ -75,7 +75,7 @@ In practice, you would use the *WhatIf* parameter to determine the effect of the
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -205,7 +205,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Restore-Computer.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Restore-Computer.md
@@ -72,7 +72,7 @@ Because **Restore-Computer** forces a restart, this command would be entered aft
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -105,7 +105,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Resume-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Resume-Service.md
@@ -70,7 +70,7 @@ In practice, you would use the *WhatIf* parameter to determine the effect of the
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -185,7 +185,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -77,7 +77,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -143,7 +143,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-Content.md
@@ -79,7 +79,7 @@ Without them, the command fails because the two functions will be trying to acce
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -353,7 +353,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-Item.md
@@ -71,7 +71,7 @@ The *Options* parameter is available in **Set-Item** only when you use it with t
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -266,7 +266,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -136,7 +136,7 @@ This command is equivalent to using the *InputObject* parameter to specify the o
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -353,7 +353,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-Service.md
@@ -167,7 +167,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -315,7 +315,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
@@ -340,7 +340,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -523,7 +523,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Start-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Start-Service.md
@@ -111,7 +111,7 @@ To verify that the command succeeded, run **Get-Service**.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -229,7 +229,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Start-Transaction.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Start-Transaction.md
@@ -279,7 +279,7 @@ When the time-out expires, you are not notified, but the **Status** property of 
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -366,7 +366,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Stop-Computer.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Stop-Computer.md
@@ -145,7 +145,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -300,7 +300,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Stop-Process.md
@@ -130,7 +130,7 @@ As a result, the process is stopped without confirmation.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -229,7 +229,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Stop-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Stop-Service.md
@@ -81,7 +81,7 @@ The command uses the *Confirm* parameter to request confirmation from the user b
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -227,7 +227,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Suspend-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Suspend-Service.md
@@ -82,7 +82,7 @@ The *Confirm* parameter prompts you for confirmation before suspending each of t
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -201,7 +201,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
@@ -91,7 +91,7 @@ The **If** statement checks the value that **Test-ComputerSecureChannel** return
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -160,7 +160,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Management/Undo-Transaction.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Undo-Transaction.md
@@ -111,7 +111,7 @@ The results show that the transaction is rolled back, and that the subscriber co
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -127,7 +127,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.ODataUtils/Export-ODataEndpointProxy.md
+++ b/reference/5.0/Microsoft.PowerShell.ODataUtils/Export-ODataEndpointProxy.md
@@ -105,7 +105,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -289,7 +289,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Security/Set-Acl.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Set-Acl.md
@@ -165,7 +165,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -331,7 +331,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
@@ -107,7 +107,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -236,7 +236,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -147,7 +147,7 @@ It also shows how to use the Unblock-File cmdlet to unblock scripts, so that you
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -239,7 +239,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Clear-Variable.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Clear-Variable.md
@@ -64,7 +64,7 @@ After the cmdlet completes the operation, the variable named Processes still exi
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -190,7 +190,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Debug-Runspace.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Debug-Runspace.md
@@ -89,7 +89,7 @@ Because there's a breakpoint in the script, the debugger opens.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -168,7 +168,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
@@ -111,7 +111,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -159,7 +159,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
@@ -130,7 +130,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -181,7 +181,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -131,7 +131,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -296,7 +296,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -88,7 +88,7 @@ This eliminates the risk of exposing plain-text passwords in your script.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -236,7 +236,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -154,7 +154,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -333,7 +333,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Import-Alias.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Import-Alias.md
@@ -49,7 +49,7 @@ This command imports alias information from a file named test.txt.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -160,7 +160,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/New-Alias.md
@@ -53,7 +53,7 @@ The last line of the command uses Get-Alias to get the new alias and pipes it to
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -204,7 +204,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/New-TemporaryFile.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/New-TemporaryFile.md
@@ -44,7 +44,7 @@ You can use this file later in your script.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -60,7 +60,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/New-Variable.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/New-Variable.md
@@ -107,7 +107,7 @@ The user who has loaded the module cannot view or change the value of the Counte
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -288,7 +288,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Out-File.md
@@ -113,7 +113,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -261,7 +261,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Remove-Event.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Remove-Event.md
@@ -62,7 +62,7 @@ This command deletes all events from the event queue.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -111,7 +111,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
@@ -106,7 +106,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -137,7 +137,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Remove-TypeData.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Remove-TypeData.md
@@ -106,7 +106,7 @@ The command uses the Invoke-Command cmdlet to remove extended type data for all 
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -181,7 +181,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Remove-Variable.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Remove-Variable.md
@@ -41,7 +41,7 @@ This command deletes the $Smp variable.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -149,7 +149,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -97,7 +97,7 @@ Then, to run the **Set-Location** command, the user can type either `CD32` or `g
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -251,7 +251,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Set-Date.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Set-Date.md
@@ -96,7 +96,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -159,7 +159,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -87,7 +87,7 @@ The sample output shows the difference in the behavior of public and private var
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -307,7 +307,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Unblock-File.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Unblock-File.md
@@ -91,7 +91,7 @@ This command shows how to find and unblock Windows PowerShell scripts.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -142,7 +142,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Unregister-Event.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Unregister-Event.md
@@ -75,7 +75,7 @@ To complete the task, the *Force* parameter is also required on **Unregister-Eve
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -140,7 +140,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -104,7 +104,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -141,7 +141,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -180,7 +180,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -607,7 +607,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Disable-DscDebug.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Disable-DscDebug.md
@@ -91,7 +91,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -124,7 +124,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Enable-DscDebug.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Enable-DscDebug.md
@@ -107,7 +107,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -140,7 +140,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/New-DSCCheckSum.md
+++ b/reference/5.0/PSDesiredStateConfiguration/New-DSCCheckSum.md
@@ -51,7 +51,7 @@ Specifying the *Force* parameter causes the command to overwrite any checksum fi
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -112,7 +112,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Publish-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Publish-DscConfiguration.md
@@ -86,7 +86,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -166,7 +166,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Remove-DscConfigurationDocument.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Remove-DscConfigurationDocument.md
@@ -93,7 +93,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -166,7 +166,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Restore-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Restore-DscConfiguration.md
@@ -104,7 +104,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -137,7 +137,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
@@ -102,7 +102,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -169,7 +169,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Start-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Start-DscConfiguration.md
@@ -133,7 +133,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -272,7 +272,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
@@ -95,7 +95,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -144,7 +144,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Update-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Update-DscConfiguration.md
@@ -90,7 +90,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -177,7 +177,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSScheduledJob/Disable-JobTrigger.md
+++ b/reference/5.0/PSScheduledJob/Disable-JobTrigger.md
@@ -88,7 +88,7 @@ A pipeline operator sends the daily job triggers to the **Disable-JobTrigger** c
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -137,7 +137,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSScheduledJob/Disable-ScheduledJob.md
+++ b/reference/5.0/PSScheduledJob/Disable-ScheduledJob.md
@@ -128,7 +128,7 @@ Use the GlobalID value when precision is required, such as when you are disablin
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -210,7 +210,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSScheduledJob/Enable-JobTrigger.md
+++ b/reference/5.0/PSScheduledJob/Enable-JobTrigger.md
@@ -97,7 +97,7 @@ The properties include a new JobName property that displays the name of the sche
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -146,7 +146,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSScheduledJob/Enable-ScheduledJob.md
+++ b/reference/5.0/PSScheduledJob/Enable-ScheduledJob.md
@@ -106,7 +106,7 @@ The command uses the *Name* parameter of **Enable-ScheduledJob** to enable the I
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -188,7 +188,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSScheduledJob/Register-ScheduledJob.md
+++ b/reference/5.0/PSScheduledJob/Register-ScheduledJob.md
@@ -180,7 +180,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -424,7 +424,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PSScheduledJob/Unregister-ScheduledJob.md
+++ b/reference/5.0/PSScheduledJob/Unregister-ScheduledJob.md
@@ -89,7 +89,7 @@ The command uses the Invoke-Command cmdlet to run the **Unregister-ScheduledJob*
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -171,7 +171,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PackageManagement/Install-Package.md
+++ b/reference/5.0/PackageManagement/Install-Package.md
@@ -152,7 +152,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -533,7 +533,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PackageManagement/Register-PackageSource.md
+++ b/reference/5.0/PackageManagement/Register-PackageSource.md
@@ -51,7 +51,7 @@ If you do not add the *Trusted* parameter, by default, the package is not truste
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -219,7 +219,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PackageManagement/Save-Package.md
+++ b/reference/5.0/PackageManagement/Save-Package.md
@@ -121,7 +121,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -430,7 +430,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PackageManagement/Set-PackageSource.md
+++ b/reference/5.0/PackageManagement/Set-PackageSource.md
@@ -64,7 +64,7 @@ It also changes the package source to be trusted, so that users who install pack
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -281,7 +281,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PackageManagement/Uninstall-Package.md
+++ b/reference/5.0/PackageManagement/Uninstall-Package.md
@@ -109,7 +109,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -356,7 +356,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PackageManagement/Unregister-PackageSource.md
+++ b/reference/5.0/PackageManagement/Unregister-PackageSource.md
@@ -70,7 +70,7 @@ The *Force* parameter ensures that you are not prompted to confirm that you want
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -242,7 +242,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PowershellGet/Install-Module.md
+++ b/reference/5.0/PowershellGet/Install-Module.md
@@ -84,7 +84,7 @@ This example installs the newest version of the module ContosoServer to $home\Do
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -240,7 +240,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PowershellGet/Publish-Module.md
+++ b/reference/5.0/PowershellGet/Publish-Module.md
@@ -68,7 +68,7 @@ If MyDscModule is not a valid manifest module that specifies a name, version, de
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -261,7 +261,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PowershellGet/Save-Module.md
+++ b/reference/5.0/PowershellGet/Save-Module.md
@@ -95,7 +95,7 @@ The final command displays the contents of the C:\MyLocalModules folder.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -255,7 +255,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PowershellGet/Uninstall-Module.md
+++ b/reference/5.0/PowershellGet/Uninstall-Module.md
@@ -47,7 +47,7 @@ This command gets version 3.6.0.0 of the module named xPSDesiredStateConfigurati
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -155,7 +155,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.0/PowershellGet/Update-Module.md
+++ b/reference/5.0/PowershellGet/Update-Module.md
@@ -79,7 +79,7 @@ This example installs (or reinstalls) the newest version of ContosoModule from t
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -163,7 +163,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Clear-History.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Clear-History.md
@@ -91,7 +91,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -160,7 +160,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Connect-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Connect-PSSession.md
@@ -346,7 +346,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -587,7 +587,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Debug-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Debug-Job.md
@@ -87,7 +87,7 @@ This command breaks into a running job with an ID of 3.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -169,7 +169,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Disable-PSRemoting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Disable-PSRemoting.md
@@ -235,7 +235,7 @@ The output shows that the AccessDenied security descriptor for all network users
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -266,7 +266,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Disable-PSSessionConfiguration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Disable-PSSessionConfiguration.md
@@ -120,7 +120,7 @@ This example shows the effect of disabling a session configuration.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -186,7 +186,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -250,7 +250,7 @@ Values set for the session take precedence over values set in the session config
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -424,7 +424,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Enable-PSRemoting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Enable-PSRemoting.md
@@ -96,7 +96,7 @@ This includes locations in different subnets.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -150,7 +150,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Enable-PSSessionConfiguration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Enable-PSSessionConfiguration.md
@@ -77,7 +77,7 @@ This command re-enables the MaintenanceShell session configuration and specifies
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -190,7 +190,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Export-Console.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Export-Console.md
@@ -115,7 +115,7 @@ This command exports the names of all the Windows PowerShell snap-ins in the cur
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -189,7 +189,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/ForEach-Object.md
@@ -207,7 +207,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -312,7 +312,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Invoke-History.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Invoke-History.md
@@ -75,7 +75,7 @@ The pipeline operator (|) passes the commands to **Invoke-History**, which runs 
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -111,7 +111,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -340,7 +340,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -935,7 +935,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -404,7 +404,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -696,7 +696,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Register-PSSessionConfiguration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Register-PSSessionConfiguration.md
@@ -298,7 +298,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -705,7 +705,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Remove-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Remove-Job.md
@@ -196,7 +196,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -354,7 +354,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Remove-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Remove-Module.md
@@ -99,7 +99,7 @@ This command uses the *ModuleInfo* parameter to remove the BitsTransfer module.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -182,7 +182,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Remove-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Remove-PSSession.md
@@ -164,7 +164,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -312,7 +312,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Remove-PSSnapin.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Remove-PSSnapin.md
@@ -63,7 +63,7 @@ This command removes all Windows PowerShell snap-ins that have names that includ
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -111,7 +111,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Resume-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Resume-Job.md
@@ -174,7 +174,7 @@ For information about the Suspend-Workflow, see about_Suspend-Workflow.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -328,7 +328,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Set-PSSessionConfiguration.md
@@ -245,7 +245,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -612,7 +612,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Stop-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Stop-Job.md
@@ -177,7 +177,7 @@ For more information about remote background jobs, see about_Remote_Jobs.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -340,7 +340,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Suspend-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Suspend-Job.md
@@ -162,7 +162,7 @@ It cannot be suspended correctly and might not resume correctly.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -338,7 +338,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Unregister-PSSessionConfiguration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Unregister-PSSessionConfiguration.md
@@ -104,7 +104,7 @@ This time, the session fails because the MaintenanceShell configuration has been
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -179,7 +179,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Update-Help.md
@@ -208,7 +208,7 @@ The script uses the **PSCustomObject** class and a hash table to create a custom
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -418,7 +418,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -85,7 +85,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -206,7 +206,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Add-LocalGroupMember.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Add-LocalGroupMember.md
@@ -60,7 +60,7 @@ This example uses a placeholder value for the user name of an account at Outlook
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -137,7 +137,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Disable-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Disable-LocalUser.md
@@ -60,7 +60,7 @@ That cmdlet disables that account.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -122,7 +122,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Enable-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Enable-LocalUser.md
@@ -60,7 +60,7 @@ That cmdlet enables that account.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -122,7 +122,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalGroup.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalGroup.md
@@ -39,7 +39,7 @@ This command creates a group named SecurityGroup04.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -87,7 +87,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
@@ -111,7 +111,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -262,7 +262,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalGroup.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalGroup.md
@@ -56,7 +56,7 @@ This command deletes the group named SecurityGroup04.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -118,7 +118,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalGroupMember.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalGroupMember.md
@@ -54,7 +54,7 @@ This example uses a placeholder value for the user name of an account at Outlook
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -134,7 +134,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Remove-LocalUser.md
@@ -50,7 +50,7 @@ This command deletes the user account named AdminContoso02.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -112,7 +112,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Rename-LocalGroup.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Rename-LocalGroup.md
@@ -50,7 +50,7 @@ This command renames a security group named SecurityGroup.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -127,7 +127,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Rename-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Rename-LocalUser.md
@@ -50,7 +50,7 @@ This command renames the user account named Admin02.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -127,7 +127,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Set-LocalGroup.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Set-LocalGroup.md
@@ -50,7 +50,7 @@ This command changes the description of a local group.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -128,7 +128,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/Set-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/Set-LocalUser.md
@@ -105,7 +105,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -249,7 +249,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Add-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Add-Computer.md
@@ -143,7 +143,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -414,7 +414,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Add-Content.md
@@ -88,7 +88,7 @@ The *Force* parameter is not required for this command.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -357,7 +357,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Clear-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Clear-Content.md
@@ -60,7 +60,7 @@ Using a filter to restrict the command to files with the .log file name extensio
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -242,7 +242,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Clear-EventLog.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Clear-EventLog.md
@@ -102,7 +102,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -134,7 +134,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Clear-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Clear-Item.md
@@ -68,7 +68,7 @@ To delete the value of a registry entry, use the Clear-ItemPropertycmdlet.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -233,7 +233,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Clear-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Clear-ItemProperty.md
@@ -53,7 +53,7 @@ It uses the *Name* parameter to specify the Options value.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -247,7 +247,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Clear-RecycleBin.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Clear-RecycleBin.md
@@ -35,7 +35,7 @@ PS C:\>
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -77,7 +77,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Complete-Transaction.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Complete-Transaction.md
@@ -176,7 +176,7 @@ However, when you add the *UseTransaction* parameter to the dir command, the com
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -192,7 +192,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Copy-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Copy-Item.md
@@ -164,7 +164,7 @@ Since this command uses the *Recurse* parameter, the operation will create the s
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -412,7 +412,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Copy-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Copy-ItemProperty.md
@@ -50,7 +50,7 @@ This command copies the property named MyProperty from the MyApplication registr
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -250,7 +250,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Debug-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Debug-Process.md
@@ -120,7 +120,7 @@ The second command uses the *InputObject* parameter of the **Debug-Process** cmd
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -188,7 +188,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
@@ -55,7 +55,7 @@ The command uses the *Drive* parameter, but it omits the Drive parameter name.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -92,7 +92,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Enable-ComputerRestore.md
@@ -53,7 +53,7 @@ This command enables System Restore on the C: and D: drives of the local compute
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -90,7 +90,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Invoke-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Invoke-Item.md
@@ -59,7 +59,7 @@ In this case, opening in Excel is the default action for .xls files.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -203,7 +203,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Invoke-WmiMethod.md
@@ -308,7 +308,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -481,7 +481,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Limit-EventLog.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Limit-EventLog.md
@@ -99,7 +99,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -193,7 +193,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Move-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Move-Item.md
@@ -113,7 +113,7 @@ The *Destination* parameter does not require a literal path, because the Destina
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -309,7 +309,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Move-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Move-ItemProperty.md
@@ -51,7 +51,7 @@ This command moves the Version registry value, and its data, from the MyApp subk
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -257,7 +257,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-Item.md
@@ -101,7 +101,7 @@ Because *Path* takes multiple strings, you can use it to create multiple items.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -254,7 +254,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/New-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-ItemProperty.md
@@ -82,7 +82,7 @@ For more information, see about_Pipelines.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -312,7 +312,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/New-PSDrive.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-PSDrive.md
@@ -186,7 +186,7 @@ This example shows the difference between a persistent mapped network drive and 
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -371,7 +371,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-Service.md
@@ -93,7 +93,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -216,7 +216,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Remove-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Remove-Computer.md
@@ -109,7 +109,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -234,7 +234,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Remove-EventLog.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Remove-EventLog.md
@@ -145,7 +145,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -195,7 +195,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Remove-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Remove-Item.md
@@ -96,7 +96,7 @@ If the key contains subkeys and you omit the *Recurse* parameter, you are prompt
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -308,7 +308,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Remove-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Remove-ItemProperty.md
@@ -79,7 +79,7 @@ Then, it uses the *Name* parameter of **Remove-ItemProperty** to specify the nam
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -256,7 +256,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Remove-PSDrive.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Remove-PSDrive.md
@@ -64,7 +64,7 @@ The command uses the Get-PSDrive cmdlet to get the drives and **Remove-PSDrive**
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -181,7 +181,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Remove-WmiObject.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Remove-WmiObject.md
@@ -221,7 +221,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -378,7 +378,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Rename-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Rename-Computer.md
@@ -94,7 +94,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -236,7 +236,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Rename-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Rename-Item.md
@@ -99,7 +99,7 @@ The backslash character is not required in .log because it is a string, not a re
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -248,7 +248,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Rename-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Rename-ItemProperty.md
@@ -51,7 +51,7 @@ This command renames the config registry entry that is contained in the HKEY_LOC
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -253,7 +253,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Reset-ComputerMachinePassword.md
@@ -59,7 +59,7 @@ For more information about remote commands in Windows PowerShell, see about_Remo
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -114,7 +114,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -169,7 +169,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -420,7 +420,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Restart-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Restart-Service.md
@@ -75,7 +75,7 @@ In practice, you would use the *WhatIf* parameter to determine the effect of the
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -205,7 +205,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Restore-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Restore-Computer.md
@@ -72,7 +72,7 @@ Because **Restore-Computer** forces a restart, this command would be entered aft
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -105,7 +105,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Resume-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Resume-Service.md
@@ -70,7 +70,7 @@ In practice, you would use the *WhatIf* parameter to determine the effect of the
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -185,7 +185,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Clipboard.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Clipboard.md
@@ -92,7 +92,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -158,7 +158,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Content.md
@@ -79,7 +79,7 @@ Without them, the command fails because the two functions will be trying to acce
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -353,7 +353,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Item.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Item.md
@@ -71,7 +71,7 @@ The *Options* parameter is available in **Set-Item** only when you use it with t
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -266,7 +266,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-ItemProperty.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-ItemProperty.md
@@ -136,7 +136,7 @@ This command is equivalent to using the *InputObject* parameter to specify the o
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -353,7 +353,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Service.md
@@ -167,7 +167,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -315,7 +315,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-TimeZone.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-TimeZone.md
@@ -50,7 +50,7 @@ This command sets the time zone on the local computer to Pacific Standard Time.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -127,7 +127,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-WmiInstance.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-WmiInstance.md
@@ -340,7 +340,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -523,7 +523,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Start-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Start-Service.md
@@ -111,7 +111,7 @@ To verify that the command succeeded, run **Get-Service**.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -229,7 +229,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Start-Transaction.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Start-Transaction.md
@@ -279,7 +279,7 @@ When the time-out expires, you are not notified, but the **Status** property of 
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -366,7 +366,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Stop-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Stop-Computer.md
@@ -145,7 +145,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -300,7 +300,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Stop-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Stop-Process.md
@@ -130,7 +130,7 @@ As a result, the process is stopped without confirmation.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -229,7 +229,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Stop-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Stop-Service.md
@@ -81,7 +81,7 @@ The command uses the *Confirm* parameter to request confirmation from the user b
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -227,7 +227,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Suspend-Service.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Suspend-Service.md
@@ -82,7 +82,7 @@ The *Confirm* parameter prompts you for confirmation before suspending each of t
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -201,7 +201,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Test-ComputerSecureChannel.md
@@ -91,7 +91,7 @@ The **If** statement checks the value that **Test-ComputerSecureChannel** return
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -160,7 +160,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Management/Undo-Transaction.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Undo-Transaction.md
@@ -111,7 +111,7 @@ The results show that the transaction is rolled back, and that the subscriber co
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -127,7 +127,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.ODataUtils/Export-ODataEndpointProxy.md
+++ b/reference/5.1/Microsoft.PowerShell.ODataUtils/Export-ODataEndpointProxy.md
@@ -105,7 +105,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -289,7 +289,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Operation.Validation/Invoke-OperationValidation.md
+++ b/reference/5.1/Microsoft.PowerShell.Operation.Validation/Invoke-OperationValidation.md
@@ -86,7 +86,7 @@ This command gets the module named OperationValidation, and uses the pipeline op
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -166,7 +166,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Security/New-FileCatalog.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/New-FileCatalog.md
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -91,7 +91,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Security/Set-Acl.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Set-Acl.md
@@ -165,7 +165,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -331,7 +331,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Set-AuthenticodeSignature.md
@@ -114,7 +114,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -275,7 +275,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Set-ExecutionPolicy.md
@@ -147,7 +147,7 @@ It also shows how to use the Unblock-File cmdlet to unblock scripts, so that you
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -239,7 +239,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Security/Test-FileCatalog.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Test-FileCatalog.md
@@ -49,7 +49,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -104,7 +104,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Clear-Variable.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Clear-Variable.md
@@ -64,7 +64,7 @@ After the cmdlet completes the operation, the variable named Processes still exi
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -190,7 +190,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Debug-Runspace.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Debug-Runspace.md
@@ -89,7 +89,7 @@ Because there's a breakpoint in the script, the debugger opens.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -168,7 +168,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Disable-PSBreakpoint.md
@@ -111,7 +111,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -160,7 +160,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Enable-PSBreakpoint.md
@@ -130,7 +130,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -181,7 +181,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -130,7 +130,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -297,7 +297,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -88,7 +88,7 @@ This eliminates the risk of exposing plain-text passwords in your script.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -236,7 +236,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -154,7 +154,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -334,7 +334,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-Alias.md
@@ -49,7 +49,7 @@ This command imports alias information from a file named test.txt.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -160,7 +160,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Alias.md
@@ -53,7 +53,7 @@ The last line of the command uses Get-Alias to get the new alias and pipes it to
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -204,7 +204,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-TemporaryFile.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-TemporaryFile.md
@@ -44,7 +44,7 @@ You can use this file later in your script.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -60,7 +60,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/New-Variable.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/New-Variable.md
@@ -107,7 +107,7 @@ The user who has loaded the module cannot view or change the value of the Counte
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -287,7 +287,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-File.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-File.md
@@ -113,7 +113,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -261,7 +261,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Remove-Event.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Remove-Event.md
@@ -62,7 +62,7 @@ This command deletes all events from the event queue.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -111,7 +111,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Remove-PSBreakpoint.md
@@ -106,7 +106,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -137,7 +137,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Remove-TypeData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Remove-TypeData.md
@@ -106,7 +106,7 @@ The command uses the Invoke-Command cmdlet to remove extended type data for all 
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -181,7 +181,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Remove-Variable.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Remove-Variable.md
@@ -41,7 +41,7 @@ This command deletes the $Smp variable.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -149,7 +149,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-Alias.md
@@ -97,7 +97,7 @@ Then, to run the **Set-Location** command, the user can type either `CD32` or `g
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -251,7 +251,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-Date.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-Date.md
@@ -96,7 +96,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -158,7 +158,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-Variable.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-Variable.md
@@ -87,7 +87,7 @@ The sample output shows the difference in the behavior of public and private var
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -305,7 +305,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Unblock-File.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Unblock-File.md
@@ -91,7 +91,7 @@ This command shows how to find and unblock Windows PowerShell scripts.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -142,7 +142,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Unregister-Event.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Unregister-Event.md
@@ -75,7 +75,7 @@ To complete the task, the *Force* parameter is also required on **Unregister-Eve
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -140,7 +140,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Update-FormatData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Update-FormatData.md
@@ -104,7 +104,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -141,7 +141,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Update-TypeData.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Update-TypeData.md
@@ -180,7 +180,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -607,7 +607,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Disable-DscDebug.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Disable-DscDebug.md
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -113,7 +113,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Enable-DscDebug.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Enable-DscDebug.md
@@ -96,7 +96,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -129,7 +129,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/New-DSCCheckSum.md
+++ b/reference/5.1/PSDesiredStateConfiguration/New-DSCCheckSum.md
@@ -51,7 +51,7 @@ Specifying the *Force* parameter causes the command to overwrite any checksum fi
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -112,7 +112,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Publish-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Publish-DscConfiguration.md
@@ -86,7 +86,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -166,7 +166,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Remove-DscConfigurationDocument.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Remove-DscConfigurationDocument.md
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -142,7 +142,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Restore-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Restore-DscConfiguration.md
@@ -91,7 +91,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -122,7 +122,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
@@ -102,7 +102,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -184,7 +184,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Start-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Start-DscConfiguration.md
@@ -133,7 +133,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -272,7 +272,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Stop-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Stop-DscConfiguration.md
@@ -82,7 +82,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -128,7 +128,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Update-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Update-DscConfiguration.md
@@ -90,7 +90,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -177,7 +177,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSScheduledJob/Disable-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Disable-JobTrigger.md
@@ -88,7 +88,7 @@ A pipeline operator sends the daily job triggers to the **Disable-JobTrigger** c
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -137,7 +137,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSScheduledJob/Disable-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Disable-ScheduledJob.md
@@ -128,7 +128,7 @@ Use the GlobalID value when precision is required, such as when you are disablin
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -210,7 +210,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSScheduledJob/Enable-JobTrigger.md
+++ b/reference/5.1/PSScheduledJob/Enable-JobTrigger.md
@@ -97,7 +97,7 @@ The properties include a new JobName property that displays the name of the sche
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -146,7 +146,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSScheduledJob/Enable-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Enable-ScheduledJob.md
@@ -106,7 +106,7 @@ The command uses the *Name* parameter of **Enable-ScheduledJob** to enable the I
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -188,7 +188,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSScheduledJob/Register-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Register-ScheduledJob.md
@@ -180,7 +180,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -424,7 +424,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PSScheduledJob/Unregister-ScheduledJob.md
+++ b/reference/5.1/PSScheduledJob/Unregister-ScheduledJob.md
@@ -89,7 +89,7 @@ The command uses the Invoke-Command cmdlet to run the **Unregister-ScheduledJob*
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -171,7 +171,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PackageManagement/Install-Package.md
+++ b/reference/5.1/PackageManagement/Install-Package.md
@@ -219,7 +219,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -786,7 +786,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PackageManagement/Install-PackageProvider.md
+++ b/reference/5.1/PackageManagement/Install-PackageProvider.md
@@ -117,7 +117,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -329,7 +329,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PackageManagement/Register-PackageSource.md
+++ b/reference/5.1/PackageManagement/Register-PackageSource.md
@@ -75,7 +75,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -302,7 +302,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PackageManagement/Save-Package.md
+++ b/reference/5.1/PackageManagement/Save-Package.md
@@ -170,7 +170,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -614,7 +614,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PackageManagement/Set-PackageSource.md
+++ b/reference/5.1/PackageManagement/Set-PackageSource.md
@@ -96,7 +96,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -372,7 +372,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PackageManagement/Uninstall-Package.md
+++ b/reference/5.1/PackageManagement/Uninstall-Package.md
@@ -151,7 +151,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -469,7 +469,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PackageManagement/Unregister-PackageSource.md
+++ b/reference/5.1/PackageManagement/Unregister-PackageSource.md
@@ -99,7 +99,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -300,7 +300,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PowershellGet/Install-Module.md
+++ b/reference/5.1/PowershellGet/Install-Module.md
@@ -102,7 +102,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -318,7 +318,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PowershellGet/Install-Script.md
+++ b/reference/5.1/PowershellGet/Install-Script.md
@@ -177,7 +177,7 @@ The final command gets installed scripts and displays the results.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -383,7 +383,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PowershellGet/New-ScriptFileInfo.md
+++ b/reference/5.1/PowershellGet/New-ScriptFileInfo.md
@@ -191,7 +191,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -452,7 +452,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PowershellGet/Publish-Module.md
+++ b/reference/5.1/PowershellGet/Publish-Module.md
@@ -68,7 +68,7 @@ If MyDscModule is not a valid manifest module that specifies a name, version, de
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -291,7 +291,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PowershellGet/Publish-Script.md
+++ b/reference/5.1/PowershellGet/Publish-Script.md
@@ -110,7 +110,7 @@ The final command uses the Find-Script cmdlet to find Demo-Script.ps1 in the Loc
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -224,7 +224,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PowershellGet/Save-Module.md
+++ b/reference/5.1/PowershellGet/Save-Module.md
@@ -98,7 +98,7 @@ The final command displays the contents of the C:\MyLocalModules folder.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -303,7 +303,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PowershellGet/Save-Script.md
+++ b/reference/5.1/PowershellGet/Save-Script.md
@@ -69,7 +69,7 @@ The second command uses the Test-ScriptFileInfo cmdlet to validate the script.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -273,7 +273,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PowershellGet/Uninstall-Module.md
+++ b/reference/5.1/PowershellGet/Uninstall-Module.md
@@ -63,7 +63,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -171,7 +171,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PowershellGet/Uninstall-Script.md
+++ b/reference/5.1/PowershellGet/Uninstall-Script.md
@@ -46,7 +46,7 @@ This command uninstalls version 2.5 of the script file named MyScript.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -154,7 +154,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PowershellGet/Update-Module.md
+++ b/reference/5.1/PowershellGet/Update-Module.md
@@ -80,7 +80,7 @@ This example installs (or reinstalls) the newest version of ContosoModule from t
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -209,7 +209,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PowershellGet/Update-ModuleManifest.md
+++ b/reference/5.1/PowershellGet/Update-ModuleManifest.md
@@ -150,7 +150,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -738,7 +738,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PowershellGet/Update-Script.md
+++ b/reference/5.1/PowershellGet/Update-Script.md
@@ -47,7 +47,7 @@ The second command gets Fabrikam-Script and displays the results.
 ## PARAMETERS
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -170,7 +170,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml

--- a/reference/5.1/PowershellGet/Update-ScriptFileInfo.md
+++ b/reference/5.1/PowershellGet/Update-ScriptFileInfo.md
@@ -114,7 +114,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -394,7 +394,6 @@ Accept wildcard characters: False
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
-The cmdlet is not run.Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
 ```yaml


### PR DESCRIPTION
Used the following PowerShell Code:
```powershell

# Find the offending files
$x = dir *.md -Recurse | select-string 'Prompts you for confirmation before running the cmdlet.Prompts you for confirmation before running the cmdlet.'
$y = dir *.md -Recurse | select-string 'The cmdlet is not run.Shows what would happen if the cmdlet runs.'

# Fix the offending files
$x | % {$content = gc $_.path; $content[($_.Linenumber-1)] = 'Prompts you for confirmation before running the cmdlet.'; set-content $_.path -value $content}
$y | % {$content = gc $_.path; $content1 = $content[0..($_.Linenumber-2)]; $content2 = $content[($_.Linenumber)..($content.Length-1)];set-content $_.path -Value $content1; A
dd-Content $_.path -Value $content2}
```

Fixes #848