### PR TITLE
Fix 3.0, 4.0, 5.0, 5.1, 6 about_Functions_Advanced

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -46,19 +46,21 @@ a name that includes a verb (Send) and noun (Greeting) pair similar to the
 verb-noun pair of a compiled cmdlet. However, functions are not required
 to have a verb-noun name.
 
+```powershell
 function Send-Greeting
 {
-[CmdletBinding()]
-Param(
-[Parameter(Mandatory=$true)]
-[string] $Name
-# )
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string] $Name
+    )
 
-Process
-{
-write-host ("Hello " + $Name + "!")
+    Process
+    {
+        write-host ("Hello " + $Name + "!")
+    }
 }
-}
+```
 
 The parameters of the function are declared by using the Parameter
 attribute. This attribute can be used alone, or it can be combined with
@@ -95,4 +97,4 @@ pass named parameters.
 
 [about_Functions_OutputTypeAttribute](about_Functions_OutputTypeAttribute.md)
 
-Windows PowerShell Cmdlets (http://go.microsoft.com/fwlink/?LinkID=135279)
+[Windows PowerShell Cmdlets](http://go.microsoft.com/fwlink/?LinkID=135279)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -46,19 +46,21 @@ a name that includes a verb (Send) and noun (Greeting) pair similar to the
 verb-noun pair of a compiled cmdlet. However, functions are not required
 to have a verb-noun name.
 
+```powershell
 function Send-Greeting
 {
-[CmdletBinding()]
-Param(
-[Parameter(Mandatory=$true)]
-[string] $Name
-# )
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string] $Name
+    )
 
-Process
-{
-write-host ("Hello " + $Name + "!")
+    Process
+    {
+        write-host ("Hello " + $Name + "!")
+    }
 }
-}
+```
 
 The parameters of the function are declared by using the Parameter
 attribute. This attribute can be used alone, or it can be combined with
@@ -95,4 +97,4 @@ pass named parameters.
 
 [about_Functions_OutputTypeAttribute](about_Functions_OutputTypeAttribute.md)
 
-Windows PowerShell Cmdlets (http://go.microsoft.com/fwlink/?LinkID=135279)
+[Windows PowerShell Cmdlets](http://go.microsoft.com/fwlink/?LinkID=135279)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -46,19 +46,21 @@ a name that includes a verb (Send) and noun (Greeting) pair similar to the
 verb-noun pair of a compiled cmdlet. However, functions are not required
 to have a verb-noun name.
 
+```powershell
 function Send-Greeting
 {
-[CmdletBinding()]
-Param(
-[Parameter(Mandatory=$true)]
-[string] $Name
-# )
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string] $Name
+    )
 
-Process
-{
-write-host ("Hello " + $Name + "!")
+    Process
+    {
+        write-host ("Hello " + $Name + "!")
+    }
 }
-}
+```
 
 The parameters of the function are declared by using the Parameter
 attribute. This attribute can be used alone, or it can be combined with
@@ -95,4 +97,4 @@ pass named parameters.
 
 [about_Functions_OutputTypeAttribute](about_Functions_OutputTypeAttribute.md)
 
-Windows PowerShell Cmdlets (http://go.microsoft.com/fwlink/?LinkID=135279)
+[Windows PowerShell Cmdlets](http://go.microsoft.com/fwlink/?LinkID=135279)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -46,19 +46,21 @@ a name that includes a verb (Send) and noun (Greeting) pair similar to the
 verb-noun pair of a compiled cmdlet. However, functions are not required
 to have a verb-noun name.
 
+```powershell
 function Send-Greeting
 {
-[CmdletBinding()]
-Param(
-[Parameter(Mandatory=$true)]
-[string] $Name
-# )
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string] $Name
+    )
 
-Process
-{
-write-host ("Hello " + $Name + "!")
+    Process
+    {
+        write-host ("Hello " + $Name + "!")
+    }
 }
-}
+```
 
 The parameters of the function are declared by using the Parameter
 attribute. This attribute can be used alone, or it can be combined with
@@ -95,4 +97,4 @@ pass named parameters.
 
 [about_Functions_OutputTypeAttribute](about_Functions_OutputTypeAttribute.md)
 
-Windows PowerShell Cmdlets (http://go.microsoft.com/fwlink/?LinkID=135279)
+[Windows PowerShell Cmdlets](http://go.microsoft.com/fwlink/?LinkID=135279)

--- a/reference/6/About/about_Functions_Advanced.md
+++ b/reference/6/About/about_Functions_Advanced.md
@@ -46,19 +46,21 @@ a name that includes a verb (Send) and noun (Greeting) pair similar to the
 verb-noun pair of a compiled cmdlet. However, functions are not required
 to have a verb-noun name.
 
+```powershell
 function Send-Greeting
 {
-[CmdletBinding()]
-Param(
-[Parameter(Mandatory=$true)]
-[string] $Name
-# )
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string] $Name
+    )
 
-Process
-{
-write-host ("Hello " + $Name + "!")
+    Process
+    {
+        write-host ("Hello " + $Name + "!")
+    }
 }
-}
+```
 
 The parameters of the function are declared by using the Parameter
 attribute. This attribute can be used alone, or it can be combined with
@@ -95,4 +97,4 @@ pass named parameters.
 
 [about_Functions_OutputTypeAttribute](about_Functions_OutputTypeAttribute.md)
 
-Windows PowerShell Cmdlets (http://go.microsoft.com/fwlink/?LinkID=135279)
+[Windows PowerShell Cmdlets](http://go.microsoft.com/fwlink/?LinkID=135279)


### PR DESCRIPTION
- Fix the example code formatting all versions
- Fix the "Windows PowerShell Cmdlets" link all versions

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document
