### PR TITLE
Fixed typo on Get-DscConfigurationStatus

### DIFF
--- a/reference/5.1/PSDesiredStateConfiguration/Get-DscConfigurationStatus.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Get-DscConfigurationStatus.md
@@ -49,7 +49,7 @@ This command gets information about all the configurations that were run on the 
 
 ### Example 3: Get information on the configuration run on a remote computer
 ```
-PS C:\> Get-DscConfigurationStaus -CimSession "Server01"
+PS C:\> Get-DscConfigurationStatus -CimSession "Server01"
 ```
 
 This command gets the configuration run details of the remote computer named Server01.


### PR DESCRIPTION

Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ X ] Impacts 5.1 document
- [ X ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ X ] The documented feature was introduced in version 5.0 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
