### PR TITLE
Fixed 5.0 save-module as well for #874

### DIFF
--- a/reference/5.0/PowershellGet/Save-Module.md
+++ b/reference/5.0/PowershellGet/Save-Module.md
@@ -52,16 +52,22 @@ The module is not installed.
 ## EXAMPLES
 
 ### Example 1: Find modules and save them locally
-```
-PS C:\>Find-Module -Name "AzureAutomationDebug" -Repository "PSGallery"
+
+```powershell
+PS C:\> Find-Module -Name "AzureAutomationDebug" -Repository "PSGallery"
 Version    Name                                Type       Repository           Description
 -------    ----                                ----       ----------           -----------
-1.3.5      AzureAutomationDebug                Module     PSGallery            Module for debugging Azure Automation runbooks, emulating AA native cmdlets PS C:\>Find-Module -Name "AzureAutomationDebug" -Repository "PSGallery" -IncludeDependencies
+1.3.5      AzureAutomationDebug                Module     PSGallery            Module for debugging Azure Automation runbooks, emulating AA native cmdlets
+
+PS C:\> Find-Module -Name "AzureAutomationDebug" -Repository "PSGallery" -IncludeDependencies
 Version    Name                                Type       Repository           Description
 -------    ----                                ----       ----------           -----------
 1.3.5      AzureAutomationDebug                Module     PSGallery            Module for debugging Azure Automation runbooks, emulating AA native cmdlets
 1.0.1      AzureRM.Automation                  Module     PSGallery            Microsoft Azure PowerShell - Automation service cmdlets for Azure Resource Manager
-1.0.1      AzureRM.profile                     Module     PSGallery            Microsoft Azure PowerShell - Profile credential management cmdlets for Azure Resource Manager PS C:\>Find-Module -Name "AzureAutomationDebug" -Repository "PSGallery" | Save-Module -Path "C:\MyLocalModules\"
+1.0.1      AzureRM.profile                     Module     PSGallery            Microsoft Azure PowerShell - Profile credential management cmdlets for Azure Resource Manager
+
+PS C:\> Find-Module -Name "AzureAutomationDebug" -Repository "PSGallery" | Save-Module -Path "C:\MyLocalModules\"
+
 PS C:\> dir C:\MyLocalModules\
     Directory: C:\MyLocalModules
 
@@ -71,6 +77,7 @@ Mode                LastWriteTime         Length Name
 d-----       12/14/2015  11:20 AM                AzureAutomationDebug
 d-----       12/14/2015  11:20 AM                AzureRM.Automation
 d-----       12/14/2015  11:20 AM                AzureRM.profile PS C:\>Save-Module -LiteralPath "C:\MyLocalModules\" -Name "xPSDesiredStateConfiguration" -Repository "PSGallery" -MinimumVersion 2.0 -MaximumVersion 3.5.0
+
 PS C:\> dir C:\MyLocalModules
    Directory: C:\MyLocalModules
 

--- a/reference/5.1/PowershellGet/Save-Module.md
+++ b/reference/5.1/PowershellGet/Save-Module.md
@@ -55,20 +55,22 @@ The module is not installed.
 ## EXAMPLES
 
 ### Example 1: Find modules and save them locally
-```
-PS C:\>Find-Module -Name "AzureAutomationDebug" -Repository "PSGallery"
+
+```powershell
+PS C:\> Find-Module -Name "AzureAutomationDebug" -Repository "PSGallery"
 Version    Name                                Type       Repository           Description
 -------    ----                                ----       ----------           -----------
 1.3.5      AzureAutomationDebug                Module     PSGallery            Module for debugging Azure Automation runbooks, emulating AA native cmdlets
 
-PS C:\>Find-Module -Name "AzureAutomationDebug" -Repository "PSGallery" -IncludeDependencies
+PS C:\> Find-Module -Name "AzureAutomationDebug" -Repository "PSGallery" -IncludeDependencies
 Version    Name                                Type       Repository           Description
 -------    ----                                ----       ----------           -----------
 1.3.5      AzureAutomationDebug                Module     PSGallery            Module for debugging Azure Automation runbooks, emulating AA native cmdlets
 1.0.1      AzureRM.Automation                  Module     PSGallery            Microsoft Azure PowerShell - Automation service cmdlets for Azure Resource Manager
 1.0.1      AzureRM.profile                     Module     PSGallery            Microsoft Azure PowerShell - Profile credential management cmdlets for Azure Resource Manager
 
-PS C:\>Find-Module -Name "AzureAutomationDebug" -Repository "PSGallery" | Save-Module -Path "C:\MyLocalModules\"
+PS C:\> Find-Module -Name "AzureAutomationDebug" -Repository "PSGallery" | Save-Module -Path "C:\MyLocalModules\"
+
 PS C:\> dir C:\MyLocalModules\
     Directory: C:\MyLocalModules
 
@@ -79,7 +81,8 @@ d-----       12/14/2015  11:20 AM                AzureAutomationDebug
 d-----       12/14/2015  11:20 AM                AzureRM.Automation
 d-----       12/14/2015  11:20 AM                AzureRM.profile
 
-PS C:\>Save-Module -LiteralPath "C:\MyLocalModules\" -Name "xPSDesiredStateConfiguration" -Repository "PSGallery" -MinimumVersion 2.0 -MaximumVersion 3.5.0
+PS C:\> Save-Module -LiteralPath "C:\MyLocalModules\" -Name "xPSDesiredStateConfiguration" -Repository "PSGallery" -MinimumVersion 2.0 -MaximumVersion 3.5.0
+
 PS C:\> dir C:\MyLocalModules
    Directory: C:\MyLocalModules
 


### PR DESCRIPTION
Additionally for 5.1 docuement:
- Added space after PS prompt
- Indicated that the code block is 'PowerShell' code block for correct
rendering formatting