### PR TITLE
Fix code style of Microsoft.PowerShell.Archive

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/5.0/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -16,84 +16,84 @@ Creates an archive, or zipped file, from specified files and folders.
 ## SYNTAX
 
 ### Path (Default)
-```
+```powershell
 Compress-Archive [-Path] <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### PathWithUpdate
-```
+```powershell
 Compress-Archive [-Path] <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-Update]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### PathWithForce
-```
+```powershell
 Compress-Archive [-Path] <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-Force] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPathWithUpdate
-```
+```powershell
 Compress-Archive -LiteralPath <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-Update]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPathWithForce
-```
+```powershell
 Compress-Archive -LiteralPath <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-Force]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPath
-```
+```powershell
 Compress-Archive -LiteralPath <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Compress-Archive** cmdlet creates a zipped (or compressed) archive file from one or more specified files or folders.
+The `Compress-Archive` cmdlet creates a zipped (or compressed) archive file from one or more specified files or folders.
 An archive file allows multiple files to be packaged, and optionally compressed, into a single zipped file for easier distribution and storage.
 An archive file can be compressed by using the compression algorithm specified by the CompressionLevel parameter.
 
-Because **Compress-Archive** relies upon the Microsoft .NET Framework API **System.IO.Compression.ZipArchive** to compress files, the maximum file size that you can compress by using **Compress-Archive** is currently 2 GB.
+Because `Compress-Archive` relies upon the Microsoft .NET Framework API `System.IO.Compression.ZipArchive` to compress files, the maximum file size that you can compress by using `Compress-Archive` is currently 2 GB.
 This is a limitation of the underlying API.
 
 ## EXAMPLES
 
 ### Example 1: Create an archive file
-```
-PS C:\> Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip
+```powershell
+Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip
 ```
 
-This command creates a new archive file, Draft.zip, by compressing two files, Draftdoc.docx and diagram2.vsd, specified by the *LiteralPath* parameter.
+This command creates a new archive file, Draft.zip, by compressing two files, Draftdoc.docx and diagram2.vsd, specified by the **LiteralPath** parameter.
 The compression level specified for this operation is Optimal.
 
 ### Example 2: Create an archive with wildcard characters
-```
-PS C:\> Compress-Archive -Path C:\Reference\* -CompressionLevel Fastest -DestinationPath C:\Archives\Draft
+```powershell
+Compress-Archive -Path C:\Reference\* -CompressionLevel Fastest -DestinationPath C:\Archives\Draft
 ```
 
 This command creates a new archive file, Draft.zip, in the C:\Archives folder.
-Note that though the file name extension .zip was not added to the value of the *DestinationPath* parameter, Windows PowerShell appends this to the specified archive file name automatically.
-The new archive file contains every file in the C:\Reference folder, because a wildcard character was used in place of specific file names in the *Path* parameter.
+Note that though the file name extension .zip was not added to the value of the **DestinationPath** parameter, Windows PowerShell appends this to the specified archive file name automatically.
+The new archive file contains every file in the C:\Reference folder, because a wildcard character was used in place of specific file names in the **Path** parameter.
 The specified compression level is Fastest, which might result in a larger output file, but compresses a large number of files faster.
 
 ### Example 3: Update an existing archive file
-```
-PS C:\> Compress-Archive -Path C:\Reference\* -Update -DestinationPath C:\Archives\Draft.Zip
+```powershell
+Compress-Archive -Path C:\Reference\* -Update -DestinationPath C:\Archives\Draft.Zip
 ```
 
 This command updates an existing archive file, Draft.Zip, in the C:\Archives folder.
 The command is run to update Draft.Zip with newer versions of existing files that came from the C:\Reference folder, and also to add new files that have been added to C:\Reference since Draft.Zip was initially created.
 
 ### Example 4: Create an archive from an entire folder
-```
-PS C:\> Compress-Archive -Path C:\Reference -DestinationPath C:\Archives\Draft
+```powershell
+Compress-Archive -Path C:\Reference -DestinationPath C:\Archives\Draft
 ```
 
 This command creates an archive from an entire folder, C:\Reference.
-Note that though the file name extension .zip was not added to the value of the *DestinationPath* parameter, Windows PowerShell appends this to the specified archive file name automatically.
+Note that though the file name extension .zip was not added to the value of the **DestinationPath** parameter, Windows PowerShell appends this to the specified archive file name automatically.
 
 ## PARAMETERS
 
@@ -142,8 +142,8 @@ Accept wildcard characters: False
 ### -DestinationPath
 Specifies the path to the archive output file.
 This parameter is required.
-The specified *DestinationPath* value should include the desired name of the output zipped file; it specifies either the absolute or relative path to the zipped file.
-If the file name specified in *DestinationPath* does not have a .zip file name extension, the cmdlet adds a .zip file name extension.
+The specified **DestinationPath** value should include the desired name of the output zipped file; it specifies either the absolute or relative path to the zipped file.
+If the file name specified in **DestinationPath** does not have a .zip file name extension, the cmdlet adds a .zip file name extension.
 
 ```yaml
 Type: String
@@ -174,7 +174,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies the path or paths to the files that you want to add to the archive zipped file.
-Unlike the *Path* parameter, the value of *LiteralPath* is used exactly as it is typed.
+Unlike the **Path** parameter, the value of **LiteralPath** is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose each escape character in single quotation marks, to instruct Windows PowerShell not to interpret any characters as escape sequences.
 To specify multiple paths, and include files in multiple locations in your output zipped file, use commas to separate the paths.

--- a/reference/5.0/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/5.0/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -16,36 +16,36 @@ Extracts files from a specified archive (zipped) file.
 ## SYNTAX
 
 ### Path (Default)
-```
+```powershell
 Expand-Archive [-Path] <String> [[-DestinationPath] <String>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ### LiteralPath
-```
+```powershell
 Expand-Archive -LiteralPath <String> [[-DestinationPath] <String>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Expand-Archive** cmdlet extracts files from a specified zipped archive file to a specified destination folder.
+The `Expand-Archive` cmdlet extracts files from a specified zipped archive file to a specified destination folder.
 An archive file allows multiple files to be packaged, and optionally compressed, into a single zipped file for easier distribution and storage.
 
 ## EXAMPLES
 
 ### Example 1: Extract the contents of an archive
-```
-PS C:\> Expand-Archive -LiteralPath C:\Archives\Draft.Zip -DestinationPath C:\Reference
+```powershell
+Expand-Archive -LiteralPath C:\Archives\Draft.Zip -DestinationPath C:\Reference
 ```
 
-This command extracts the contents of an existing archive file, Draft.zip, into the folder specified by the *DestinationPath* parameter, C:\Reference.
+This command extracts the contents of an existing archive file, Draft.zip, into the folder specified by the **DestinationPath** parameter, C:\Reference.
 
 ### Example 2: Extract the contents of an archive in the current folder
-```
-PS C:\> Expand-Archive -Path Draft.Zip -DestinationPath C:\Reference
+```powershell
+Expand-Archive -Path Draft.Zip -DestinationPath C:\Reference
 ```
 
-This command extracts the contents of an existing archive file in the current folder, Draft.zip, into the folder specified by the *DestinationPath* parameter, C:\Reference.
+This command extracts the contents of an existing archive file in the current folder, Draft.zip, into the folder specified by the **DestinationPath** parameter, C:\Reference.
 
 ## PARAMETERS
 
@@ -98,7 +98,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies the path to an archive file.
-Unlike the *Path* parameter, the value of *LiteralPath* is used exactly as it is typed.
+Unlike the **Path** parameter, the value of **LiteralPath** is used exactly as it is typed.
 Wildcard characters are not supported.
 If the path includes escape characters, enclose each escape character in single quotation marks, to instruct Windows PowerShell not to interpret any characters as escape sequences.
 

--- a/reference/5.1/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/5.1/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -16,84 +16,84 @@ Creates an archive, or zipped file, from specified files and folders.
 ## SYNTAX
 
 ### Path (Default)
-```
+```powershell
 Compress-Archive [-Path] <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### PathWithUpdate
-```
+```powershell
 Compress-Archive [-Path] <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-Update]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### PathWithForce
-```
+```powershell
 Compress-Archive [-Path] <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-Force] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPathWithUpdate
-```
+```powershell
 Compress-Archive -LiteralPath <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-Update]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPathWithForce
-```
+```powershell
 Compress-Archive -LiteralPath <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-Force]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPath
-```
+```powershell
 Compress-Archive -LiteralPath <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Compress-Archive** cmdlet creates a zipped (or compressed) archive file from one or more specified files or folders.
+The `Compress-Archive` cmdlet creates a zipped (or compressed) archive file from one or more specified files or folders.
 An archive file allows multiple files to be packaged, and optionally compressed, into a single zipped file for easier distribution and storage.
 An archive file can be compressed by using the compression algorithm specified by the CompressionLevel parameter.
 
-Because **Compress-Archive** relies upon the Microsoft .NET Framework API **System.IO.Compression.ZipArchive** to compress files, the maximum file size that you can compress by using **Compress-Archive** is currently 2 GB.
+Because `Compress-Archive` relies upon the Microsoft .NET Framework API `System.IO.Compression.ZipArchive` to compress files, the maximum file size that you can compress by using `Compress-Archive` is currently 2 GB.
 This is a limitation of the underlying API.
 
 ## EXAMPLES
 
 ### Example 1: Create an archive file
-```
-PS C:\> Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip
+```powershell
+Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip
 ```
 
-This command creates a new archive file, Draft.zip, by compressing two files, Draftdoc.docx and diagram2.vsd, specified by the *LiteralPath* parameter.
+This command creates a new archive file, Draft.zip, by compressing two files, Draftdoc.docx and diagram2.vsd, specified by the **LiteralPath** parameter.
 The compression level specified for this operation is Optimal.
 
 ### Example 2: Create an archive with wildcard characters
-```
-PS C:\> Compress-Archive -Path C:\Reference\* -CompressionLevel Fastest -DestinationPath C:\Archives\Draft
+```powershell
+Compress-Archive -Path C:\Reference\* -CompressionLevel Fastest -DestinationPath C:\Archives\Draft
 ```
 
 This command creates a new archive file, Draft.zip, in the C:\Archives folder.
-Note that though the file name extension .zip was not added to the value of the *DestinationPath* parameter, Windows PowerShell appends this to the specified archive file name automatically.
-The new archive file contains every file in the C:\Reference folder, because a wildcard character was used in place of specific file names in the *Path* parameter.
+Note that though the file name extension .zip was not added to the value of the **DestinationPath** parameter, Windows PowerShell appends this to the specified archive file name automatically.
+The new archive file contains every file in the C:\Reference folder, because a wildcard character was used in place of specific file names in the **Path** parameter.
 The specified compression level is Fastest, which might result in a larger output file, but compresses a large number of files faster.
 
 ### Example 3: Update an existing archive file
-```
-PS C:\> Compress-Archive -Path C:\Reference\* -Update -DestinationPath C:\Archives\Draft.Zip
+```powershell
+Compress-Archive -Path C:\Reference\* -Update -DestinationPath C:\Archives\Draft.Zip
 ```
 
 This command updates an existing archive file, Draft.Zip, in the C:\Archives folder.
 The command is run to update Draft.Zip with newer versions of existing files that came from the C:\Reference folder, and also to add new files that have been added to C:\Reference since Draft.Zip was initially created.
 
 ### Example 4: Create an archive from an entire folder
-```
-PS C:\> Compress-Archive -Path C:\Reference -DestinationPath C:\Archives\Draft
+```powershell
+Compress-Archive -Path C:\Reference -DestinationPath C:\Archives\Draft
 ```
 
 This command creates an archive from an entire folder, C:\Reference.
-Note that though the file name extension .zip was not added to the value of the *DestinationPath* parameter, Windows PowerShell appends this to the specified archive file name automatically.
+Note that though the file name extension .zip was not added to the value of the **DestinationPath** parameter, Windows PowerShell appends this to the specified archive file name automatically.
 
 ## PARAMETERS
 
@@ -142,8 +142,8 @@ Accept wildcard characters: False
 ### -DestinationPath
 Specifies the path to the archive output file.
 This parameter is required.
-The specified *DestinationPath* value should include the desired name of the output zipped file; it specifies either the absolute or relative path to the zipped file.
-If the file name specified in *DestinationPath* does not have a .zip file name extension, the cmdlet adds a .zip file name extension.
+The specified **DestinationPath** value should include the desired name of the output zipped file; it specifies either the absolute or relative path to the zipped file.
+If the file name specified in **DestinationPath** does not have a .zip file name extension, the cmdlet adds a .zip file name extension.
 
 ```yaml
 Type: String
@@ -174,7 +174,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies the path or paths to the files that you want to add to the archive zipped file.
-Unlike the *Path* parameter, the value of *LiteralPath* is used exactly as it is typed.
+Unlike the **Path** parameter, the value of **LiteralPath** is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose each escape character in single quotation marks, to instruct Windows PowerShell not to interpret any characters as escape sequences.
 To specify multiple paths, and include files in multiple locations in your output zipped file, use commas to separate the paths.

--- a/reference/5.1/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/5.1/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -16,36 +16,36 @@ Extracts files from a specified archive (zipped) file.
 ## SYNTAX
 
 ### Path (Default)
-```
+```powershell
 Expand-Archive [-Path] <String> [[-DestinationPath] <String>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ### LiteralPath
-```
+```powershell
 Expand-Archive -LiteralPath <String> [[-DestinationPath] <String>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Expand-Archive** cmdlet extracts files from a specified zipped archive file to a specified destination folder.
+The `Expand-Archive` cmdlet extracts files from a specified zipped archive file to a specified destination folder.
 An archive file allows multiple files to be packaged, and optionally compressed, into a single zipped file for easier distribution and storage.
 
 ## EXAMPLES
 
 ### Example 1: Extract the contents of an archive
-```
-PS C:\> Expand-Archive -LiteralPath C:\Archives\Draft.Zip -DestinationPath C:\Reference
+```powershell
+Expand-Archive -LiteralPath C:\Archives\Draft.Zip -DestinationPath C:\Reference
 ```
 
-This command extracts the contents of an existing archive file, Draft.zip, into the folder specified by the *DestinationPath* parameter, C:\Reference.
+This command extracts the contents of an existing archive file, Draft.zip, into the folder specified by the **DestinationPath** parameter, C:\Reference.
 
 ### Example 2: Extract the contents of an archive in the current folder
-```
-PS C:\> Expand-Archive -Path Draft.Zip -DestinationPath C:\Reference
+```powershell
+Expand-Archive -Path Draft.Zip -DestinationPath C:\Reference
 ```
 
-This command extracts the contents of an existing archive file in the current folder, Draft.zip, into the folder specified by the *DestinationPath* parameter, C:\Reference.
+This command extracts the contents of an existing archive file in the current folder, Draft.zip, into the folder specified by the **DestinationPath** parameter, C:\Reference.
 
 ## PARAMETERS
 
@@ -98,7 +98,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies the path to an archive file.
-Unlike the *Path* parameter, the value of *LiteralPath* is used exactly as it is typed.
+Unlike the **Path** parameter, the value of **LiteralPath** is used exactly as it is typed.
 Wildcard characters are not supported.
 If the path includes escape characters, enclose each escape character in single quotation marks, to instruct Windows PowerShell not to interpret any characters as escape sequences.
 

--- a/reference/6/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/6/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -16,84 +16,84 @@ Creates an archive, or zipped file, from specified files and folders.
 ## SYNTAX
 
 ### Path (Default)
-```
+```powershell
 Compress-Archive [-Path] <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### PathWithUpdate
-```
+```powershell
 Compress-Archive [-Path] <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-Update]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### PathWithForce
-```
+```powershell
 Compress-Archive [-Path] <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-Force] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPathWithUpdate
-```
+```powershell
 Compress-Archive -LiteralPath <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-Update]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPathWithForce
-```
+```powershell
 Compress-Archive -LiteralPath <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-Force]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### LiteralPath
-```
+```powershell
 Compress-Archive -LiteralPath <String[]> [-DestinationPath] <String> [-CompressionLevel <String>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Compress-Archive** cmdlet creates a zipped (or compressed) archive file from one or more specified files or folders.
+The `Compress-Archive` cmdlet creates a zipped (or compressed) archive file from one or more specified files or folders.
 An archive file allows multiple files to be packaged, and optionally compressed, into a single zipped file for easier distribution and storage.
 An archive file can be compressed by using the compression algorithm specified by the CompressionLevel parameter.
 
-Because **Compress-Archive** relies upon the Microsoft .NET Framework API **System.IO.Compression.ZipArchive** to compress files, the maximum file size that you can compress by using **Compress-Archive** is currently 2 GB.
+Because `Compress-Archive` relies upon the Microsoft .NET Framework API `System.IO.Compression.ZipArchive` to compress files, the maximum file size that you can compress by using `Compress-Archive` is currently 2 GB.
 This is a limitation of the underlying API.
 
 ## EXAMPLES
 
 ### Example 1: Create an archive file
-```
-PS C:\> Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip
+```powershell
+Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip
 ```
 
-This command creates a new archive file, Draft.zip, by compressing two files, Draftdoc.docx and diagram2.vsd, specified by the *LiteralPath* parameter.
+This command creates a new archive file, Draft.zip, by compressing two files, Draftdoc.docx and diagram2.vsd, specified by the **LiteralPath** parameter.
 The compression level specified for this operation is Optimal.
 
 ### Example 2: Create an archive with wildcard characters
-```
-PS C:\> Compress-Archive -Path C:\Reference\* -CompressionLevel Fastest -DestinationPath C:\Archives\Draft
+```powershell
+Compress-Archive -Path C:\Reference\* -CompressionLevel Fastest -DestinationPath C:\Archives\Draft
 ```
 
 This command creates a new archive file, Draft.zip, in the C:\Archives folder.
-Note that though the file name extension .zip was not added to the value of the *DestinationPath* parameter, Windows PowerShell appends this to the specified archive file name automatically.
-The new archive file contains every file in the C:\Reference folder, because a wildcard character was used in place of specific file names in the *Path* parameter.
+Note that though the file name extension .zip was not added to the value of the **DestinationPath** parameter, Windows PowerShell appends this to the specified archive file name automatically.
+The new archive file contains every file in the C:\Reference folder, because a wildcard character was used in place of specific file names in the **Path** parameter.
 The specified compression level is Fastest, which might result in a larger output file, but compresses a large number of files faster.
 
 ### Example 3: Update an existing archive file
-```
-PS C:\> Compress-Archive -Path C:\Reference\* -Update -DestinationPath C:\Archives\Draft.Zip
+```powershell
+Compress-Archive -Path C:\Reference\* -Update -DestinationPath C:\Archives\Draft.Zip
 ```
 
 This command updates an existing archive file, Draft.Zip, in the C:\Archives folder.
 The command is run to update Draft.Zip with newer versions of existing files that came from the C:\Reference folder, and also to add new files that have been added to C:\Reference since Draft.Zip was initially created.
 
 ### Example 4: Create an archive from an entire folder
-```
-PS C:\> Compress-Archive -Path C:\Reference -DestinationPath C:\Archives\Draft
+```powershell
+Compress-Archive -Path C:\Reference -DestinationPath C:\Archives\Draft
 ```
 
 This command creates an archive from an entire folder, C:\Reference.
-Note that though the file name extension .zip was not added to the value of the *DestinationPath* parameter, Windows PowerShell appends this to the specified archive file name automatically.
+Note that though the file name extension .zip was not added to the value of the **DestinationPath** parameter, Windows PowerShell appends this to the specified archive file name automatically.
 
 ## PARAMETERS
 
@@ -126,8 +126,8 @@ Accept wildcard characters: False
 ### -DestinationPath
 Specifies the path to the archive output file.
 This parameter is required.
-The specified *DestinationPath* value should include the desired name of the output zipped file; it specifies either the absolute or relative path to the zipped file.
-If the file name specified in *DestinationPath* does not have a .zip file name extension, the cmdlet adds a .zip file name extension.
+The specified **DestinationPath** value should include the desired name of the output zipped file; it specifies either the absolute or relative path to the zipped file.
+If the file name specified in **DestinationPath** does not have a .zip file name extension, the cmdlet adds a .zip file name extension.
 
 ```yaml
 Type: String
@@ -143,7 +143,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies the path or paths to the files that you want to add to the archive zipped file.
-Unlike the *Path* parameter, the value of *LiteralPath* is used exactly as it is typed.
+Unlike the **Path** parameter, the value of **LiteralPath** is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose each escape character in single quotation marks, to instruct Windows PowerShell not to interpret any characters as escape sequences.
 To specify multiple paths, and include files in multiple locations in your output zipped file, use commas to separate the paths.

--- a/reference/6/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/6/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -16,36 +16,36 @@ Extracts files from a specified archive (zipped) file.
 ## SYNTAX
 
 ### Path (Default)
-```
+```powershell
 Expand-Archive [-Path] <String> [[-DestinationPath] <String>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ### LiteralPath
-```
+```powershell
 Expand-Archive -LiteralPath <String> [[-DestinationPath] <String>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Expand-Archive** cmdlet extracts files from a specified zipped archive file to a specified destination folder.
+The `Expand-Archive` cmdlet extracts files from a specified zipped archive file to a specified destination folder.
 An archive file allows multiple files to be packaged, and optionally compressed, into a single zipped file for easier distribution and storage.
 
 ## EXAMPLES
 
 ### Example 1: Extract the contents of an archive
-```
-PS C:\> Expand-Archive -LiteralPath C:\Archives\Draft.Zip -DestinationPath C:\Reference
+```powershell
+Expand-Archive -LiteralPath C:\Archives\Draft.Zip -DestinationPath C:\Reference
 ```
 
-This command extracts the contents of an existing archive file, Draft.zip, into the folder specified by the *DestinationPath* parameter, C:\Reference.
+This command extracts the contents of an existing archive file, Draft.zip, into the folder specified by the **DestinationPath** parameter, C:\Reference.
 
 ### Example 2: Extract the contents of an archive in the current folder
-```
-PS C:\> Expand-Archive -Path Draft.Zip -DestinationPath C:\Reference
+```powershell
+Expand-Archive -Path Draft.Zip -DestinationPath C:\Reference
 ```
 
-This command extracts the contents of an existing archive file in the current folder, Draft.zip, into the folder specified by the *DestinationPath* parameter, C:\Reference.
+This command extracts the contents of an existing archive file in the current folder, Draft.zip, into the folder specified by the **DestinationPath** parameter, C:\Reference.
 
 ## PARAMETERS
 
@@ -83,7 +83,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies the path to an archive file.
-Unlike the *Path* parameter, the value of *LiteralPath* is used exactly as it is typed.
+Unlike the **Path** parameter, the value of **LiteralPath** is used exactly as it is typed.
 Wildcard characters are not supported.
 If the path includes escape characters, enclose each escape character in single quotation marks, to instruct Windows PowerShell not to interpret any characters as escape sequences.
 


### PR DESCRIPTION
Following the [style guide](https://github.com/PowerShell/PowerShell-Docs/blob/18b4423c9750bf9761bdf5ed82093e886f89fe56/STYLE.md):
* \`\`\` -> \`\`\`powershell
* \*\*cmdlet\*\* -> \`cmdlet\`
* \*parameter\* -> \*\*parameter\*\*
* Remove 'PS C:\> '

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
