### PR TITLE
Updated content per user request

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
@@ -1,22 +1,21 @@
 ---
-description:  
+description: Introduces the escape character in PowerShell and explains its effect.
 manager:  carmonm
 ms.topic:  reference
 author:  jpjofre
 ms.prod:  powershell
 keywords:  powershell,cmdlet
-ms.date:  2016-12-12
+ms.date:  2017-05-08
 title:  about_Escape_Characters
 ms.technology:  powershell
 ---
 
 # About Escape Characters
-## about_Escape_Characters
-
+## about\_Escape\_Characters
 
 # SHORT DESCRIPTION
 
-Introduces the escape character in Windows PowerShell and explains
+Introduces the escape character in PowerShell and explains
 its effect.
 
 # LONG DESCRIPTION
@@ -24,95 +23,133 @@ its effect.
 Escape characters are used to assign a special interpretation to
 the characters that follow it.
 
-In Windows PowerShell, the escape character is the backtick (`), also
+In PowerShell, the escape character is the backtick (`), also
 called the grave accent (ASCII 96). The escape character can be used
 to indicate a literal, to indicate line continuation, and to indicate
 special characters.
 
 In a call to another program, instead of using escape characters
-to prevent Windows PowerShell from misinterpreting program arguments,
+to prevent PowerShell from misinterpreting program arguments,
 you can use the stop-parsing symbol (--%). The stop-parsing symbol
-is introduced in Windows PowerShell 3.0.
+is introduced in PowerShell 3.0.
 
 # ESCAPING A VARIABLE
 
 When an escape character precedes a variable, it prevents a value from
-being substituted for the variable.
+being substituted for the variable. This is mostly used inside a double
+quotes string.
 
 For example:
 
-PS C:> $a = 5
-PS C:\> "The value is stored in $a."
-The value is stored in 5.
+```powershell
+$a = 5
 
-PS C:> $a = 5
-PS C:\> "The value is stored in `$a."
+# normal use of variable to be substituted
+"The value is stored in $a."
+
+# escaping the variable prevents substitution
+"The value is stored in `$a."
+```
+
+```output
+The value is stored in 5.
 The value is stored in $a.
+```
 
 # ESCAPING QUOTATION MARKS
 
+When an escape character precedes a double quotation mark,
+PowerShell interprets the double quotation mark as a character,
+not as a string delimiter.
 
-When an escape character precedes a
-double quotation mark, Windows PowerShell interprets the double quotation
-mark as a character, not as a string delimiter.
+This next example generates an error because the double quote in parenthesis
+is not escaped, signaling the end of a string; this leaves the closing
+parenthesis exposed as the next token for the parser.
 
-PS C:> "Use quotation marks (") to indicate a string."
+```powershell
+"Use quotation marks (") to indicate a string."
+```
+
+```output
+
+At C:\tmp\Untitled-14.ps1:4 char:23
++ $a = "Use quotation (") marks to enclose a string""
++                       ~
 Unexpected token ')' in expression or statement.
-At line:1 char:25
-+ "Use quotation marks (") <<<<  to indicate a string."
+```
 
-PS C:> "Use quotation marks (`") to indicate a string."
-Use quotation marks (") to indicate a string.
+This next example properly escapes the double quote,
+allowing the author to include a double quote in a string.
+
+```powershell
+"Use quotation marks (`") to indicate a string."
+```
+
+```output
+
+Use quotation (") marks to enclose a string
+```
 
 # USING LINE CONTINUATION
 
-
-The escape character tells Windows PowerShell that the command continues
-on the next line.
+When the escape character is the last character of a line,
+the escape character tells PowerShell that the command continues
+on the next line. To use line continuation there must be a space
+or a properly closed token before the escape character.
 
 For example:
 
-PS C:> Get-Process `
->> PowerShell
+```powershell
+Get-Process `
+PowerShell
+```
 
+```output
 Handles  NPM(K)    PM(K)      WS(K) VM(M)   CPU(s)     Id ProcessName
 -------  ------    -----      ----- -----   ------     -- -----------
 340       8    34556      31864   149     0.98   2036 PowerShell
+```
 
 # USING SPECIAL CHARACTERS
-
 
 When used within quotation marks, the escape character indicates a
 special character that provides instructions to the command parser.
 
-The following special characters are recognized by Windows PowerShell:
+The following special characters are recognized by PowerShell:
 
-`0    Null
-`a    Alert
-`b    Backspace
-`f    Form feed
-`n    New line
-`r    Carriage return
-`t    Horizontal tab
-`v    Vertical tab
+Escape Sequence | Special Character
+-- | --
+`0 | Null
+`a | Alert
+`b | Backspace
+`f | Form feed
+`n | New line
+`r | Carriage return
+`t | Horizontal tab
+`v | Vertical tab
 
 For example:
 
-PS C:> "12345678123456781`nCol1`tColumn2`tCol3"
+```powershell
+"12345678123456781`nCol1`tColumn2`tCol3"
+```
+
+```output
 # 12345678123456781
 
-Col1    Column2 Col3
+Col1 Column2 Col3
+```
 
 For more information, type:
-Get-Help about_Special_Characters
+Get-Help about\_Special\_Characters
 
 # STOP-PARSING SYMBOL
 
 When calling other programs, you can use the stop-parsing
-symbol (--%) to prevent Windows PowerShell from generating
+symbol (--%) to prevent PowerShell from generating
 errors or misinterpreting program arguments. The stop-parsing
 symbol is an alternative to using escape characters in program
-calls. It is introduced in Windows PowerShell 3.0.
+calls. It is introduced in PowerShell 3.0.
 
 For example, the following command uses the stop-parsing
 symbol in an Icacls command:
@@ -120,8 +157,10 @@ symbol in an Icacls command:
 icacls X:\VMS --% /grant Dom\HVAdmin:(CI)(OI)F
 
 For more information about the stop-parsing symbol,
-see about_Parsing.
+see about\_Parsing.
 
 # SEE ALSO
 
-[about_Quoting_Rules](about_Quoting_Rules.md)
+- [about_Quoting_Rules](about_Quoting_Rules.md)
+- [about_Special_Characters](about_Special_Characters.md)
+- [about_Parsing](about_Parsing.md)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
@@ -1,22 +1,21 @@
 ---
-description:  
+description: Introduces the escape character in PowerShell and explains its effect.
 manager:  carmonm
 ms.topic:  reference
 author:  jpjofre
 ms.prod:  powershell
 keywords:  powershell,cmdlet
-ms.date:  2016-12-12
+ms.date:  2017-05-08
 title:  about_Escape_Characters
 ms.technology:  powershell
 ---
 
 # About Escape Characters
-## about_Escape_Characters
-
+## about\_Escape\_Characters
 
 # SHORT DESCRIPTION
 
-Introduces the escape character in Windows PowerShell and explains
+Introduces the escape character in PowerShell and explains
 its effect.
 
 # LONG DESCRIPTION
@@ -24,95 +23,133 @@ its effect.
 Escape characters are used to assign a special interpretation to
 the characters that follow it.
 
-In Windows PowerShell, the escape character is the backtick (`), also
+In PowerShell, the escape character is the backtick (`), also
 called the grave accent (ASCII 96). The escape character can be used
 to indicate a literal, to indicate line continuation, and to indicate
 special characters.
 
 In a call to another program, instead of using escape characters
-to prevent Windows PowerShell from misinterpreting program arguments,
+to prevent PowerShell from misinterpreting program arguments,
 you can use the stop-parsing symbol (--%). The stop-parsing symbol
-is introduced in Windows PowerShell 3.0.
+is introduced in PowerShell 3.0.
 
 # ESCAPING A VARIABLE
 
 When an escape character precedes a variable, it prevents a value from
-being substituted for the variable.
+being substituted for the variable. This is mostly used inside a double
+quotes string.
 
 For example:
 
-PS C:> $a = 5
-PS C:\> "The value is stored in $a."
-The value is stored in 5.
+```powershell
+$a = 5
 
-PS C:> $a = 5
-PS C:\> "The value is stored in `$a."
+# normal use of variable to be substituted
+"The value is stored in $a."
+
+# escaping the variable prevents substitution
+"The value is stored in `$a."
+```
+
+```output
+The value is stored in 5.
 The value is stored in $a.
+```
 
 # ESCAPING QUOTATION MARKS
 
+When an escape character precedes a double quotation mark,
+PowerShell interprets the double quotation mark as a character,
+not as a string delimiter.
 
-When an escape character precedes a
-double quotation mark, Windows PowerShell interprets the double quotation
-mark as a character, not as a string delimiter.
+This next example generates an error because the double quote in parenthesis
+is not escaped, signaling the end of a string; this leaves the closing
+parenthesis exposed as the next token for the parser.
 
-PS C:> "Use quotation marks (") to indicate a string."
+```powershell
+"Use quotation marks (") to indicate a string."
+```
+
+```output
+
+At C:\tmp\Untitled-14.ps1:4 char:23
++ $a = "Use quotation (") marks to enclose a string""
++                       ~
 Unexpected token ')' in expression or statement.
-At line:1 char:25
-+ "Use quotation marks (") <<<<  to indicate a string."
+```
 
-PS C:> "Use quotation marks (`") to indicate a string."
-Use quotation marks (") to indicate a string.
+This next example properly escapes the double quote,
+allowing the author to include a double quote in a string.
+
+```powershell
+"Use quotation marks (`") to indicate a string."
+```
+
+```output
+
+Use quotation (") marks to enclose a string
+```
 
 # USING LINE CONTINUATION
 
-
-The escape character tells Windows PowerShell that the command continues
-on the next line.
+When the escape character is the last character of a line,
+the escape character tells PowerShell that the command continues
+on the next line. To use line continuation there must be a space
+or a properly closed token before the escape character.
 
 For example:
 
-PS C:> Get-Process `
->> PowerShell
+```powershell
+Get-Process `
+PowerShell
+```
 
+```output
 Handles  NPM(K)    PM(K)      WS(K) VM(M)   CPU(s)     Id ProcessName
 -------  ------    -----      ----- -----   ------     -- -----------
 340       8    34556      31864   149     0.98   2036 PowerShell
+```
 
 # USING SPECIAL CHARACTERS
-
 
 When used within quotation marks, the escape character indicates a
 special character that provides instructions to the command parser.
 
-The following special characters are recognized by Windows PowerShell:
+The following special characters are recognized by PowerShell:
 
-`0    Null
-`a    Alert
-`b    Backspace
-`f    Form feed
-`n    New line
-`r    Carriage return
-`t    Horizontal tab
-`v    Vertical tab
+Escape Sequence | Special Character
+-- | --
+`0 | Null
+`a | Alert
+`b | Backspace
+`f | Form feed
+`n | New line
+`r | Carriage return
+`t | Horizontal tab
+`v | Vertical tab
 
 For example:
 
-PS C:> "12345678123456781`nCol1`tColumn2`tCol3"
+```powershell
+"12345678123456781`nCol1`tColumn2`tCol3"
+```
+
+```output
 # 12345678123456781
 
-Col1    Column2 Col3
+Col1 Column2 Col3
+```
 
 For more information, type:
-Get-Help about_Special_Characters
+Get-Help about\_Special\_Characters
 
 # STOP-PARSING SYMBOL
 
 When calling other programs, you can use the stop-parsing
-symbol (--%) to prevent Windows PowerShell from generating
+symbol (--%) to prevent PowerShell from generating
 errors or misinterpreting program arguments. The stop-parsing
 symbol is an alternative to using escape characters in program
-calls. It is introduced in Windows PowerShell 3.0.
+calls. It is introduced in PowerShell 3.0.
 
 For example, the following command uses the stop-parsing
 symbol in an Icacls command:
@@ -120,8 +157,10 @@ symbol in an Icacls command:
 icacls X:\VMS --% /grant Dom\HVAdmin:(CI)(OI)F
 
 For more information about the stop-parsing symbol,
-see about_Parsing.
+see about\_Parsing.
 
 # SEE ALSO
 
-[about_Quoting_Rules](about_Quoting_Rules.md)
+- [about_Quoting_Rules](about_Quoting_Rules.md)
+- [about_Special_Characters](about_Special_Characters.md)
+- [about_Parsing](about_Parsing.md)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
@@ -1,22 +1,21 @@
 ---
-description:  
+description: Introduces the escape character in PowerShell and explains its effect.
 manager:  carmonm
 ms.topic:  reference
 author:  jpjofre
 ms.prod:  powershell
 keywords:  powershell,cmdlet
-ms.date:  2016-12-12
+ms.date:  2017-05-08
 title:  about_Escape_Characters
 ms.technology:  powershell
 ---
 
 # About Escape Characters
-## about_Escape_Characters
-
+## about\_Escape\_Characters
 
 # SHORT DESCRIPTION
 
-Introduces the escape character in Windows PowerShell and explains
+Introduces the escape character in PowerShell and explains
 its effect.
 
 # LONG DESCRIPTION
@@ -24,95 +23,133 @@ its effect.
 Escape characters are used to assign a special interpretation to
 the characters that follow it.
 
-In Windows PowerShell, the escape character is the backtick (`), also
+In PowerShell, the escape character is the backtick (`), also
 called the grave accent (ASCII 96). The escape character can be used
 to indicate a literal, to indicate line continuation, and to indicate
 special characters.
 
 In a call to another program, instead of using escape characters
-to prevent Windows PowerShell from misinterpreting program arguments,
+to prevent PowerShell from misinterpreting program arguments,
 you can use the stop-parsing symbol (--%). The stop-parsing symbol
-is introduced in Windows PowerShell 3.0.
+is introduced in PowerShell 3.0.
 
 # ESCAPING A VARIABLE
 
 When an escape character precedes a variable, it prevents a value from
-being substituted for the variable.
+being substituted for the variable. This is mostly used inside a double
+quotes string.
 
 For example:
 
-PS C:> $a = 5
-PS C:\> "The value is stored in $a."
-The value is stored in 5.
+```powershell
+$a = 5
 
-PS C:> $a = 5
-PS C:\> "The value is stored in `$a."
+# normal use of variable to be substituted
+"The value is stored in $a."
+
+# escaping the variable prevents substitution
+"The value is stored in `$a."
+```
+
+```output
+The value is stored in 5.
 The value is stored in $a.
+```
 
 # ESCAPING QUOTATION MARKS
 
+When an escape character precedes a double quotation mark,
+PowerShell interprets the double quotation mark as a character,
+not as a string delimiter.
 
-When an escape character precedes a
-double quotation mark, Windows PowerShell interprets the double quotation
-mark as a character, not as a string delimiter.
+This next example generates an error because the double quote in parenthesis
+is not escaped, signaling the end of a string; this leaves the closing
+parenthesis exposed as the next token for the parser.
 
-PS C:> "Use quotation marks (") to indicate a string."
+```powershell
+"Use quotation marks (") to indicate a string."
+```
+
+```output
+
+At C:\tmp\Untitled-14.ps1:4 char:23
++ $a = "Use quotation (") marks to enclose a string""
++                       ~
 Unexpected token ')' in expression or statement.
-At line:1 char:25
-+ "Use quotation marks (") <<<<  to indicate a string."
+```
 
-PS C:> "Use quotation marks (`") to indicate a string."
-Use quotation marks (") to indicate a string.
+This next example properly escapes the double quote,
+allowing the author to include a double quote in a string.
+
+```powershell
+"Use quotation marks (`") to indicate a string."
+```
+
+```output
+
+Use quotation (") marks to enclose a string
+```
 
 # USING LINE CONTINUATION
 
-
-The escape character tells Windows PowerShell that the command continues
-on the next line.
+When the escape character is the last character of a line,
+the escape character tells PowerShell that the command continues
+on the next line. To use line continuation there must be a space
+or a properly closed token before the escape character.
 
 For example:
 
-PS C:> Get-Process `
->> PowerShell
+```powershell
+Get-Process `
+PowerShell
+```
 
+```output
 Handles  NPM(K)    PM(K)      WS(K) VM(M)   CPU(s)     Id ProcessName
 -------  ------    -----      ----- -----   ------     -- -----------
 340       8    34556      31864   149     0.98   2036 PowerShell
+```
 
 # USING SPECIAL CHARACTERS
-
 
 When used within quotation marks, the escape character indicates a
 special character that provides instructions to the command parser.
 
-The following special characters are recognized by Windows PowerShell:
+The following special characters are recognized by PowerShell:
 
-`0    Null
-`a    Alert
-`b    Backspace
-`f    Form feed
-`n    New line
-`r    Carriage return
-`t    Horizontal tab
-`v    Vertical tab
+Escape Sequence | Special Character
+-- | --
+`0 | Null
+`a | Alert
+`b | Backspace
+`f | Form feed
+`n | New line
+`r | Carriage return
+`t | Horizontal tab
+`v | Vertical tab
 
 For example:
 
-PS C:> "12345678123456781`nCol1`tColumn2`tCol3"
+```powershell
+"12345678123456781`nCol1`tColumn2`tCol3"
+```
+
+```output
 # 12345678123456781
 
-Col1    Column2 Col3
+Col1 Column2 Col3
+```
 
 For more information, type:
-Get-Help about_Special_Characters
+Get-Help about\_Special\_Characters
 
 # STOP-PARSING SYMBOL
 
 When calling other programs, you can use the stop-parsing
-symbol (--%) to prevent Windows PowerShell from generating
+symbol (--%) to prevent PowerShell from generating
 errors or misinterpreting program arguments. The stop-parsing
 symbol is an alternative to using escape characters in program
-calls. It is introduced in Windows PowerShell 3.0.
+calls. It is introduced in PowerShell 3.0.
 
 For example, the following command uses the stop-parsing
 symbol in an Icacls command:
@@ -120,8 +157,10 @@ symbol in an Icacls command:
 icacls X:\VMS --% /grant Dom\HVAdmin:(CI)(OI)F
 
 For more information about the stop-parsing symbol,
-see about_Parsing.
+see about\_Parsing.
 
 # SEE ALSO
 
-[about_Quoting_Rules](about_Quoting_Rules.md)
+- [about_Quoting_Rules](about_Quoting_Rules.md)
+- [about_Special_Characters](about_Special_Characters.md)
+- [about_Parsing](about_Parsing.md)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Escape_Characters.md
@@ -1,22 +1,21 @@
 ---
-description:  
+description: Introduces the escape character in PowerShell and explains its effect.
 manager:  carmonm
 ms.topic:  reference
 author:  jpjofre
 ms.prod:  powershell
 keywords:  powershell,cmdlet
-ms.date:  2016-12-12
+ms.date:  2017-05-08
 title:  about_Escape_Characters
 ms.technology:  powershell
 ---
 
 # About Escape Characters
-## about_Escape_Characters
-
+## about\_Escape\_Characters
 
 # SHORT DESCRIPTION
 
-Introduces the escape character in Windows PowerShell and explains
+Introduces the escape character in PowerShell and explains
 its effect.
 
 # LONG DESCRIPTION
@@ -24,95 +23,133 @@ its effect.
 Escape characters are used to assign a special interpretation to
 the characters that follow it.
 
-In Windows PowerShell, the escape character is the backtick (`), also
+In PowerShell, the escape character is the backtick (`), also
 called the grave accent (ASCII 96). The escape character can be used
 to indicate a literal, to indicate line continuation, and to indicate
 special characters.
 
 In a call to another program, instead of using escape characters
-to prevent Windows PowerShell from misinterpreting program arguments,
+to prevent PowerShell from misinterpreting program arguments,
 you can use the stop-parsing symbol (--%). The stop-parsing symbol
-is introduced in Windows PowerShell 3.0.
+is introduced in PowerShell 3.0.
 
 # ESCAPING A VARIABLE
 
 When an escape character precedes a variable, it prevents a value from
-being substituted for the variable.
+being substituted for the variable. This is mostly used inside a double
+quotes string.
 
 For example:
 
-PS C:> $a = 5
-PS C:\> "The value is stored in $a."
-The value is stored in 5.
+```powershell
+$a = 5
 
-PS C:> $a = 5
-PS C:\> "The value is stored in `$a."
+# normal use of variable to be substituted
+"The value is stored in $a."
+
+# escaping the variable prevents substitution
+"The value is stored in `$a."
+```
+
+```output
+The value is stored in 5.
 The value is stored in $a.
+```
 
 # ESCAPING QUOTATION MARKS
 
+When an escape character precedes a double quotation mark,
+PowerShell interprets the double quotation mark as a character,
+not as a string delimiter.
 
-When an escape character precedes a
-double quotation mark, Windows PowerShell interprets the double quotation
-mark as a character, not as a string delimiter.
+This next example generates an error because the double quote in parenthesis
+is not escaped, signaling the end of a string; this leaves the closing
+parenthesis exposed as the next token for the parser.
 
-PS C:> "Use quotation marks (") to indicate a string."
+```powershell
+"Use quotation marks (") to indicate a string."
+```
+
+```output
+
+At C:\tmp\Untitled-14.ps1:4 char:23
++ $a = "Use quotation (") marks to enclose a string""
++                       ~
 Unexpected token ')' in expression or statement.
-At line:1 char:25
-+ "Use quotation marks (") <<<<  to indicate a string."
+```
 
-PS C:> "Use quotation marks (`") to indicate a string."
-Use quotation marks (") to indicate a string.
+This next example properly escapes the double quote,
+allowing the author to include a double quote in a string.
+
+```powershell
+"Use quotation marks (`") to indicate a string."
+```
+
+```output
+
+Use quotation (") marks to enclose a string
+```
 
 # USING LINE CONTINUATION
 
-
-The escape character tells Windows PowerShell that the command continues
-on the next line.
+When the escape character is the last character of a line,
+the escape character tells PowerShell that the command continues
+on the next line. To use line continuation there must be a space
+or a properly closed token before the escape character.
 
 For example:
 
-PS C:> Get-Process `
->> PowerShell
+```powershell
+Get-Process `
+PowerShell
+```
 
+```output
 Handles  NPM(K)    PM(K)      WS(K) VM(M)   CPU(s)     Id ProcessName
 -------  ------    -----      ----- -----   ------     -- -----------
 340       8    34556      31864   149     0.98   2036 PowerShell
+```
 
 # USING SPECIAL CHARACTERS
-
 
 When used within quotation marks, the escape character indicates a
 special character that provides instructions to the command parser.
 
-The following special characters are recognized by Windows PowerShell:
+The following special characters are recognized by PowerShell:
 
-`0    Null
-`a    Alert
-`b    Backspace
-`f    Form feed
-`n    New line
-`r    Carriage return
-`t    Horizontal tab
-`v    Vertical tab
+Escape Sequence | Special Character
+-- | --
+`0 | Null
+`a | Alert
+`b | Backspace
+`f | Form feed
+`n | New line
+`r | Carriage return
+`t | Horizontal tab
+`v | Vertical tab
 
 For example:
 
-PS C:> "12345678123456781`nCol1`tColumn2`tCol3"
+```powershell
+"12345678123456781`nCol1`tColumn2`tCol3"
+```
+
+```output
 # 12345678123456781
 
-Col1    Column2 Col3
+Col1 Column2 Col3
+```
 
 For more information, type:
-Get-Help about_Special_Characters
+Get-Help about\_Special\_Characters
 
 # STOP-PARSING SYMBOL
 
 When calling other programs, you can use the stop-parsing
-symbol (--%) to prevent Windows PowerShell from generating
+symbol (--%) to prevent PowerShell from generating
 errors or misinterpreting program arguments. The stop-parsing
 symbol is an alternative to using escape characters in program
-calls. It is introduced in Windows PowerShell 3.0.
+calls. It is introduced in PowerShell 3.0.
 
 For example, the following command uses the stop-parsing
 symbol in an Icacls command:
@@ -120,8 +157,10 @@ symbol in an Icacls command:
 icacls X:\VMS --% /grant Dom\HVAdmin:(CI)(OI)F
 
 For more information about the stop-parsing symbol,
-see about_Parsing.
+see about\_Parsing.
 
 # SEE ALSO
 
-[about_Quoting_Rules](about_Quoting_Rules.md)
+- [about_Quoting_Rules](about_Quoting_Rules.md)
+- [about_Special_Characters](about_Special_Characters.md)
+- [about_Parsing](about_Parsing.md)

--- a/reference/6/About/about_Escape_Characters.md
+++ b/reference/6/About/about_Escape_Characters.md
@@ -1,22 +1,21 @@
 ---
-description:  
+description: Introduces the escape character in PowerShell and explains its effect.
 manager:  carmonm
 ms.topic:  reference
 author:  jpjofre
 ms.prod:  powershell
 keywords:  powershell,cmdlet
-ms.date:  2016-12-12
+ms.date:  2017-05-08
 title:  about_Escape_Characters
 ms.technology:  powershell
 ---
 
 # About Escape Characters
-## about_Escape_Characters
-
+## about\_Escape\_Characters
 
 # SHORT DESCRIPTION
 
-Introduces the escape character in Windows PowerShell and explains
+Introduces the escape character in PowerShell and explains
 its effect.
 
 # LONG DESCRIPTION
@@ -24,95 +23,133 @@ its effect.
 Escape characters are used to assign a special interpretation to
 the characters that follow it.
 
-In Windows PowerShell, the escape character is the backtick (`), also
+In PowerShell, the escape character is the backtick (`), also
 called the grave accent (ASCII 96). The escape character can be used
 to indicate a literal, to indicate line continuation, and to indicate
 special characters.
 
 In a call to another program, instead of using escape characters
-to prevent Windows PowerShell from misinterpreting program arguments,
+to prevent PowerShell from misinterpreting program arguments,
 you can use the stop-parsing symbol (--%). The stop-parsing symbol
-is introduced in Windows PowerShell 3.0.
+is introduced in PowerShell 3.0.
 
 # ESCAPING A VARIABLE
 
 When an escape character precedes a variable, it prevents a value from
-being substituted for the variable.
+being substituted for the variable. This is mostly used inside a double
+quotes string.
 
 For example:
 
-PS C:> $a = 5
-PS C:\> "The value is stored in $a."
-The value is stored in 5.
+```powershell
+$a = 5
 
-PS C:> $a = 5
-PS C:\> "The value is stored in `$a."
+# normal use of variable to be substituted
+"The value is stored in $a."
+
+# escaping the variable prevents substitution
+"The value is stored in `$a."
+```
+
+```output
+The value is stored in 5.
 The value is stored in $a.
+```
 
 # ESCAPING QUOTATION MARKS
 
+When an escape character precedes a double quotation mark,
+PowerShell interprets the double quotation mark as a character,
+not as a string delimiter.
 
-When an escape character precedes a
-double quotation mark, Windows PowerShell interprets the double quotation
-mark as a character, not as a string delimiter.
+This next example generates an error because the double quote in parenthesis
+is not escaped, signaling the end of a string; this leaves the closing
+parenthesis exposed as the next token for the parser.
 
-PS C:> "Use quotation marks (") to indicate a string."
+```powershell
+"Use quotation marks (") to indicate a string."
+```
+
+```output
+
+At C:\tmp\Untitled-14.ps1:4 char:23
++ $a = "Use quotation (") marks to enclose a string""
++                       ~
 Unexpected token ')' in expression or statement.
-At line:1 char:25
-+ "Use quotation marks (") <<<<  to indicate a string."
+```
 
-PS C:> "Use quotation marks (`") to indicate a string."
-Use quotation marks (") to indicate a string.
+This next example properly escapes the double quote,
+allowing the author to include a double quote in a string.
+
+```powershell
+"Use quotation marks (`") to indicate a string."
+```
+
+```output
+
+Use quotation (") marks to enclose a string
+```
 
 # USING LINE CONTINUATION
 
-
-The escape character tells Windows PowerShell that the command continues
-on the next line.
+When the escape character is the last character of a line,
+the escape character tells PowerShell that the command continues
+on the next line. To use line continuation there must be a space
+or a properly closed token before the escape character.
 
 For example:
 
-PS C:> Get-Process `
->> PowerShell
+```powershell
+Get-Process `
+PowerShell
+```
 
+```output
 Handles  NPM(K)    PM(K)      WS(K) VM(M)   CPU(s)     Id ProcessName
 -------  ------    -----      ----- -----   ------     -- -----------
 340       8    34556      31864   149     0.98   2036 PowerShell
+```
 
 # USING SPECIAL CHARACTERS
-
 
 When used within quotation marks, the escape character indicates a
 special character that provides instructions to the command parser.
 
-The following special characters are recognized by Windows PowerShell:
+The following special characters are recognized by PowerShell:
 
-`0    Null
-`a    Alert
-`b    Backspace
-`f    Form feed
-`n    New line
-`r    Carriage return
-`t    Horizontal tab
-`v    Vertical tab
+Escape Sequence | Special Character
+-- | --
+`0 | Null
+`a | Alert
+`b | Backspace
+`f | Form feed
+`n | New line
+`r | Carriage return
+`t | Horizontal tab
+`v | Vertical tab
 
 For example:
 
-PS C:> "12345678123456781`nCol1`tColumn2`tCol3"
+```powershell
+"12345678123456781`nCol1`tColumn2`tCol3"
+```
+
+```output
 # 12345678123456781
 
-Col1    Column2 Col3
+Col1 Column2 Col3
+```
 
 For more information, type:
-Get-Help about_Special_Characters
+Get-Help about\_Special\_Characters
 
 # STOP-PARSING SYMBOL
 
 When calling other programs, you can use the stop-parsing
-symbol (--%) to prevent Windows PowerShell from generating
+symbol (--%) to prevent PowerShell from generating
 errors or misinterpreting program arguments. The stop-parsing
 symbol is an alternative to using escape characters in program
-calls. It is introduced in Windows PowerShell 3.0.
+calls. It is introduced in PowerShell 3.0.
 
 For example, the following command uses the stop-parsing
 symbol in an Icacls command:
@@ -120,8 +157,10 @@ symbol in an Icacls command:
 icacls X:\VMS --% /grant Dom\HVAdmin:(CI)(OI)F
 
 For more information about the stop-parsing symbol,
-see about_Parsing.
+see about\_Parsing.
 
 # SEE ALSO
 
-[about_Quoting_Rules](about_Quoting_Rules.md)
+- [about_Quoting_Rules](about_Quoting_Rules.md)
+- [about_Special_Characters](about_Special_Characters.md)
+- [about_Parsing](about_Parsing.md)


### PR DESCRIPTION
User request:
"_Please mention that, when using a backtick as a continuation character, there must be no trailing space (or it escapes the space) and there must be a preceding space or the preceding token must be enclosed. 

https://windowsserver.uservoice.com/forums/301869-powershell/suggestions/13073505-about-escape-characters-doesn-t-mention-syntax-reqVersion(s) of document impacted_"

------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

