### PR TITLE
Skip CI for commits outside reference

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,4 +23,5 @@ artifacts:
 only_commits:
   files:
     - reference/**/*
-    - appveyor.*
+    - 'appveyor.ps1'
+    - 'appveyor.yml'


### PR DESCRIPTION
Appveyor is not currently skipping commits outside reference. I made a small syntactical change that I believe *might* fix this problem. If it doesn't, I have a support ticket ready to submit