### PR TITLE
Update about_pipelines.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -207,6 +207,7 @@ is much like saving the service objects in a variable and using the InputObject 
 of Format-Table to submit the service object.
 
 $services = get-service
+
 format-table -inputobject $services -property name, dependentservices
 
 or imbedding the command in the parameter value


### PR DESCRIPTION
"$services = get-service format-table -inputobject $services -property name, dependentservices"
appeared as a single line instead of two distinct lines.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ x] Impacts 5.1 document
- [ x] Impacts 5.0 document
- [ x] Impacts 4.0 document
- [ x] Impacts 3.0 document

