### PR TITLE
PSVersionTable example formatting was broken in powershell help

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -341,46 +341,21 @@ Contains a read-only hash table that displays details about the version of  Wind
 
 
 ```
-CLRVersion:            The version of the common language runtime (CLR)
-```
+CLRVersion:                 The version of the common language runtime (CLR)
 
+BuildVersion:               The build number of the current version
 
+PSVersion:                  The Windows PowerShell version number
 
-```
-BuildVersion:          The build number of the current version
-```
+WSManStackVersion:          The version number of the WS-Management stack
 
+PSCompatibleVersions:       Versions of Windows PowerShell that are  
+                              compatible with the current version
 
+SerializationVersion        The version of the serialization method
 
-```
-PSVersion:             The Windows PowerShell version number
-```
-
-
-
-```
-WSManStackVersion:     The version number of the WS-Management stack
-```
-
-
-
-```
-PSCompatibleVersions:  Versions of Windows PowerShell that are  
-                             compatible with the current version
-```
-
-
-
-```
-SerializationVersion   The version of the serialization method
-```
-
-
-
-```
-PSRemotingProtocolVersion  
-                             The version of the Windows PowerShell remote  
-                             management protocol
+PSRemotingProtocolVersion   The version of the Windows PowerShell remote  
+                              management protocol
 ```
 
 


### PR DESCRIPTION
![psversiontable](https://cloud.githubusercontent.com/assets/2458645/21028226/29c8faec-bd62-11e6-86c0-ca6478aae18c.png)

Gross!

By arranging this as one contiguous code block, I believe the formatting issue will be resolved. (Is it possible to run the md -> help.txt conversion process to test the documentation "build"?)