### PR TITLE
Fix Get-Date -Hour -Minute -Second range

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Date.md
@@ -323,7 +323,7 @@ Accept wildcard characters: False
 
 ### -Hour
 Specifies the hour that is displayed.
-Enter a value from 1 to 23.
+Enter a value from 0 to 23.
 The default is the current hour.
 
 ```yaml
@@ -359,7 +359,7 @@ Accept wildcard characters: False
 
 ### -Minute
 Specifies the minute that is displayed.
-Enter a value from 1 to 59.
+Enter a value from 0 to 59.
 The default value is the current minutes.
 
 ```yaml
@@ -393,7 +393,7 @@ Accept wildcard characters: False
 
 ### -Second
 Specifies the second that is displayed.
-Enter a value from 1 to 59.
+Enter a value from 0 to 59.
 The default is the current second.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Date.md
@@ -321,7 +321,7 @@ Accept wildcard characters: False
 
 ### -Hour
 Specifies the hour that is displayed.
-Enter a value from 1 to 23.
+Enter a value from 0 to 23.
 The default is the current hour.
 
 ```yaml
@@ -357,7 +357,7 @@ Accept wildcard characters: False
 
 ### -Minute
 Specifies the minute that is displayed.
-Enter a value from 1 to 59.
+Enter a value from 0 to 59.
 The default value is the current minutes.
 
 ```yaml
@@ -391,7 +391,7 @@ Accept wildcard characters: False
 
 ### -Second
 Specifies the second that is displayed.
-Enter a value from 1 to 59.
+Enter a value from 0 to 59.
 The default is the current second.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Date.md
@@ -332,7 +332,7 @@ Accept wildcard characters: False
 
 ### -Hour
 Specifies the hour that is displayed.
-Enter a value from 1 to 23.
+Enter a value from 0 to 23.
 The default is the current hour.
 
 ```yaml
@@ -368,7 +368,7 @@ Accept wildcard characters: False
 
 ### -Minute
 Specifies the minute that is displayed.
-Enter a value from 1 to 59.
+Enter a value from 0 to 59.
 The default value is the current minutes.
 
 ```yaml
@@ -402,7 +402,7 @@ Accept wildcard characters: False
 
 ### -Second
 Specifies the second that is displayed.
-Enter a value from 1 to 59.
+Enter a value from 0 to 59.
 The default is the current second.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Date.md
@@ -332,7 +332,7 @@ Accept wildcard characters: False
 
 ### -Hour
 Specifies the hour that is displayed.
-Enter a value from 1 to 23.
+Enter a value from 0 to 23.
 The default is the current hour.
 
 ```yaml
@@ -368,7 +368,7 @@ Accept wildcard characters: False
 
 ### -Minute
 Specifies the minute that is displayed.
-Enter a value from 1 to 59.
+Enter a value from 0 to 59.
 The default value is the current minutes.
 
 ```yaml
@@ -402,7 +402,7 @@ Accept wildcard characters: False
 
 ### -Second
 Specifies the second that is displayed.
-Enter a value from 1 to 59.
+Enter a value from 0 to 59.
 The default is the current second.
 
 ```yaml

--- a/reference/6/Microsoft.PowerShell.Utility/Get-Date.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Date.md
@@ -332,7 +332,7 @@ Accept wildcard characters: False
 
 ### -Hour
 Specifies the hour that is displayed.
-Enter a value from 1 to 23.
+Enter a value from 0 to 23.
 The default is the current hour.
 
 ```yaml
@@ -399,7 +399,7 @@ Accept wildcard characters: False
 
 ### -Minute
 Specifies the minute that is displayed.
-Enter a value from 1 to 59.
+Enter a value from 0 to 59.
 The default value is the current minutes.
 
 ```yaml
@@ -433,7 +433,7 @@ Accept wildcard characters: False
 
 ### -Second
 Specifies the second that is displayed.
-Enter a value from 1 to 59.
+Enter a value from 0 to 59.
 The default is the current second.
 
 ```yaml


### PR DESCRIPTION
Hour is [from 0 to 23](https://github.com/PowerShell/PowerShell/blob/5ee4ec1e1e0bb9e1497eb13bb2ceb7eab8b37426/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs#L113)
Minute is [from 0 to 59](https://github.com/PowerShell/PowerShell/blob/5ee4ec1e1e0bb9e1497eb13bb2ceb7eab8b37426/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs#L134)
Second is [from 0 to 59](https://github.com/PowerShell/PowerShell/blob/5ee4ec1e1e0bb9e1497eb13bb2ceb7eab8b37426/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs#L155)

Test cases:
```
0..23 | % { Get-Date -Hour $_ }
0..59 | % { Get-Date -Minute $_ }
0..59 | % { Get-Date -Second $_ }
```
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document
