### PR TITLE
Fix Get-Member example

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Member.md
@@ -73,8 +73,8 @@ Because the Get-Member part of the command does not have any parameters, it uses
 As such, it gets all member types, but it does not get static members and does not display intrinsic members.
 ### Example 2
 ```
-PS C:\> get-service | get-member -force
-PS C:\> (get-service -schedule).psbase
+PS C:\> Get-Service | Get-Member -Force
+PS C:\> (Get-Service Schedule).PSBase
 ```
 
 This example gets all of the members (properties and methods) of the service objects (System.ServiceProcess.ServiceController) retrieved by the Get-Service cmdlet, including the intrinsic members, such as PSBase and PSObject, and the get_ and set_ methods.

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Member.md
@@ -77,8 +77,8 @@ As such, it gets all member types, but it does not get static members and does n
 
 ### Example 2
 ```
-PS C:\> get-service | get-member -force
-PS C:\> (get-service -schedule).psbase
+PS C:\> Get-Service | Get-Member -Force
+PS C:\> (Get-Service Schedule).PSBase
 ```
 
 This example gets all of the members (properties and methods) of the service objects (System.ServiceProcess.ServiceController) retrieved by the Get-Service cmdlet, including the intrinsic members, such as PSBase and PSObject, and the get_ and set_ methods.

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Member.md
@@ -77,7 +77,7 @@ As such, it gets all member types, but it does not get static members and does n
 ### Example 2: Get members of service objects
 ```
 PS C:\> Get-Service | Get-Member -Force
-PS C:\> (Get-Service -Schedule).PSBase
+PS C:\> (Get-Service Schedule).PSBase
 ```
 
 This example gets all of the members (properties and methods) of the service objects (System.ServiceProcess.ServiceController) retrieved by the Get-Service cmdlet, including the intrinsic members, such as PSBase and PSObject, and the get_ and set_ methods.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
@@ -77,7 +77,7 @@ As such, it gets all member types, but it does not get static members and does n
 ### Example 2: Get members of service objects
 ```
 PS C:\> Get-Service | Get-Member -Force
-PS C:\> (Get-Service -Schedule).PSBase
+PS C:\> (Get-Service Schedule).PSBase
 ```
 
 This example gets all of the members (properties and methods) of the service objects (System.ServiceProcess.ServiceController) retrieved by the Get-Service cmdlet, including the intrinsic members, such as PSBase and PSObject, and the get_ and set_ methods.

--- a/reference/6/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Member.md
@@ -78,7 +78,7 @@ As such, it gets all member types, but it does not get static members and does n
 ### Example 2: Get members of service objects
 ```
 PS C:\> Get-Service | Get-Member -Force
-PS C:\> (Get-Service -Schedule).PSBase
+PS C:\> (Get-Service Schedule).PSBase
 ```
 
 This example gets all of the members (properties and methods) of the service objects (System.ServiceProcess.ServiceController) retrieved by the Get-Service cmdlet, including the intrinsic members, such as PSBase and PSObject, and the get_ and set_ methods.


### PR DESCRIPTION
The "Example 2" throws exception:

```
PS> (Get-Service -Schedule).PSBase
Get-Service : A parameter cannot be found that matches parameter name 'Schedule'.
At line:1 char:14
+ (Get-Service -Schedule).PSBase
+              ~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Get-Service], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Microsoft.PowerShell.Commands.GetServiceCommand
```

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
