### PR TITLE
About_ files: broken characters and en-dashes

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Aliases.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Aliases.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Describes how to use alternate names for cmdlets and commands in  Windows PowerShell�.
+Describes how to use alternate names for cmdlets and commands in  Windows PowerShell.
 
 
 ## LONG DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Describes variables that store state information for  Windows PowerShell�. These variables are created and maintained by  Windows PowerShell.
+Describes variables that store state information for  Windows PowerShell. These variables are created and maintained by  Windows PowerShell.
 
 
 ## LONG DESCRIPTION
@@ -171,7 +171,7 @@ $currentDay = 0
 ```
 foreach($day in $calendar)  
 {  
-    if($day –ne $null)  
+    if($day -ne $null)  
     {  
         "Appointment on $($days[$currentDay]): $day"  
     }  

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Debuggers.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Debuggers.md
@@ -271,7 +271,7 @@ setting workflow variables from within the debugger is not supported.
 available.
 -- Workflow debugging works only with synchronous running of workflows from
 a Windows PowerShell script. You cannot debug workflows if they are
-running as a job (with the –AsJob parameter).
+running as a job (with the -AsJob parameter).
 -- Other nested debugging scenarios--such as a workflow calling another
 workflow, or a workflow calling a script--are not implemented.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -173,7 +173,7 @@ defined for the parameter.
 
 To use this function, type the following command:
 
-C:\PS> function Get-SmallFiles –Size 50
+C:\PS> function Get-SmallFiles -Size 50
 
 You can also enter a value for a named parameter without the parameter
 name. For example, the following command gives the same result as a

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -226,7 +226,7 @@ function <name> {
 Causes Windows PowerShell to exit a script or a Windows PowerShell
 instance.
 
-When you run 'powershell.exe –File <path to a script>', you can only
+When you run 'powershell.exe -File <path to a script>', you can only
 set the %ERRORLEVEL% variable to a value other than zero by using the
 exit statement. In the following example, the user sets the error level
 variable value to 4 by adding 'exit 4' to the script file _test.ps1_.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Methods.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Methods.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Describes how to use methods to perform actions on objects in  Windows PowerShell�.
+Describes how to use methods to perform actions on objects in  Windows PowerShell.
 
 
 ## LONG DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -57,7 +57,7 @@ in the session, so you can find a command and use it without importing.
 
 Any of the following commands will import a module into your session.
 #Run the command
-Get-Mailbox –Identity Chris
+Get-Mailbox -Identity Chris
 
 #Get the command
 Get-Command Get-Mailbox
@@ -184,7 +184,7 @@ Get-Help <command-name> -Online
 
 To download and install the help files for the commands in a module,
 type:
-Update-Help –Module <module-name>
+Update-Help -Module <module-name>
 
 For more information, see Get-Help and Update-Help.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Object_Creation.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Object_Creation.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Explains how to create objects in  Windows PowerShell�.
+Explains how to create objects in  Windows PowerShell.
 
 
 ## LONG DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operators.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Describes the operators that are supported by  Windows PowerShell�.
+Describes the operators that are supported by  Windows PowerShell.
 
 
 ## LONG DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PSSessions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PSSessions.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Describes  Windows PowerShell� sessions (PSSessions) and explains how to establish a persistent connection to a remote computer.
+Describes  Windows PowerShell sessions (PSSessions) and explains how to establish a persistent connection to a remote computer.
 
 
 ## LONG DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PSSnapins.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PSSnapins.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Describes  Windows PowerShell� snap-ins and shows how to use and manage them.
+Describes  Windows PowerShell snap-ins and shows how to use and manage them.
 
 
 ## LONG DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PackageManagement.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PackageManagement.md
@@ -82,7 +82,7 @@ if the specified provider is not available, PackageManagement prompts you to boo
 Chocolatey provider is not already installed, PackageManagement bootstrapping installs
 the provider.
 
-Find-Package –Provider Chocolatey <PackageName>
+Find-Package -Provider Chocolatey <PackageName>
 
 If the Chocolatey provider is not already installed, when you run the
 preceding command, you are prompted to install it.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameters.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Describes how to work with command parameters in  Windows PowerShell�.
+Describes how to work with command parameters in  Windows PowerShell.
 
 
 ## LONG DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameters_Default_Values.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Parameters_Default_Values.md
@@ -32,7 +32,7 @@ This feature is especially useful when you must specify the same alternate param
 
 If the desired default value varies predictably, you can specify a script block that provides different default values for a parameter under different conditions.
 
-$PSDefaultParameterValues was introduced in  Windows PowerShell� 3.0.
+$PSDefaultParameterValues was introduced in  Windows PowerShell 3.0.
 
 
 ### SYNTAX
@@ -107,7 +107,7 @@ The following command sets the default value of the Autosize parameter of the Fo
 
 
 ```
-$PSDefaultParameterValues=@{"Format-Table:AutoSize"={if ($host.Name –eq "ConsoleHost"){$true}}}
+$PSDefaultParameterValues=@{"Format-Table:AutoSize"={if ($host.Name -eq "ConsoleHost"){$true}}}
 ```
 
 
@@ -117,7 +117,7 @@ The following command sets the default value of the ScriptBlock parameter of Inv
 
 
 ```
-$PSDefaultParameterValues=@{"Invoke-Command:ScriptBlock"={{Get-EventLog –Log System}}}
+$PSDefaultParameterValues=@{"Invoke-Command:ScriptBlock"={{Get-EventLog -Log System}}}
 ```
 
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Path_Syntax.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Path_Syntax.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Describes the full and relative path name formats in  Windows PowerShell�.
+Describes the full and relative path name formats in  Windows PowerShell.
 
 
 ## LONG DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_PowerShell_Ise_exe.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_PowerShell_Ise_exe.md
@@ -37,8 +37,8 @@ or ISE.
 PowerShell_Ise[.exe]
 PowerShell_ISE[.exe]
 ISE[.exe]
-[–File]<FilePath[]> [–NoProfile] [–MTA]
-–Help | ? | -? | /?
+[-File]<FilePath[]> [-NoProfile] [-MTA]
+-Help | ? | -? | /?
 Displays the syntax and describes the command-line switches.
 
 # PARAMETERS

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Prompts.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Prompts.md
@@ -24,7 +24,7 @@ Describes the Prompt function and demonstrates how to create a custom Prompt fun
 
 
 ## LONG DESCRIPTION
-The  Windows PowerShell� command prompt indicates that  Windows PowerShell is ready to run a command:
+The  Windows PowerShell command prompt indicates that  Windows PowerShell is ready to run a command:
 
 
 ```

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Properties.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Properties.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Describes how to use object properties in  Windows PowerShell�.
+Describes how to use object properties in  Windows PowerShell.
 
 
 ## LONG DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Describes rules for using single and double quotation marks in  Windows PowerShell�.
+Describes rules for using single and double quotation marks in  Windows PowerShell.
 
 
 ## LONG DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Explains how to redirect output from  Windows PowerShell� to text files.
+Explains how to redirect output from  Windows PowerShell to text files.
 
 
 ## LONG DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -39,7 +39,7 @@ characters in the brackets.
 
 [range]  Matches at least one of the      "and" -match "[a-e]nd"
 characters within the range.
-The use of a hyphen (–) allows
+The use of a hyphen (-) allows
 you to specify an adjacent
 character.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Contains questions and answers about running remote commands in  Windows PowerShell�.
+Contains questions and answers about running remote commands in  Windows PowerShell.
 
 
 ## LONG DESCRIPTION
@@ -325,7 +325,7 @@ Create the following registry entry, and then set its value to 1: LocalAccountTo
 
 You can use the following  Windows PowerShell command to add this entry:
 
-New-ItemProperty ` –Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System ` –Name LocalAccountTokenFilterPolicy –propertyType DWord –Value 1
+New-ItemProperty ` -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System ` -Name LocalAccountTokenFilterPolicy -propertyType DWord -Value 1
 
 --  Windows Server 2003, Windows Server 2008, Windows Server 2012, Windows Server 2012 R2:
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Jobs.md
@@ -48,7 +48,7 @@ The procedure for starting a background job in an interactive session is almost 
 
 
 #### STEP 1: ENTER-PSSESSION
-Use the Enter-PSSession cmdlet to start an interactive session with a remote computer. You can use the ComputerName parameter of Enter-PSSession to establish a temporary connection for the interactive session. Or, you can use the Session parameter to run the interactive session in a  Windows PowerShell� session (PSSession).
+Use the Enter-PSSession cmdlet to start an interactive session with a remote computer. You can use the ComputerName parameter of Enter-PSSession to establish a temporary connection for the interactive session. Or, you can use the Session parameter to run the interactive session in a  Windows PowerShell session (PSSession).
 
 The following command starts an interactive session on the Server01 computer.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -135,7 +135,7 @@ access from all locations on client and server versions of Windows, use
 the Set-NetFirewallRule cmdlet in the NetSecurity module. Run the following
 command:
 
-Set-NetFirewallRule –Name "WINRM-HTTP-In-TCP-PUBLIC" –RemoteAddress Any
+Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP-PUBLIC" -RemoteAddress Any
 
 In Windows PowerShell 2.0, on server versions of Windows, Enable-PSRemoting
 creates firewall rules that permit remote access on all networks.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -183,7 +183,7 @@ and creates a firewall rule that allows traffic from the same local subnet.
 To remove the local subnet restriction on public networks and allow
 remote access from any location, run the following command:
 
-Set-NetFirewallRule –Name "WINRM-HTTP-In-TCP-PUBLIC" –RemoteAddress Any
+Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP-PUBLIC" -RemoteAddress Any
 
 The Set-NetFirewallRule cmdlet is exported by the NetSecurity module.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -24,7 +24,7 @@ Prevents a script from running without the required elements.
 
 
 ## LONG DESCRIPTION
-The \#Requires statement prevents a script from running unless the  Windows PowerShell� version, modules, snap-ins, and module and snap-in version prerequisites are met. If the prerequisites are not met,  Windows PowerShell does not run the script.
+The \#Requires statement prevents a script from running unless the  Windows PowerShell version, modules, snap-ins, and module and snap-in version prerequisites are met. If the prerequisites are not met,  Windows PowerShell does not run the script.
 
 You can use \#Requires statements in any script. You cannot use them in functions, cmdlets, or snap-ins.
 
@@ -34,9 +34,9 @@ You can use \#Requires statements in any script. You cannot use them in function
 
 ```
 #Requires -Version <N>[.<n>]   
-#Requires –PSSnapin <PSSnapin-Name> [-Version <N>[.<n>]]  
+#Requires -PSSnapin <PSSnapin-Name> [-Version <N>[.<n>]]  
 #Requires -Modules { <Module-Name> | <Hashtable> }   
-#Requires –ShellId <ShellId>  
+#Requires -ShellId <ShellId>  
 #Requires -RunAsAdministrator
 ```
 
@@ -71,7 +71,7 @@ For example:
 
 
 ```
-#Requires –PSSnapin DiskSnapin -Version 1.2
+#Requires -PSSnapin DiskSnapin -Version 1.2
 ```
 
 
@@ -107,7 +107,7 @@ For example,
 
 
 ```
-#Requires –ShellId MyLocalShell
+#Requires -ShellId MyLocalShell
 ```
 
 
@@ -129,9 +129,9 @@ The following script has two \#Requires statements. If the requirements specifie
 
 
 ```
-#Requires –Modules PSWorkflow  
- #Requires –Version 3  
- Param  
+#Requires -Modules PSWorkflow  
+#Requires -Version 3  
+Param  
 (  
     [parameter(Mandatory=$true)]  
     [String[]]  

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Return.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Return.md
@@ -28,7 +28,7 @@ The Return keyword exits a function, script, or script block. It can be used to 
 
 Users who are familiar with languages like C or C\# might want to use the Return keyword to make the logic of leaving a scope explicit.
 
-In  Windows PowerShell�, the results of each statement are returned as output, even without a statement that contains the Return keyword. Languages like C or C\# return only the value or values that are specified by the Return keyword.
+In  Windows PowerShell, the results of each statement are returned as output, even without a statement that contains the Return keyword. Languages like C or C\# return only the value or values that are specified by the Return keyword.
 
 
 ### SYNTAX

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Script_Internationalization.md
@@ -103,7 +103,7 @@ the same name as the script and the .psd1 file name extension. Store the files
 in subdirectories of the script directory with names of cultures in the following
 format:
 
-<language>–<region>
+<language>-<region>
 
 Examples: de-DE, ar-SA, and zh-Hans
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Scripts.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Scripts.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Describes how to run and write scripts in  Windows PowerShell�.
+Describes how to run and write scripts in  Windows PowerShell.
 
 
 ## LONG DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Trap.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Trap.md
@@ -24,7 +24,7 @@ Describes a keyword that handles a terminating error.
 
 
 ## LONG DESCRIPTION
-A terminating error stops a statement from running. If  Windows PowerShell� does not handle a terminating error in some way,  Windows PowerShell also stops running the function or script in the current pipeline. In other languages, such as C\#, terminating errors are referred to as exceptions.
+A terminating error stops a statement from running. If  Windows PowerShell does not handle a terminating error in some way,  Windows PowerShell also stops running the function or script in the current pipeline. In other languages, such as C\#, terminating errors are referred to as exceptions.
 
 The Trap keyword specifies a list of statements to run when a terminating error occurs. Trap statements handle the terminating errors and allow execution of the script or function to continue instead of stopping.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Try_Catch_Finally.md
@@ -26,7 +26,7 @@ Describes how to use the Try, Catch, and Finally blocks to handle terminating er
 ## LONG DESCRIPTION
 Use Try, Catch, and Finally blocks to respond to or handle terminating errors in scripts. The Trap statement can also be used to handle terminating errors in scripts. For more information, see about_Trap.
 
-A terminating error stops a statement from running. If  Windows PowerShell� does not handle a terminating error in some way,  Windows PowerShell also stops running the function or script using the current pipeline. In other languages, such as C\#, terminating errors are referred to as exceptions. For more information about errors, see about_Errors.
+A terminating error stops a statement from running. If  Windows PowerShell does not handle a terminating error in some way,  Windows PowerShell also stops running the function or script using the current pipeline. In other languages, such as C\#, terminating errors are referred to as exceptions. For more information about errors, see about_Errors.
 
 Use the Try block to define a section of a script in which you want  Windows PowerShell to monitor for errors. When an error occurs within the Try block, the error is first saved to the $Error automatic variable.  Windows PowerShell then searches for a Catch block to handle the error. If the Try statement does not have a  matching Catch block,  Windows PowerShell continues to search for an appropriate Catch block or Trap statement in the parent scopes. After a Catch block is completed or if no appropriate Catch block or Trap statement is found, the Finally block is run. If the error cannot be handled, the error is written to the error stream.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Type_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Type_Operators.md
@@ -28,7 +28,7 @@ The Boolean type operators (-is and -isNot) tell whether an object is an instanc
 
 The -as operator tries to convert the input object to the specified .NET Framework type. If it succeeds, it returns the converted object. It if fails, it returns nothing. It does not return an error.
 
-The following table lists the type operators in  Windows PowerShell�.
+The following table lists the type operators in  Windows PowerShell.
 
 
 ```

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -306,8 +306,8 @@ DHCP Server module on a computer that does not have network access.
 First, run Export-CliXml to export the PSModuleInfo object to
 a shared folder or to removable media.
 
-$m = Get-Module -Name DhcpServer –ListAvailable
-Export-CliXml –Path E:\UsbFlashDrive\DhcpModule.xml –InputObject $m
+$m = Get-Module -Name DhcpServer -ListAvailable
+Export-CliXml -Path E:\UsbFlashDrive\DhcpModule.xml -InputObject $m
 
 Next, transport the removable media to a computer that has
 Internet access, and then import the PSModuleInfo object with
@@ -315,14 +315,14 @@ Import-CliXml. Run Save-Help to save the Help for the imported
 DhcpServer module PSModuleInfo object.
 
 $deserialized_m = Import-CliXml E:\UsbFlashDrive\DhcpModule.xml
-Save-Help -Module $deserialized_m –DestinationPath
+Save-Help -Module $deserialized_m -DestinationPath
 E:\UsbFlashDrive\SavedHelp
 
 Finally, transport the removable media back to the computer that
 does not have network access, and then install the help by running
 Update-Help.
 
-Update-Help –Module DhcpServer –SourcePath
+Update-Help -Module DhcpServer -SourcePath
 E:\UsbFlashDrive\SavedHelp
 
 # NOTES:

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Variables.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Describes how variables store values that can be used in  Windows PowerShell�.
+Describes how variables store values that can be used in  Windows PowerShell.
 
 
 ## LONG DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_WMI.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_WMI.md
@@ -26,7 +26,7 @@ Windows Management Instrumentation (WMI) uses the Common Information Model (CIM)
 ## LONG DESCRIPTION
 Windows Management Instrumentation (WMI) is Microsoft’s implementation of Web-Based Enterprise Management (WBEM), the industry standard.
 
-Classic WMI uses DCOM to communicate with networked devices to manage remote systems.  Windows PowerShell� 3.0 introduces a CIM provider model that uses WinRM to remove the dependency on DCOM. This CIM provider model also uses new WMI provider APIs that enable developers to write  Windows PowerShell cmdlets in native code (C\+\+).
+Classic WMI uses DCOM to communicate with networked devices to manage remote systems.  Windows PowerShell 3.0 introduces a CIM provider model that uses WinRM to remove the dependency on DCOM. This CIM provider model also uses new WMI provider APIs that enable developers to write  Windows PowerShell cmdlets in native code (C\+\+).
 
 Do not confuse WMI providers with  Windows PowerShell providers. Many Windows features have an associated WMI provider that exposes their management capabilities. To get WMI providers, run a WMI query that gets instances of the __Provider WMI class, such as the following query.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_WMI_Cmdlets.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_WMI_Cmdlets.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Provides background information about Windows Management Instrumentation (WMI) and  Windows PowerShell�.
+Provides background information about Windows Management Instrumentation (WMI) and  Windows PowerShell.
 
 
 ## LONG DESCRIPTION
@@ -211,7 +211,7 @@ http://go.microsoft.com/fwlink/?LinkId=142213
 ```
 
 
-And, see "Secrets of Windows Management Instrumentation – Troubleshooting and Tips" in the Microsoft TechNet Script Center:
+And, see "Secrets of Windows Management Instrumentation - Troubleshooting and Tips" in the Microsoft TechNet Script Center:
 
 
 ```

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_WQL.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_WQL.md
@@ -123,14 +123,14 @@ SMBIOSBIOSVersion : 8BET56WW (1.36 )
 Manufacturer      : LENOVO
 Name              : Default System BIOS
 SerialNumber      : R9FPY3P
-Version           : LENOVO – 1360
+Version           : LENOVO - 1360
 
 You can also save the WQL statement in a variable
 and then use the variable as the value of the Query
 parameter, as shown in the following command.
 
 PS C:> $query = "Select * from Win32_Bios"
-PS C:> Get-WmiObject –Query $query
+PS C:> Get-WmiObject -Query $query
 
 You can use either format with any WQL statement.
 The following command uses the query in the
@@ -167,7 +167,7 @@ example, the following command also gets the values
 of the Name and Version properties of instances of
 the Win32_Bios WMI class.
 
-PS C:> Get-WmiObject –Class Win32_Bios -Property Name, Version
+PS C:> Get-WmiObject -Class Win32_Bios -Property Name, Version
 
 # __GENUS          : 2
 
@@ -218,7 +218,7 @@ SMBIOSBIOSVersion : 8BET56WW (1.36 )
 Manufacturer      : LENOVO
 Name              : Default System BIOS
 SerialNumber      : R9FPY3P
-Version           : LENOVO – 1360
+Version           : LENOVO - 1360
 
 Get-CimInstance returns a CimInstance object, instead of
 the ManagementObject that Get-WmiObject returns, but
@@ -263,7 +263,7 @@ SMBIOSBIOSVersion : 8BET56WW (1.36 )
 Manufacturer      : LENOVO
 Name              : Default System BIOS
 SerialNumber      : R9FPY3P
-Version           : LENOVO – 1360
+Version           : LENOVO - 1360
 
 NOTE: Only selected object properties are displayed
 by default. These properties are defined in the
@@ -281,7 +281,7 @@ SMBIOSBIOSVersion : 8BET56WW (1.36 )
 Manufacturer      : LENOVO
 Name              : Default System BIOS
 SerialNumber      : R9FPY3P
-Version           : LENOVO – 1360
+Version           : LENOVO - 1360
 
 When you use the [wmisearcher] type accelerator, it
 changes the query string into a ManagementObjectSearcher

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_While.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_While.md
@@ -34,7 +34,7 @@ while (<condition>){<statement list>}
 ```
 
 
-When you run a While statement,  Windows PowerShell� evaluates the <condition> section of the statement before entering the <statement list> section. The condition portion of the statement resolves to either true or false. As long as the condition remains true,  Windows PowerShell reruns the <statement list> section.
+When you run a While statement,  Windows PowerShell evaluates the <condition> section of the statement before entering the <statement list> section. The condition portion of the statement resolves to either true or false. As long as the condition remains true,  Windows PowerShell reruns the <statement list> section.
 
 The <statement list> section of the statement contains one or more commands that are run each time the loop is entered or repeated.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Windows_RT.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Windows_RT.md
@@ -20,7 +20,7 @@ ms.topic: article
 
 
 ## SHORT DESCRIPTION
-Explains limitations of  Windows PowerShell� 4.0 on Windows RT 8.1.
+Explains limitations of  Windows PowerShell 4.0 on Windows RT 8.1.
 
 
 ## LONG DESCRIPTION


### PR DESCRIPTION
A number of the about_ files had a broken symbol after the words Windows PowerShell near the header, [like this](https://msdn.microsoft.com/en-us/powershell/reference/5.1/microsoft.powershell.core/about/about_requires):

![brokenchar](https://cloud.githubusercontent.com/assets/2458645/21028040/68d4fdea-bd61-11e6-8e87-7bbdbd0e7bfe.png)

I removed the broken character from all about_ files. Also, I noticed in the powershell console, that various helpfiles have hyphens stored as en-dashes. See inconsistency in about_requires:

![en-dashes](https://cloud.githubusercontent.com/assets/2458645/21028135/cddd3c8e-bd61-11e6-8e90-6edd7e3f0f40.png)

I searched the about_ files and found no legitimate en-dashes, so I replaced them all with hyphens.