### PR TITLE
More consistency in code examples

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -45,12 +45,13 @@ This cmdlet was introduced in Windows PowerShell 3.0.
 Get the latest feeds from the PowerShell team's blog.
 
 ```PowerShell
-Invoke-RestMethod -Uri https://blogs.msdn.microsoft.com/powershell/feed/ |
+PS C:\>Invoke-RestMethod -Uri https://blogs.msdn.microsoft.com/powershell/feed/ |
     Format-Table -Property Title, PubDate
 ```
 
+Output:
 ```
-PS C:\ >Invoke-RestMethod -Uri https://blogs.msdn.microsoft.com/powershell/feed/ |
+PS C:\>Invoke-RestMethod -Uri https://blogs.msdn.microsoft.com/powershell/feed/ |
     Format-Table -Property Title, PubDate
 
 
@@ -70,7 +71,7 @@ PowerShell on Linux and Open Source!                                 Thu, 18 Aug
 
 
 
-PS C:\ >
+PS C:\>
 ```
 
 This command uses the **Invoke-RestMethod** cmdlet
@@ -111,19 +112,6 @@ $Body = @{
 Invoke-RestMethod -Method Post -Uri $url -Credential $Cred -Body $body -OutFile output.csv
 ```
 
-```
-cmdlet Get-Credential at command pipeline position 1
-
-Supply values for the following parameters:
-{"preview":true,"offset":0,"result":{"sourcetype":"contoso1","count":"9624"}}
-
-{"preview":true,"offset":1,"result":{"sourcetype":"contoso2","count":"152"}}
-
-{"preview":true,"offset":2,"result":{"sourcetype":"contoso3","count":"88494"}}
-
-{"preview":true,"offset":3,"result":{"sourcetype":"contoso4","count":"15277"}}
-```
-
 ## PARAMETERS
 
 ### -Body
@@ -140,14 +128,16 @@ When the body is a form, or it is the output of another **Invoke-WebRequest** ca
 
 For example:
 
-`$R = Invoke-WebRequest http://website.com/login.aspx`
-`$R.Forms\[0\].Name = "MyName"`
-`$R.Forms\[0\].Password = "MyPassword"`
-`Invoke-RestMethod http://website.com/service.aspx -Body $R`
-
+```
+$R = Invoke-WebRequest http://website.com/login.aspx
+$R.Forms[0].Name = "MyName"
+$R.Forms[0].Password = "MyPassword"
+Invoke-RestMethod http://website.com/service.aspx -Body $R
+```
 - or -
-
-`Invoke-RestMethod http://website.com/service.aspx -Body $R.Forms\[0\]`
+```
+Invoke-RestMethod http://website.com/service.aspx -Body $R.Forms[0]
+```
 
 ```yaml
 Type: Object
@@ -531,14 +521,16 @@ When the body is a form, or it is the output of another **Invoke-WebRequest** ca
 
 For example:
 
-`$R = Invoke-WebRequest http://website.com/login.aspx`
-`$R.Forms\[0\].Name = "MyName"`
-`$R.Forms\[0\].Password = "MyPassword"`
-`Invoke-RestMethod http://website.com/service.aspx -Body $R`
-
+```
+$R = Invoke-WebRequest http://website.com/login.aspx
+$R.Forms[0].Name = "MyName"
+$R.Forms[0].Password = "MyPassword"
+Invoke-RestMethod http://website.com/service.aspx -Body $R
+```
 - or -
-
-`Invoke-RestMethod http://website.com/service.aspx -Body $R.Forms\[0\]`
+```
+Invoke-RestMethod http://website.com/service.aspx -Body $R.Forms[0]
+```
 
 ```yaml
 Type: SwitchParameter
@@ -572,11 +564,13 @@ Specifies a user agent string for the web request.
 
 The default user agent is similar to Mozilla/5.0 (Windows NT; Windows NT 6.1; en-US) WindowsPowerShell/3.0 with slight variations for each operating system and platform.
 
-To test a website with the standard user agent string that is used by most Internet browsers, use the properties of the PSUserAgenthttp://msdn.microsoft.com/en-us/library/windows/desktop/hh484857(v=vs.85).aspx class, such as Chrome, FireFox, InternetExplorer, Opera, and Safari.
+To test a website with the standard user agent string that is used by most Internet browsers, use the properties of the [PSUserAgent](<http://msdn.microsoft.com/en-us/library/windows/desktop/hh484857(v=vs.85).aspx>) class, such as Chrome, FireFox, InternetExplorer, Opera, and Safari.
 
-For example, the following command uses the user agent string for Internet.
+For example, the following command uses the user agent string for Internet Explorer.
 
-`Invoke-WebRequest -Uri http://website.com/ -UserAgent (\[Microsoft.PowerShell.Commands.PSUserAgent\]::InternetExplorer)`
+```
+Invoke-WebRequest -Uri http://website.com/ -UserAgent ([Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer)
+```
 
 ```yaml
 Type: String


### PR DESCRIPTION
Don't syntax highlight what is only output. Avoid highlighting sections where the code ends up looking terrible. Fixed the missing Explorer in UserAgent.

Removed a large block of text that appeared to be leaked output of an invocation of Get-Credential rather than an actual intended input to the script or a human readable output.

There are still some references to Invoke-WebRequest rather than Invoke-RestMethod like in `-UserAgent`. This should also be made more consistent with the Invoke-WebRequest page regarding usage of the prompt for one-off commands and avoiding it for blocks of code/comments so that the larger examples are easier to copy and paste.