### PR TITLE
Fix Convert-String example

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Utility/Convert-String.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Convert-String.md
@@ -33,16 +33,16 @@ The **Convert-String** cmdlet formats a string to match the format of examples.
 
 ### Example 1: Convert format of a string
 ```
-PS C:\> $Names = "Evan Narvaez","David Chew","Elisa Daugherty"
-Convert-String -InputObject $Names -Example "Patti Fuller = Fuller, P."
-Narvaez, E. 
-Chew, D. 
-Daugherty, E.
+PS C:\> "Mu Han", "Jim Hance", "David Ahs", "Kim Akers" | Convert-String -Example "Ed Wilson=Wilson, E."
+Han, M.
+Hance, J.
+Ahs, D.
+Akers, K.
 ```
 
-The first command creates an array named **$Names** that contains first and last names.
+The first command creates an array that contains first and last names.
 
-The second command formats the names in **$Names** according to the example.
+The second command formats the names according to the example.
 It puts the surname first in the output, followed by an initial.
 
 ### Example 2: Format process information

--- a/reference/5.1/Microsoft.PowerShell.Utility/Convert-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Convert-String.md
@@ -33,16 +33,16 @@ The **Convert-String** cmdlet formats a string to match the format of examples.
 
 ### Example 1: Convert format of a string
 ```
-PS C:\> $Names = "Evan Narvaez","David Chew","Elisa Daugherty"
-Convert-String -InputObject $Names -Example "Patti Fuller = Fuller, P."
-Narvaez, E. 
-Chew, D. 
-Daugherty, E.
+PS C:\> "Mu Han", "Jim Hance", "David Ahs", "Kim Akers" | Convert-String -Example "Ed Wilson=Wilson, E."
+Han, M.
+Hance, J.
+Ahs, D.
+Akers, K.
 ```
 
-The first command creates an array named **$Names** that contains first and last names.
+The first command creates an array that contains first and last names.
 
-The second command formats the names in **$Names** according to the example.
+The second command formats the names according to the example.
 It puts the surname first in the output, followed by an initial.
 
 ### Example 2: Format process information


### PR DESCRIPTION
The "Example 1" doesn't work:
```
PS> $Names = "Evan Narvaez","David Chew","Elisa Daugherty"
PS> Convert-String -InputObject $Names -Example "Patti Fuller = Fuller, P."
Convert-String : Cannot convert 'System.Object[]' to the type 'System.String' required by parameter 'InputObject'. Specified method is not supported.
At line:1 char:29
+ Convert-String -InputObject $Names -Example "Patti Fuller = Fuller, P ...
+                             ~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Convert-String], ParameterBindingException
    + FullyQualifiedErrorId : CannotConvertArgument,Microsoft.PowerShell.Commands.StringManipulation.ConvertStringCommand
```

My pull request is a copy from [Hey, Scripting Guy! Blog](https://blogs.technet.microsoft.com/heyscriptingguy/2015/08/17/use-the-powershell-5-convert-string-cmdlet/).

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
