### PR TITLE
Updated examples for consistency, fixed link

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -136,14 +136,16 @@ When the body is a form, or it is the output of an **Invoke-WebRequest** call, W
 
 For example:
 
-`$R = Invoke-WebRequest http://website.com/login.aspx`
-`$R.Forms\[0\].Name = "MyName"`
-`$R.Forms\[0\].Password = "MyPassword"`
-`Invoke-RestMethod http://website.com/service.aspx -Body $R`
-
+```
+$R = Invoke-WebRequest http://website.com/login.aspx
+$R.Forms[0].Name = "MyName"
+$R.Forms[0].Password = "MyPassword"
+Invoke-RestMethod http://website.com/service.aspx -Body $R
+```
 - or -
-
-`Invoke-RestMethod http://website.com/service.aspx -Body $R.Forms\[0\]`
+```
+Invoke-RestMethod http://website.com/service.aspx -Body $R.Forms[0]
+```
 
 ```yaml
 Type: Object
@@ -553,11 +555,13 @@ Specifies a user agent string for the web request.
 
 The default user agent is similar to Mozilla/5.0 (Windows NT; Windows NT 6.1; en-US) WindowsPowerShell/3.0 with slight variations for each operating system and platform.
 
-To test a website with the standard user agent string that is used by most Internet browsers, use the properties of the PSUserAgenthttp://msdn.microsoft.com/en-us/library/windows/desktop/hh484857(v=vs.85).aspx class, such as Chrome, FireFox, InternetExplorer, Opera, and Safari.
+To test a website with the standard user agent string that is used by most Internet browsers, use the properties of the [PSUserAgent](<http://msdn.microsoft.com/en-us/library/windows/desktop/hh484857(v=vs.85).aspx>) class, such as Chrome, FireFox, InternetExplorer, Opera, and Safari.
 
 For example, the following command uses the user agent string for Internet
 
-`Invoke-WebRequest -Uri http://website.com/ -UserAgent (\[Microsoft.PowerShell.Commands.PSUserAgent\]::InternetExplorer)`
+```
+Invoke-WebRequest -Uri http://website.com/ -UserAgent ([Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer)
+```
 
 ```yaml
 Type: String

--- a/reference/5.1/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -557,7 +557,7 @@ The default user agent is similar to Mozilla/5.0 (Windows NT; Windows NT 6.1; en
 
 To test a website with the standard user agent string that is used by most Internet browsers, use the properties of the [PSUserAgent](<http://msdn.microsoft.com/en-us/library/windows/desktop/hh484857(v=vs.85).aspx>) class, such as Chrome, FireFox, InternetExplorer, Opera, and Safari.
 
-For example, the following command uses the user agent string for Internet
+For example, the following command uses the user agent string for Internet Explorer
 
 ```
 Invoke-WebRequest -Uri http://website.com/ -UserAgent ([Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer)

--- a/reference/5.1/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -53,59 +53,59 @@ Sorting by the shortest HTML value often helps you find the most specific elemen
 
 ### Example 2: Use a stateful web service
 ```
-The first command uses the **Invoke-WebRequest** cmdlet to send a sign-in request. The command specifies a value of "FB" for the value of the *SessionVariable* parameter, and saves the result in the $R variable.When the command completes, the $R variable contains an **HtmlWebResponseObject** and the $FB variable contains a **WebRequestSession** object.
+# The first command uses the **Invoke-WebRequest** cmdlet to send a sign-in request. The command specifies a value of "FB" for the value of the *SessionVariable* parameter, and saves the result in the $R variable.When the command completes, the $R variable contains an **HtmlWebResponseObject** and the $FB variable contains a **WebRequestSession** object.
 PS C:\>$R=Invoke-WebRequest http://www.facebook.com/login.php -SessionVariable fb
 
-The second command shows the **WebRequestSession** object in the $FB variable.
+# The second command shows the **WebRequestSession** object in the $FB variable.
 PS C:\>$FB
 
-The third command gets the first form in the **Forms** property of the HTTP response object in the $R variable, and saves it in the $Form variable.
+# The third command gets the first form in the **Forms** property of the HTTP response object in the $R variable, and saves it in the $Form variable.
 PS C:\>$Form = $R.Forms[0]
 
-The fourth command pipes the properties of the form in the $Form variable into a list by using the Format-List cmdlet.
+# The fourth command pipes the properties of the form in the $Form variable into a list by using the Format-List cmdlet.
 PS C:\>$Form | Format-List
 
-The fifth command displays the keys and values in the hash table (dictionary) object in the Fields property of the form.
+# The fifth command displays the keys and values in the hash table (dictionary) object in the Fields property of the form.
 PS C:\>$Form.fields
 
-The sixth and seventh commands populate the values of the email and pass keys of the hash table in the **Fields** property of the form. You can replace the email and password with values that you want to use.
+# The sixth and seventh commands populate the values of the email and pass keys of the hash table in the **Fields** property of the form. You can replace the email and password with values that you want to use.
 PS C:\>$Form.Fields["email"]="User01@Fabrikam.com"
 $Form.Fields["pass"]="P@ssw0rd"
 
-The eighth command uses the **Invoke-WebRequest** cmdlet to sign into the Facebook web service.The value of the *Uri* parameter is the value of the **Action** property of the form. The **WebRequestSession** object in the $FB variable (the session variable specified in the first command) is now the value of the *WebSession* parameter. The value of the *Body* parameter is the hash table in the Fields property of the form and the value of the *Method* parameter is POST. The command saves the output in the $R variable.
+# The eighth command uses the **Invoke-WebRequest** cmdlet to sign into the Facebook web service.The value of the *Uri* parameter is the value of the **Action** property of the form. The **WebRequestSession** object in the $FB variable (the session variable specified in the first command) is now the value of the *WebSession* parameter. The value of the *Body* parameter is the hash table in the Fields property of the form and the value of the *Method* parameter is POST. The command saves the output in the $R variable.
 PS C:\>$R=Invoke-WebRequest -Uri ("https://www.facebook.com" + $Form.Action) -WebSession $FB -Method POST -Body $Form.Fields
 
-The full script, then, is as follows.
-PS C:\># Sends a sign-in request by running the Invoke-WebRequest cmdlet. The command specifies a value of "fb" for the SessionVariable parameter, and saves the results in the $R variable.
+# The full script, then, is as follows.
+# Sends a sign-in request by running the Invoke-WebRequest cmdlet. The command specifies a value of "fb" for the SessionVariable parameter, and saves the results in the $R variable.
 
-$R=Invoke-WebRequest http://www.facebook.com/login.php -SessionVariable fb
+PS C:\>$R=Invoke-WebRequest http://www.facebook.com/login.php -SessionVariable fb
 
 # Use the session variable that you created in Example 1. Output displays values for Headers, Cookies, Credentials, etc. 
 
-$FB
+PS C:\>$FB
 
 # Gets the first form in the Forms property of the HTTP response object in the $R variable, and saves it in the $Form variable. 
 
-$Form = $R.Forms[0]
+PS C:\>$Form = $R.Forms[0]
 
 # Pipes the form properties that are stored in the $Forms variable into the Format-List cmdlet, to display those properties in a list. 
 
-$Form | Format-List
+PS C:\>$Form | Format-List
 
 # Displays the keys and values in the hash table (dictionary) object in the Fields property of the form.
 
-$Form.fields
+PS C:\>$Form.fields
 
 # The next two commands populate the values of the "email" and "pass" keys of the hash table in the Fields property of the form. Of course, you can replace the email and password with values that you want to use. 
 
-$Form.Fields["email"] = "User01@Fabrikam.com"
-$Form.Fields["pass"] = "P@ssw0rd"
+PS C:\>$Form.Fields["email"] = "User01@Fabrikam.com"
+PS C:\>$Form.Fields["pass"] = "P@ssw0rd"
 
 # The final command uses the Invoke-WebRequest cmdlet to sign in to the Facebook web service. 
 
-$R=Invoke-WebRequest -Uri ("https://www.facebook.com" + $Form.Action) -WebSession $FB -Method POST -Body $Form.Fields
+PS C:\>$R=Invoke-WebRequest -Uri ("https://www.facebook.com" + $Form.Action) -WebSession $FB -Method POST -Body $Form.Fields
 
-When the command finishes, the **StatusDescription** property of the web response object in the $R variable indicates that the user is signed in successfully.
+# When the command finishes, the **StatusDescription** property of the web response object in the $R variable indicates that the user is signed in successfully.
 PS C:\>$R.StatusDescription
 ```
 
@@ -137,14 +137,14 @@ When the body is a form, or it is the output of an **Invoke-WebRequest** call, W
 For example:
 
 ```
-$R = Invoke-WebRequest http://website.com/login.aspx
-$R.Forms[0].Name = "MyName"
-$R.Forms[0].Password = "MyPassword"
-Invoke-RestMethod http://website.com/service.aspx -Body $R
+PS C:\>$R = Invoke-WebRequest http://website.com/login.aspx
+PS C:\>$R.Forms[0].Name = "MyName"
+PS C:\>$R.Forms[0].Password = "MyPassword"
+PS C:\>Invoke-RestMethod http://website.com/service.aspx -Body $R
 ```
 - or -
 ```
-Invoke-RestMethod http://website.com/service.aspx -Body $R.Forms[0]
+PS C:\>Invoke-RestMethod http://website.com/service.aspx -Body $R.Forms[0]
 ```
 
 ```yaml
@@ -560,7 +560,7 @@ To test a website with the standard user agent string that is used by most Inter
 For example, the following command uses the user agent string for Internet Explorer
 
 ```
-Invoke-WebRequest -Uri http://website.com/ -UserAgent ([Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer)
+PS C:\>Invoke-WebRequest -Uri http://website.com/ -UserAgent ([Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer)
 ```
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -82,31 +82,31 @@ PS C:\>$R=Invoke-WebRequest http://www.facebook.com/login.php -SessionVariable f
 
 # Use the session variable that you created in Example 1. Output displays values for Headers, Cookies, Credentials, etc. 
 
-PS C:\>$FB
+$FB
 
 # Gets the first form in the Forms property of the HTTP response object in the $R variable, and saves it in the $Form variable. 
 
-PS C:\>$Form = $R.Forms[0]
+$Form = $R.Forms[0]
 
 # Pipes the form properties that are stored in the $Forms variable into the Format-List cmdlet, to display those properties in a list. 
 
-PS C:\>$Form | Format-List
+$Form | Format-List
 
 # Displays the keys and values in the hash table (dictionary) object in the Fields property of the form.
 
-PS C:\>$Form.fields
+$Form.fields
 
 # The next two commands populate the values of the "email" and "pass" keys of the hash table in the Fields property of the form. Of course, you can replace the email and password with values that you want to use. 
 
-PS C:\>$Form.Fields["email"] = "User01@Fabrikam.com"
-PS C:\>$Form.Fields["pass"] = "P@ssw0rd"
+$Form.Fields["email"] = "User01@Fabrikam.com"
+$Form.Fields["pass"] = "P@ssw0rd"
 
 # The final command uses the Invoke-WebRequest cmdlet to sign in to the Facebook web service. 
 
-PS C:\>$R=Invoke-WebRequest -Uri ("https://www.facebook.com" + $Form.Action) -WebSession $FB -Method POST -Body $Form.Fields
+$R=Invoke-WebRequest -Uri ("https://www.facebook.com" + $Form.Action) -WebSession $FB -Method POST -Body $Form.Fields
 
 # When the command finishes, the **StatusDescription** property of the web response object in the $R variable indicates that the user is signed in successfully.
-PS C:\>$R.StatusDescription
+$R.StatusDescription
 ```
 
 This example shows how to use the **Invoke-WebRequest** cmdlet with a stateful web service, such as Facebook.
@@ -138,9 +138,9 @@ For example:
 
 ```
 PS C:\>$R = Invoke-WebRequest http://website.com/login.aspx
-PS C:\>$R.Forms[0].Name = "MyName"
-PS C:\>$R.Forms[0].Password = "MyPassword"
-PS C:\>Invoke-RestMethod http://website.com/service.aspx -Body $R
+$R.Forms[0].Name = "MyName"
+$R.Forms[0].Password = "MyPassword"
+Invoke-RestMethod http://website.com/service.aspx -Body $R
 ```
 - or -
 ```


### PR DESCRIPTION
By using triple backtick syntax it becomes unnecessary to escape special characters in monospace sections.
Using angle brackets to enclose a URL that contains parentheses assists the parser in linking the full URL.
Brought back the Explorer!