### PR TITLE
Clarify -FileList for parameter (v3.0, v.4.0, v5.0)

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -361,8 +361,7 @@ Accept wildcard characters: False
 ### -FileList
 Specifies all items that are included in the module.
 
-This key is designed to act as a module inventory.
-The files listed in the key are not automatically exported with the module.
+This key is designed to act as a module inventory. The files listed in the key are included when the module is published, but any functions are not automatically exported.
 
 ```yaml
 Type: String[]

--- a/reference/4.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -405,8 +405,7 @@ Accept wildcard characters: False
 ### -FileList
 Specifies all items that are included in the module.
 
-This key is designed to act as a module inventory.
-The files listed in the key are not automatically exported with the module.
+This key is designed to act as a module inventory. The files listed in the key are included when the module is published, but any functions are not automatically exported.
 
 ```yaml
 Type: String[]

--- a/reference/5.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -423,8 +423,7 @@ Accept wildcard characters: True
 ### -FileList
 Specifies all items that are included in the module.
 
-This key is designed to act as a module inventory.
-The files listed in the key are not automatically exported with the module.
+This key is designed to act as a module inventory. The files listed in the key are included when the module is published, but any functions are not automatically exported.
 
 ```yaml
 Type: String[]


### PR DESCRIPTION
v5.1 already merged in #1135 

When consulting this document it was unclear whether files included in -FileList would be published along with the other module files when pushed to a PSRepository. They are, hence the clarification update.

Version(s) of document impacted
------------------------------
- [ X] Impacts 5.0 document
- [ X] Impacts 4.0 document
- [ X] Impacts 3.0 document