### PR TITLE
Invalid propertyname

### DIFF
--- a/dsc/configData.md
+++ b/dsc/configData.md
@@ -50,7 +50,7 @@ $MyData =
 
         @{
             NodeName    = 'VM-2'
-            FeatureName = 'VMHost'
+            Role = 'VMHost'
         }
     )
 }


### PR DESCRIPTION
Changed Feature in the node hashtable to role, this should have failed when this was tested, as the nodename vm-2 had no role == vmhost.