### PR TITLE
Fix LinkId for Register-ArgumentCompleter

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -10,7 +10,7 @@ title: Register-ArgumentCompleter
 ms.technology:  powershell
 external help file:   System.Management.Automation.dll-Help.xml
 schema:   2.0.0
-online version:   http://go.microsoft.com/fwlink/?LinkId=822079
+online version:   http://go.microsoft.com/fwlink/?LinkId=821507
 ---
 
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -9,7 +9,7 @@ ms.date:  2016-12-12
 title: Register-ArgumentCompleter
 ms.technology:  powershell
 schema:   2.0.0
-online version:   http://go.microsoft.com/fwlink/?LinkId=821506
+online version:   http://go.microsoft.com/fwlink/?LinkId=821507
 external help file:   System.Management.Automation.dll-Help.xml
 ---
 

--- a/reference/6/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/6/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -8,7 +8,7 @@ ms.date: 2016-12-12
 ms.prod: powershell
 ms.technology: powershell
 ms.topic: reference
-online version: http://go.microsoft.com/fwlink/?LinkId=821506
+online version: http://go.microsoft.com/fwlink/?LinkId=821507
 schema: 2.0.0
 title: Register-ArgumentCompleter
 ---


### PR DESCRIPTION
Please fix the incorrect "online version" values as follows:
x LinkId=822079 (Windows Server Future Resources)
x LinkId=821506 (Receive-PSSession)
o LinkId=821507 (Register-ArgumentCompleter)

I found that when I executed `Get-Help Register-ArgumentCompleter -Online` and forwarded to the Receive-PSSession page.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
