### PR TITLE
Markdown-aware ps1xml pages -- Example for consideration

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -30,7 +30,7 @@ extended data for types in the current session.
 
 This topic describes Types.ps1xml files. For more information about using the
 Update-TypeData cmdlet to add dynamic extended type data to the current session
-see Update-TypeData (http://go.microsoft.com/fwlink/?LinkID=113421).
+see [Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData.md).
 
 ## About Extended Type Data
 
@@ -49,14 +49,14 @@ PS C:> (Get-Date).DateTime
 Sunday, January 29, 2012 9:43:57 AM
 ```
 
-You won't find the DateTime property in the description of the System.DateTime
-structure (<http://msdn.microsoft.com/library/system.datetime.aspx>),
+You won't find the DateTime property in the description of the [System.DateTime
+structure](http://msdn.microsoft.com/library/system.datetime.aspx),
 because Windows PowerShell adds the property and it is visible only in
 Windows PowerShell.
 
 To add the DateTime property to all Windows PowerShell sessions, Windows PowerShell
 defines the DateTime property in the Types.ps1xml file in the Windows PowerShell
-installation directory (`$pshome`).
+installation directory (`$PSHOME`).
 
 Adding Extended Type Data to Windows PowerShell.
 
@@ -89,11 +89,11 @@ cmdlet.
 
 ## Built-in Types.ps1xml Files
 
-The Types.ps1xml files in the `$pshome` directory are added automatically to
+The Types.ps1xml files in the `$PSHOME` directory are added automatically to
 every session.
 
 The Types.ps1xml file in the Windows PowerShell installation directory
-(`$pshome`) is an XML-based text file that lets you add properties and
+(`$PSHOME`) is an XML-based text file that lets you add properties and
 methods to the objects that are used in Windows PowerShell. Windows
 PowerShell has built-in Types.ps1xml files that add several elements
 to the .NET Framework types, but you can create additional Types.ps1xml
@@ -132,11 +132,11 @@ The command returns the following results.
 Name           MemberType    Definition
 ----           ----------    ----------
 Count          AliasProperty Count = Length
-Address        Method        System.Object& Address(Int32 )
+Address        Method        System.Object& Address(Int32)
 Clone          Method        System.Object Clone()
 CopyTo         Method        System.Void CopyTo(Array array, Int32 index):
 Equals         Method        System.Boolean Equals(Object obj)
-Get            Method        System.Object Get(Int32 )
+Get            Method        System.Object Get(Int32)
 # ...
 ```
 
@@ -145,12 +145,12 @@ As a result, you can use either the Count property or the Length property
 of arrays in Windows PowerShell. For example:
 
 ```powershell
-C:\PS> (1, 2, 3, 4).count
+C:\PS> (1, 2, 3, 4).Count
 # 4
 ```
 
 ```powershell
-C:\PS> (1, 2, 3, 4).length
+C:\PS> (1, 2, 3, 4).Length
 # 4
 ```
 
@@ -166,7 +166,7 @@ To create a new file, start by copying an existing Types.ps1xml file. The
 new file can have any name, but it must have a .ps1xml file name
 extension. You can place the new file in any directory that is accessible
 to Windows PowerShell, but it is useful to place the files in the Windows
-PowerShell installation directory (`$pshome`) or in a subdirectory of the
+PowerShell installation directory (`$PSHOME`) or in a subdirectory of the
 installation directory.
 
 When you have saved the new file, use the Update-TypeData cmdlet to add
@@ -194,10 +194,10 @@ its creation time and the current time in days.
 
 It is easiest to use the original Types.ps1xml file as a template
 for the new file. The following command copies the original file to
-a file called `MyTypes.ps1xml` in the `$pshome` directory.
+a file called `MyTypes.ps1xml` in the `$PSHOME` directory.
 
 ```powershell
-copy-item Types.ps1xml MyTypes.ps1xml
+Copy-Item Types.ps1xml MyTypes.ps1xml
 ```
 
 Next, open the Types.ps1xml file in any XML or text editor, such
@@ -241,7 +241,7 @@ for file objects.
       <ScriptProperty>
         <Name>Age</Name>
         <GetScriptBlock>
-          ((get-date) - ($this.creationtime)).days
+          ((Get-Date) - ($this.CreationTime)).Days
         </GetScriptBlock>
       </ScriptProperty>
     </Members>
@@ -256,16 +256,16 @@ new file in a higher precedence order than the original file. (For more
 information about Update-TypeData, see Update-TypeData.)
 
 ```powershell
-update-typedata -prependpath $pshome\MyTypes.ps1xml
+Update-TypeData -PrependPath $PSHOME\MyTypes.ps1xml
 ```
 
 To test the change, run a `Get-ChildItem` command to get the
-PowerShell.exe file in the `$pshome` directory, and then pipe the file to
+PowerShell.exe file in the `$PSHOME` directory, and then pipe the file to
 the `Format-List` cmdlet to list all of the properties of the file. As a
 result of the change, the Age property appears in the list.
 
 ```powershell
-get-childitem $pshome\PowerShell.exe | format-list -property *
+Get-ChildItem $PSHOME\PowerShell.exe | Format-List -Property *
 
 PSPath            : Microsoft.PowerShell.Core\FileSystem::C:\WINDOWS...
 PSParentPath      : Microsoft.PowerShell.Core\FileSystem::C:\WINDOWS...
@@ -284,7 +284,7 @@ You can also display the Age property of the file by using the following
 command.
 
 ```powershell
-(get-childitem $pshome\PowerShell.exe).age
+(Get-ChildItem $PSHOME\PowerShell.exe).Age
 # 16
 ```
 
@@ -553,9 +553,9 @@ property of the `GetVersionInfo` static method of
 </Type>
 ```
 
-For more information, see the Windows PowerShell Software Development
-Kit (SDK) in the MSDN (Microsoft Developer Network) library
-at <http://go.microsoft.com/fwlink/?LinkId=144538>.
+For more information, see the [Windows PowerShell Software Development
+Kit (SDK) in the MSDN (Microsoft Developer Network)
+library](http://go.microsoft.com/fwlink/?LinkId=144538).
 
 ## Update-TypeData
 
@@ -591,14 +591,14 @@ a digital signature. For more information, see `about_Signing`.
 
 [about_Signing](about_Signing.md)
 
-Copy-Item (<http://go.microsoft.com/fwlink/?LinkID=113292>)
+[Copy-Item](../../Microsoft.PowerShell.Management/Copy-Item.md)
 
-Copy-ItemProperty (<http://go.microsoft.com/fwlink/?LinkID=113293>)
+[Copy-ItemProperty](../../Microsoft.PowerShell.Management/Copy-ItemProperty.md)
 
-Get-Member (<http://go.microsoft.com/fwlink/?LinkID=113322>)
+[Get-Member](../../Microsoft.PowerShell.Utility/Get-Member.md)
 
-Get-TypeData (<http://go.microsoft.com/fwlink/?LinkID=217033>)
+[Get-TypeData](../../Microsoft.PowerShell.Utility/Get-TypeData.md)
 
-Remove-TypeData (<http://go.microsoft.com/fwlink/?LinkID=217038>)
+[Remove-TypeData](../../Microsoft.PowerShell.Utility/Remove-TypeData.md)
 
-Update-TypeData (<http://go.microsoft.com/fwlink/?LinkID=113421>)
+[Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData.md)

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -13,8 +13,6 @@ ms.technology:  powershell
 # About Types.ps1xml
 ## about_Types.ps1xml
 
-
-
 # SHORT DESCRIPTION
 
 Explains how to use Types.ps1xml files to extend the types of objects
@@ -26,15 +24,15 @@ Extended type data defines additional properties and methods ("members")
 of object types in Windows PowerShell. There are two techniques for adding
 extended type data to a Windows PowerShell session.
 
--- Types.ps1xml file: An XML file that defines extended type data.
--- Update-TypeData: A cmdlet that reloads Types.ps1xml files and defines
+- Types.ps1xml file: An XML file that defines extended type data.
+- Update-TypeData: A cmdlet that reloads Types.ps1xml files and defines
 extended data for types in the current session.
 
 This topic describes Types.ps1xml files. For more information about using the
 Update-TypeData cmdlet to add dynamic extended type data to the current session
 see Update-TypeData (http://go.microsoft.com/fwlink/?LinkID=113421).
 
-About Extended Type Data
+## About Extended Type Data
 
 Extended type data defines additional properties and methods ("members")
 of object types in Windows PowerShell. You can extend any type that is
@@ -46,86 +44,91 @@ For example, Windows PowerShell adds a DateTime property to all
 System.DateTime objects, such as the ones that the Get-Date cmdlet
 returns.
 
+```powershell
 PS C:> (Get-Date).DateTime
 Sunday, January 29, 2012 9:43:57 AM
+```
 
 You won't find the DateTime property in the description of the System.DateTime
-structure (http://msdn.microsoft.com/library/system.datetime.aspx),
+structure (<http://msdn.microsoft.com/library/system.datetime.aspx>),
 because Windows PowerShell adds the property and it is visible only in
 Windows PowerShell.
 
 To add the DateTime property to all Windows PowerShell sessions, Windows PowerShell
 defines the DateTime property in the Types.ps1xml file in the Windows PowerShell
-installation directory ($pshome).
+installation directory (`$pshome`).
 
 Adding Extended Type Data to Windows PowerShell.
 
 There are three sources of extended type data in Windows PowerShell sessions.
 
---  The Types.ps1xml files in the Windows PowerShell installation directory
+-  The Types.ps1xml files in the Windows PowerShell installation directory
 are loaded automatically into every Windows PowerShell session.
-
---  The Types.ps1xml files that modules export are loaded when the module
+-  The Types.ps1xml files that modules export are loaded when the module
 is imported into the current session.
-
---  Extended type data that is defined by using the Update-TypeData cmdlet
+-  Extended type data that is defined by using the Update-TypeData cmdlet
 is added only to the current session. It is not saved in a file.
 
 In the session, the extended type data from the three sources is applied
 to objects in the same way and is available on all objects of the specified
 types.
 
-The TypeData Cmdlets
+## The TypeData Cmdlets
 
 The following TypeData cmdlets are included in the Microsoft.PowerShell.Utility
 module in Windows PowerShell 3.0 and later versions of Windows PowerShell.
 
-Get-TypeData:     Gets extended type data in the current session.
-Update-TypeData:  Reloads Types.ps1xml files. Adds extended type
-data to the current session.
-Remove-TypeData:  Removes extended type data from the current
-session.
+|              |                                                 |
+| ------------ | ----------------------------------------------- |
+| Get-TypeData |  Gets extended type data in the current session |
+| Update-TypeData |  Reloads Types.ps1xml files. Adds extended type data to the current session. |
+| Remove-TypeData |  Removes extended type data from the current session. |
 
 For more information about these cmdlets, see the help topic for each
 cmdlet.
 
-Built-in Types.ps1xml Files
+## Built-in Types.ps1xml Files
 
-The Types.ps1xml files in the $pshome directory are added automatically to
+The Types.ps1xml files in the `$pshome` directory are added automatically to
 every session.
 
 The Types.ps1xml file in the Windows PowerShell installation directory
-($pshome) is an XML-based text file that lets you add properties and
+(`$pshome`) is an XML-based text file that lets you add properties and
 methods to the objects that are used in Windows PowerShell. Windows
 PowerShell has built-in Types.ps1xml files that add several elements
 to the .NET Framework types, but you can create additional Types.ps1xml
 files to further extend the types.
 
-For example, by default, array objects (System.Array) have a Length
+For example, by default, array objects (`System.Array`) have a `Length`
 property that lists the number of objects in the array. However, because
 the name "length" does not clearly describe the property, Windows
 PowerShell adds an alias property named "Count" that displays the same
-value. The following XML adds the Count property to the System.Array type.
+value. The following XML adds the `Count` property to the `System.Array` type.
 
+```xml
 <Type>
-<Name>System.Array</Name>
-<Members>
-<AliasProperty>
-<Name>Count</Name>
-<ReferencedMemberName>
-Length
-</ReferencedMemberName>
-</AliasProperty>
-</Members>
+  <Name>System.Array</Name>
+  <Members>
+    <AliasProperty>
+      <Name>Count</Name>
+      <ReferencedMemberName>
+        Length
+      </ReferencedMemberName>
+    </AliasProperty>
+  </Members>
 </Type>
+```
 
-To get the new AliasProperty, use a Get-Member command on any array, as shown
+To get the new `AliasProperty`, use a `Get-Member` command on any array, as shown
 in the following example.
 
+```powershell
 Get-Member -inputobject (1,2,3,4)
+```
 
 The command returns the following results.
 
+```powershell
 Name           MemberType    Definition
 ----           ----------    ----------
 Count          AliasProperty Count = Length
@@ -135,20 +138,23 @@ CopyTo         Method        System.Void CopyTo(Array array, Int32 index):
 Equals         Method        System.Boolean Equals(Object obj)
 Get            Method        System.Object Get(Int32 )
 # ...
+```
 
 
 As a result, you can use either the Count property or the Length property
 of arrays in Windows PowerShell. For example:
 
+```powershell
 C:\PS> (1, 2, 3, 4).count
 # 4
+```
 
-
+```powershell
 C:\PS> (1, 2, 3, 4).length
 # 4
+```
 
-
-Creating New Types.ps1xml Files
+## Creating New Types.ps1xml Files
 
 The .ps1xml files that are installed with Windows PowerShell are
 digitally signed to prevent tampering because the formatting can include
@@ -160,7 +166,7 @@ To create a new file, start by copying an existing Types.ps1xml file. The
 new file can have any name, but it must have a .ps1xml file name
 extension. You can place the new file in any directory that is accessible
 to Windows PowerShell, but it is useful to place the files in the Windows
-PowerShell installation directory ($pshome) or in a subdirectory of the
+PowerShell installation directory (`$pshome`) or in a subdirectory of the
 installation directory.
 
 When you have saved the new file, use the Update-TypeData cmdlet to add
@@ -171,85 +177,94 @@ Update-TypeData affects only the current session. To make the change to
 all future sessions, export the console, or add the Update-TypeData
 command to your Windows PowerShell profile.
 
-Types.ps1xml and Add-Member
+## Types.ps1xml and Add-Member
 
 The Types.ps1xml files add properties and methods to all the instances
 of the objects of the specified .NET Framework type in the affected
 Windows PowerShell session. However, if you need to add properties or
 methods only to one instance of an object, use the Add-Member cmdlet.
 
-For more information,see Add-Member.
+For more information, see `Add-Member`.
 
-Example: Adding an Age Member to FileInfo Objects
+## Example: Adding an Age Member to FileInfo Objects
 
 This example shows how to add an Age property to file objects
-(System.IO.FileInfo). The age of a file is the difference between
+(`System.IO.FileInfo`). The age of a file is the difference between
 its creation time and the current time in days.
 
 It is easiest to use the original Types.ps1xml file as a template
 for the new file. The following command copies the original file to
-a file called MyTypes.ps1xml in the $pshome directory.
+a file called `MyTypes.ps1xml` in the `$pshome` directory.
 
+```powershell
 copy-item Types.ps1xml MyTypes.ps1xml
+```
 
 Next, open the Types.ps1xml file in any XML or text editor, such
 as Notepad. Because the Age property is calculated by using a script
-block, find a <ScriptProperty> tag to use as a model for the new Age
+block, find a `<ScriptProperty>` tag to use as a model for the new Age
 property.
 
-Copy the XML between the <Type> and </Type> tags of the code to create
+Copy the XML between the `<Type>` and `</Type>` tags of the code to create
 the script property. Then, delete the remainder of the file, except for
-the opening <?xml> and <Types> tags and the closing </Types> tag. You
+the opening `<?xml>` and `<Types>` tags and the closing `</Types>` tag. You
 must also delete the digital signature to prevent errors.
 
 Begin with the model script property, such as the following script
 property, which was copied from the original Types.ps1xml file.
 
+```xml
 <?xml version="1.0" encoding="utf-8" ?>
 <Types>
-<Type>
-<Name>System.Guid</Name>
-<Members>
-<ScriptProperty>
-<Name>Guid</Name>
-<GetScriptBlock>$this.ToString()</GetScriptBlock>
-</ScriptProperty>
-</Members>
-</Type>
+  <Type>
+    <Name>System.Guid</Name>
+    <Members>
+      <ScriptProperty>
+        <Name>Guid</Name>
+        <GetScriptBlock>$this.ToString()</GetScriptBlock>
+      </ScriptProperty>
+    </Members>
+  </Type>
 </Types>
+```
 
 Then, change the name of the .NET Framework type, the name of the
 property, and the value of the script block to create an Age property
 for file objects.
 
+```xml
 <?xml version="1.0" encoding="utf-8" ?>
 <Types>
-<Type>
-<Name>System.IO.FileInfo</Name>
-<Members>
-<ScriptProperty>
-<Name>Age</Name>
-<GetScriptBlock>
-((get-date) - ($this.creationtime)).days
-</GetScriptBlock>
-</ScriptProperty>
-</Members>
-</Type>
+  <Type>
+    <Name>System.IO.FileInfo</Name>
+    <Members>
+      <ScriptProperty>
+        <Name>Age</Name>
+        <GetScriptBlock>
+          ((get-date) - ($this.creationtime)).days
+        </GetScriptBlock>
+      </ScriptProperty>
+    </Members>
+  </Type>
 </Types>
+```
 
-After you save the file and close it, run an Update-TypeData command,
+After you save the file and close it, run an `Update-TypeData` command,
 such as the following command, to add the new Types.ps1xml file to the
 current session. The command uses the PrependData parameter to place the
 new file in a higher precedence order than the original file. (For more
 information about Update-TypeData, see Update-TypeData.)
 
+```powershell
 update-typedata -prependpath $pshome\MyTypes.ps1xml
+```
 
-To test the change, run a Get-ChildItem command to get the
-PowerShell.exe file in the $pshome directory, and then pipe the file to
-the Format-List cmdlet to list all of the properties of the file. As a
+To test the change, run a `Get-ChildItem` command to get the
+PowerShell.exe file in the `$pshome` directory, and then pipe the file to
+the `Format-List` cmdlet to list all of the properties of the file. As a
 result of the change, the Age property appears in the list.
 
+```powershell
 get-childitem $pshome\PowerShell.exe | format-list -property *
 
 PSPath            : Microsoft.PowerShell.Core\FileSystem::C:\WINDOWS...
@@ -263,310 +278,327 @@ VersionInfo       : File:             C:\WINDOWS\system32\WindowsPow...
 InternalName:     POWERSHELL
 OriginalFilename: PowerShell.EXE
 # ...
-
+```
 
 You can also display the Age property of the file by using the following
 command.
 
+```powershell
 (get-childitem $pshome\PowerShell.exe).age
 # 16
+```
 
+## The XML in Types.ps1xml Files
 
-The XML in Types.ps1xml Files
-
-The <Types> tag encloses all of the types that are defined in the file.
-There should be only one pair of <Types> tags.
+The `<Types>` tag encloses all of the types that are defined in the file.
+There should be only one pair of `<Types>` tags.
 
 Each .NET Framework type mentioned in the file should be represented by
-a pair of <Type> tags.
+a pair of `<Type>` tags.
 
 The type tags must contain the following tags:
 
-<Name>: A pair of <Name> tags that enclose the name of the affected
+`<Name>`: A pair of `<Name>` tags that enclose the name of the affected
 .NET Framework type.
 
-<Members>: A pair of <Members> tags that enclose the tags for the
+`<Members>`: A pair of <Members> tags that enclose the tags for the
 new properties and methods that are defined for the
 .NET Framework type.
 
 Any of the following member tags can be inside the <Members> tags.
 
-<AliasProperty>: Defines a new name for an existing property.
+`<AliasProperty>`: Defines a new name for an existing property.
 
-The <AliasProperty> tag must have a pair of <Name> tags that specify
+The `<AliasProperty>` tag must have a pair of <Name> tags that specify
 the name of the new property and a pair of <ReferencedMemberName> tags
 that specify the existing property.
 
-For example, the Count alias property is an alias for the Length
+For example, the `Count` alias property is an alias for the `Length`
 property of array objects.
 
+```xml
 <Type>
-<Name>System.Array</Name>
-<Members>
-<AliasProperty>
-<Name>Count</Name>
-<ReferencedMemberName>Length</ReferencedMemberName>
-</AliasProperty>
-</Members>
+  <Name>System.Array</Name>
+  <Members>
+    <AliasProperty>
+      <Name>Count</Name>
+      <ReferencedMemberName>Length</ReferencedMemberName>
+    </AliasProperty>
+  </Members>
 </Type>
+```
 
-<CodeMethod>:  References a static method of a .NET Framework class.
+`<CodeMethod>`:  References a static method of a .NET Framework class.
 
-The <CodeMethod> tag must have a pair of <Name> tags that specify
-the name of the new method and a pair of <GetCodeReference> tags
+The `<CodeMethod>` tag must have a pair of `<Name>` tags that specify
+the name of the new method and a pair of `<GetCodeReference>` tags
 that specify the code in which the method is defined.
 
-For example, the Mode property of directories (System.IO.DirectoryInfo
+For example, the `Mode` property of directories (`System.IO.DirectoryInfo`
 objects) is a code property defined in the Windows PowerShell
 FileSystem provider.
 
+```xml
 <Type>
-<Name>System.IO.DirectoryInfo</Name>
-<Members>
-<CodeProperty>
-<Name>Mode</Name>
-<GetCodeReference>
-<TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
-<MethodName>Mode</MethodName>
-</GetCodeReference>
-</CodeProperty>
-</Members>
+  <Name>System.IO.DirectoryInfo</Name>
+  <Members>
+    <CodeProperty>
+      <Name>Mode</Name>
+      <GetCodeReference>
+        <TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
+        <MethodName>Mode</MethodName>
+      </GetCodeReference>
+    </CodeProperty>
+  </Members>
 </Type>
+```
 
-<CodeProperty>: References a static method of a .NET Framework class.
+`<CodeProperty>`: References a static method of a .NET Framework class.
 
-The <CodeProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <GetCodeReference> tags
+The `<CodeProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<GetCodeReference>` tags
 that specify the code in which the property is defined.
 
-For example, the Mode property of directories (System.IO.DirectoryInfo
+For example, the `Mode` property of directories (`System.IO.DirectoryInfo`
 objects) is a code property defined in the Windows PowerShell
 FileSystem provider.
 
+```xml
 <Type>
-<Name>System.IO.DirectoryInfo</Name>
-<Members>
-<CodeProperty>
-<Name>Mode</Name>
-<GetCodeReference>
-<TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
-<MethodName>Mode</MethodName>
-</GetCodeReference>
-</CodeProperty>
-</Members>
+  <Name>System.IO.DirectoryInfo</Name>
+  <Members>
+    <CodeProperty>
+      <Name>Mode</Name>
+      <GetCodeReference>
+        <TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
+        <MethodName>Mode</MethodName>
+      </GetCodeReference>
+    </CodeProperty>
+  </Members>
 </Type>
+```
 
-<MemberSet>: Defines a collection of members (properties and methods).
+`<MemberSet>`: Defines a collection of members (properties and methods).
 
-The <MemberSet> tags appear within the primary <Members> tags. The
-tags must enclose a pair of <Name> tags surrounding the name of the
-member set and a pair of secondary <Members> tags that surround the
+The `<MemberSet>` tags appear within the primary `<Members>` tags. The
+tags must enclose a pair of `<Name>` tags surrounding the name of the
+member set and a pair of secondary `<Members>` tags that surround the
 members (properties and methods) in the set. Any of the tags that
-create a property (such as <NoteProperty> or <ScriptProperty>) or a
-method (such as <Method> or <ScriptMethod>) can be members of the set.
+create a property (such as `<NoteProperty>` or `<ScriptProperty>`) or a
+method (such as `<Method>` or `<ScriptMethod>`) can be members of the set.
 
-In Types.ps1xml files, the <MemberSet> tag is used to define the
+In Types.ps1xml files, the `<MemberSet>` tag is used to define the
 default views of the .NET Framework objects in Windows PowerShell. In
-this case, the name of the member set (the value within the <Name>
+this case, the name of the member set (the value within the `<Name>`
 tags) is always "PsStandardMembers", and the names of the properties
-(the value of the <Name> tag) are one of the following:
+(the value of the `<Name>` tag) are one of the following:
 
-- DefaultDisplayProperty: A single property of an object.
-
-- DefaultDisplayPropertySet: One or more properties of an object.
-
-- DefaultKeyPropertySet: One or more key properties of an object.
+- `DefaultDisplayProperty`: A single property of an object.
+- `DefaultDisplayPropertySet`: One or more properties of an object.
+- `DefaultKeyPropertySet`: One or more key properties of an object.
 A key property identifies instances of property values, such as
 the ID number of items in a session history.
 
 For example, the following XML defines the default display of services
-(System.ServiceProcess.ServiceController objects) that are returned by
-the Get-Service cmdlet. It defines a member set named
+(`System.ServiceProcess.ServiceController` objects) that are returned by
+the `Get-Service` cmdlet. It defines a member set named
 "PsStandardMembers" that consists of a default property set with the
-Status, Name, and DisplayName properties.
+`Status`, `Name`, and `DisplayName` properties.
 
+```xml
 <Type>
-<Name>System.ServiceProcess.ServiceController</Name>
-<Members>
-<MemberSet>
-<Name>PSStandardMembers</Name>
-<Members>
-<PropertySet>
-<Name>DefaultDisplayPropertySet</Name>
-<ReferencedProperties>
-<Name>Status</Name>
-<Name>Name</Name>
-<Name>DisplayName</Name>
-</ReferencedProperties>
-</PropertySet>
-</Members>
-</MemberSet>
-</Members>
+  <Name>System.ServiceProcess.ServiceController</Name>
+  <Members>
+    <MemberSet>
+      <Name>PSStandardMembers</Name>
+      <Members>
+        <PropertySet>
+          <Name>DefaultDisplayPropertySet</Name>
+          <ReferencedProperties>
+            <Name>Status</Name>
+            <Name>Name</Name>
+            <Name>DisplayName</Name>
+          </ReferencedProperties>
+        </PropertySet>
+      </Members>
+    </MemberSet>
+  </Members>
 </Type>
+```
 
-<Method>: References a native method of the underlying object.
+`<Method>`: References a native method of the underlying object.
 
-<Methods>: A collection of the methods of the object.
+`<Methods>`: A collection of the methods of the object.
 
-<NoteProperty>: Defines a property with a static value.
+`<NoteProperty>`: Defines a property with a static value.
 
-The <NoteProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <Value> tags that specify
+The `<NoteProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<Value>` tags that specify
 the value of the property.
 
-For example, the following XML creates a Status property for
-directories (System.IO.DirectoryInfo objects). The value of the
-Status property is always "Success".
+For example, the following XML creates a `Status` property for
+directories (`System.IO.DirectoryInfo` objects). The value of the
+`Status` property is always "Success".
 
+```xml
 <Type>
-<Name>System.IO.DirectoryInfo</Name>
-<Members>
-<NoteProperty>
-<Name>Status</Name>
-<Value>Success</Value>
-</NoteProperty>
-</Members>
+  <Name>System.IO.DirectoryInfo</Name>
+  <Members>
+    <NoteProperty>
+      <Name>Status</Name>
+      <Value>Success</Value>
+    </NoteProperty>
+  </Members>
 </Type>
+```
 
-<ParameterizedProperty>: Properties that take arguments and return a
+`<ParameterizedProperty>`: Properties that take arguments and return a
 value.
 
-<Properties>: A collection of the properties of the object.
+`<Properties>`: A collection of the properties of the object.
 
-<Property>: A property of the base object.
+`<Property>`: A property of the base object.
 
-<PropertySet>: Defines a collection of properties of the object.
+`<PropertySet>`: Defines a collection of properties of the object.
 
-The <PropertySet> tag must have a pair of <Name> tags that specify
-the name of the property set and a pair of <ReferencedProperty> tags
+The `<PropertySet>` tag must have a pair of `<Name>` tags that specify
+the name of the property set and a pair of `<ReferencedProperty>` tags
 that specify the properties. The names of the properties are enclosed
-in <Name> tag pairs.
+in `<Name>` tag pairs.
 
-In Types.ps1xml, <PropertySet> tags are used to define sets of
+In Types.ps1xml, `<PropertySet>` tags are used to define sets of
 properties for the default display of an object. You can identify the
-default displays by the value "PsStandardMembers" in the <Name> tag
-of a <MemberSet> tag.
+default displays by the value "PsStandardMembers" in the `<Name>` tag
+of a `<MemberSet>` tag.
 
-For example, the following XML creates a Status property for
-directories (System.IO.DirectoryInfo objects). The value of the Status
+For example, the following XML creates a `Status` property for
+directories (`System.IO.DirectoryInfo` objects). The value of the `Status`
 property is always "Success".
 
+```xml
 <Type>
-<Name>System.ServiceProcess.ServiceController</Name>
-<Members>
-<MemberSet>
-<Name>PSStandardMembers</Name>
-<Members>
-<PropertySet>
-<Name>DefaultDisplayPropertySet</Name>
-<ReferencedProperties>
-<Name>Status</Name
-<Name>Name</Name>
-<Name>DisplayName</Name>
-</ReferencedProperties>
-</PropertySet>
-<Members>
-<MemberSet>
-<Members>
-<Type>
+  <Name>System.ServiceProcess.ServiceController</Name>
+  <Members>
+    <MemberSet>
+      <Name>PSStandardMembers</Name>
+      <Members>
+        <PropertySet>
+          <Name>DefaultDisplayPropertySet</Name>
+          <ReferencedProperties>
+            <Name>Status</Name>
+            <Name>Name</Name>
+            <Name>DisplayName</Name>
+          </ReferencedProperties>
+        </PropertySet>
+      </Members>
+    </MemberSet>
+  </Members>
+</Type>
+```
 
-<ScriptMethod>: Defines a method whose value is the output of a script.
+`<ScriptMethod>`: Defines a method whose value is the output of a script.
 
-The <ScriptMethod> tag must have a pair of <Name> tags that specify
-the name of the new method and a pair of <Script> tags that enclose
+The `<ScriptMethod>` tag must have a pair of `<Name>` tags that specify
+the name of the new method and a pair of `<Script>` tags that enclose
 the script block that returns the method result.
 
-For example, the ConvertToDateTime and ConvertFromDateTime methods of
-management objects (System.System.Management.ManagementObject) are
-script methods that use the ToDateTime and ToDmtfDateTime static
-methods of the System.Management.ManagementDateTimeConverter class.
+For example, the `ConvertToDateTime` and `ConvertFromDateTime` methods of
+management objects (`System.System.Management.ManagementObject`) are
+script methods that use the `ToDateTime` and `ToDmtfDateTime` static
+methods of the `System.Management.ManagementDateTimeConverter` class.
 
+```xml
 <Type>
-<Name>System.Management.ManagementObject</Name>
-<Members>
-<ScriptMethod>
-<Name>ConvertToDateTime</Name>
-<Script>
-[System.Management.ManagementDateTimeConverter]::ToDateTime($args[0])
-</Script>
-</ScriptMethod>
-<ScriptMethod>
-<Name>ConvertFromDateTime</Name>
-<Script>
-[System.Management.ManagementDateTimeConverter]::ToDmtfDateTime($args[0])
-</Script>
-</ScriptMethod>
-</Members>
+  <Name>System.Management.ManagementObject</Name>
+  <Members>
+    <ScriptMethod>
+      <Name>ConvertToDateTime</Name>
+      <Script>
+        [System.Management.ManagementDateTimeConverter]::ToDateTime($args[0])
+      </Script>
+    </ScriptMethod>
+    <ScriptMethod>
+      <Name>ConvertFromDateTime</Name>
+      <Script>
+        [System.Management.ManagementDateTimeConverter]::ToDmtfDateTime($args[0])
+      </Script>
+    </ScriptMethod>
+  </Members>
 </Type>
+```
 
-<ScriptProperty>: Defines a property whose value is the output of a
+`<ScriptProperty>`: Defines a property whose value is the output of a
 script.
 
-The <ScriptProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <GetScriptBlock> tags
+The `<ScriptProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<GetScriptBlock>` tags
 that enclose the script block that returns the property value.
 
-For example, the VersionInfo property of files (System.IO.FileInfo
-objects) is a script property that results from using the FullName
-property of the GetVersionInfo static method of
-System.Diagnostics.FileVersionInfo objects.
+For example, the `VersionInfo` property of files (`System.IO.FileInfo`
+objects) is a script property that results from using the `FullName`
+property of the `GetVersionInfo` static method of
+`System.Diagnostics.FileVersionInfo` objects.
 
+```xml
 <Type>
-<Name>System.IO.FileInfo</Name>
-<Members>
-<ScriptProperty>
-<Name>VersionInfo</Name>
-<GetScriptBlock>
-[System.Diagnostics.FileVersionInfo]::GetVersionInfo($this.FullName)
-</GetScriptBlock>
-</ScriptProperty>
-</Members>
+  <Name>System.IO.FileInfo</Name>
+  <Members>
+    <ScriptProperty>
+      <Name>VersionInfo</Name>
+      <GetScriptBlock>
+        [System.Diagnostics.FileVersionInfo]::GetVersionInfo($this.FullName)
+      </GetScriptBlock>
+    </ScriptProperty>
+  </Members>
 </Type>
+```
 
 For more information, see the Windows PowerShell Software Development
-Kit (SDK) in the MSDN (Microsoft Developer Network )library
-at http://go.microsoft.com/fwlink/?LinkId=144538.
+Kit (SDK) in the MSDN (Microsoft Developer Network) library
+at <http://go.microsoft.com/fwlink/?LinkId=144538>.
 
-Update-TypeData
+## Update-TypeData
 
 To load your Types.ps1xml files into a Windows PowerShell session, run
-the Update-TypeData cmdlet. If you want the types in your file to take
+the `Update-TypeData` cmdlet. If you want the types in your file to take
 precedence over types in the built-in Types.ps1xml file, add the
-PrependData parameter of Update-TypeData. Update-TypeData affects only
+`PrependData` parameter of `Update-TypeData`. `Update-TypeData` affects only
 the current session. To make the change to all future sessions, export
-the session, or add the Update-TypeData command to your Windows
+the session, or add the `Update-TypeData` command to your Windows
 PowerShell profile.
 
 Exceptions that occur in properties, or from adding properties to an
-Update-TypeData command, do not report errors to StdErr. This is to
+`Update-TypeData` command, do not report errors to `StdErr`. This is to
 suppress exceptions that would occur in many common types during formatting
 and outputting. If you are getting .NET Framework properties, you can work
 around the suppression of exceptions by using method syntax instead, as
 shown in the following example:
 
+```powershell
 "hello".get_Length()
+```
 
 Note that method syntax can only be used with .NET Framework properties.
-Properties that are added by running the Update-TypeData cmdlet cannot
+Properties that are added by running the `Update-TypeData` cmdlet cannot
 use method syntax.
 
-Signing a Types.ps1xml File
+## Signing a Types.ps1xml File
 
 To protect users of your Types.ps1xml file, you can sign the file using
-a digital signature. For more information, see about_Signing.
+a digital signature. For more information, see `about_Signing`.
 
 # SEE ALSO
 
 [about_Signing](about_Signing.md)
 
-Copy-Item (http://go.microsoft.com/fwlink/?LinkID=113292)
+Copy-Item (<http://go.microsoft.com/fwlink/?LinkID=113292>)
 
-Copy-ItemProperty (http://go.microsoft.com/fwlink/?LinkID=113293)
+Copy-ItemProperty (<http://go.microsoft.com/fwlink/?LinkID=113293>)
 
-Get-Member (http://go.microsoft.com/fwlink/?LinkID=113322)
+Get-Member (<http://go.microsoft.com/fwlink/?LinkID=113322>)
 
-Get-TypeData (http://go.microsoft.com/fwlink/?LinkID=217033)
+Get-TypeData (<http://go.microsoft.com/fwlink/?LinkID=217033>)
 
-Remove-TypeData (http://go.microsoft.com/fwlink/?LinkID=217038)
+Remove-TypeData (<http://go.microsoft.com/fwlink/?LinkID=217038>)
 
-Update-TypeData (http://go.microsoft.com/fwlink/?LinkID=113421)
+Update-TypeData (<http://go.microsoft.com/fwlink/?LinkID=113421>)

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -49,7 +49,7 @@ PS C:> (Get-Date).DateTime
 Sunday, January 29, 2012 9:43:57 AM
 ```
 
-You won't find the DateTime property in the description of the [System.DateTime
+You won't find the DateTime property in the description of the [`System.DateTime`
 structure](http://msdn.microsoft.com/library/system.datetime.aspx),
 because Windows PowerShell adds the property and it is visible only in
 Windows PowerShell.

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -25,7 +25,7 @@ of object types in Windows PowerShell. There are two techniques for adding
 extended type data to a Windows PowerShell session.
 
 - Types.ps1xml file: An XML file that defines extended type data.
-- Update-TypeData: A cmdlet that reloads Types.ps1xml files and defines
+- `Update-TypeData`: A cmdlet that reloads Types.ps1xml files and defines
 extended data for types in the current session.
 
 This topic describes Types.ps1xml files. For more information about using the
@@ -177,7 +177,7 @@ Update-TypeData affects only the current session. To make the change to
 all future sessions, export the console, or add the Update-TypeData
 command to your Windows PowerShell profile.
 
-## Types.ps1xml and Add-Member
+## Types.ps1xml and `Add-Member`
 
 The Types.ps1xml files add properties and methods to all the instances
 of the objects of the specified .NET Framework type in the affected
@@ -186,7 +186,7 @@ methods only to one instance of an object, use the Add-Member cmdlet.
 
 For more information, see `Add-Member`.
 
-## Example: Adding an Age Member to FileInfo Objects
+## Example: Adding an `Age` Member to `FileInfo` Objects
 
 This example shows how to add an Age property to file objects
 (`System.IO.FileInfo`). The age of a file is the difference between

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -27,7 +27,7 @@ of object types in Windows PowerShell. There are two techniques for adding
 extended type data to a Windows PowerShell session.
 
 - Types.ps1xml file: An XML file that defines extended type data.
-- Update-TypeData: A cmdlet that reloads Types.ps1xml files and defines
+- `Update-TypeData`: A cmdlet that reloads Types.ps1xml files and defines
 extended data for types in the current session.
 
 This topic describes Types.ps1xml files. For more information about using the
@@ -105,7 +105,7 @@ files to further extend the types.
 
 For example, by default, array objects (`System.Array`) have a `Length`
 property that lists the number of objects in the array. However, because
-the name "length" does not clearly describe the property, Windows
+the name "Length" does not clearly describe the property, Windows
 PowerShell adds an alias property named "Count" that displays the same
 value. The following XML adds the `Count` property to the `System.Array` type.
 
@@ -181,7 +181,7 @@ use the `PrependData` parameter of the `Update-TypeData` cmdlet.
 all future sessions, export the console, or add the `Update-TypeData`
 command to your Windows PowerShell profile.
 
-## Types.ps1xml and Add-Member
+## Types.ps1xml and `Add-Member`
 
 The Types.ps1xml files add properties and methods to all the instances
 of the objects of the specified .NET Framework type in the affected
@@ -190,7 +190,7 @@ methods only to one instance of an object, use the `Add-Member` cmdlet.
 
 For more information, see [Add-Member](../../Microsoft.PowerShell.Utility/Add-Member.md).
 
-## Example: Adding an Age Member to FileInfo Objects
+## Example: Adding an `Age` Member to `FileInfo` Objects
 
 This example shows how to add an Age property to file objects
 (`System.IO.FileInfo`). The age of a file is the difference between
@@ -564,7 +564,7 @@ For more information, see the [Windows PowerShell Software Development
 Kit (SDK) in the MSDN (Microsoft Developer Network)
 library](http://go.microsoft.com/fwlink/?LinkId=144538).
 
-## Update-TypeData
+## `Update-TypeData`
 
 To load your Types.ps1xml files into a Windows PowerShell session, run
 the `Update-TypeData` cmdlet. If you want the types in your file to take

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -26,15 +26,15 @@ Extended type data defines additional properties and methods ("members")
 of object types in Windows PowerShell. There are two techniques for adding
 extended type data to a Windows PowerShell session.
 
--- Types.ps1xml file: An XML file that defines extended type data.
--- Update-TypeData: A cmdlet that reloads Types.ps1xml files and defines
+- Types.ps1xml file: An XML file that defines extended type data.
+- Update-TypeData: A cmdlet that reloads Types.ps1xml files and defines
 extended data for types in the current session.
 
 This topic describes Types.ps1xml files. For more information about using the
-Update-TypeData cmdlet to add dynamic extended type data to the current session
-see Update-TypeData (http://go.microsoft.com/fwlink/?LinkID=113421).
+`Update-TypeData` cmdlet to add dynamic extended type data to the current session
+see [Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData.md).
 
-About Extended Type Data
+## About Extended Type Data
 
 Extended type data defines additional properties and methods ("members")
 of object types in Windows PowerShell. You can extend any type that is
@@ -42,113 +42,123 @@ supported by Windows PowerShell and use the added properties and methods
 in the same way that you use the properties that are defined on the object
 types.
 
-For example, Windows PowerShell adds a DateTime property to all
-System.DateTime objects, such as the ones that the Get-Date cmdlet
+For example, Windows PowerShell adds a `DateTime` property to all
+`System.DateTime` objects, such as the ones that the `Get-Date` cmdlet
 returns.
 
+```powershell
 PS C:> (Get-Date).DateTime
 Sunday, January 29, 2012 9:43:57 AM
+```
 
-You won't find the DateTime property in the description of the System.DateTime
-structure (http://msdn.microsoft.com/library/system.datetime.aspx),
+You won't find the DateTime property in the description of the [`System.DateTime`
+structure](http://msdn.microsoft.com/library/system.datetime.aspx),
 because Windows PowerShell adds the property and it is visible only in
 Windows PowerShell.
 
 To add the DateTime property to all Windows PowerShell sessions, Windows PowerShell
 defines the DateTime property in the Types.ps1xml file in the Windows PowerShell
-installation directory ($pshome).
+installation directory (`$PSHOME`).
 
-Adding Extended Type Data to Windows PowerShell.
+## Adding Extended Type Data to Windows PowerShell.
 
 There are three sources of extended type data in Windows PowerShell sessions.
 
---  The Types.ps1xml files in the Windows PowerShell installation directory
+-  The Types.ps1xml files in the Windows PowerShell installation directory
 are loaded automatically into every Windows PowerShell session.
 
---  The Types.ps1xml files that modules export are loaded when the module
+-  The Types.ps1xml files that modules export are loaded when the module
 is imported into the current session.
 
---  Extended type data that is defined by using the Update-TypeData cmdlet
+-  Extended type data that is defined by using the `Update-TypeData` cmdlet
 is added only to the current session. It is not saved in a file.
 
 In the session, the extended type data from the three sources is applied
 to objects in the same way and is available on all objects of the specified
 types.
 
-The TypeData Cmdlets
+## The TypeData Cmdlets
 
 The following TypeData cmdlets are included in the Microsoft.PowerShell.Utility
 module in Windows PowerShell 3.0 and later versions of Windows PowerShell.
 
-Get-TypeData:     Gets extended type data in the current session.
-Update-TypeData:  Reloads Types.ps1xml files. Adds extended type
-data to the current session.
-Remove-TypeData:  Removes extended type data from the current
-session.
+|                 |                                                      |
+| --------------- | ---------------------------------------------------  |
+| Get-TypeData    | Gets extended type data in the current session.      |
+| Update-TypeData | Reloads Types.ps1xml files. Adds extended type data to the current session. |
+| Remove-TypeData | Removes extended type data from the current session. |
 
 For more information about these cmdlets, see the help topic for each
 cmdlet.
 
-Built-in Types.ps1xml Files
+## Built-in Types.ps1xml Files
 
-The Types.ps1xml files in the $pshome directory are added automatically to
+The Types.ps1xml files in the `$PSHOME` directory are added automatically to
 every session.
 
 The Types.ps1xml file in the Windows PowerShell installation directory
-($pshome) is an XML-based text file that lets you add properties and
+(`$PSHOME`) is an XML-based text file that lets you add properties and
 methods to the objects that are used in Windows PowerShell. Windows
 PowerShell has built-in Types.ps1xml files that add several elements
 to the .NET Framework types, but you can create additional Types.ps1xml
 files to further extend the types.
 
-For example, by default, array objects (System.Array) have a Length
+For example, by default, array objects (`System.Array`) have a `Length`
 property that lists the number of objects in the array. However, because
 the name "length" does not clearly describe the property, Windows
 PowerShell adds an alias property named "Count" that displays the same
-value. The following XML adds the Count property to the System.Array type.
+value. The following XML adds the `Count` property to the `System.Array` type.
 
+```xml
 <Type>
-<Name>System.Array</Name>
-<Members>
-<AliasProperty>
-<Name>Count</Name>
-<ReferencedMemberName>
-Length
-</ReferencedMemberName>
-</AliasProperty>
-</Members>
+  <Name>System.Array</Name>
+  <Members>
+    <AliasProperty>
+      <Name>Count</Name>
+      <ReferencedMemberName>
+        Length
+      </ReferencedMemberName>
+    </AliasProperty>
+  </Members>
 </Type>
+```
 
-To get the new AliasProperty, use a Get-Member command on any array, as shown
+To get the new `AliasProperty`, use a `Get-Member` command on any array, as shown
 in the following example.
 
-Get-Member -inputobject (1,2,3,4)
+```powershell
+Get-Member -InputObject (1,2,3,4)
+```
 
 The command returns the following results.
 
+```powershell
 Name           MemberType    Definition
 ----           ----------    ----------
 Count          AliasProperty Count = Length
-Address        Method        System.Object& Address(Int32 )
+Address        Method        System.Object& Address(Int32)
 Clone          Method        System.Object Clone()
 CopyTo         Method        System.Void CopyTo(Array array, Int32 index):
 Equals         Method        System.Boolean Equals(Object obj)
-Get            Method        System.Object Get(Int32 )
+Get            Method        System.Object Get(Int32)
 # ...
+```
 
 
-As a result, you can use either the Count property or the Length property
+As a result, you can use either the `Count` property or the `Length` property
 of arrays in Windows PowerShell. For example:
 
-C:\PS> (1, 2, 3, 4).count
+```powershell
+C:\PS> (1, 2, 3, 4).Count
 # 4
+```
 
-
-C:\PS> (1, 2, 3, 4).length
+```powershell
+C:\PS> (1, 2, 3, 4).Length
 # 4
+```
 
-
-Creating New Types.ps1xml Files
+## Creating New Types.ps1xml Files
 
 The .ps1xml files that are installed with Windows PowerShell are
 digitally signed to prevent tampering because the formatting can include
@@ -160,97 +170,107 @@ To create a new file, start by copying an existing Types.ps1xml file. The
 new file can have any name, but it must have a .ps1xml file name
 extension. You can place the new file in any directory that is accessible
 to Windows PowerShell, but it is useful to place the files in the Windows
-PowerShell installation directory ($pshome) or in a subdirectory of the
+PowerShell installation directory (`$PSHOME`) or in a subdirectory of the
 installation directory.
 
-When you have saved the new file, use the Update-TypeData cmdlet to add
+When you have saved the new file, use the `Update-TypeData` cmdlet to add
 the new file to your Windows PowerShell session. If you want your types
 to take precedence over the types that are defined in the built-in file,
-use the PrependData parameter of the Update-TypeData cmdlet.
-Update-TypeData affects only the current session. To make the change to
-all future sessions, export the console, or add the Update-TypeData
+use the `PrependData` parameter of the `Update-TypeData` cmdlet.
+`Update-TypeData` affects only the current session. To make the change to
+all future sessions, export the console, or add the `Update-TypeData`
 command to your Windows PowerShell profile.
 
-Types.ps1xml and Add-Member
+## Types.ps1xml and Add-Member
 
 The Types.ps1xml files add properties and methods to all the instances
 of the objects of the specified .NET Framework type in the affected
 Windows PowerShell session. However, if you need to add properties or
-methods only to one instance of an object, use the Add-Member cmdlet.
+methods only to one instance of an object, use the `Add-Member` cmdlet.
 
-For more information,see Add-Member.
+For more information, see [Add-Member](../../Microsoft.PowerShell.Utility/Add-Member.md).
 
-Example: Adding an Age Member to FileInfo Objects
+## Example: Adding an Age Member to FileInfo Objects
 
 This example shows how to add an Age property to file objects
-(System.IO.FileInfo). The age of a file is the difference between
+(`System.IO.FileInfo`). The age of a file is the difference between
 its creation time and the current time in days.
 
 It is easiest to use the original Types.ps1xml file as a template
 for the new file. The following command copies the original file to
-a file called MyTypes.ps1xml in the $pshome directory.
+a file called MyTypes.ps1xml in the `$PSHOME` directory.
 
-copy-item Types.ps1xml MyTypes.ps1xml
+```powershell
+Copy-Item Types.ps1xml MyTypes.ps1xml
+```
 
 Next, open the Types.ps1xml file in any XML or text editor, such
 as Notepad. Because the Age property is calculated by using a script
-block, find a <ScriptProperty> tag to use as a model for the new Age
+block, find a `<ScriptProperty>` tag to use as a model for the new `Age`
 property.
 
-Copy the XML between the <Type> and </Type> tags of the code to create
+Copy the XML between the `<Type>` and `</Type>` tags of the code to create
 the script property. Then, delete the remainder of the file, except for
-the opening <?xml> and <Types> tags and the closing </Types> tag. You
+the opening `<?xml>` and `<Types>` tags and the closing `</Types>` tag. You
 must also delete the digital signature to prevent errors.
 
 Begin with the model script property, such as the following script
 property, which was copied from the original Types.ps1xml file.
 
+```xml
 <?xml version="1.0" encoding="utf-8" ?>
 <Types>
-<Type>
-<Name>System.Guid</Name>
-<Members>
-<ScriptProperty>
-<Name>Guid</Name>
-<GetScriptBlock>$this.ToString()</GetScriptBlock>
-</ScriptProperty>
-</Members>
-</Type>
+  <Type>
+    <Name>System.Guid</Name>
+    <Members>
+      <ScriptProperty>
+        <Name>Guid</Name>
+        <GetScriptBlock>$this.ToString()</GetScriptBlock>
+      </ScriptProperty>
+    </Members>
+  </Type>
 </Types>
+```
 
 Then, change the name of the .NET Framework type, the name of the
-property, and the value of the script block to create an Age property
+property, and the value of the script block to create an `Age` property
 for file objects.
 
+```xml
 <?xml version="1.0" encoding="utf-8" ?>
 <Types>
-<Type>
-<Name>System.IO.FileInfo</Name>
-<Members>
-<ScriptProperty>
-<Name>Age</Name>
-<GetScriptBlock>
-((get-date) - ($this.creationtime)).days
-</GetScriptBlock>
-</ScriptProperty>
-</Members>
-</Type>
+  <Type>
+    <Name>System.IO.FileInfo</Name>
+    <Members>
+      <ScriptProperty>
+        <Name>Age</Name>
+        <GetScriptBlock>
+          ((Get-Date) - ($this.CreationTime)).Days
+        </GetScriptBlock>
+      </ScriptProperty>
+    </Members>
+  </Type>
 </Types>
+```
 
-After you save the file and close it, run an Update-TypeData command,
+After you save the file and close it, run an `Update-TypeData` command,
 such as the following command, to add the new Types.ps1xml file to the
-current session. The command uses the PrependData parameter to place the
+current session. The command uses the `PrependData` parameter to place the
 new file in a higher precedence order than the original file. (For more
-information about Update-TypeData, see Update-TypeData.)
+information about `Update-TypeData`, see
+[Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData.md).)
 
-update-typedata -prependpath $pshome\MyTypes.ps1xml
+```powershell
+Update-TypeData -PrependPath $PSHOME\MyTypes.ps1xml
+```
 
-To test the change, run a Get-ChildItem command to get the
-PowerShell.exe file in the $pshome directory, and then pipe the file to
-the Format-List cmdlet to list all of the properties of the file. As a
-result of the change, the Age property appears in the list.
+To test the change, run a `Get-ChildItem` command to get the
+PowerShell.exe file in the `$PSHOME` directory, and then pipe the file to
+the `Format-List` cmdlet to list all of the properties of the file. As a
+result of the change, the `Age` property appears in the list.
 
-get-childitem $pshome\PowerShell.exe | format-list -property *
+```powershell
+Get-ChildItem $PSHOME\PowerShell.exe | Format-List -Property *
 
 PSPath            : Microsoft.PowerShell.Core\FileSystem::C:\WINDOWS...
 PSParentPath      : Microsoft.PowerShell.Core\FileSystem::C:\WINDOWS...
@@ -263,310 +283,329 @@ VersionInfo       : File:             C:\WINDOWS\system32\WindowsPow...
 InternalName:     POWERSHELL
 OriginalFilename: PowerShell.EXE
 # ...
+```
 
-
-You can also display the Age property of the file by using the following
+You can also display the `Age` property of the file by using the following
 command.
 
-(get-childitem $pshome\PowerShell.exe).age
+```powershell
+(Get-GhildItem $PSHOME\PowerShell.exe).Age
 # 16
-
+```
 
 The XML in Types.ps1xml Files
 
-The <Types> tag encloses all of the types that are defined in the file.
-There should be only one pair of <Types> tags.
+The `<Types>` tag encloses all of the types that are defined in the file.
+There should be only one pair of `<Types>` tags.
 
 Each .NET Framework type mentioned in the file should be represented by
-a pair of <Type> tags.
+a pair of `<Type>` tags.
 
 The type tags must contain the following tags:
 
-<Name>: A pair of <Name> tags that enclose the name of the affected
+`<Name>`: A pair of `<Name>` tags that enclose the name of the affected
 .NET Framework type.
 
-<Members>: A pair of <Members> tags that enclose the tags for the
+`<Members>`: A pair of `<Members>` tags that enclose the tags for the
 new properties and methods that are defined for the
 .NET Framework type.
 
-Any of the following member tags can be inside the <Members> tags.
+Any of the following member tags can be inside the `<Members>` tags.
 
-<AliasProperty>: Defines a new name for an existing property.
+`<AliasProperty>`: Defines a new name for an existing property.
 
-The <AliasProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <ReferencedMemberName> tags
+The `<AliasProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<ReferencedMemberName>` tags
 that specify the existing property.
 
-For example, the Count alias property is an alias for the Length
+For example, the `Count` alias property is an alias for the `Length`
 property of array objects.
 
+```xml
 <Type>
-<Name>System.Array</Name>
-<Members>
-<AliasProperty>
-<Name>Count</Name>
-<ReferencedMemberName>Length</ReferencedMemberName>
-</AliasProperty>
-</Members>
+  <Name>System.Array</Name>
+  <Members>
+    <AliasProperty>
+      <Name>Count</Name>
+      <ReferencedMemberName>Length</ReferencedMemberName>
+    </AliasProperty>
+  </Members>
 </Type>
+```
 
-<CodeMethod>:  References a static method of a .NET Framework class.
+`<CodeMethod>`:  References a static method of a .NET Framework class.
 
-The <CodeMethod> tag must have a pair of <Name> tags that specify
-the name of the new method and a pair of <GetCodeReference> tags
+The `<CodeMethod>` tag must have a pair of `<Name>` tags that specify
+the name of the new method and a pair of `<GetCodeReference>` tags
 that specify the code in which the method is defined.
 
 For example, the Mode property of directories (System.IO.DirectoryInfo
 objects) is a code property defined in the Windows PowerShell
 FileSystem provider.
 
+```xml
 <Type>
-<Name>System.IO.DirectoryInfo</Name>
-<Members>
-<CodeProperty>
-<Name>Mode</Name>
-<GetCodeReference>
-<TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
-<MethodName>Mode</MethodName>
-</GetCodeReference>
-</CodeProperty>
-</Members>
+  <Name>System.IO.DirectoryInfo</Name>
+  <Members>
+    <CodeProperty>
+      <Name>Mode</Name>
+      <GetCodeReference>
+        <TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
+        <MethodName>Mode</MethodName>
+      </GetCodeReference>
+    </CodeProperty>
+  </Members>
 </Type>
+```
 
-<CodeProperty>: References a static method of a .NET Framework class.
+`<CodeProperty>`: References a static method of a .NET Framework class.
 
-The <CodeProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <GetCodeReference> tags
+The `<CodeProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<GetCodeReference>` tags
 that specify the code in which the property is defined.
 
-For example, the Mode property of directories (System.IO.DirectoryInfo
+For example, the `Mode` property of directories (`System.IO.DirectoryInfo`
 objects) is a code property defined in the Windows PowerShell
 FileSystem provider.
 
+```xml
 <Type>
-<Name>System.IO.DirectoryInfo</Name>
-<Members>
-<CodeProperty>
-<Name>Mode</Name>
-<GetCodeReference>
-<TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
-<MethodName>Mode</MethodName>
-</GetCodeReference>
-</CodeProperty>
-</Members>
+  <Name>System.IO.DirectoryInfo</Name>
+  <Members>
+    <CodeProperty>
+      <Name>Mode</Name>
+      <GetCodeReference>
+        <TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
+        <MethodName>Mode</MethodName>
+      </GetCodeReference>
+    </CodeProperty>
+  </Members>
 </Type>
+```
 
-<MemberSet>: Defines a collection of members (properties and methods).
+`<MemberSet>`: Defines a collection of members (properties and methods).
 
-The <MemberSet> tags appear within the primary <Members> tags. The
-tags must enclose a pair of <Name> tags surrounding the name of the
-member set and a pair of secondary <Members> tags that surround the
+The `<MemberSet>` tags appear within the primary `<Members>` tags. The
+tags must enclose a pair of `<Name>` tags surrounding the name of the
+member set and a pair of secondary `<Members>` tags that surround the
 members (properties and methods) in the set. Any of the tags that
-create a property (such as <NoteProperty> or <ScriptProperty>) or a
-method (such as <Method> or <ScriptMethod>) can be members of the set.
+create a property (such as `<NoteProperty>` or `<ScriptProperty>`) or a
+method (such as `<Method>` or `<ScriptMethod>`) can be members of the set.
 
-In Types.ps1xml files, the <MemberSet> tag is used to define the
+In Types.ps1xml files, the `<MemberSet>` tag is used to define the
 default views of the .NET Framework objects in Windows PowerShell. In
-this case, the name of the member set (the value within the <Name>
+this case, the name of the member set (the value within the `<Name>`
 tags) is always "PsStandardMembers", and the names of the properties
-(the value of the <Name> tag) are one of the following:
+(the value of the `<Name>` tag) are one of the following:
 
-- DefaultDisplayProperty: A single property of an object.
+- `DefaultDisplayProperty`: A single property of an object.
 
-- DefaultDisplayPropertySet: One or more properties of an object.
+- `DefaultDisplayPropertySet`: One or more properties of an object.
 
-- DefaultKeyPropertySet: One or more key properties of an object.
+- `DefaultKeyPropertySet`: One or more key properties of an object.
 A key property identifies instances of property values, such as
 the ID number of items in a session history.
 
 For example, the following XML defines the default display of services
-(System.ServiceProcess.ServiceController objects) that are returned by
-the Get-Service cmdlet. It defines a member set named
+(`System.ServiceProcess.ServiceController` objects) that are returned by
+the `Get-Service` cmdlet. It defines a member set named
 "PsStandardMembers" that consists of a default property set with the
-Status, Name, and DisplayName properties.
+`Status`, `Name`, and `DisplayName` properties.
 
+```xml
 <Type>
-<Name>System.ServiceProcess.ServiceController</Name>
-<Members>
-<MemberSet>
-<Name>PSStandardMembers</Name>
-<Members>
-<PropertySet>
-<Name>DefaultDisplayPropertySet</Name>
-<ReferencedProperties>
-<Name>Status</Name>
-<Name>Name</Name>
-<Name>DisplayName</Name>
-</ReferencedProperties>
-</PropertySet>
-</Members>
-</MemberSet>
-</Members>
+  <Name>System.ServiceProcess.ServiceController</Name>
+  <Members>
+    <MemberSet>
+      <Name>PSStandardMembers</Name>
+      <Members>
+        <PropertySet>
+          <Name>DefaultDisplayPropertySet</Name>
+          <ReferencedProperties>
+            <Name>Status</Name>
+            <Name>Name</Name>
+            <Name>DisplayName</Name>
+          </ReferencedProperties>
+        </PropertySet>
+      </Members>
+    </MemberSet>
+  </Members>
 </Type>
+```
 
-<Method>: References a native method of the underlying object.
+`<Method>`: References a native method of the underlying object.
 
-<Methods>: A collection of the methods of the object.
+`<Methods>`: A collection of the methods of the object.
 
-<NoteProperty>: Defines a property with a static value.
+`<NoteProperty>`: Defines a property with a static value.
 
-The <NoteProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <Value> tags that specify
+The `<NoteProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<Value>` tags that specify
 the value of the property.
 
-For example, the following XML creates a Status property for
-directories (System.IO.DirectoryInfo objects). The value of the
-Status property is always "Success".
+For example, the following XML creates a `Status` property for
+directories (`System.IO.DirectoryInfo` objects). The value of the
+`Status` property is always "Success".
 
+```xml
 <Type>
-<Name>System.IO.DirectoryInfo</Name>
-<Members>
-<NoteProperty>
-<Name>Status</Name>
-<Value>Success</Value>
-</NoteProperty>
-</Members>
+  <Name>System.IO.DirectoryInfo</Name>
+  <Members>
+    <NoteProperty>
+      <Name>Status</Name>
+      <Value>Success</Value>
+    </NoteProperty>
+  </Members>
 </Type>
+```
 
-<ParameterizedProperty>: Properties that take arguments and return a
+`<ParameterizedProperty>`: Properties that take arguments and return a
 value.
 
-<Properties>: A collection of the properties of the object.
+`<Properties>`: A collection of the properties of the object.
 
-<Property>: A property of the base object.
+`<Property>`: A property of the base object.
 
-<PropertySet>: Defines a collection of properties of the object.
+`<PropertySet>`: Defines a collection of properties of the object.
 
-The <PropertySet> tag must have a pair of <Name> tags that specify
-the name of the property set and a pair of <ReferencedProperty> tags
+The `<PropertySet>` tag must have a pair of `<Name>` tags that specify
+the name of the property set and a pair of `<ReferencedProperty>` tags
 that specify the properties. The names of the properties are enclosed
-in <Name> tag pairs.
+in `<Name>` tag pairs.
 
-In Types.ps1xml, <PropertySet> tags are used to define sets of
+In Types.ps1xml, `<PropertySet>` tags are used to define sets of
 properties for the default display of an object. You can identify the
-default displays by the value "PsStandardMembers" in the <Name> tag
-of a <MemberSet> tag.
+default displays by the value "PsStandardMembers" in the `<Name>` tag
+of a `<MemberSet>` tag.
 
-For example, the following XML creates a Status property for
-directories (System.IO.DirectoryInfo objects). The value of the Status
+For example, the following XML creates a `Status` property for
+directories (`System.IO.DirectoryInfo` objects). The value of the `Status`
 property is always "Success".
 
+```xml
 <Type>
-<Name>System.ServiceProcess.ServiceController</Name>
-<Members>
-<MemberSet>
-<Name>PSStandardMembers</Name>
-<Members>
-<PropertySet>
-<Name>DefaultDisplayPropertySet</Name>
-<ReferencedProperties>
-<Name>Status</Name
-<Name>Name</Name>
-<Name>DisplayName</Name>
-</ReferencedProperties>
-</PropertySet>
-<Members>
-<MemberSet>
-<Members>
+  <Name>System.ServiceProcess.ServiceController</Name>
+  <Members>
+    <MemberSet>
+      <Name>PSStandardMembers</Name>
+      <Members>
+        <PropertySet>
+          <Name>DefaultDisplayPropertySet</Name>
+          <ReferencedProperties>
+            <Name>Status</Name>
+            <Name>Name</Name>
+            <Name>DisplayName</Name>
+          </ReferencedProperties>
+        </PropertySet>
+      </Members>
+    </MemberSet>
+  </Members>
 <Type>
+```
 
-<ScriptMethod>: Defines a method whose value is the output of a script.
+`<ScriptMethod>`: Defines a method whose value is the output of a script.
 
-The <ScriptMethod> tag must have a pair of <Name> tags that specify
-the name of the new method and a pair of <Script> tags that enclose
+The `<ScriptMethod>` tag must have a pair of `<Name>` tags that specify
+the name of the new method and a pair of `<Script>` tags that enclose
 the script block that returns the method result.
 
-For example, the ConvertToDateTime and ConvertFromDateTime methods of
-management objects (System.System.Management.ManagementObject) are
-script methods that use the ToDateTime and ToDmtfDateTime static
-methods of the System.Management.ManagementDateTimeConverter class.
+For example, the `ConvertToDateTime` and `ConvertFromDateTime` methods of
+management objects (`System.System.Management.ManagementObject`) are
+script methods that use the `ToDateTime` and `ToDmtfDateTime` static
+methods of the `System.Management.ManagementDateTimeConverter` class.
 
+```xml
 <Type>
-<Name>System.Management.ManagementObject</Name>
-<Members>
-<ScriptMethod>
-<Name>ConvertToDateTime</Name>
-<Script>
-[System.Management.ManagementDateTimeConverter]::ToDateTime($args[0])
-</Script>
-</ScriptMethod>
-<ScriptMethod>
-<Name>ConvertFromDateTime</Name>
-<Script>
-[System.Management.ManagementDateTimeConverter]::ToDmtfDateTime($args[0])
-</Script>
-</ScriptMethod>
-</Members>
+  <Name>System.Management.ManagementObject</Name>
+  <Members>
+    <ScriptMethod>
+      <Name>ConvertToDateTime</Name>
+      <Script>
+        [System.Management.ManagementDateTimeConverter]::ToDateTime($args[0])
+      </Script>
+    </ScriptMethod>
+    <ScriptMethod>
+      <Name>ConvertFromDateTime</Name>
+      <Script>
+        [System.Management.ManagementDateTimeConverter]::ToDmtfDateTime($args[0])
+      </Script>
+    </ScriptMethod>
+  </Members>
 </Type>
+```
 
-<ScriptProperty>: Defines a property whose value is the output of a
+`<ScriptProperty>`: Defines a property whose value is the output of a
 script.
 
-The <ScriptProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <GetScriptBlock> tags
+The `<ScriptProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<GetScriptBlock>` tags
 that enclose the script block that returns the property value.
 
-For example, the VersionInfo property of files (System.IO.FileInfo
-objects) is a script property that results from using the FullName
-property of the GetVersionInfo static method of
-System.Diagnostics.FileVersionInfo objects.
+For example, the `VersionInfo` property of files (`System.IO.FileInfo`
+objects) is a script property that results from using the `FullName`
+property of the `GetVersionInfo` static method of
+`System.Diagnostics.FileVersionInfo` objects.
 
+```xml
 <Type>
-<Name>System.IO.FileInfo</Name>
-<Members>
-<ScriptProperty>
-<Name>VersionInfo</Name>
-<GetScriptBlock>
-[System.Diagnostics.FileVersionInfo]::GetVersionInfo($this.FullName)
-</GetScriptBlock>
-</ScriptProperty>
-</Members>
+  <Name>System.IO.FileInfo</Name>
+  <Members>
+    <ScriptProperty>
+      <Name>VersionInfo</Name>
+      <GetScriptBlock>
+        [System.Diagnostics.FileVersionInfo]::GetVersionInfo($this.FullName)
+      </GetScriptBlock>
+    </ScriptProperty>
+  </Members>
 </Type>
+```
 
-For more information, see the Windows PowerShell Software Development
-Kit (SDK) in the MSDN (Microsoft Developer Network )library
-at http://go.microsoft.com/fwlink/?LinkId=144538.
+For more information, see the [Windows PowerShell Software Development
+Kit (SDK) in the MSDN (Microsoft Developer Network)
+library](http://go.microsoft.com/fwlink/?LinkId=144538).
 
-Update-TypeData
+## Update-TypeData
 
 To load your Types.ps1xml files into a Windows PowerShell session, run
-the Update-TypeData cmdlet. If you want the types in your file to take
+the `Update-TypeData` cmdlet. If you want the types in your file to take
 precedence over types in the built-in Types.ps1xml file, add the
-PrependData parameter of Update-TypeData. Update-TypeData affects only
+`PrependData` parameter of `Update-TypeData`. `Update-TypeData` affects only
 the current session. To make the change to all future sessions, export
-the session, or add the Update-TypeData command to your Windows
+the session, or add the `Update-TypeData` command to your Windows
 PowerShell profile.
 
 Exceptions that occur in properties, or from adding properties to an
-Update-TypeData command, do not report errors to StdErr. This is to
+`Update-TypeData` command, do not report errors to `StdErr`. This is to
 suppress exceptions that would occur in many common types during formatting
 and outputting. If you are getting .NET Framework properties, you can work
 around the suppression of exceptions by using method syntax instead, as
 shown in the following example:
-
+ 
+ ```powershell
 "hello".get_Length()
+```
 
 Note that method syntax can only be used with .NET Framework properties.
-Properties that are added by running the Update-TypeData cmdlet cannot
+Properties that are added by running the `Update-TypeData` cmdlet cannot
 use method syntax.
 
-Signing a Types.ps1xml File
+## Signing a Types.ps1xml File
 
 To protect users of your Types.ps1xml file, you can sign the file using
-a digital signature. For more information, see about_Signing.
+a digital signature. For more information, see [about_Signing](about_Signing).
 
 # SEE ALSO
 
 [about_Signing](about_Signing.md)
 
-Copy-Item (http://go.microsoft.com/fwlink/?LinkID=113292)
+[Copy-Item](../../Microsoft.PowerShell.Management/Copy-Item.md)
 
-Copy-ItemProperty (http://go.microsoft.com/fwlink/?LinkID=113293)
+[Copy-ItemProperty](../../Microsoft.PowerShell.Management/Copy-ItemProperty.md)
 
-Get-Member (http://go.microsoft.com/fwlink/?LinkID=113322)
+[Get-Member](../../Microsoft.PowerShell.Utility/Get-Member.md)
 
-Get-TypeData (http://go.microsoft.com/fwlink/?LinkID=217033)
+[Get-TypeData](../../Microsoft.PowerShell.Utility/Get-TypeData.md)
 
-Remove-TypeData (http://go.microsoft.com/fwlink/?LinkID=217038)
+[Remove-TypeData](../../Microsoft.PowerShell.Utility/Remove-TypeData.md)
 
-Update-TypeData (http://go.microsoft.com/fwlink/?LinkID=113421)
+[Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData,md)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -592,7 +592,7 @@ use method syntax.
 ## Signing a Types.ps1xml File
 
 To protect users of your Types.ps1xml file, you can sign the file using
-a digital signature. For more information, see [about_Signing](about_Signing).
+a digital signature. For more information, see [about_Signing](about_Signing.md).
 
 # SEE ALSO
 
@@ -608,4 +608,4 @@ a digital signature. For more information, see [about_Signing](about_Signing).
 
 [Remove-TypeData](../../Microsoft.PowerShell.Utility/Remove-TypeData.md)
 
-[Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData,md)
+[Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData.md)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -26,15 +26,15 @@ Extended type data defines additional properties and methods ("members")
 of object types in Windows PowerShell. There are two techniques for adding
 extended type data to a Windows PowerShell session.
 
--- Types.ps1xml file: An XML file that defines extended type data.
--- Update-TypeData: A cmdlet that reloads Types.ps1xml files and defines
+- Types.ps1xml file: An XML file that defines extended type data.
+- `Update-TypeData`: A cmdlet that reloads Types.ps1xml files and defines
 extended data for types in the current session.
 
 This topic describes Types.ps1xml files. For more information about using the
-Update-TypeData cmdlet to add dynamic extended type data to the current session
-see Update-TypeData (http://go.microsoft.com/fwlink/?LinkID=113421).
+`Update-TypeData` cmdlet to add dynamic extended type data to the current session
+see [Update-TypeData](../../Microsoft.Management.Utility/Update-TypeData.md).
 
-About Extended Type Data
+## About Extended Type Data
 
 Extended type data defines additional properties and methods ("members")
 of object types in Windows PowerShell. You can extend any type that is
@@ -42,113 +42,122 @@ supported by Windows PowerShell and use the added properties and methods
 in the same way that you use the properties that are defined on the object
 types.
 
-For example, Windows PowerShell adds a DateTime property to all
-System.DateTime objects, such as the ones that the Get-Date cmdlet
+For example, Windows PowerShell adds a `DateTime` property to all
+`System.DateTime` objects, such as the ones that the `Get-Date` cmdlet
 returns.
 
+```powershell
 PS C:> (Get-Date).DateTime
 Sunday, January 29, 2012 9:43:57 AM
+```
 
-You won't find the DateTime property in the description of the System.DateTime
-structure (http://msdn.microsoft.com/library/system.datetime.aspx),
+You won't find the `DateTime` property in the description of the [`System.DateTime`
+structure](http://msdn.microsoft.com/library/system.datetime.aspx),
 because Windows PowerShell adds the property and it is visible only in
 Windows PowerShell.
 
-To add the DateTime property to all Windows PowerShell sessions, Windows PowerShell
-defines the DateTime property in the Types.ps1xml file in the Windows PowerShell
-installation directory ($pshome).
+To add the `DateTime` property to all Windows PowerShell sessions, Windows PowerShell
+defines the `DateTime` property in the Types.ps1xml file in the Windows PowerShell
+installation directory (`$pshome`).
 
-Adding Extended Type Data to Windows PowerShell.
+## Adding Extended Type Data to Windows PowerShell.
 
 There are three sources of extended type data in Windows PowerShell sessions.
 
---  The Types.ps1xml files in the Windows PowerShell installation directory
+- The Types.ps1xml files in the Windows PowerShell installation directory
 are loaded automatically into every Windows PowerShell session.
 
---  The Types.ps1xml files that modules export are loaded when the module
+- The Types.ps1xml files that modules export are loaded when the module
 is imported into the current session.
 
---  Extended type data that is defined by using the Update-TypeData cmdlet
+- Extended type data that is defined by using the `Update-TypeData` cmdlet
 is added only to the current session. It is not saved in a file.
 
 In the session, the extended type data from the three sources is applied
 to objects in the same way and is available on all objects of the specified
 types.
 
-The TypeData Cmdlets
+## The TypeData Cmdlets
 
 The following TypeData cmdlets are included in the Microsoft.PowerShell.Utility
 module in Windows PowerShell 3.0 and later versions of Windows PowerShell.
 
-Get-TypeData:     Gets extended type data in the current session.
-Update-TypeData:  Reloads Types.ps1xml files. Adds extended type
-data to the current session.
-Remove-TypeData:  Removes extended type data from the current
-session.
+|                 |                                                       |
+| --------------- | ----------------------------------------------------- |
+| Get-TypeData    | Gets extended type data in the current session.       |
+| Update-TypeData | Reloads Types.ps1xml files. Adds extended type data to the current session. |
+| Remove-TypeData | Removes extended type data from the current session.  |
 
 For more information about these cmdlets, see the help topic for each
 cmdlet.
 
-Built-in Types.ps1xml Files
+## Built-in Types.ps1xml Files
 
 The Types.ps1xml files in the $pshome directory are added automatically to
 every session.
 
 The Types.ps1xml file in the Windows PowerShell installation directory
-($pshome) is an XML-based text file that lets you add properties and
+(`$pshome`) is an XML-based text file that lets you add properties and
 methods to the objects that are used in Windows PowerShell. Windows
 PowerShell has built-in Types.ps1xml files that add several elements
 to the .NET Framework types, but you can create additional Types.ps1xml
 files to further extend the types.
 
-For example, by default, array objects (System.Array) have a Length
+For example, by default, array objects (`System.Array`) have a `Length`
 property that lists the number of objects in the array. However, because
-the name "length" does not clearly describe the property, Windows
+the name "Length" does not clearly describe the property, Windows
 PowerShell adds an alias property named "Count" that displays the same
-value. The following XML adds the Count property to the System.Array type.
+value. The following XML adds the `Count` property to the `System.Array` type.
 
+```xml
 <Type>
-<Name>System.Array</Name>
-<Members>
-<AliasProperty>
-<Name>Count</Name>
-<ReferencedMemberName>
-Length
-</ReferencedMemberName>
-</AliasProperty>
-</Members>
+  <Name>System.Array</Name>
+  <Members>
+    <AliasProperty>
+      <Name>Count</Name>
+      <ReferencedMemberName>
+        Length
+      </ReferencedMemberName>
+    </AliasProperty>
+  </Members>
 </Type>
+```
 
-To get the new AliasProperty, use a Get-Member command on any array, as shown
+To get the new `AliasProperty`, use a `Get-Member` command on any array, as shown
 in the following example.
 
+```powershell
 Get-Member -inputobject (1,2,3,4)
+```
 
 The command returns the following results.
 
+```powershell
 Name           MemberType    Definition
 ----           ----------    ----------
 Count          AliasProperty Count = Length
-Address        Method        System.Object& Address(Int32 )
+Address        Method        System.Object& Address(Int32)
 Clone          Method        System.Object Clone()
 CopyTo         Method        System.Void CopyTo(Array array, Int32 index):
 Equals         Method        System.Boolean Equals(Object obj)
-Get            Method        System.Object Get(Int32 )
+Get            Method        System.Object Get(Int32)
 # ...
+```
 
-
-As a result, you can use either the Count property or the Length property
+As a result, you can use either the `Count` property or the `Length` property
 of arrays in Windows PowerShell. For example:
 
+```powershell
 C:\PS> (1, 2, 3, 4).count
 # 4
+```
 
-
+```powershell
 C:\PS> (1, 2, 3, 4).length
 # 4
+```
 
-
-Creating New Types.ps1xml Files
+## Creating New Types.ps1xml Files
 
 The .ps1xml files that are installed with Windows PowerShell are
 digitally signed to prevent tampering because the formatting can include
@@ -160,97 +169,107 @@ To create a new file, start by copying an existing Types.ps1xml file. The
 new file can have any name, but it must have a .ps1xml file name
 extension. You can place the new file in any directory that is accessible
 to Windows PowerShell, but it is useful to place the files in the Windows
-PowerShell installation directory ($pshome) or in a subdirectory of the
+PowerShell installation directory (`$pshome`) or in a subdirectory of the
 installation directory.
 
-When you have saved the new file, use the Update-TypeData cmdlet to add
+When you have saved the new file, use the `Update-TypeData` cmdlet to add
 the new file to your Windows PowerShell session. If you want your types
 to take precedence over the types that are defined in the built-in file,
-use the PrependData parameter of the Update-TypeData cmdlet.
-Update-TypeData affects only the current session. To make the change to
-all future sessions, export the console, or add the Update-TypeData
+use the `PrependData` parameter of the `Update-TypeData` cmdlet.
+`Update-TypeData` affects only the current session. To make the change to
+all future sessions, export the console, or add the `Update-TypeData`
 command to your Windows PowerShell profile.
 
-Types.ps1xml and Add-Member
+## Types.ps1xml and `Add-Member`
 
 The Types.ps1xml files add properties and methods to all the instances
 of the objects of the specified .NET Framework type in the affected
 Windows PowerShell session. However, if you need to add properties or
 methods only to one instance of an object, use the Add-Member cmdlet.
 
-For more information,see Add-Member.
+For more information, see [Add-Member](../../Microsoft.PowerShell.Utility/Add-Member.md).
 
-Example: Adding an Age Member to FileInfo Objects
+## Example: Adding an `Age` Member to `FileInfo` Objects
 
-This example shows how to add an Age property to file objects
-(System.IO.FileInfo). The age of a file is the difference between
+This example shows how to add an `Age` property to file objects
+(`System.IO.FileInfo`). The age of a file is the difference between
 its creation time and the current time in days.
 
 It is easiest to use the original Types.ps1xml file as a template
 for the new file. The following command copies the original file to
 a file called MyTypes.ps1xml in the $pshome directory.
 
-copy-item Types.ps1xml MyTypes.ps1xml
+```powershell
+Copy-Item Types.ps1xml MyTypes.ps1xml
+```
 
 Next, open the Types.ps1xml file in any XML or text editor, such
-as Notepad. Because the Age property is calculated by using a script
-block, find a <ScriptProperty> tag to use as a model for the new Age
+as Notepad. Because the `Age` property is calculated by using a script
+block, find a `<ScriptProperty>` tag to use as a model for the new `Age`
 property.
 
-Copy the XML between the <Type> and </Type> tags of the code to create
+Copy the XML between the `<Type>` and `</Type>` tags of the code to create
 the script property. Then, delete the remainder of the file, except for
-the opening <?xml> and <Types> tags and the closing </Types> tag. You
+the opening `<?xml>` and `<Types>` tags and the closing `</Types>` tag. You
 must also delete the digital signature to prevent errors.
 
 Begin with the model script property, such as the following script
 property, which was copied from the original Types.ps1xml file.
 
+```xml
 <?xml version="1.0" encoding="utf-8" ?>
 <Types>
-<Type>
-<Name>System.Guid</Name>
-<Members>
-<ScriptProperty>
-<Name>Guid</Name>
-<GetScriptBlock>$this.ToString()</GetScriptBlock>
-</ScriptProperty>
-</Members>
-</Type>
+  <Type>
+    <Name>System.Guid</Name>
+    <Members>
+      <ScriptProperty>
+        <Name>Guid</Name>
+        <GetScriptBlock>$this.ToString()</GetScriptBlock>
+      </ScriptProperty>
+    </Members>
+  </Type>
 </Types>
+```
 
 Then, change the name of the .NET Framework type, the name of the
-property, and the value of the script block to create an Age property
+property, and the value of the script block to create an `Age` property
 for file objects.
 
+```xml
 <?xml version="1.0" encoding="utf-8" ?>
 <Types>
-<Type>
-<Name>System.IO.FileInfo</Name>
-<Members>
-<ScriptProperty>
-<Name>Age</Name>
-<GetScriptBlock>
-((get-date) - ($this.creationtime)).days
-</GetScriptBlock>
-</ScriptProperty>
-</Members>
-</Type>
+  <Type>
+    <Name>System.IO.FileInfo</Name>
+    <Members>
+      <ScriptProperty>
+        <Name>Age</Name>
+        <GetScriptBlock>
+          ((Get-Date) - ($this.CreationTime)).Days
+        </GetScriptBlock>
+      </ScriptProperty>
+    </Members>
+  </Type>
 </Types>
+```
 
-After you save the file and close it, run an Update-TypeData command,
+After you save the file and close it, run an `Update-TypeData` command,
 such as the following command, to add the new Types.ps1xml file to the
-current session. The command uses the PrependData parameter to place the
+current session. The command uses the `PrependData` parameter to place the
 new file in a higher precedence order than the original file. (For more
-information about Update-TypeData, see Update-TypeData.)
+information about `Update-TypeData`, see
+[Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData.md).)
 
-update-typedata -prependpath $pshome\MyTypes.ps1xml
+```powershell
+Update-TypeData -PrependPath $pshome\MyTypes.ps1xml
+```
 
-To test the change, run a Get-ChildItem command to get the
-PowerShell.exe file in the $pshome directory, and then pipe the file to
-the Format-List cmdlet to list all of the properties of the file. As a
+To test the change, run a `Get-ChildItem` command to get the
+PowerShell.exe file in the `$pshome` directory, and then pipe the file to
+the `Format-List` cmdlet to list all of the properties of the file. As a
 result of the change, the Age property appears in the list.
 
-get-childitem $pshome\PowerShell.exe | format-list -property *
+```powershell
+Get-ChildItem $pshome\PowerShell.exe | Format-List -Property *
 
 PSPath            : Microsoft.PowerShell.Core\FileSystem::C:\WINDOWS...
 PSParentPath      : Microsoft.PowerShell.Core\FileSystem::C:\WINDOWS...
@@ -263,310 +282,329 @@ VersionInfo       : File:             C:\WINDOWS\system32\WindowsPow...
 InternalName:     POWERSHELL
 OriginalFilename: PowerShell.EXE
 # ...
+```
 
-
-You can also display the Age property of the file by using the following
+You can also display the `Age` property of the file by using the following
 command.
 
-(get-childitem $pshome\PowerShell.exe).age
+```powershell
+(Get-ChildItem $pshome\PowerShell.exe).Age
 # 16
+```
 
+## The XML in Types.ps1xml Files
 
-The XML in Types.ps1xml Files
-
-The <Types> tag encloses all of the types that are defined in the file.
-There should be only one pair of <Types> tags.
+The `<Types>` tag encloses all of the types that are defined in the file.
+There should be only one pair of `<Types>` tags.
 
 Each .NET Framework type mentioned in the file should be represented by
-a pair of <Type> tags.
+a pair of `<Type>` tags.
 
 The type tags must contain the following tags:
 
-<Name>: A pair of <Name> tags that enclose the name of the affected
+`<Name>`: A pair of `<Name>` tags that enclose the name of the affected
 .NET Framework type.
 
-<Members>: A pair of <Members> tags that enclose the tags for the
+`<Members>`: A pair of `<Members>` tags that enclose the tags for the
 new properties and methods that are defined for the
 .NET Framework type.
 
-Any of the following member tags can be inside the <Members> tags.
+Any of the following member tags can be inside the `<Members>` tags.
 
-<AliasProperty>: Defines a new name for an existing property.
+`<AliasProperty>`: Defines a new name for an existing property.
 
-The <AliasProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <ReferencedMemberName> tags
+The `<AliasProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<ReferencedMemberName>` tags
 that specify the existing property.
 
-For example, the Count alias property is an alias for the Length
+For example, the `Count` alias property is an alias for the `Length`
 property of array objects.
 
+```xml
 <Type>
-<Name>System.Array</Name>
-<Members>
-<AliasProperty>
-<Name>Count</Name>
-<ReferencedMemberName>Length</ReferencedMemberName>
-</AliasProperty>
-</Members>
+  <Name>System.Array</Name>
+  <Members>
+    <AliasProperty>
+      <Name>Count</Name>
+      <ReferencedMemberName>Length</ReferencedMemberName>
+    </AliasProperty>
+  </Members>
 </Type>
+```
 
-<CodeMethod>:  References a static method of a .NET Framework class.
+`<CodeMethod>`:  References a static method of a .NET Framework class.
 
-The <CodeMethod> tag must have a pair of <Name> tags that specify
-the name of the new method and a pair of <GetCodeReference> tags
+The `<CodeMethod>` tag must have a pair of `<Name>` tags that specify
+the name of the new method and a pair of `<GetCodeReference>` tags
 that specify the code in which the method is defined.
 
-For example, the Mode property of directories (System.IO.DirectoryInfo
+For example, the `Mode` property of directories (`System.IO.DirectoryInfo`
 objects) is a code property defined in the Windows PowerShell
 FileSystem provider.
 
+```xml
 <Type>
-<Name>System.IO.DirectoryInfo</Name>
-<Members>
-<CodeProperty>
-<Name>Mode</Name>
-<GetCodeReference>
-<TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
-<MethodName>Mode</MethodName>
-</GetCodeReference>
-</CodeProperty>
-</Members>
+  <Name>System.IO.DirectoryInfo</Name>
+  <Members>
+    <CodeProperty>
+      <Name>Mode</Name>
+      <GetCodeReference>
+        <TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
+        <MethodName>Mode</MethodName>
+      </GetCodeReference>
+    </CodeProperty>
+  </Members>
 </Type>
+```
 
-<CodeProperty>: References a static method of a .NET Framework class.
+`<CodeProperty>`: References a static method of a .NET Framework class.
 
-The <CodeProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <GetCodeReference> tags
+The `<CodeProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<GetCodeReference>` tags
 that specify the code in which the property is defined.
 
-For example, the Mode property of directories (System.IO.DirectoryInfo
+For example, the `Mode` property of directories (`System.IO.DirectoryInfo`
 objects) is a code property defined in the Windows PowerShell
 FileSystem provider.
 
+```xml
 <Type>
-<Name>System.IO.DirectoryInfo</Name>
-<Members>
-<CodeProperty>
-<Name>Mode</Name>
-<GetCodeReference>
-<TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
-<MethodName>Mode</MethodName>
-</GetCodeReference>
-</CodeProperty>
-</Members>
+  <Name>System.IO.DirectoryInfo</Name>
+  <Members>
+    <CodeProperty>
+      <Name>Mode</Name>
+      <GetCodeReference>
+        <TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
+        <MethodName>Mode</MethodName>
+      </GetCodeReference>
+    </CodeProperty>
+  </Members>
 </Type>
+```
 
-<MemberSet>: Defines a collection of members (properties and methods).
+`<MemberSet>`: Defines a collection of members (properties and methods).
 
-The <MemberSet> tags appear within the primary <Members> tags. The
-tags must enclose a pair of <Name> tags surrounding the name of the
-member set and a pair of secondary <Members> tags that surround the
+The `<MemberSet>` tags appear within the primary `<Members>` tags. The
+tags must enclose a pair of `<Name>` tags surrounding the name of the
+member set and a pair of secondary `<Members>` tags that surround the
 members (properties and methods) in the set. Any of the tags that
-create a property (such as <NoteProperty> or <ScriptProperty>) or a
-method (such as <Method> or <ScriptMethod>) can be members of the set.
+create a property (such as `<NoteProperty>` or `<ScriptProperty>`) or a
+method (such as `<Method>` or `<ScriptMethod>`) can be members of the set.
 
-In Types.ps1xml files, the <MemberSet> tag is used to define the
+In Types.ps1xml files, the `<MemberSet>` tag is used to define the
 default views of the .NET Framework objects in Windows PowerShell. In
-this case, the name of the member set (the value within the <Name>
+this case, the name of the member set (the value within the `<Name>`
 tags) is always "PsStandardMembers", and the names of the properties
 (the value of the <Name> tag) are one of the following:
 
-- DefaultDisplayProperty: A single property of an object.
+- `DefaultDisplayProperty`: A single property of an object.
 
-- DefaultDisplayPropertySet: One or more properties of an object.
+- `DefaultDisplayPropertySet`: One or more properties of an object.
 
-- DefaultKeyPropertySet: One or more key properties of an object.
+- `DefaultKeyPropertySet`: One or more key properties of an object.
 A key property identifies instances of property values, such as
 the ID number of items in a session history.
 
 For example, the following XML defines the default display of services
-(System.ServiceProcess.ServiceController objects) that are returned by
-the Get-Service cmdlet. It defines a member set named
+(`System.ServiceProcess.ServiceController` objects) that are returned by
+the `Get-Service` cmdlet. It defines a member set named
 "PsStandardMembers" that consists of a default property set with the
-Status, Name, and DisplayName properties.
+`Status`, `Name`, and `DisplayName` properties.
 
+```xml
 <Type>
-<Name>System.ServiceProcess.ServiceController</Name>
-<Members>
-<MemberSet>
-<Name>PSStandardMembers</Name>
-<Members>
-<PropertySet>
-<Name>DefaultDisplayPropertySet</Name>
-<ReferencedProperties>
-<Name>Status</Name>
-<Name>Name</Name>
-<Name>DisplayName</Name>
-</ReferencedProperties>
-</PropertySet>
-</Members>
-</MemberSet>
-</Members>
+  <Name>System.ServiceProcess.ServiceController</Name>
+  <Members>
+    <MemberSet>
+      <Name>PSStandardMembers</Name>
+      <Members>
+        <PropertySet>
+          <Name>DefaultDisplayPropertySet</Name>
+          <ReferencedProperties>
+            <Name>Status</Name>
+            <Name>Name</Name>
+            <Name>DisplayName</Name>
+          </ReferencedProperties>
+        </PropertySet>
+      </Members>
+    </MemberSet>
+  </Members>
 </Type>
+```
 
-<Method>: References a native method of the underlying object.
+`<Method>`: References a native method of the underlying object.
 
-<Methods>: A collection of the methods of the object.
+`<Methods>`: A collection of the methods of the object.
 
-<NoteProperty>: Defines a property with a static value.
+`<NoteProperty>`: Defines a property with a static value.
 
-The <NoteProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <Value> tags that specify
+The `<NoteProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<Value>` tags that specify
 the value of the property.
 
-For example, the following XML creates a Status property for
-directories (System.IO.DirectoryInfo objects). The value of the
-Status property is always "Success".
+For example, the following XML creates a `Status` property for
+directories (`System.IO.DirectoryInfo` objects). The value of the
+`Status` property is always "Success".
 
+```xml
 <Type>
-<Name>System.IO.DirectoryInfo</Name>
-<Members>
-<NoteProperty>
-<Name>Status</Name>
-<Value>Success</Value>
-</NoteProperty>
-</Members>
+  <Name>System.IO.DirectoryInfo</Name>
+  <Members>
+    <NoteProperty>
+      <Name>Status</Name>
+      <Value>Success</Value>
+    </NoteProperty>
+  </Members>
 </Type>
+```
 
-<ParameterizedProperty>: Properties that take arguments and return a
+`<ParameterizedProperty>`: Properties that take arguments and return a
 value.
 
-<Properties>: A collection of the properties of the object.
+`<Properties>`: A collection of the properties of the object.
 
-<Property>: A property of the base object.
+`<Property>`: A property of the base object.
 
-<PropertySet>: Defines a collection of properties of the object.
+`<PropertySet>`: Defines a collection of properties of the object.
 
-The <PropertySet> tag must have a pair of <Name> tags that specify
-the name of the property set and a pair of <ReferencedProperty> tags
+The `<PropertySet>` tag must have a pair of `<Name>` tags that specify
+the name of the property set and a pair of `<ReferencedProperty>` tags
 that specify the properties. The names of the properties are enclosed
-in <Name> tag pairs.
+in `<Name>` tag pairs.
 
-In Types.ps1xml, <PropertySet> tags are used to define sets of
+In Types.ps1xml, `<PropertySet>` tags are used to define sets of
 properties for the default display of an object. You can identify the
-default displays by the value "PsStandardMembers" in the <Name> tag
-of a <MemberSet> tag.
+default displays by the value "PsStandardMembers" in the `<Name>` tag
+of a `<MemberSet>` tag.
 
-For example, the following XML creates a Status property for
-directories (System.IO.DirectoryInfo objects). The value of the Status
+For example, the following XML creates a `Status` property for
+directories (`System.IO.DirectoryInfo` objects). The value of the `Status`
 property is always "Success".
 
+```xml
 <Type>
-<Name>System.ServiceProcess.ServiceController</Name>
-<Members>
-<MemberSet>
-<Name>PSStandardMembers</Name>
-<Members>
-<PropertySet>
-<Name>DefaultDisplayPropertySet</Name>
-<ReferencedProperties>
-<Name>Status</Name
-<Name>Name</Name>
-<Name>DisplayName</Name>
-</ReferencedProperties>
-</PropertySet>
-<Members>
-<MemberSet>
-<Members>
+  <Name>System.ServiceProcess.ServiceController</Name>
+  <Members>
+    <MemberSet>
+      <Name>PSStandardMembers</Name>
+      <Members>
+        <PropertySet>
+          <Name>DefaultDisplayPropertySet</Name>
+          <ReferencedProperties>
+            <Name>Status</Name>
+            <Name>Name</Name>
+            <Name>DisplayName</Name>
+          </ReferencedProperties>
+        </PropertySet>
+      </Members>
+    </MemberSet>
+  </Members>
 <Type>
+```
 
-<ScriptMethod>: Defines a method whose value is the output of a script.
+`<ScriptMethod>`: Defines a method whose value is the output of a script.
 
-The <ScriptMethod> tag must have a pair of <Name> tags that specify
-the name of the new method and a pair of <Script> tags that enclose
+The `<ScriptMethod>` tag must have a pair of `<Name>` tags that specify
+the name of the new method and a pair of `<Script>` tags that enclose
 the script block that returns the method result.
 
-For example, the ConvertToDateTime and ConvertFromDateTime methods of
-management objects (System.System.Management.ManagementObject) are
-script methods that use the ToDateTime and ToDmtfDateTime static
-methods of the System.Management.ManagementDateTimeConverter class.
+For example, the `ConvertToDateTime` and `ConvertFromDateTime` methods of
+management objects (`System.System.Management.ManagementObject`) are
+script methods that use the `ToDateTime` and `ToDmtfDateTime` static
+methods of the `System.Management.ManagementDateTimeConverter` class.
 
+```xml
 <Type>
-<Name>System.Management.ManagementObject</Name>
-<Members>
-<ScriptMethod>
-<Name>ConvertToDateTime</Name>
-<Script>
-[System.Management.ManagementDateTimeConverter]::ToDateTime($args[0])
-</Script>
-</ScriptMethod>
-<ScriptMethod>
-<Name>ConvertFromDateTime</Name>
-<Script>
-[System.Management.ManagementDateTimeConverter]::ToDmtfDateTime($args[0])
-</Script>
-</ScriptMethod>
-</Members>
+  <Name>System.Management.ManagementObject</Name>
+  <Members>
+    <ScriptMethod>
+      <Name>ConvertToDateTime</Name>
+      <Script>
+        [System.Management.ManagementDateTimeConverter]::ToDateTime($args[0])
+      </Script>
+    </ScriptMethod>
+    <ScriptMethod>
+      <Name>ConvertFromDateTime</Name>
+      <Script>
+        [System.Management.ManagementDateTimeConverter]::ToDmtfDateTime($args[0])
+      </Script>
+    </ScriptMethod>
+  </Members>
 </Type>
+```
 
-<ScriptProperty>: Defines a property whose value is the output of a
+`<ScriptProperty>`: Defines a property whose value is the output of a
 script.
 
-The <ScriptProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <GetScriptBlock> tags
+The `<ScriptProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<GetScriptBlock>` tags
 that enclose the script block that returns the property value.
 
-For example, the VersionInfo property of files (System.IO.FileInfo
-objects) is a script property that results from using the FullName
-property of the GetVersionInfo static method of
-System.Diagnostics.FileVersionInfo objects.
+For example, the `VersionInfo` property of files (`System.IO.FileInfo`
+objects) is a script property that results from using the `FullName`
+property of the `GetVersionInfo` static method of
+`System.Diagnostics.FileVersionInfo` objects.
 
+```xml
 <Type>
-<Name>System.IO.FileInfo</Name>
-<Members>
-<ScriptProperty>
-<Name>VersionInfo</Name>
-<GetScriptBlock>
-[System.Diagnostics.FileVersionInfo]::GetVersionInfo($this.FullName)
-</GetScriptBlock>
-</ScriptProperty>
-</Members>
+  <Name>System.IO.FileInfo</Name>
+  <Members>
+    <ScriptProperty>
+      <Name>VersionInfo</Name>
+      <GetScriptBlock>
+        [System.Diagnostics.FileVersionInfo]::GetVersionInfo($this.FullName)
+      </GetScriptBlock>
+    </ScriptProperty>
+  </Members>
 </Type>
+```
 
-For more information, see the Windows PowerShell Software Development
-Kit (SDK) in the MSDN (Microsoft Developer Network )library
-at http://go.microsoft.com/fwlink/?LinkId=144538.
+For more information, see the [Windows PowerShell Software Development
+Kit (SDK) in the MSDN (Microsoft Developer Network)
+library](http://go.microsoft.com/fwlink/?LinkId=144538).
 
-Update-TypeData
+## `Update-TypeData`
 
 To load your Types.ps1xml files into a Windows PowerShell session, run
-the Update-TypeData cmdlet. If you want the types in your file to take
+the `Update-TypeData` cmdlet. If you want the types in your file to take
 precedence over types in the built-in Types.ps1xml file, add the
-PrependData parameter of Update-TypeData. Update-TypeData affects only
+PrependData parameter of `Update-TypeData`. `Update-TypeData` affects only
 the current session. To make the change to all future sessions, export
-the session, or add the Update-TypeData command to your Windows
+the session, or add the `Update-TypeData` command to your Windows
 PowerShell profile.
 
 Exceptions that occur in properties, or from adding properties to an
-Update-TypeData command, do not report errors to StdErr. This is to
+`Update-TypeData` command, do not report errors to `StdErr`. This is to
 suppress exceptions that would occur in many common types during formatting
 and outputting. If you are getting .NET Framework properties, you can work
 around the suppression of exceptions by using method syntax instead, as
 shown in the following example:
 
+```powershell
 "hello".get_Length()
+```
 
 Note that method syntax can only be used with .NET Framework properties.
-Properties that are added by running the Update-TypeData cmdlet cannot
+Properties that are added by running the `Update-TypeData` cmdlet cannot
 use method syntax.
 
-Signing a Types.ps1xml File
+## Signing a Types.ps1xml File
 
 To protect users of your Types.ps1xml file, you can sign the file using
-a digital signature. For more information, see about_Signing.
+a digital signature. For more information, see [about_Signing](about_Signing.md).
 
 # SEE ALSO
 
 [about_Signing](about_Signing.md)
 
-Copy-Item (http://go.microsoft.com/fwlink/?LinkID=113292)
+[Copy-Item](../../Microsoft.PowerShell.Management/Copy-Item.md)
 
-Copy-ItemProperty (http://go.microsoft.com/fwlink/?LinkID=113293)
+[Copy-ItemProperty](../../Microsoft.PowerShell.Management/Copy-Item.md)
 
-Get-Member (http://go.microsoft.com/fwlink/?LinkID=113322)
+[Get-Member](../../Microsoft.PowerShell.Utility/Get-Member.md)
 
-Get-TypeData (http://go.microsoft.com/fwlink/?LinkID=217033)
+[Get-TypeData](../../Microsoft.PowerShell.Utility/Get-TypeData.md)
 
-Remove-TypeData (http://go.microsoft.com/fwlink/?LinkID=217038)
+[Remove-TypeData](../../Microsoft.PowerShell.Utility/Remove-TypeData.md)
 
-Update-TypeData (http://go.microsoft.com/fwlink/?LinkID=113421)
+[Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData.md)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -58,7 +58,7 @@ Windows PowerShell.
 
 To add the `DateTime` property to all Windows PowerShell sessions, Windows PowerShell
 defines the `DateTime` property in the Types.ps1xml file in the Windows PowerShell
-installation directory (`$pshome`).
+installation directory (`$PSHOME`).
 
 ## Adding Extended Type Data to Windows PowerShell.
 
@@ -93,11 +93,11 @@ cmdlet.
 
 ## Built-in Types.ps1xml Files
 
-The Types.ps1xml files in the $pshome directory are added automatically to
+The Types.ps1xml files in the $PSHOME directory are added automatically to
 every session.
 
 The Types.ps1xml file in the Windows PowerShell installation directory
-(`$pshome`) is an XML-based text file that lets you add properties and
+(`$PSHOME`) is an XML-based text file that lets you add properties and
 methods to the objects that are used in Windows PowerShell. Windows
 PowerShell has built-in Types.ps1xml files that add several elements
 to the .NET Framework types, but you can create additional Types.ps1xml
@@ -169,7 +169,7 @@ To create a new file, start by copying an existing Types.ps1xml file. The
 new file can have any name, but it must have a .ps1xml file name
 extension. You can place the new file in any directory that is accessible
 to Windows PowerShell, but it is useful to place the files in the Windows
-PowerShell installation directory (`$pshome`) or in a subdirectory of the
+PowerShell installation directory (`$PSHOME`) or in a subdirectory of the
 installation directory.
 
 When you have saved the new file, use the `Update-TypeData` cmdlet to add
@@ -197,7 +197,7 @@ its creation time and the current time in days.
 
 It is easiest to use the original Types.ps1xml file as a template
 for the new file. The following command copies the original file to
-a file called MyTypes.ps1xml in the $pshome directory.
+a file called MyTypes.ps1xml in the $PSHOME directory.
 
 ```powershell
 Copy-Item Types.ps1xml MyTypes.ps1xml
@@ -260,16 +260,16 @@ information about `Update-TypeData`, see
 [Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData.md).)
 
 ```powershell
-Update-TypeData -PrependPath $pshome\MyTypes.ps1xml
+Update-TypeData -PrependPath $PSHOME\MyTypes.ps1xml
 ```
 
 To test the change, run a `Get-ChildItem` command to get the
-PowerShell.exe file in the `$pshome` directory, and then pipe the file to
+PowerShell.exe file in the `$PSHOME` directory, and then pipe the file to
 the `Format-List` cmdlet to list all of the properties of the file. As a
 result of the change, the Age property appears in the list.
 
 ```powershell
-Get-ChildItem $pshome\PowerShell.exe | Format-List -Property *
+Get-ChildItem $PSHOME\PowerShell.exe | Format-List -Property *
 
 PSPath            : Microsoft.PowerShell.Core\FileSystem::C:\WINDOWS...
 PSParentPath      : Microsoft.PowerShell.Core\FileSystem::C:\WINDOWS...
@@ -288,7 +288,7 @@ You can also display the `Age` property of the file by using the following
 command.
 
 ```powershell
-(Get-ChildItem $pshome\PowerShell.exe).Age
+(Get-ChildItem $PSHOME\PowerShell.exe).Age
 # 16
 ```
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -32,7 +32,7 @@ extended data for types in the current session.
 
 This topic describes Types.ps1xml files. For more information about using the
 `Update-TypeData` cmdlet to add dynamic extended type data to the current session
-see [Update-TypeData](../../Microsoft.Management.Utility/Update-TypeData.md).
+see [Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData.md).
 
 ## About Extended Type Data
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -58,7 +58,7 @@ Windows PowerShell.
 
 To add the `DateTime` property to all Windows PowerShell sessions, Windows PowerShell
 defines the `DateTime` property in the Types.ps1xml file in the Windows PowerShell
-installation directory (`$pshome`).
+installation directory (`$PSHOME`).
 
 ## Adding Extended Type Data to Windows PowerShell.
 
@@ -92,11 +92,11 @@ For more information about these cmdlets, see the help topic for each cmdlet.
 
 ## Built-in Types.ps1xml Files
 
-The Types.ps1xml files in the $pshome directory are added automatically to
+The Types.ps1xml files in the $PSHOME directory are added automatically to
 every session.
 
 The Types.ps1xml file in the Windows PowerShell installation directory
-(`$pshome`) is an XML-based text file that lets you add properties and
+(`$PSHOME`) is an XML-based text file that lets you add properties and
 methods to the objects that are used in Windows PowerShell. Windows
 PowerShell has built-in Types.ps1xml files that add several elements
 to the .NET Framework types, but you can create additional Types.ps1xml
@@ -168,7 +168,7 @@ To create a new file, start by copying an existing Types.ps1xml file. The
 new file can have any name, but it must have a .ps1xml file name
 extension. You can place the new file in any directory that is accessible
 to Windows PowerShell, but it is useful to place the files in the Windows
-PowerShell installation directory (`$pshome`) or in a subdirectory of the
+PowerShell installation directory (`$PSHOME`) or in a subdirectory of the
 installation directory.
 
 When you have saved the new file, use the `Update-TypeData` cmdlet to add
@@ -196,7 +196,7 @@ its creation time and the current time in days.
 
 It is easiest to use the original Types.ps1xml file as a template
 for the new file. The following command copies the original file to
-a file called MyTypes.ps1xml in the `$pshome` directory.
+a file called MyTypes.ps1xml in the `$PSHOME` directory.
 
 ```powershell
 Copy-Item Types.ps1xml MyTypes.ps1xml
@@ -259,16 +259,16 @@ information about `Update-TypeData`, see
 [Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData.md).)
 
 ```powershell
-Update-Typedata -PrependPath $pshome\MyTypes.ps1xml
+Update-Typedata -PrependPath $PSHOME\MyTypes.ps1xml
 ```
 
 To test the change, run a `Get-ChildItem` command to get the
-PowerShell.exe file in the `$pshome` directory, and then pipe the file to
+PowerShell.exe file in the `$PSHOME` directory, and then pipe the file to
 the `Format-List` cmdlet to list all of the properties of the file. As a
 result of the change, the `Age` property appears in the list.
 
 ```powershell
-Get-ChildItem $pshome\PowerShell.exe | Format-List -Property *
+Get-ChildItem $PSHOME\PowerShell.exe | Format-List -Property *
 
 PSPath            : Microsoft.PowerShell.Core\FileSystem::C:\WINDOWS...
 PSParentPath      : Microsoft.PowerShell.Core\FileSystem::C:\WINDOWS...
@@ -287,7 +287,7 @@ You can also display the `Age` property of the file by using the following
 command.
 
 ```powershell
-(Get-ChildItem $pshome\PowerShell.exe).Age
+(Get-ChildItem $PSHOME\PowerShell.exe).Age
 # 16
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -26,15 +26,15 @@ Extended type data defines additional properties and methods ("members")
 of object types in Windows PowerShell. There are two techniques for adding
 extended type data to a Windows PowerShell session.
 
--- Types.ps1xml file: An XML file that defines extended type data.
--- Update-TypeData: A cmdlet that reloads Types.ps1xml files and defines
+- Types.ps1xml file: An XML file that defines extended type data.
+- `Update-TypeData`: A cmdlet that reloads Types.ps1xml files and defines
 extended data for types in the current session.
 
 This topic describes Types.ps1xml files. For more information about using the
-Update-TypeData cmdlet to add dynamic extended type data to the current session
-see Update-TypeData (http://go.microsoft.com/fwlink/?LinkID=113421).
+`Update-TypeData` cmdlet to add dynamic extended type data to the current session
+see [Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData.md).
 
-About Extended Type Data
+## About Extended Type Data
 
 Extended type data defines additional properties and methods ("members")
 of object types in Windows PowerShell. You can extend any type that is
@@ -42,113 +42,121 @@ supported by Windows PowerShell and use the added properties and methods
 in the same way that you use the properties that are defined on the object
 types.
 
-For example, Windows PowerShell adds a DateTime property to all
-System.DateTime objects, such as the ones that the Get-Date cmdlet
+For example, Windows PowerShell adds a `DateTime` property to all
+`System.DateTime` objects, such as the ones that the `Get-Date` cmdlet
 returns.
 
+```powershell
 PS C:> (Get-Date).DateTime
 Sunday, January 29, 2012 9:43:57 AM
+```
 
-You won't find the DateTime property in the description of the System.DateTime
-structure (http://msdn.microsoft.com/library/system.datetime.aspx),
+You won't find the `DateTime` property in the description of the [`System.DateTime`
+structure](http://msdn.microsoft.com/library/system.datetime.aspx),
 because Windows PowerShell adds the property and it is visible only in
 Windows PowerShell.
 
-To add the DateTime property to all Windows PowerShell sessions, Windows PowerShell
-defines the DateTime property in the Types.ps1xml file in the Windows PowerShell
-installation directory ($pshome).
+To add the `DateTime` property to all Windows PowerShell sessions, Windows PowerShell
+defines the `DateTime` property in the Types.ps1xml file in the Windows PowerShell
+installation directory (`$pshome`).
 
-Adding Extended Type Data to Windows PowerShell.
+## Adding Extended Type Data to Windows PowerShell.
 
 There are three sources of extended type data in Windows PowerShell sessions.
 
---  The Types.ps1xml files in the Windows PowerShell installation directory
+- The Types.ps1xml files in the Windows PowerShell installation directory
 are loaded automatically into every Windows PowerShell session.
 
---  The Types.ps1xml files that modules export are loaded when the module
+- The Types.ps1xml files that modules export are loaded when the module
 is imported into the current session.
 
---  Extended type data that is defined by using the Update-TypeData cmdlet
+- Extended type data that is defined by using the `Update-TypeData` cmdlet
 is added only to the current session. It is not saved in a file.
 
 In the session, the extended type data from the three sources is applied
 to objects in the same way and is available on all objects of the specified
 types.
 
-The TypeData Cmdlets
+## The TypeData Cmdlets
 
 The following TypeData cmdlets are included in the Microsoft.PowerShell.Utility
 module in Windows PowerShell 3.0 and later versions of Windows PowerShell.
 
-Get-TypeData:     Gets extended type data in the current session.
-Update-TypeData:  Reloads Types.ps1xml files. Adds extended type
-data to the current session.
-Remove-TypeData:  Removes extended type data from the current
-session.
+|                 |                                                                 |
+| --------------- | --------------------------------------------------------------- |
+| Get-TypeData    | Gets extended type data in the current session.                 |
+| Update-TypeData | Reloads Types.ps1xml files. Adds extended type data to the current session. |
+| Remove-TypeData |  Removes extended type data from the current session.
 
-For more information about these cmdlets, see the help topic for each
-cmdlet.
+For more information about these cmdlets, see the help topic for each cmdlet.
 
-Built-in Types.ps1xml Files
+## Built-in Types.ps1xml Files
 
 The Types.ps1xml files in the $pshome directory are added automatically to
 every session.
 
 The Types.ps1xml file in the Windows PowerShell installation directory
-($pshome) is an XML-based text file that lets you add properties and
+(`$pshome`) is an XML-based text file that lets you add properties and
 methods to the objects that are used in Windows PowerShell. Windows
 PowerShell has built-in Types.ps1xml files that add several elements
 to the .NET Framework types, but you can create additional Types.ps1xml
 files to further extend the types.
 
-For example, by default, array objects (System.Array) have a Length
+For example, by default, array objects (`System.Array`) have a `Length`
 property that lists the number of objects in the array. However, because
-the name "length" does not clearly describe the property, Windows
+the name "Length" does not clearly describe the property, Windows
 PowerShell adds an alias property named "Count" that displays the same
-value. The following XML adds the Count property to the System.Array type.
+value. The following XML adds the Count property to the `System.Array` type.
 
+```xml
 <Type>
-<Name>System.Array</Name>
-<Members>
-<AliasProperty>
-<Name>Count</Name>
-<ReferencedMemberName>
-Length
-</ReferencedMemberName>
-</AliasProperty>
-</Members>
+  <Name>System.Array</Name>
+  <Members>
+    <AliasProperty>
+      <Name>Count</Name>
+      <ReferencedMemberName>
+        Length
+      </ReferencedMemberName>
+    </AliasProperty>
+  </Members>
 </Type>
+```
 
-To get the new AliasProperty, use a Get-Member command on any array, as shown
+To get the new `AliasProperty`, use a `Get-Member` command on any array, as shown
 in the following example.
 
-Get-Member -inputobject (1,2,3,4)
+```powershell
+Get-Member -InputObject (1,2,3,4)
+```
 
 The command returns the following results.
 
+```powershell
 Name           MemberType    Definition
 ----           ----------    ----------
 Count          AliasProperty Count = Length
-Address        Method        System.Object& Address(Int32 )
+Address        Method        System.Object& Address(Int32)
 Clone          Method        System.Object Clone()
 CopyTo         Method        System.Void CopyTo(Array array, Int32 index):
 Equals         Method        System.Boolean Equals(Object obj)
-Get            Method        System.Object Get(Int32 )
+Get            Method        System.Object Get(Int32)
 # ...
-
+```
 
 As a result, you can use either the Count property or the Length property
 of arrays in Windows PowerShell. For example:
 
+```powershell
 C:\PS> (1, 2, 3, 4).count
 # 4
+```
 
-
+```powershell
 C:\PS> (1, 2, 3, 4).length
 # 4
+```
 
-
-Creating New Types.ps1xml Files
+## Creating New Types.ps1xml Files
 
 The .ps1xml files that are installed with Windows PowerShell are
 digitally signed to prevent tampering because the formatting can include
@@ -160,97 +168,107 @@ To create a new file, start by copying an existing Types.ps1xml file. The
 new file can have any name, but it must have a .ps1xml file name
 extension. You can place the new file in any directory that is accessible
 to Windows PowerShell, but it is useful to place the files in the Windows
-PowerShell installation directory ($pshome) or in a subdirectory of the
+PowerShell installation directory (`$pshome`) or in a subdirectory of the
 installation directory.
 
-When you have saved the new file, use the Update-TypeData cmdlet to add
+When you have saved the new file, use the `Update-TypeData` cmdlet to add
 the new file to your Windows PowerShell session. If you want your types
 to take precedence over the types that are defined in the built-in file,
-use the PrependData parameter of the Update-TypeData cmdlet.
-Update-TypeData affects only the current session. To make the change to
-all future sessions, export the console, or add the Update-TypeData
+use the PrependData parameter of the `Update-TypeData` cmdlet.
+`Update-TypeData` affects only the current session. To make the change to
+all future sessions, export the console, or add the `Update-TypeData`
 command to your Windows PowerShell profile.
 
-Types.ps1xml and Add-Member
+## Types.ps1xml and Add-Member
 
 The Types.ps1xml files add properties and methods to all the instances
 of the objects of the specified .NET Framework type in the affected
 Windows PowerShell session. However, if you need to add properties or
-methods only to one instance of an object, use the Add-Member cmdlet.
+methods only to one instance of an object, use the `Add-Member` cmdlet.
 
-For more information,see Add-Member.
+For more information, see [Add-Member](../../Microsoft.PowerShell.Utility/Add-Member.md).
 
-Example: Adding an Age Member to FileInfo Objects
+## Example: Adding an `Age` Member to `FileInfo` Objects
 
-This example shows how to add an Age property to file objects
-(System.IO.FileInfo). The age of a file is the difference between
+This example shows how to add an `Age` property to file objects
+(`System.IO.FileInfo`). The age of a file is the difference between
 its creation time and the current time in days.
 
 It is easiest to use the original Types.ps1xml file as a template
 for the new file. The following command copies the original file to
-a file called MyTypes.ps1xml in the $pshome directory.
+a file called MyTypes.ps1xml in the `$pshome` directory.
 
-copy-item Types.ps1xml MyTypes.ps1xml
+```powershell
+Copy-Item Types.ps1xml MyTypes.ps1xml
+```
 
 Next, open the Types.ps1xml file in any XML or text editor, such
-as Notepad. Because the Age property is calculated by using a script
-block, find a <ScriptProperty> tag to use as a model for the new Age
+as Notepad. Because the `Age` property is calculated by using a script
+block, find a `<ScriptProperty>` tag to use as a model for the new `Age`
 property.
 
-Copy the XML between the <Type> and </Type> tags of the code to create
+Copy the XML between the `<Type>` and `</Type>` tags of the code to create
 the script property. Then, delete the remainder of the file, except for
-the opening <?xml> and <Types> tags and the closing </Types> tag. You
+the opening `<?xml>` and `<Types>` tags and the closing `</Types>` tag. You
 must also delete the digital signature to prevent errors.
 
 Begin with the model script property, such as the following script
 property, which was copied from the original Types.ps1xml file.
 
+```xml
 <?xml version="1.0" encoding="utf-8" ?>
 <Types>
-<Type>
-<Name>System.Guid</Name>
-<Members>
-<ScriptProperty>
-<Name>Guid</Name>
-<GetScriptBlock>$this.ToString()</GetScriptBlock>
-</ScriptProperty>
-</Members>
-</Type>
+  <Type>
+    <Name>System.Guid</Name>
+    <Members>
+      <ScriptProperty>
+        <Name>Guid</Name>
+        <GetScriptBlock>$this.ToString()</GetScriptBlock>
+      </ScriptProperty>
+    </Members>
+  </Type>
 </Types>
+```
 
 Then, change the name of the .NET Framework type, the name of the
-property, and the value of the script block to create an Age property
+property, and the value of the script block to create an `Age` property
 for file objects.
 
+```xml
 <?xml version="1.0" encoding="utf-8" ?>
 <Types>
-<Type>
-<Name>System.IO.FileInfo</Name>
-<Members>
-<ScriptProperty>
-<Name>Age</Name>
-<GetScriptBlock>
-((get-date) - ($this.creationtime)).days
-</GetScriptBlock>
-</ScriptProperty>
-</Members>
-</Type>
+  <Type>
+    <Name>System.IO.FileInfo</Name>
+    <Members>
+      <ScriptProperty>
+        <Name>Age</Name>
+        <GetScriptBlock>
+          ((get-date) - ($this.creationtime)).days
+        </GetScriptBlock>
+      </ScriptProperty>
+    </Members>
+  </Type>
 </Types>
+```
 
-After you save the file and close it, run an Update-TypeData command,
+After you save the file and close it, run an `Update-TypeData` command,
 such as the following command, to add the new Types.ps1xml file to the
-current session. The command uses the PrependData parameter to place the
+current session. The command uses the `PrependData` parameter to place the
 new file in a higher precedence order than the original file. (For more
-information about Update-TypeData, see Update-TypeData.)
+information about `Update-TypeData`, see
+[Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData.md).)
 
-update-typedata -prependpath $pshome\MyTypes.ps1xml
+```powershell
+Update-Typedata -PrependPath $pshome\MyTypes.ps1xml
+```
 
-To test the change, run a Get-ChildItem command to get the
-PowerShell.exe file in the $pshome directory, and then pipe the file to
-the Format-List cmdlet to list all of the properties of the file. As a
-result of the change, the Age property appears in the list.
+To test the change, run a `Get-ChildItem` command to get the
+PowerShell.exe file in the `$pshome` directory, and then pipe the file to
+the `Format-List` cmdlet to list all of the properties of the file. As a
+result of the change, the `Age` property appears in the list.
 
-get-childitem $pshome\PowerShell.exe | format-list -property *
+```powershell
+Get-ChildItem $pshome\PowerShell.exe | Format-List -Property *
 
 PSPath            : Microsoft.PowerShell.Core\FileSystem::C:\WINDOWS...
 PSParentPath      : Microsoft.PowerShell.Core\FileSystem::C:\WINDOWS...
@@ -263,310 +281,329 @@ VersionInfo       : File:             C:\WINDOWS\system32\WindowsPow...
 InternalName:     POWERSHELL
 OriginalFilename: PowerShell.EXE
 # ...
+```
 
-
-You can also display the Age property of the file by using the following
+You can also display the `Age` property of the file by using the following
 command.
 
-(get-childitem $pshome\PowerShell.exe).age
+```powershell
+(Get-ChildItem $pshome\PowerShell.exe).Age
 # 16
+```
 
+## The XML in Types.ps1xml Files
 
-The XML in Types.ps1xml Files
-
-The <Types> tag encloses all of the types that are defined in the file.
-There should be only one pair of <Types> tags.
+The `<Types>` tag encloses all of the types that are defined in the file.
+There should be only one pair of `<Types>` tags.
 
 Each .NET Framework type mentioned in the file should be represented by
-a pair of <Type> tags.
+a pair of `<Type>` tags.
 
 The type tags must contain the following tags:
 
-<Name>: A pair of <Name> tags that enclose the name of the affected
+`<Name>`: A pair of `<Name>` tags that enclose the name of the affected
 .NET Framework type.
 
-<Members>: A pair of <Members> tags that enclose the tags for the
+`<Members>`: A pair of `<Members>` tags that enclose the tags for the
 new properties and methods that are defined for the
 .NET Framework type.
 
-Any of the following member tags can be inside the <Members> tags.
+Any of the following member tags can be inside the `<Members>` tags.
 
-<AliasProperty>: Defines a new name for an existing property.
+`<AliasProperty>`: Defines a new name for an existing property.
 
-The <AliasProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <ReferencedMemberName> tags
+The `<AliasProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<ReferencedMemberName>` tags
 that specify the existing property.
 
-For example, the Count alias property is an alias for the Length
+For example, the `Count` alias property is an alias for the `Length`
 property of array objects.
 
+```xml
 <Type>
-<Name>System.Array</Name>
-<Members>
-<AliasProperty>
-<Name>Count</Name>
-<ReferencedMemberName>Length</ReferencedMemberName>
-</AliasProperty>
-</Members>
+  <Name>System.Array</Name>
+  <Members>
+    <AliasProperty>
+      <Name>Count</Name>
+      <ReferencedMemberName>Length</ReferencedMemberName>
+    </AliasProperty>
+  </Members>
 </Type>
+```
 
-<CodeMethod>:  References a static method of a .NET Framework class.
+`<CodeMethod>`:  References a static method of a .NET Framework class.
 
-The <CodeMethod> tag must have a pair of <Name> tags that specify
-the name of the new method and a pair of <GetCodeReference> tags
+The `<CodeMethod>` tag must have a pair of `<Name>` tags that specify
+the name of the new method and a pair of `<GetCodeReference>` tags
 that specify the code in which the method is defined.
 
-For example, the Mode property of directories (System.IO.DirectoryInfo
+For example, the Mode property of directories (`System.IO.DirectoryInfo`
 objects) is a code property defined in the Windows PowerShell
 FileSystem provider.
 
+```xml
 <Type>
-<Name>System.IO.DirectoryInfo</Name>
-<Members>
-<CodeProperty>
-<Name>Mode</Name>
-<GetCodeReference>
-<TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
-<MethodName>Mode</MethodName>
-</GetCodeReference>
-</CodeProperty>
-</Members>
+  <Name>System.IO.DirectoryInfo</Name>
+  <Members>
+    <CodeProperty>
+      <Name>Mode</Name>
+      <GetCodeReference>
+        <TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
+        <MethodName>Mode</MethodName>
+      </GetCodeReference>
+    </CodeProperty>
+  </Members>
 </Type>
+```
 
-<CodeProperty>: References a static method of a .NET Framework class.
+`<CodeProperty>`: References a static method of a .NET Framework class.
 
-The <CodeProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <GetCodeReference> tags
+The `<CodeProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<GetCodeReference>` tags
 that specify the code in which the property is defined.
 
-For example, the Mode property of directories (System.IO.DirectoryInfo
+For example, the `Mode` property of directories (`System.IO.DirectoryInfo`
 objects) is a code property defined in the Windows PowerShell
 FileSystem provider.
 
+```xml
 <Type>
-<Name>System.IO.DirectoryInfo</Name>
-<Members>
-<CodeProperty>
-<Name>Mode</Name>
-<GetCodeReference>
-<TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
-<MethodName>Mode</MethodName>
-</GetCodeReference>
-</CodeProperty>
-</Members>
+  <Name>System.IO.DirectoryInfo</Name>
+  <Members>
+    <CodeProperty>
+      <Name>Mode</Name>
+      <GetCodeReference>
+        <TypeName>Microsoft.PowerShell.Commands.FileSystemProvider</TypeName>
+        <MethodName>Mode</MethodName>
+      </GetCodeReference>
+    </CodeProperty>
+  </Members>
 </Type>
+```
 
-<MemberSet>: Defines a collection of members (properties and methods).
+`<MemberSet>`: Defines a collection of members (properties and methods).
 
-The <MemberSet> tags appear within the primary <Members> tags. The
-tags must enclose a pair of <Name> tags surrounding the name of the
-member set and a pair of secondary <Members> tags that surround the
+The `<MemberSet>` tags appear within the primary `<Members>` tags. The
+tags must enclose a pair of `<Name>` tags surrounding the name of the
+member set and a pair of secondary `<Members>` tags that surround the
 members (properties and methods) in the set. Any of the tags that
-create a property (such as <NoteProperty> or <ScriptProperty>) or a
-method (such as <Method> or <ScriptMethod>) can be members of the set.
+create a property (such as `<NoteProperty>` or `<ScriptProperty>`) or a
+method (such as `<Method>` or `<ScriptMethod>`) can be members of the set.
 
-In Types.ps1xml files, the <MemberSet> tag is used to define the
+In Types.ps1xml files, the `<MemberSet>` tag is used to define the
 default views of the .NET Framework objects in Windows PowerShell. In
-this case, the name of the member set (the value within the <Name>
+this case, the name of the member set (the value within the `<Name>`
 tags) is always "PsStandardMembers", and the names of the properties
-(the value of the <Name> tag) are one of the following:
+(the value of the `<Name>` tag) are one of the following:
 
-- DefaultDisplayProperty: A single property of an object.
+- `DefaultDisplayProperty`: A single property of an object.
 
-- DefaultDisplayPropertySet: One or more properties of an object.
+- `DefaultDisplayPropertySet`: One or more properties of an object.
 
-- DefaultKeyPropertySet: One or more key properties of an object.
+- `DefaultKeyPropertySet`: One or more key properties of an object.
 A key property identifies instances of property values, such as
 the ID number of items in a session history.
 
 For example, the following XML defines the default display of services
-(System.ServiceProcess.ServiceController objects) that are returned by
-the Get-Service cmdlet. It defines a member set named
+(`System.ServiceProcess.ServiceController` objects) that are returned by
+the `Get-Service` cmdlet. It defines a member set named
 "PsStandardMembers" that consists of a default property set with the
-Status, Name, and DisplayName properties.
+`Status`, `Name`, and `DisplayName` properties.
 
+```xml
 <Type>
-<Name>System.ServiceProcess.ServiceController</Name>
-<Members>
-<MemberSet>
-<Name>PSStandardMembers</Name>
-<Members>
-<PropertySet>
-<Name>DefaultDisplayPropertySet</Name>
-<ReferencedProperties>
-<Name>Status</Name>
-<Name>Name</Name>
-<Name>DisplayName</Name>
-</ReferencedProperties>
-</PropertySet>
-</Members>
-</MemberSet>
-</Members>
+  <Name>System.ServiceProcess.ServiceController</Name>
+  <Members>
+    <MemberSet>
+      <Name>PSStandardMembers</Name>
+      <Members>
+        <PropertySet>
+          <Name>DefaultDisplayPropertySet</Name>
+          <ReferencedProperties>
+            <Name>Status</Name>
+            <Name>Name</Name>
+            <Name>DisplayName</Name>
+          </ReferencedProperties>
+        </PropertySet>
+      </Members>
+    </MemberSet>
+  </Members>
 </Type>
+```
 
-<Method>: References a native method of the underlying object.
+`<Method>`: References a native method of the underlying object.
 
-<Methods>: A collection of the methods of the object.
+`<Methods>`: A collection of the methods of the object.
 
-<NoteProperty>: Defines a property with a static value.
+`<NoteProperty>`: Defines a property with a static value.
 
-The <NoteProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <Value> tags that specify
+The `<NoteProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<Value>` tags that specify
 the value of the property.
 
 For example, the following XML creates a Status property for
-directories (System.IO.DirectoryInfo objects). The value of the
-Status property is always "Success".
+directories (`System.IO.DirectoryInfo` objects). The value of the
+`Status` property is always "Success".
 
+```xml
 <Type>
-<Name>System.IO.DirectoryInfo</Name>
-<Members>
-<NoteProperty>
-<Name>Status</Name>
-<Value>Success</Value>
-</NoteProperty>
-</Members>
+  <Name>System.IO.DirectoryInfo</Name>
+  <Members>
+    <NoteProperty>
+      <Name>Status</Name>
+      <Value>Success</Value>
+    </NoteProperty>
+  </Members>
 </Type>
+```
 
-<ParameterizedProperty>: Properties that take arguments and return a
+`<ParameterizedProperty>`: Properties that take arguments and return a
 value.
 
-<Properties>: A collection of the properties of the object.
+`<Properties>`: A collection of the properties of the object.
 
-<Property>: A property of the base object.
+`<Property>`: A property of the base object.
 
-<PropertySet>: Defines a collection of properties of the object.
+`<PropertySet>`: Defines a collection of properties of the object.
 
-The <PropertySet> tag must have a pair of <Name> tags that specify
-the name of the property set and a pair of <ReferencedProperty> tags
+The `<PropertySet>` tag must have a pair of `<Name>` tags that specify
+the name of the property set and a pair of `<ReferencedProperty>` tags
 that specify the properties. The names of the properties are enclosed
-in <Name> tag pairs.
+in `<Name>` tag pairs.
 
-In Types.ps1xml, <PropertySet> tags are used to define sets of
+In Types.ps1xml, `<PropertySet>` tags are used to define sets of
 properties for the default display of an object. You can identify the
-default displays by the value "PsStandardMembers" in the <Name> tag
-of a <MemberSet> tag.
+default displays by the value "PsStandardMembers" in the `<Name>` tag
+of a `<MemberSet>` tag.
 
 For example, the following XML creates a Status property for
-directories (System.IO.DirectoryInfo objects). The value of the Status
+directories (`System.IO.DirectoryInfo` objects). The value of the `Status`
 property is always "Success".
 
+```xml
 <Type>
-<Name>System.ServiceProcess.ServiceController</Name>
-<Members>
-<MemberSet>
-<Name>PSStandardMembers</Name>
-<Members>
-<PropertySet>
-<Name>DefaultDisplayPropertySet</Name>
-<ReferencedProperties>
-<Name>Status</Name
-<Name>Name</Name>
-<Name>DisplayName</Name>
-</ReferencedProperties>
-</PropertySet>
-<Members>
-<MemberSet>
-<Members>
-<Type>
+  <Name>System.ServiceProcess.ServiceController</Name>
+  <Members>
+    <MemberSet>
+      <Name>PSStandardMembers</Name>
+      <Members>
+        <PropertySet>
+          <Name>DefaultDisplayPropertySet</Name>
+          <ReferencedProperties>
+            <Name>Status</Name>
+            <Name>Name</Name>
+            <Name>DisplayName</Name>
+          </ReferencedProperties>
+        </PropertySet>
+      </Members>
+    </MemberSet>
+  </Members>
+</Type>
+```
 
-<ScriptMethod>: Defines a method whose value is the output of a script.
+`<ScriptMethod>`: Defines a method whose value is the output of a script.
 
-The <ScriptMethod> tag must have a pair of <Name> tags that specify
-the name of the new method and a pair of <Script> tags that enclose
+The `<ScriptMethod>` tag must have a pair of `<Name>` tags that specify
+the name of the new method and a pair of `<Script>` tags that enclose
 the script block that returns the method result.
 
-For example, the ConvertToDateTime and ConvertFromDateTime methods of
-management objects (System.System.Management.ManagementObject) are
-script methods that use the ToDateTime and ToDmtfDateTime static
-methods of the System.Management.ManagementDateTimeConverter class.
+For example, the `ConvertToDateTime` and `ConvertFromDateTime` methods of
+management objects (`System.System.Management.ManagementObject`) are
+script methods that use the `ToDateTime` and `ToDmtfDateTime` static
+methods of the `System.Management.ManagementDateTimeConverter` class.
 
+```xml
 <Type>
-<Name>System.Management.ManagementObject</Name>
-<Members>
-<ScriptMethod>
-<Name>ConvertToDateTime</Name>
-<Script>
-[System.Management.ManagementDateTimeConverter]::ToDateTime($args[0])
-</Script>
-</ScriptMethod>
-<ScriptMethod>
-<Name>ConvertFromDateTime</Name>
-<Script>
-[System.Management.ManagementDateTimeConverter]::ToDmtfDateTime($args[0])
-</Script>
-</ScriptMethod>
-</Members>
+  <Name>System.Management.ManagementObject</Name>
+  <Members>
+    <ScriptMethod>
+      <Name>ConvertToDateTime</Name>
+      <Script>
+        [System.Management.ManagementDateTimeConverter]::ToDateTime($args[0])
+      </Script>
+    </ScriptMethod>
+    <ScriptMethod>
+      <Name>ConvertFromDateTime</Name>
+      <Script>
+        [System.Management.ManagementDateTimeConverter]::ToDmtfDateTime($args[0])
+      </Script>
+    </ScriptMethod>
+  </Members>
 </Type>
+```
 
-<ScriptProperty>: Defines a property whose value is the output of a
+`<ScriptProperty>`: Defines a property whose value is the output of a
 script.
 
-The <ScriptProperty> tag must have a pair of <Name> tags that specify
-the name of the new property and a pair of <GetScriptBlock> tags
+The `<ScriptProperty>` tag must have a pair of `<Name>` tags that specify
+the name of the new property and a pair of `<GetScriptBlock>` tags
 that enclose the script block that returns the property value.
 
-For example, the VersionInfo property of files (System.IO.FileInfo
-objects) is a script property that results from using the FullName
-property of the GetVersionInfo static method of
-System.Diagnostics.FileVersionInfo objects.
+For example, the `VersionInfo` property of files (`System.IO.FileInfo`
+objects) is a script property that results from using the `FullName`
+property of the `GetVersionInfo` static method of
+`System.Diagnostics.FileVersionInfo` objects.
 
+```xml
 <Type>
-<Name>System.IO.FileInfo</Name>
-<Members>
-<ScriptProperty>
-<Name>VersionInfo</Name>
-<GetScriptBlock>
-[System.Diagnostics.FileVersionInfo]::GetVersionInfo($this.FullName)
-</GetScriptBlock>
-</ScriptProperty>
-</Members>
+  <Name>System.IO.FileInfo</Name>
+  <Members>
+    <ScriptProperty>
+      <Name>VersionInfo</Name>
+      <GetScriptBlock>
+        [System.Diagnostics.FileVersionInfo]::GetVersionInfo($this.FullName)
+      </GetScriptBlock>
+    </ScriptProperty>
+  </Members>
 </Type>
+```
 
-For more information, see the Windows PowerShell Software Development
-Kit (SDK) in the MSDN (Microsoft Developer Network )library
-at http://go.microsoft.com/fwlink/?LinkId=144538.
+For more information, see the [Windows PowerShell Software Development
+Kit (SDK) in the MSDN (Microsoft Developer Network)
+library](http://go.microsoft.com/fwlink/?LinkId=144538).
 
-Update-TypeData
+## `Update-TypeData`
 
 To load your Types.ps1xml files into a Windows PowerShell session, run
-the Update-TypeData cmdlet. If you want the types in your file to take
+the `Update-TypeData` cmdlet. If you want the types in your file to take
 precedence over types in the built-in Types.ps1xml file, add the
-PrependData parameter of Update-TypeData. Update-TypeData affects only
+PrependData parameter of `Update-TypeData`. `Update-TypeData` affects only
 the current session. To make the change to all future sessions, export
-the session, or add the Update-TypeData command to your Windows
+the session, or add the `Update-TypeData` command to your Windows
 PowerShell profile.
 
 Exceptions that occur in properties, or from adding properties to an
-Update-TypeData command, do not report errors to StdErr. This is to
+`Update-TypeData` command, do not report errors to `StdErr`. This is to
 suppress exceptions that would occur in many common types during formatting
 and outputting. If you are getting .NET Framework properties, you can work
 around the suppression of exceptions by using method syntax instead, as
 shown in the following example:
 
+```powershell
 "hello".get_Length()
+```
 
 Note that method syntax can only be used with .NET Framework properties.
-Properties that are added by running the Update-TypeData cmdlet cannot
+Properties that are added by running the `Update-TypeData` cmdlet cannot
 use method syntax.
 
-Signing a Types.ps1xml File
+## Signing a Types.ps1xml File
 
 To protect users of your Types.ps1xml file, you can sign the file using
-a digital signature. For more information, see about_Signing.
+a digital signature. For more information, see [about_Signing](about_Signing.md).
 
 # SEE ALSO
 
 [about_Signing](about_Signing.md)
 
-Copy-Item (http://go.microsoft.com/fwlink/?LinkID=113292)
+[Copy-Item](../../Microsoft.PowerShell.Management/Copy-Item.md)
 
-Copy-ItemProperty (http://go.microsoft.com/fwlink/?LinkID=113293)
+[Copy-ItemProperty](../../Microsoft.PowerShell.Management/Copy-ItemProperty.md)
 
-Get-Member (http://go.microsoft.com/fwlink/?LinkID=113322)
+[Get-Member](../../Microsoft.PowerShell.Utility/Get-Member.md)
 
-Get-TypeData (http://go.microsoft.com/fwlink/?LinkID=217033)
+[Get-TypeData](../../Microsoft.PowerShell.Utility/Get-TypeData.md)
 
-Remove-TypeData (http://go.microsoft.com/fwlink/?LinkID=217038)
+[Remove-TypeData](../../Microsoft.PowerShell.Utility/Remove-TypeData.md)
 
-Update-TypeData (http://go.microsoft.com/fwlink/?LinkID=113421)
+[Update-TypeData](../../Microsoft.PowerShell.Utility/Update-TypeData.md)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -243,7 +243,7 @@ for file objects.
       <ScriptProperty>
         <Name>Age</Name>
         <GetScriptBlock>
-          ((get-date) - ($this.creationtime)).days
+          ((Get-Date) - ($this.CreationTime)).Days
         </GetScriptBlock>
       </ScriptProperty>
     </Members>

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -92,7 +92,7 @@ For more information about these cmdlets, see the help topic for each cmdlet.
 
 ## Built-in Types.ps1xml Files
 
-The Types.ps1xml files in the $PSHOME directory are added automatically to
+The Types.ps1xml files in the `$PSHOME` directory are added automatically to
 every session.
 
 The Types.ps1xml file in the Windows PowerShell installation directory


### PR DESCRIPTION
This updates the `about_Types.ps1xml` page for the 3.0 reference as an example of possible markdown-aware formatting for the `about_*.ps1xml` pages.

I thought I would submit a single file before going ahead and making lots of changes to discuss:
- Whether this change is desired or useful
- What style of markdown is best, e.g. when to put terms in backticks, whether tables should be used
- Whether this change is alright when done incrementally, or if it (and all the other `about_*`) pages should be updated all at once

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] ~~This PR partially fixes the issue, and issue #1076  tracks the remaining work~~
