### PR TITLE
update scope of validateset attribute

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -555,6 +555,20 @@ either Chocolate, Strawberry, or Vanilla.
 [String][ValidateSet("Chocolate", "Strawberry", "Vanilla")]$flavor = Strawberry
 ```
 
+Note that the validation occurs whenever that variable is assigned even
+within the script.
+For example, the following results in an error at runtime:
+
+```powershell
+Param
+(
+    [ValidateSet("hello","world")]
+    [String]$Message
+)
+
+$Message = "bye"
+```
+
 ## ValidateNotNull Validation Attribute
 
 The ValidateNotNull attribute specifies that the parameter

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -555,6 +555,20 @@ either Chocolate, Strawberry, or Vanilla.
 [String][ValidateSet("Chocolate", "Strawberry", "Vanilla")]$flavor = Strawberry
 ```
 
+Note that the validation occurs whenever that variable is assigned even
+within the script.
+For example, the following results in an error at runtime:
+
+```powershell
+Param
+(
+    [ValidateSet("hello","world")]
+    [String]$Message
+)
+
+$Message = "bye"
+```
+
 ## ValidateNotNull Validation Attribute
 
 The ValidateNotNull attribute specifies that the parameter

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -555,6 +555,20 @@ either Chocolate, Strawberry, or Vanilla.
 [String][ValidateSet("Chocolate", "Strawberry", "Vanilla")]$flavor = Strawberry
 ```
 
+Note that the validation occurs whenever that variable is assigned even
+within the script.
+For example, the following results in an error at runtime:
+
+```powershell
+Param
+(
+    [ValidateSet("hello","world")]
+    [String]$Message
+)
+
+$Message = "bye"
+```
+
 ## ValidateNotNull Validation Attribute
 
 The ValidateNotNull attribute specifies that the parameter

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -571,6 +571,20 @@ either Chocolate, Strawberry, or Vanilla.
 [String][ValidateSet("Chocolate", "Strawberry", "Vanilla")]$flavor = Strawberry
 ```
 
+Note that the validation occurs whenever that variable is assigned even
+within the script.
+For example, the following results in an error at runtime:
+
+```powershell
+Param
+(
+    [ValidateSet("hello","world")]
+    [String]$Message
+)
+
+$Message = "bye"
+```
+
 ## ValidateNotNull Validation Attribute
 
 The ValidateNotNull attribute specifies that the parameter

--- a/reference/6/About/about_Functions_Advanced_Parameters.md
+++ b/reference/6/About/about_Functions_Advanced_Parameters.md
@@ -572,6 +572,20 @@ either Chocolate, Strawberry, or Vanilla.
 [String][ValidateSet("Chocolate", "Strawberry", "Vanilla")]$flavor = Strawberry
 ```
 
+Note that the validation occurs whenever that variable is assigned even
+within the script.
+For example, the following results in an error at runtime:
+
+```powershell
+Param
+(
+    [ValidateSet("hello","world")]
+    [String]$Message
+)
+
+$Message = "bye"
+```
+
 ## ValidateNotNull Validation Attribute
 
 The ValidateNotNull attribute specifies that the parameter


### PR DESCRIPTION
added clarifying language on scope of when validateset applies

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
