### PR TITLE
Refer to actual .NET date-time format strings

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -252,10 +252,10 @@ As a result, some of the properties and methods of **DateTime** objects might no
 
 Starting in Windows PowerShell 5.0, you can use the following additional formats as values for the *Format* parameter.
 
-- FileDate. A file or path-friendly representation of the current date in local time. It is in the form of yyyymmdd ( using 4 digits, 2 digits, and 2 digits). An example of results when you use this format is 20150302.
-- FileDateUniversal. A file or path-friendly representation of the current date in universal time. It is in the form of yyyymmdd + 'Z' (using 4 digits, 2 digits, and 2 digits). An example of results when you use this format is 20150302Z.
-- FileDateTime. A file or path-friendly representation of the current date and time in local time, in 24-hour format. It is in the form of yyyymmdd + 'T' + hhmmssmsms, where msms is a four-character representation of milliseconds. An example of results when you use this format is 20150302T1240514987.
-- FileDateTimeUniversal. A file or path-friendly representation of the current date and time in universal time, in 24-hour format. It is in the form of yyyymmdd + 'T' + hhmmssmsms, where msms is a four-character representation of milliseconds, + 'Z'. An example of results when you use this format is 20150302T0840539947Z.
+- FileDate. A file or path-friendly representation of the current date in local time. It is in the form of yyyyMMdd (case-sensitive, using a 4-digit year, 2-digit month, and 2-digit day). An example of results when you use this format is 20150302.
+- FileDateUniversal. A file or path-friendly representation of the current date in universal time (UTC). It is in the form of yyyyMMddZ (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, and the letter "Z" as the UTC indicator). An example of results when you use this format is 20150302Z.
+- FileDateTime. A file or path-friendly representation of the current date and time in local time, in 24-hour format. It is in the form of yyyyMMddThhmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, the letter "T" as a time separator, 2-digit hour, 2-digit minute, 2-digit second, and 4-digit millisecond). An example of results when you use this format is 20150302T1240514987.
+- FileDateTimeUniversal. A file or path-friendly representation of the current date and time in universal time (UTC), in 24-hour format. It is in the form of yyyyMMddThhmmssffffZ (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, the letter "T" as a time separator, 2-digit hour, 2-digit minute, 2-digit second, 4-digit millisecond, and the letter "Z" as the UTC indicator). An example of results when you use this format is 20150302T0840539947Z.
 
 ```yaml
 Type: String


### PR DESCRIPTION
The help for the -Format parameter described the new formats that were added to PS 5+ (FileDate, FileDateUniversal, FileDateTime, and FileDateTimeUniversal), but the description of these formats was misleading because it didn't properly relate to actual .NET DateTime format strings (that can even be used in the -Format parameter). I have corrected this so that the actual format string used behind the scenes is referred to in the docs, along with a brief description that indicates what the format means and highlights the importance of case-sensitivity in the format string.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 5 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
