### PR TITLE
Fix Write-Error Example 4 in 3.0, 4.0, 5.0, 5.1, and 6

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Write-Error.md
@@ -74,8 +74,8 @@ PS C:\> Write-Error -Message "Error: Too many input values." -Category InvalidAr
 This command declares a non-terminating error and specifies an error category.
 ### Example 4
 ```
-PS C:\> $e = [System.Exception]@{$e = [System.Exception]@{Source="Get-ParameterNames.ps1";HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}
-PS C:\> Write-Error $e -Message "Files not found. The $Files location does not contain any XML files."
+PS C:\> $E = [System.Exception]@{Source="Get-ParameterNames.ps1";HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}
+PS C:\> Write-Error -Exception $E -Message "Files not found. The $Files location does not contain any XML files."
 ```
 
 This command uses an **Exception** object to declare a non-terminating error.

--- a/reference/4.0/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Write-Error.md
@@ -80,8 +80,8 @@ This command declares a non-terminating error and specifies an error category.
 
 ### Example 4
 ```
-PS C:\> $e = [System.Exception]@{$e = [System.Exception]@{Source="Get-ParameterNames.ps1";HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}
-PS C:\> Write-Error $e -Message "Files not found. The $Files location does not contain any XML files."
+PS C:\> $E = [System.Exception]@{Source="Get-ParameterNames.ps1";HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}
+PS C:\> Write-Error -Exception $E -Message "Files not found. The $Files location does not contain any XML files."
 ```
 
 This command uses an **Exception** object to declare a non-terminating error.

--- a/reference/5.0/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Write-Error.md
@@ -80,8 +80,8 @@ This command declares a non-terminating error and specifies an error category.
 
 ### Example 4: Write an error using an Exception object
 ```
-PS C:\> $E = [System.Exception]@{$e = [System.Exception]@{Source="Get-ParameterNames.ps1";HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}
-PS C:\> Write-Error $E -Message "Files not found. The $Files location does not contain any XML files."
+PS C:\> $E = [System.Exception]@{Source="Get-ParameterNames.ps1";HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}
+PS C:\> Write-Error -Exception $E -Message "Files not found. The $Files location does not contain any XML files."
 ```
 
 This command uses an **Exception** object to declare a non-terminating error.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Error.md
@@ -80,8 +80,8 @@ This command declares a non-terminating error and specifies an error category.
 
 ### Example 4: Write an error using an Exception object
 ```
-PS C:\> $E = [System.Exception]@{$e = [System.Exception]@{Source="Get-ParameterNames.ps1";HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}
-PS C:\> Write-Error $E -Message "Files not found. The $Files location does not contain any XML files."
+PS C:\> $E = [System.Exception]@{Source="Get-ParameterNames.ps1";HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}
+PS C:\> Write-Error -Exception $E -Message "Files not found. The $Files location does not contain any XML files."
 ```
 
 This command uses an **Exception** object to declare a non-terminating error.

--- a/reference/6/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Write-Error.md
@@ -82,8 +82,8 @@ This command declares a non-terminating error and specifies an error category.
 
 ### Example 4: Write an error using an Exception object
 ```
-PS C:\> $E = [System.Exception]@{$e = [System.Exception]@{Source="Get-ParameterNames.ps1";HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}
-PS C:\> Write-Error $E -Message "Files not found. The $Files location does not contain any XML files."
+PS C:\> $E = [System.Exception]@{Source="Get-ParameterNames.ps1";HelpLink="http://go.microsoft.com/fwlink/?LinkID=113425"}
+PS C:\> Write-Error -Exception $E -Message "Files not found. The $Files location does not contain any XML files."
 ```
 
 This command uses an **Exception** object to declare a non-terminating error.


### PR DESCRIPTION
Line 1 of Example 4 for Write-Error had a syntax issue (possible transposing error)
Line 2 of Example 4 resulted in a ParameterBindingException exception since the Exception parameter is not a positional parameter. Changed it to a named parameter.
Corrected in all version.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
