### PR TITLE
Added line break

### DIFF
--- a/dsc/authoringResourceComposite.md
+++ b/dsc/authoringResourceComposite.md
@@ -1,3 +1,4 @@
+
 ---
 title:   Composite resources: Using a DSC configuration as a resource
 ms.date:  2016-05-16


### PR DESCRIPTION
Missing line break was causing the metadata to render as a code block, instead of getting consumed by OPS.