### PR TITLE
Document new -SkipHeaderVerification switch on the Invoke-WebRequest and Invoke-RestMethod cmdlets

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -19,7 +19,7 @@ Sends an HTTP or HTTPS request to a RESTful web service.
 Invoke-RestMethod [-Method <WebRequestMethod>] [-UseBasicParsing] [-Uri] <Uri>
  [-WebSession <WebRequestSession>] [-SessionVariable <String>] [-Credential <PSCredential>]
  [-UseDefaultCredentials] [-CertificateThumbprint <String>] [-Certificate <X509Certificate>]
- [-UserAgent <String>] [-DisableKeepAlive] [-TimeoutSec <Int32>] [-Headers <IDictionary>]
+ [-UserAgent <String>] [-DisableKeepAlive] [-TimeoutSec <Int32>] [-Headers <IDictionary>] [-SkipHeaderValidation]
  [-MaximumRedirection <Int32>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-ProxyUseDefaultCredentials]
  [-Body <Object>] [-ContentType <String>] [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>]
  [-PassThru] [<CommonParameters>]
@@ -254,6 +254,23 @@ You cannot use this parameter to specify UserAgent or cookie headers.
 
 ```yaml
 Type: IDictionary
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipHeaderValidation
+Indicates the cmdlet should add headers to the request without validation.
+
+This switch should be used for sites that require header values that do not conform to standards. Specifying this switch disables validation to allow the value to be passed unchecked.  When specified, all headers are added without validation.
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 

--- a/reference/6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -19,7 +19,7 @@ Gets content from a web page on the Internet.
 Invoke-WebRequest [-UseBasicParsing] [-Uri] <Uri> [-WebSession <WebRequestSession>]
  [-SessionVariable <String>] [-Credential <PSCredential>] [-UseDefaultCredentials]
  [-CertificateThumbprint <String>] [-Certificate <X509Certificate>] [-UserAgent <String>]
- [-DisableKeepAlive] [-TimeoutSec <Int32>] [-Headers <IDictionary>] [-MaximumRedirection <Int32>] [-PreserveAuthorizationOnRedirect]
+ [-DisableKeepAlive] [-TimeoutSec <Int32>] [-Headers <IDictionary>] [-SkipHeaderValidation] [-MaximumRedirection <Int32>] [-PreserveAuthorizationOnRedirect]
  [-Method <WebRequestMethod>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
  [-ProxyUseDefaultCredentials] [-NoProxy] [-Body <Object>] [-ContentType <String>]
  [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>] [-PassThru]
@@ -259,6 +259,23 @@ You cannot use this parameter to specify UserAgent or cookie headers.
 Type: IDictionary
 Parameter Sets: (All)
 Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipHeaderValidation
+Indicates the cmdlet should add headers to the request without validation.
+
+This switch should be used for sites that require header values that do not conform to standards. Specifying this switch disables validation to allow the value to be passed unchecked.  When specified, all headers are added without validation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named


### PR DESCRIPTION
The fix for issue https://github.com/PowerShell/PowerShell/issues/2895 adds a new switch parameter -SkipHeaderVerification. This switch allows callers to add header values that may not be standards compliant for cases where target sites require them.

All header values are added without validation when this switch is used.