### PR TITLE
Add documentation for `e and `u{}.

### DIFF
--- a/reference/6/About/about_Escape_Characters.md
+++ b/reference/6/About/about_Escape_Characters.md
@@ -119,22 +119,49 @@ Escape Sequence | Special Character
 `0 | Null
 `a | Alert
 `b | Backspace
+`e | Escape
 `f | Form feed
 `n | New line
 `r | Carriage return
 `t | Horizontal tab
+`u{x} | Unicode escape sequence for characters with hex value x (up to xxxxxx)
 `v | Vertical tab
 
-For example:
+This next example uses new line and tab characters to format the string:
 
 ```powershell
-"12345678123456781`nCol1`tColumn2`tCol3"
+"12345678123456781`nCol1`tColumn2`tCol3`u{2195}"
 ```
 
 ```output
-# 12345678123456781
+12345678123456781
 
-Col1 Column2 Col3
+Col1 Column2 Col3↕
+```
+
+This next example uses the escape character to specify a virtual
+terminal sequence to output text with the foreground color of Orange.
+This example requires Windows 10 Anniversary Update or a Linux or
+macOS terminal that supports 24-bit color.
+
+```powershell
+$r,$g,$b = 0xff,0x66,0x00
+"`e[38;2;$r;$g;${b}mOrange text`e[0m"
+```
+
+```output
+Orange text
+```
+
+This next example uses a Unicode escape sequence to display the
+character '↕'.
+
+```powershell
+"`u{2195}"
+```
+
+```output
+↕
 ```
 
 For more information, type:

--- a/reference/6/About/about_Special_Characters.md
+++ b/reference/6/About/about_Special_Characters.md
@@ -29,10 +29,12 @@ The following special characters are recognized by Windows PowerShell:
 `0    Null
 `a    Alert
 `b    Backspace
+`e    Escape
 `f    Form feed
 `n    New line
 `r    Carriage return
 `t    Horizontal tab
+`u{x} Unicode escape sequence
 `v    Vertical tab
 --%   Stop parsing
 
@@ -65,6 +67,25 @@ does not delete any characters. The following command writes the word
 The output from this command is as follows:
 
 back out
+
+ESCAPE (`e)
+The escape character is most commonly used to specify virtual terminal
+sequences to modify the color of text in addition to other text attributes
+such as bolding and underlining as well as moving the cursor. The PowerShell
+host must support virtual terminal sequences. Windows 10 v1511 and higher,
+as well as most Linux and macOS terminals support virtual terminal sequences.
+
+The following command outputs Orange text. This requires a host capable
+of 24-bit color such as Windows 10 Anniversary Update or higher:
+
+$r,$g,$b = 0xff,0x66,0x00
+
+"`e[38;2;$r;$g;${b}mOrange text`e[0m"
+
+The output from this command is the following text with a foreground color
+of Orange:
+
+Orange text
 
 FORM FEED (`f)
 The form feed character (`f) is a print instruction that ejects the
@@ -111,6 +132,20 @@ column.
 The output from this command is:
 
 Column1         Column2         Column3
+
+UNICODE CHARACTER (`u{x})
+The Unicode escape sequence allows you to specify any Unicode character
+including Unicode surrogate characters often used for Emoji e.g. `u{1F44D}.
+The Unicode escape sequence requires at least one hex digit and supports
+up to six hex digits. The maximum hex value is 0x10FFFF.
+
+The following command outputs the character '↕':
+
+"`u{2195}"
+
+The output from this command is:
+
+↕
 
 VERTICAL TAB (`v)
 The horizontal tab character (`t) advances to the next vertical tab stop


### PR DESCRIPTION
This PR is tied to the acceptance of the PR https://github.com/PowerShell/PowerShell/pull/3958.

Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature will be introduced in version 6.0 Beta4 (hopefully - waiting on PR that implements this feature to be accepted) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
