### PR TITLE
Update PSDesiredStateConfiguration.md

### DIFF
--- a/reference/5.1/PSDesiredStateConfiguration/PSDesiredStateConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/PSDesiredStateConfiguration.md
@@ -29,12 +29,12 @@ Stops debugging of DSC resources.
 Starts debugging of all DSC resources.
 
 
-### [Get-DscConfigurationStatus](Get-DscConfigurationStatus.md)
-Retrieves data about completed configuration runs.
-
-
 ### [Get-DscConfiguration](Get-DscConfiguration.md)
 Gets the current configuration of the nodes.
+
+
+### [Get-DscConfigurationStatus](Get-DscConfigurationStatus.md)
+Retrieves data about completed configuration runs.
 
 
 ### [Get-DscLocalConfigurationManager](Get-DscLocalConfigurationManager.md)


### PR DESCRIPTION
In ths page's TOC, the order of topics below PSDesiredStateConfiguration did not match the order of topics on the page. This change fixes that error by moving Get-DSSConfiguration above Get-DSCConfigurationStatus.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
