### PR TITLE
Added a note on encoding of New-ModuleManifest

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/6/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -47,6 +47,8 @@ Unless specified in the parameter description, if you omit a parameter from the 
 In Windows PowerShell 2.0, **New-ModuleManifest** prompts you for the values of frequently used parameters that are not specified in the command, in addition to required parameter values.
 Starting in Windows PowerShell 3.0, it prompts only when required parameter values are not specified.
 
+Module manifest (.psd1) file encoding depends on environment: if it is PowerShell Core running on Linux then encoding is UTF-8 (no BOM); otherwise encoding is UTF-16 (with BOM).
+
 ## EXAMPLES
 
 ### Example 1: Create a manifest


### PR DESCRIPTION
Added a line to New-ModuleManifest docs about encoding used by cmdlet.

Version(s) of document impacted
------------------------------
- [X] Impacts 6 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version "PowerShellCore 6" of PowerShell