### PR TITLE
Revert "Add remoting requirements"

### DIFF
--- a/dsc/troubleshooting.md
+++ b/dsc/troubleshooting.md
@@ -17,7 +17,7 @@ This topic describes ways to troubleshoot DSC when problems arise.
 
 ## WinRM Dependency
 
-Windows PowerShell Desired State Configuration (DSC) depends on WinRM. WinRM is not enabled by default on Windows Server 2008 R2 and Windows 7. Run `Set-WSManQuickConfig`, in a Windows PowerShell elevated session, to enable WinRM.
+Windows PowerShell Desired State Configuration (DSC) depends on WinRM. WinRM is not enabled by default on Windows Server 2008 R2 and Windows 7. Run ```Set-WSManQuickConfig```, in a Windows PowerShell elevated session, to enable WinRM.
 
 ## Using Get-DscConfigurationStatus
 


### PR DESCRIPTION
Reverts PowerShell/PowerShell-Docs#1028
Have a feeling that rebase of this PR made the staging & live diverge after the last merge into live. 
