### PR TITLE
Docs incorrectly used New-SessionConfigurationFile

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
@@ -268,7 +268,7 @@ The Enable-PSRemoting cmdlet creates the default session configurations on your 
 
 You can use the session configuration cmdlets to edit the default session configurations, to create new session configurations, and to change the security descriptors of all the session configurations.
 
-Beginning in  Windows PowerShell 3.0, the New-SessionConfigurationFile cmdlet lets you create custom session configurations by using a text file. The file includes options for setting the language mode and for specifying the cmdlets and modules that are available in sessions that use the session configuration.
+Beginning in  Windows PowerShell 3.0, the New-PSSessionConfigurationFile cmdlet lets you create custom session configurations by using a text file. The file includes options for setting the language mode and for specifying the cmdlets and modules that are available in sessions that use the session configuration.
 
 When users use the Invoke-Command, New-PSSession, or Enter-PSSession cmdlets, they can use the ConfigurationName parameter to indicate the session configuration that is used for the session. And, they can change the default configuration that their sessions use by changing the value of the $PSSessionConfigurationName preference variable in the session.
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
@@ -268,7 +268,7 @@ The Enable-PSRemoting cmdlet creates the default session configurations on your 
 
 You can use the session configuration cmdlets to edit the default session configurations, to create new session configurations, and to change the security descriptors of all the session configurations.
 
-Beginning in  Windows PowerShell 3.0, the New-SessionConfigurationFile cmdlet lets you create custom session configurations by using a text file. The file includes options for setting the language mode and for specifying the cmdlets and modules that are available in sessions that use the session configuration.
+Beginning in  Windows PowerShell 3.0, the New-PSSessionConfigurationFile cmdlet lets you create custom session configurations by using a text file. The file includes options for setting the language mode and for specifying the cmdlets and modules that are available in sessions that use the session configuration.
 
 When users use the Invoke-Command, New-PSSession, or Enter-PSSession cmdlets, they can use the ConfigurationName parameter to indicate the session configuration that is used for the session. And, they can change the default configuration that their sessions use by changing the value of the $PSSessionConfigurationName preference variable in the session.
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
@@ -268,7 +268,7 @@ The Enable-PSRemoting cmdlet creates the default session configurations on your 
 
 You can use the session configuration cmdlets to edit the default session configurations, to create new session configurations, and to change the security descriptors of all the session configurations.
 
-Beginning in  Windows PowerShell 3.0, the New-SessionConfigurationFile cmdlet lets you create custom session configurations by using a text file. The file includes options for setting the language mode and for specifying the cmdlets and modules that are available in sessions that use the session configuration.
+Beginning in  Windows PowerShell 3.0, the New-PSSessionConfigurationFile cmdlet lets you create custom session configurations by using a text file. The file includes options for setting the language mode and for specifying the cmdlets and modules that are available in sessions that use the session configuration.
 
 When users use the Invoke-Command, New-PSSession, or Enter-PSSession cmdlets, they can use the ConfigurationName parameter to indicate the session configuration that is used for the session. And, they can change the default configuration that their sessions use by changing the value of the $PSSessionConfigurationName preference variable in the session.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_FAQ.md
@@ -268,7 +268,7 @@ The Enable-PSRemoting cmdlet creates the default session configurations on your 
 
 You can use the session configuration cmdlets to edit the default session configurations, to create new session configurations, and to change the security descriptors of all the session configurations.
 
-Beginning in  Windows PowerShell 3.0, the New-SessionConfigurationFile cmdlet lets you create custom session configurations by using a text file. The file includes options for setting the language mode and for specifying the cmdlets and modules that are available in sessions that use the session configuration.
+Beginning in  Windows PowerShell 3.0, the New-PSSessionConfigurationFile cmdlet lets you create custom session configurations by using a text file. The file includes options for setting the language mode and for specifying the cmdlets and modules that are available in sessions that use the session configuration.
 
 When users use the Invoke-Command, New-PSSession, or Enter-PSSession cmdlets, they can use the ConfigurationName parameter to indicate the session configuration that is used for the session. And, they can change the default configuration that their sessions use by changing the value of the $PSSessionConfigurationName preference variable in the session.
 

--- a/reference/6/About/about_Remote_FAQ.md
+++ b/reference/6/About/about_Remote_FAQ.md
@@ -268,7 +268,7 @@ The Enable-PSRemoting cmdlet creates the default session configurations on your 
 
 You can use the session configuration cmdlets to edit the default session configurations, to create new session configurations, and to change the security descriptors of all the session configurations.
 
-Beginning in  Windows PowerShell 3.0, the New-SessionConfigurationFile cmdlet lets you create custom session configurations by using a text file. The file includes options for setting the language mode and for specifying the cmdlets and modules that are available in sessions that use the session configuration.
+Beginning in  Windows PowerShell 3.0, the New-PSSessionConfigurationFile cmdlet lets you create custom session configurations by using a text file. The file includes options for setting the language mode and for specifying the cmdlets and modules that are available in sessions that use the session configuration.
 
 When users use the Invoke-Command, New-PSSession, or Enter-PSSession cmdlets, they can use the ConfigurationName parameter to indicate the session configuration that is used for the session. And, they can change the default configuration that their sessions use by changing the value of the $PSSessionConfigurationName preference variable in the session.
 


### PR DESCRIPTION
Docs incorrectly used New-SessionConfigurationFile when it should be New-PSSessionConfigurationFile

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
