### PR TITLE
Update Get-Service 5.0

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Management/Get-Service.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-Service.md
@@ -264,7 +264,7 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Exclude
@@ -334,7 +334,7 @@ Required: False
 Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -RequiredServices


### PR DESCRIPTION
Updated name, displayname parameters - they DO accept wild cards.
This change reflects earlier changes in 5.1 content. The 3.0 and 4.0 content is correct.