### PR TITLE
Mistake in explanation for ++ operator

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -79,7 +79,7 @@ C:\PS> $b
 -1
 ```
 
-In this example, the expression `$a++` is evaluated before `$c[$a++]`. Evaluating `$a++` changes the value of `$a`. The variable `$a` in `$b[$a]` equals `1`, not `0`, so the statement assigns a value to `$b[1]`, not `$b[0]`.
+In this example, the expression `$a++` is evaluated before `$b[$a]`. Evaluating `$a++` changes the value of `$a`. The variable `$a` in `$b[$a]` equals `1`, not `0`, so the statement assigns a value to `$b[1]`, not `$b[0]`.
 
 ## DIVISION AND ROUNDING
 


### PR DESCRIPTION
The text
`In this example, the expression $a++ is evaluated before $c[$a++].`
should be
`In this example, the expression $a++ is evaluated before $b[$a].`

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
