### PR TITLE
Adding index.md to JEA docs for loc fix

### DIFF
--- a/jea/index.md
+++ b/jea/index.md
@@ -1,0 +1,12 @@
+---
+manager:  carmonm
+ms.topic:  article
+author:  rpsqrd
+ms.author:  ryanpu
+ms.prod:  powershell
+keywords:  powershell,cmdlet,jea
+ms.date:  2017-03-06
+title:  Just Enough Administration
+ms.technology:  powershell
+redirect_url: https://msdn.microsoft.com/powershell/jea/overview
+---


### PR DESCRIPTION
Localized copies of JEA docs are redirecting /jea/index to Windows Home Server 2011 documentation. To fix this, we need to add a redirect page in the EN-US docs so the international copies pick it up and properly redirect to the overview page.