### PR TITLE
Start-Process: Verbs look better in Table

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Start-Process.md
@@ -290,12 +290,12 @@ The verbs that are available are determined by the file name extension of the fi
 
 The following table shows the verbs for some common process file types.
 
-File type      Verbs
----------      -------
-.cmd      Edit, Open, Print, Runas
-.exe      Open, RunAs
-.txt      Open, Print, PrintTo
-.wav      Open, Play
+| File type | Verbs   |
+| --------- | ------- |
+|.cmd       | Edit, Open, Print, Runas |
+|.exe       | Open, RunAs |
+|.txt       | Open, Print, PrintTo |
+|.wav       | Open, Play |
 
 To find the verbs that can be used with the file that runs in a process, use the New-Object cmdlet to create a System.Diagnostics.ProcessStartInfo object for the file.
 The available verbs are in the Verbs property of the ProcessStartInfo object.

--- a/reference/4.0/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Start-Process.md
@@ -299,12 +299,12 @@ The verbs that are available are determined by the file name extension of the fi
 
 The following table shows the verbs for some common process file types.
 
-`File type      Verbs`
-`---------      -------`
-`.cmd------Edit, Open, Print, Runas`
-`.exe------Open, RunAs`
-`.txt------Open, Print, PrintTo`
-`.wav------Open, Play`
+| File type | Verbs   |
+| --------- | ------- |
+|.cmd       | Edit, Open, Print, Runas |
+|.exe       | Open, RunAs |
+|.txt       | Open, Print, PrintTo |
+|.wav       | Open, Play |
 
 To find the verbs that can be used with the file that runs in a process, use the New-Object cmdlet to create a System.Diagnostics.ProcessStartInfo object for the file.
 The available verbs are in the Verbs property of the ProcessStartInfo object.

--- a/reference/5.0/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Start-Process.md
@@ -300,12 +300,12 @@ The verbs that are available are determined by the file name extension of the fi
 
 The following table shows the verbs for some common process file types.
 
-`File type      Verbs`
-`---------      -------`
-`.cmd------Edit, Open, Print, Runas`
-`.exe------Open, RunAs`
-`.txt------Open, Print, PrintTo`
-`.wav------Open, Play`
+| File type | Verbs   |
+| --------- | ------- |
+|.cmd       | Edit, Open, Print, Runas |
+|.exe       | Open, RunAs |
+|.txt       | Open, Print, PrintTo |
+|.wav       | Open, Play |
 
 To find the verbs that can be used with the file that runs in a process, use the New-Object cmdlet to create a **System.Diagnostics.ProcessStartInfo** object for the file.
 The available verbs are in the **Verbs** property of the **ProcessStartInfo** object.

--- a/reference/5.1/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Start-Process.md
@@ -300,12 +300,12 @@ The verbs that are available are determined by the file name extension of the fi
 
 The following table shows the verbs for some common process file types.
 
-`File type      Verbs`
-`---------      -------`
-`.cmd------Edit, Open, Print, Runas`
-`.exe------Open, RunAs`
-`.txt------Open, Print, PrintTo`
-`.wav------Open, Play`
+| File type | Verbs   |
+| --------- | ------- |
+|.cmd       | Edit, Open, Print, Runas |
+|.exe       | Open, RunAs |
+|.txt       | Open, Print, PrintTo |
+|.wav       | Open, Play |
 
 To find the verbs that can be used with the file that runs in a process, use the New-Object cmdlet to create a **System.Diagnostics.ProcessStartInfo** object for the file.
 The available verbs are in the **Verbs** property of the **ProcessStartInfo** object.

--- a/reference/6/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/6/Microsoft.PowerShell.Management/Start-Process.md
@@ -328,12 +328,12 @@ The verbs that are available are determined by the file name extension of the fi
 
 The following table shows the verbs for some common process file types.
 
-`File type      Verbs`
-`---------      -------`
-`.cmd------Edit, Open, Print, Runas`
-`.exe------Open, RunAs`
-`.txt------Open, Print, PrintTo`
-`.wav------Open, Play`
+| File type | Verbs   |
+| --------- | ------- |
+|.cmd       | Edit, Open, Print, Runas |
+|.exe       | Open, RunAs |
+|.txt       | Open, Print, PrintTo |
+|.wav       | Open, Play |
 
 To find the verbs that can be used with the file that runs in a process, use the New-Object cmdlet to create a **System.Diagnostics.ProcessStartInfo** object for the file.
 The available verbs are in the **Verbs** property of the **ProcessStartInfo** object.


### PR DESCRIPTION
In the files for the Start-Process cmdlet it says "The following table shows the verbs for some common process file types." The following information is displayed as code snippets instead (see [here](https://msdn.microsoft.com/en-us/powershell/reference/5.1/microsoft.powershell.management/start-process#-verb) for an example). This PR updates all affected versions.


Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
