### PR TITLE
Fix code style of Microsoft.PowerShell.Host

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/3.0/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -14,40 +14,40 @@ Creates a record of all or part of a Windows PowerShell session in a text file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
+```powershell
 Start-Transcript [[-Path] <String>] [-Append] [-Force] [-NoClobber] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```powershell
 Start-Transcript [[-LiteralPath] <String>] [-Append] [-Force] [-NoClobber] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Start-Transcript cmdlet creates a record of all or part of a Windows PowerShell session in a text file.
+The `Start-Transcript` cmdlet creates a record of all or part of a Windows PowerShell session in a text file.
 The transcript includes all command that the user types and all output that appears on the console.
 ## EXAMPLES
 
 ### Example 1
-```
-PS C:\> start-transcript
+```powershell
+Start-Transcript
 ```
 
 This command starts a transcript in the default file location.
 ### Example 2
-```
-PS C:\> start-transcript -path c:\transcripts\transcript0.txt -noclobber
+```powershell
+Start-Transcript -Path c:\transcripts\transcript0.txt -NoClobber
 ```
 
 This command starts a transcript in the Transcript0.txt file in C:\transcripts.
-The NoClobber parameter prevents any existing files from being overwritten.
+The **NoClobber** parameter prevents any existing files from being overwritten.
 If the Transcript0.txt file already exists, the command fails.
 ## PARAMETERS
 
 ### -Append
 Adds the new transcript to the end of an existing file.
-Use the Path parameter to specify the file.
+Use the **Path** parameter to specify the file.
 
 ```yaml
 Type: SwitchParameter
@@ -64,7 +64,7 @@ Accept wildcard characters: False
 ### -Force
 Allows the cmdlet to append the transcript to an existing read-only file.
 When used on a read-only file, the cmdlet changes the file permission to read-write.
-Even using the Force parameter, the cmdlet cannot override security restrictions.
+Even using the **Force** parameter, the cmdlet cannot override security restrictions.
 
 ```yaml
 Type: SwitchParameter
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 
 ### -NoClobber
 Will not overwrite (replace the contents) of an existing file.
-By default, if a transcript file exists in the specified path, Start-Transcript overwrites the file without warning.
+By default, if a transcript file exists in the specified path, `Start-Transcript` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -99,8 +99,8 @@ Specifies a location for the transcript file.
 Enter a path to a .txt file.
 Wildcards are not permitted.
 
-If you do not specify a path, Start-Transcript uses the path in the value of the $Transcript global variable.
-If you have not created this variable, Start-Transcript stores the transcripts in the $Home\My Documents directory as \PowerShell_transcript.\<time-stamp\>.txt files.
+If you do not specify a path, `Start-Transcript` uses the path in the value of the $Transcript global variable.
+If you have not created this variable, `Start-Transcript` stores the transcripts in the $Home\My Documents directory as \PowerShell_transcript.\<time-stamp\>.txt files.
 
 If any of the directories in the path do not exist, the command fails.
 
@@ -175,11 +175,11 @@ You cannot pipe objects to this cmdlet.
 ## OUTPUTS
 
 ### System.String
-Start-Transcript returns a string that contains a confirmation message and the path to the output file.
+`Start-Transcript` returns a string that contains a confirmation message and the path to the output file.
 ## NOTES
-* To stop a transcript, use the Stop-Transcript cmdlet.
+* To stop a transcript, use the `Stop-Transcript` cmdlet.
 
-  To record an entire session, add the Start-Transcript command to your profile.
+  To record an entire session, add the `Start-Transcript` command to your profile.
 For more information, see about_Profiles.
 
 *

--- a/reference/3.0/Microsoft.PowerShell.Host/Stop-Transcript.md
+++ b/reference/3.0/Microsoft.PowerShell.Host/Stop-Transcript.md
@@ -13,18 +13,18 @@ title:  Stop-Transcript
 Stops a transcript.
 ## SYNTAX
 
-```
+```powershell
 Stop-Transcript [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Stop-Transcript cmdlet stops a transcript that was started by using the Start-Transcript cmdlet.
+The `Stop-Transcript` cmdlet stops a transcript that was started by using the `Start-Transcript` cmdlet.
 You can also stop a transcript by ending the session.
 ## EXAMPLES
 
 ### Example 1
-```
-PS C:\> stop-transcript
+```powershell
+Stop-Transcript
 ```
 
 This command stops any running transcripts.
@@ -39,7 +39,7 @@ You cannot pipe input to this cmdlet.
 ## OUTPUTS
 
 ### System.String
-Stop-Transcript returns a string that contains a status message and the path to the output file.
+`Stop-Transcript` returns a string that contains a status message and the path to the output file.
 ## NOTES
 * If a transcript has not been started, the command fails.
 

--- a/reference/4.0/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/4.0/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -16,50 +16,50 @@ Creates a record of all or part of a Windows PowerShell session in a text file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
+```powershell
 Start-Transcript [[-Path] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```powershell
 Start-Transcript [[-LiteralPath] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### ByOutputDirectory
-```
+```powershell
 Start-Transcript [-OutputDirectory <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Start-Transcript cmdlet creates a record of all or part of a Windows PowerShell session in a text file.
+The `Start-Transcript` cmdlet creates a record of all or part of a Windows PowerShell session in a text file.
 The transcript includes all command that the user types and all output that appears on the console.
 
 ## EXAMPLES
 
 ### Example 1
-```
-PS C:\> start-transcript
+```powershell
+Start-Transcript
 ```
 
 This command starts a transcript in the default file location.
 
 ### Example 2
-```
-PS C:\> start-transcript -path c:\transcripts\transcript0.txt -noclobber
+```powershell
+Start-Transcript -Path c:\transcripts\transcript0.txt -NoClobber
 ```
 
 This command starts a transcript in the Transcript0.txt file in C:\transcripts.
-The NoClobber parameter prevents any existing files from being overwritten.
+The **NoClobber** parameter prevents any existing files from being overwritten.
 If the Transcript0.txt file already exists, the command fails.
 
 ## PARAMETERS
 
 ### -Append
 Adds the new transcript to the end of an existing file.
-Use the Path parameter to specify the file.
+Use the **Path** parameter to specify the file.
 
 ```yaml
 Type: SwitchParameter
@@ -76,7 +76,7 @@ Accept wildcard characters: False
 ### -Force
 Allows the cmdlet to append the transcript to an existing read-only file.
 When used on a read-only file, the cmdlet changes the file permission to read-write.
-Even using the Force parameter, the cmdlet cannot override security restrictions.
+Even using the **Force** parameter, the cmdlet cannot override security restrictions.
 
 ```yaml
 Type: SwitchParameter
@@ -92,7 +92,7 @@ Accept wildcard characters: False
 
 ### -NoClobber
 Will not overwrite (replace the contents) of an existing file.
-By default, if a transcript file exists in the specified path, Start-Transcript overwrites the file without warning.
+By default, if a transcript file exists in the specified path, `Start-Transcript` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -111,8 +111,8 @@ Specifies a location for the transcript file.
 Enter a path to a .txt file.
 Wildcards are not permitted.
 
-If you do not specify a path, Start-Transcript uses the path in the value of the $Transcript global variable.
-If you have not created this variable, Start-Transcript stores the transcripts in the $Home\My Documents directory as \PowerShell_transcript.\<time-stamp\>.txt files.
+If you do not specify a path, `Start-Transcript` uses the path in the value of the $Transcript global variable.
+If you have not created this variable, `Start-Transcript` stores the transcripts in the $Home\My Documents directory as \PowerShell_transcript.\<time-stamp\>.txt files.
 
 If any of the directories in the path do not exist, the command fails.
 
@@ -219,12 +219,12 @@ You cannot pipe objects to this cmdlet.
 ## OUTPUTS
 
 ### System.String
-Start-Transcript returns a string that contains a confirmation message and the path to the output file.
+`Start-Transcript` returns a string that contains a confirmation message and the path to the output file.
 
 ## NOTES
-* To stop a transcript, use the Stop-Transcript cmdlet.
+* To stop a transcript, use the `Stop-Transcript` cmdlet.
 
-  To record an entire session, add the Start-Transcript command to your profile.
+  To record an entire session, add the `Start-Transcript` command to your profile.
 For more information, see about_Profiles.
 
 *

--- a/reference/4.0/Microsoft.PowerShell.Host/Stop-Transcript.md
+++ b/reference/4.0/Microsoft.PowerShell.Host/Stop-Transcript.md
@@ -15,19 +15,19 @@ Stops a transcript.
 
 ## SYNTAX
 
-```
+```powershell
 Stop-Transcript [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Stop-Transcript cmdlet stops a transcript that was started by using the Start-Transcript cmdlet.
+The `Stop-Transcript` cmdlet stops a transcript that was started by using the `Start-Transcript` cmdlet.
 You can also stop a transcript by ending the session.
 
 ## EXAMPLES
 
 ### Example 1
-```
-PS C:\> stop-transcript
+```powershell
+Stop-Transcript
 ```
 
 This command stops any running transcripts.
@@ -45,7 +45,7 @@ You cannot pipe input to this cmdlet.
 ## OUTPUTS
 
 ### System.String
-Stop-Transcript returns a string that contains a status message and the path to the output file.
+`Stop-Transcript` returns a string that contains a status message and the path to the output file.
 
 ## NOTES
 * If a transcript has not been started, the command fails.

--- a/reference/5.0/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/5.0/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -16,56 +16,56 @@ Creates a record of all or part of a Windows PowerShell session to a text file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
+```powershell
 Start-Transcript [[-Path] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```powershell
 Start-Transcript [[-LiteralPath] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### ByOutputDirectory
-```
+```powershell
 Start-Transcript [[-OutputDirectory] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Start-Transcript** cmdlet creates a record of all or part of a Windows PowerShell session to a text file.
+The `Start-Transcript` cmdlet creates a record of all or part of a Windows PowerShell session to a text file.
 The transcript includes all command that the user types and all output that appears on the console.
 
-Starting in Windows PowerShell 5.0, **Start-Transcript** includes the host name in the generated file name of all transcripts.
+Starting in Windows PowerShell 5.0, `Start-Transcript` includes the host name in the generated file name of all transcripts.
 This is especially useful when your enterprise's logging is centralized.
-Files that are created by the **Start-Transcript** cmdlet include random characters in names to prevent potential overwrites or duplication when two or more transcripts are started simultaneously.
+Files that are created by the `Start-Transcript` cmdlet include random characters in names to prevent potential overwrites or duplication when two or more transcripts are started simultaneously.
 This also prevents unauthorized discovery of transcripts that are stored in a centralized file share.
-Additionally in Windows PowerShell 5.0, the Start-Transcript cmdlet works in Windows PowerShell ISE.
+Additionally in Windows PowerShell 5.0, the `Start-Transcript` cmdlet works in Windows PowerShell ISE.
 
 ## EXAMPLES
 
 ### Example 1: Start a transcript file with default settings
-```
-PS C:\> Start-Transcript
+```powershell
+Start-Transcript
 ```
 
 This command starts a transcript in the default file location.
 
 ### Example 2: Start a transcript file at a specific location
-```
-PS C:\> Start-Transcript -Path "C:\transcripts\transcript0.txt" -NoClobber
+```powershell
+Start-Transcript -Path "C:\transcripts\transcript0.txt" -NoClobber
 ```
 
 This command starts a transcript in the Transcript0.txt file in C:\transcripts.
-Since the *NoClobber* parameter is used, the command prevents any existing files from being overwritten.
+Since the **NoClobber** parameter is used, the command prevents any existing files from being overwritten.
 If the Transcript0.txt file already exists, the command fails.
 
 ## PARAMETERS
 
 ### -Append
 Indicates that this cmdlet adds the new transcript to the end of an existing file.
-Use the *Path* parameter to specify the file.
+Use the **Path** parameter to specify the file.
 
 ```yaml
 Type: SwitchParameter
@@ -128,7 +128,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies a location to the transcript file.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is typed.
+Unlike the **Path** parameter, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks inform Windows PowerShell not to interpret any characters as escape sequences.
@@ -147,7 +147,7 @@ Accept wildcard characters: False
 
 ### -NoClobber
 Indicates that this cmdlet will not overwrite of an existing file.
-By default, if a transcript file exists in the specified path, **Start-Transcript** overwrites the file without warning.
+By default, if a transcript file exists in the specified path, `Start-Transcript` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -182,8 +182,8 @@ Specifies a location to the transcript file.
 Enter a path to a .txt file.
 Wildcards are not permitted.
 
-If you do not specify a path, **Start-Transcript** uses the path in the value of the $Transcript global variable.
-If you have not created this variable, **Start-Transcript** stores the transcripts in the $Home\My Documents directory as \PowerShell_transcript.\<time-stamp\>.txt files.
+If you do not specify a path, `Start-Transcript` uses the path in the value of the $Transcript global variable.
+If you have not created this variable, `Start-Transcript` stores the transcripts in the $Home\My Documents directory as \PowerShell_transcript.\<time-stamp\>.txt files.
 
 If any of the directories in the path do not exist, the command fails.
 
@@ -229,9 +229,9 @@ You cannot pipe objects to this cmdlet.
 This cmdlet returns a string that contains a confirmation message and the path to the output file.
 
 ## NOTES
-* To stop a transcript, use the Stop-Transcript cmdlet.
+* To stop a transcript, use the `Stop-Transcript` cmdlet.
 
-  To record an entire session, add the **Start-Transcript** command to your profile.
+  To record an entire session, add the `Start-Transcript` command to your profile.
 For more information, see about_Profiles.
 
 *

--- a/reference/5.0/Microsoft.PowerShell.Host/Stop-Transcript.md
+++ b/reference/5.0/Microsoft.PowerShell.Host/Stop-Transcript.md
@@ -15,19 +15,19 @@ Stops a transcript.
 
 ## SYNTAX
 
-```
+```powershell
 Stop-Transcript [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Stop-Transcript** cmdlet stops a transcript that was started by the Start-Transcript cmdlet.
+The `Stop-Transcript` cmdlet stops a transcript that was started by the `Start-Transcript` cmdlet.
 Alternatively, you can end a session to stop a transcript.
 
 ## EXAMPLES
 
 ### Example 1: Stop all transcripts
-```
-PS C:\> Stop-Transcript
+```powershell
+Stop-Transcript
 ```
 
 This command stops all transcripts.

--- a/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/5.1/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -16,56 +16,56 @@ Creates a record of all or part of a Windows PowerShell session to a text file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
+```powershell
 Start-Transcript [[-Path] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```powershell
 Start-Transcript [[-LiteralPath] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### ByOutputDirectory
-```
+```powershell
 Start-Transcript [[-OutputDirectory] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Start-Transcript** cmdlet creates a record of all or part of a Windows PowerShell session to a text file.
+The `Start-Transcript` cmdlet creates a record of all or part of a Windows PowerShell session to a text file.
 The transcript includes all command that the user types and all output that appears on the console.
 
-Starting in Windows PowerShell 5.0, **Start-Transcript** includes the host name in the generated file name of all transcripts.
+Starting in Windows PowerShell 5.0, `Start-Transcript` includes the host name in the generated file name of all transcripts.
 This is especially useful when your enterprise's logging is centralized.
-Files that are created by the **Start-Transcript** cmdlet include random characters in names to prevent potential overwrites or duplication when two or more transcripts are started simultaneously.
+Files that are created by the `Start-Transcript` cmdlet include random characters in names to prevent potential overwrites or duplication when two or more transcripts are started simultaneously.
 This also prevents unauthorized discovery of transcripts that are stored in a centralized file share.
-Additionally in Windows PowerShell 5.0, the Start-Transcript cmdlet works in Windows PowerShell ISE.
+Additionally in Windows PowerShell 5.0, the `Start-Transcript` cmdlet works in Windows PowerShell ISE.
 
 ## EXAMPLES
 
 ### Example 1: Start a transcript file with default settings
-```
-PS C:\> Start-Transcript
+```powershell
+Start-Transcript
 ```
 
 This command starts a transcript in the default file location.
 
 ### Example 2: Start a transcript file at a specific location
-```
-PS C:\> Start-Transcript -Path "C:\transcripts\transcript0.txt" -NoClobber
+```powershell
+Start-Transcript -Path "C:\transcripts\transcript0.txt" -NoClobber
 ```
 
 This command starts a transcript in the Transcript0.txt file in C:\transcripts.
-Since the *NoClobber* parameter is used, the command prevents any existing files from being overwritten.
+Since the **NoClobber** parameter is used, the command prevents any existing files from being overwritten.
 If the Transcript0.txt file already exists, the command fails.
 
 ## PARAMETERS
 
 ### -Append
 Indicates that this cmdlet adds the new transcript to the end of an existing file.
-Use the *Path* parameter to specify the file.
+Use the **Path** parameter to specify the file.
 
 ```yaml
 Type: SwitchParameter
@@ -128,7 +128,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies a location to the transcript file.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is typed.
+Unlike the **Path** parameter, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks inform Windows PowerShell not to interpret any characters as escape sequences.
@@ -147,7 +147,7 @@ Accept wildcard characters: False
 
 ### -NoClobber
 Indicates that this cmdlet will not overwrite of an existing file.
-By default, if a transcript file exists in the specified path, **Start-Transcript** overwrites the file without warning.
+By default, if a transcript file exists in the specified path, `Start-Transcript` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -182,8 +182,8 @@ Specifies a location to the transcript file.
 Enter a path to a .txt file.
 Wildcards are not permitted.
 
-If you do not specify a path, **Start-Transcript** uses the path in the value of the $Transcript global variable.
-If you have not created this variable, **Start-Transcript** stores the transcripts in the $Home\My Documents directory as \PowerShell_transcript.\<time-stamp\>.txt files.
+If you do not specify a path, `Start-Transcript` uses the path in the value of the $Transcript global variable.
+If you have not created this variable, `Start-Transcript` stores the transcripts in the $Home\My Documents directory as \PowerShell_transcript.\<time-stamp\>.txt files.
 
 If any of the directories in the path do not exist, the command fails.
 
@@ -229,9 +229,9 @@ You cannot pipe objects to this cmdlet.
 This cmdlet returns a string that contains a confirmation message and the path to the output file.
 
 ## NOTES
-* To stop a transcript, use the Stop-Transcript cmdlet.
+* To stop a transcript, use the `Stop-Transcript` cmdlet.
 
-  To record an entire session, add the **Start-Transcript** command to your profile.
+  To record an entire session, add the `Start-Transcript` command to your profile.
 For more information, see about_Profiles.
 
 *

--- a/reference/5.1/Microsoft.PowerShell.Host/Stop-Transcript.md
+++ b/reference/5.1/Microsoft.PowerShell.Host/Stop-Transcript.md
@@ -15,19 +15,19 @@ Stops a transcript.
 
 ## SYNTAX
 
-```
+```powershell
 Stop-Transcript [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Stop-Transcript** cmdlet stops a transcript that was started by the Start-Transcript cmdlet.
+The `Stop-Transcript` cmdlet stops a transcript that was started by the `Start-Transcript` cmdlet.
 Alternatively, you can end a session to stop a transcript.
 
 ## EXAMPLES
 
 ### Example 1: Stop all transcripts
-```
-PS C:\> Stop-Transcript
+```powershell
+Stop-Transcript
 ```
 
 This command stops all transcripts.

--- a/reference/6/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/6/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -16,56 +16,56 @@ Creates a record of all or part of a Windows PowerShell session to a text file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
+```powershell
 Start-Transcript [[-Path] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```powershell
 Start-Transcript [[-LiteralPath] <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### ByOutputDirectory
-```
+```powershell
 Start-Transcript [-OutputDirectory <String>] [-Append] [-Force] [-NoClobber] [-IncludeInvocationHeader]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Start-Transcript** cmdlet creates a record of all or part of a Windows PowerShell session to a text file.
+The `Start-Transcript` cmdlet creates a record of all or part of a Windows PowerShell session to a text file.
 The transcript includes all command that the user types and all output that appears on the console.
 
-Starting in Windows PowerShell 5.0, **Start-Transcript** includes the host name in the generated file name of all transcripts.
+Starting in Windows PowerShell 5.0, `Start-Transcript` includes the host name in the generated file name of all transcripts.
 This is especially useful when your enterprise's logging is centralized.
-Files that are created by the **Start-Transcript** cmdlet include random characters in names to prevent potential overwrites or duplication when two or more transcripts are started simultaneously.
+Files that are created by the `Start-Transcript` cmdlet include random characters in names to prevent potential overwrites or duplication when two or more transcripts are started simultaneously.
 This also prevents unauthorized discovery of transcripts that are stored in a centralized file share.
-Additionally in Windows PowerShell 5.0, the Start-Transcript cmdlet works in Windows PowerShell ISE.
+Additionally in Windows PowerShell 5.0, the `Start-Transcript` cmdlet works in Windows PowerShell ISE.
 
 ## EXAMPLES
 
 ### Example 1: Start a transcript file with default settings
-```
-PS C:\> Start-Transcript
+```powershell
+Start-Transcript
 ```
 
 This command starts a transcript in the default file location.
 
 ### Example 2: Start a transcript file at a specific location
-```
-PS C:\> Start-Transcript -Path "C:\transcripts\transcript0.txt" -NoClobber
+```powershell
+Start-Transcript -Path "C:\transcripts\transcript0.txt" -NoClobber
 ```
 
 This command starts a transcript in the Transcript0.txt file in C:\transcripts.
-Since the *NoClobber* parameter is used, the command prevents any existing files from being overwritten.
+Since the **NoClobber** parameter is used, the command prevents any existing files from being overwritten.
 If the Transcript0.txt file already exists, the command fails.
 
 ## PARAMETERS
 
 ### -Append
 Indicates that this cmdlet adds the new transcript to the end of an existing file.
-Use the *Path* parameter to specify the file.
+Use the **Path** parameter to specify the file.
 
 ```yaml
 Type: SwitchParameter
@@ -113,7 +113,7 @@ Accept wildcard characters: False
 
 ### -NoClobber
 Indicates that this cmdlet will not overwrite of an existing file.
-By default, if a transcript file exists in the specified path, **Start-Transcript** overwrites the file without warning.
+By default, if a transcript file exists in the specified path, `Start-Transcript` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -148,8 +148,8 @@ Specifies a location to the transcript file.
 Enter a path to a .txt file.
 Wildcards are not permitted.
 
-If you do not specify a path, **Start-Transcript** uses the path in the value of the $Transcript global variable.
-If you have not created this variable, **Start-Transcript** stores the transcripts in the $Home\My Documents directory as \PowerShell_transcript.\<time-stamp\>.txt files.
+If you do not specify a path, `Start-Transcript` uses the path in the value of the $Transcript global variable.
+If you have not created this variable, `Start-Transcript` stores the transcripts in the $Home\My Documents directory as \PowerShell_transcript.\<time-stamp\>.txt files.
 
 If any of the directories in the path do not exist, the command fails.
 
@@ -167,7 +167,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies a location to the transcript file.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is typed.
+Unlike the **Path** parameter, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks inform Windows PowerShell not to interpret any characters as escape sequences.
@@ -229,9 +229,9 @@ You cannot pipe objects to this cmdlet.
 This cmdlet returns a string that contains a confirmation message and the path to the output file.
 
 ## NOTES
-* To stop a transcript, use the Stop-Transcript cmdlet.
+* To stop a transcript, use the `Stop-Transcript` cmdlet.
 
-  To record an entire session, add the **Start-Transcript** command to your profile.
+  To record an entire session, add the `Start-Transcript` command to your profile.
 For more information, see about_Profiles.
 
 *

--- a/reference/6/Microsoft.PowerShell.Host/Stop-Transcript.md
+++ b/reference/6/Microsoft.PowerShell.Host/Stop-Transcript.md
@@ -15,19 +15,19 @@ Stops a transcript.
 
 ## SYNTAX
 
-```
+```powershell
 Stop-Transcript [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Stop-Transcript** cmdlet stops a transcript that was started by the Start-Transcript cmdlet.
+The `Stop-Transcript` cmdlet stops a transcript that was started by the `Start-Transcript` cmdlet.
 Alternatively, you can end a session to stop a transcript.
 
 ## EXAMPLES
 
 ### Example 1: Stop all transcripts
-```
-PS C:\> Stop-Transcript
+```powershell
+Stop-Transcript
 ```
 
 This command stops all transcripts.


### PR DESCRIPTION
Following the [style guide](https://github.com/PowerShell/PowerShell-Docs/blob/18b4423c9750bf9761bdf5ed82093e886f89fe56/STYLE.md):
* \`\`\` -> \`\`\`powershell
* \*\*cmdlet\*\* -> \`cmdlet\`
* cmdlet -> \`cmdlet\`
* \*parameter\* -> \*\*parameter\*\*
* parameter -> \*\*parameter\*\*
* Remove 'PS C:> '
* PascalCase

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document
