### PR TITLE
Updates authoringResourceMofDesigner.md to match style guide

### DIFF
--- a/dsc/authoringResourceMofDesigner.md
+++ b/dsc/authoringResourceMofDesigner.md
@@ -28,10 +28,10 @@ Parameter name  Description
 To create the properties, we use the **New-xDscResourceProperty** cmdlet. The following PowerShell commands create the properties described above.
 
 ```powershell
-PS C:\> $UserName = New-xDscResourceProperty –Name UserName -Type String -Attribute Key
-PS C:\> $Ensure = New-xDscResourceProperty –Name Ensure -Type String -Attribute Write –ValidateSet “Present”, “Absent”
-PS C:\> $DomainCredential = New-xDscResourceProperty –Name DomainCredential-Type PSCredential -Attribute Write
-PS C:\> $Password = New-xDscResourceProperty –Name Password -Type PSCredential -Attribute Write
+$UserName = New-xDscResourceProperty –Name UserName -Type String -Attribute Key
+$Ensure = New-xDscResourceProperty –Name Ensure -Type String -Attribute Write –ValidateSet “Present”, “Absent”
+$DomainCredential = New-xDscResourceProperty –Name DomainCredential-Type PSCredential -Attribute Write
+$Password = New-xDscResourceProperty –Name Password -Type PSCredential -Attribute Write
 ```
 
 ## Create the resource
@@ -39,7 +39,7 @@ PS C:\> $Password = New-xDscResourceProperty –Name Password -Type PSCredential
 Now that the resource properties have been created, we can call the **New-xDscResource** cmdlet to create the resource. The **New-xDscResource** cmdlet takes the list of properties as parameters. It also takes the path where the module should be created, the name of the new resource, and the name of the module in which it is contained. The following PowerShell command creates the resource.
 
 ```powershell
-PS C:\> New-xDscResource –Name Demo_ADUser –Property $UserName, $Ensure, $DomainCredential, $Password –Path ‘C:\Program Files\WindowsPowerShell\Modules’ –ModuleName Demo_DSCModule
+New-xDscResource –Name Demo_ADUser –Property $UserName, $Ensure, $DomainCredential, $Password –Path ‘C:\Program Files\WindowsPowerShell\Modules’ –ModuleName Demo_DSCModule
 ```
 
 The **New-xDscResource** cmdlet creates the MOF schema, a skeleton resource script, the required directory structure for your new resource, and a manifest for the module that exposes the new resource.
@@ -50,10 +50,10 @@ The MOF schema file is at **C:\Program Files\WindowsPowerShell\Modules\Demo_DSCM
 [ClassVersion("1.0.0.0"), FriendlyName("Demo_ADUser")]
 class Demo_ADUser : OMI_BaseResource
 {
-[Key] string UserName;
-[Write, ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
-[Write, EmbeddedInstance("MSFT_Credential")] String DomainCredential;
-[Write, EmbeddedInstance("MSFT_Credential")] String Password;
+  [Key] string UserName;
+  [Write, ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+  [Write, EmbeddedInstance("MSFT_Credential")] String DomainCredential;
+  [Write, EmbeddedInstance("MSFT_Credential")] String Password;
 };
 ```
 
@@ -62,59 +62,59 @@ The resource script is at **C:\Program Files\WindowsPowerShell\Modules\Demo_DSCM
 ```powershell
 function Get-TargetResource
 {
-[CmdletBinding()]
-[OutputType([System.Collections.Hashtable])]
-param
-(
-[parameter(Mandatory = $true)]
-[System.String]
-$UserName
-)
+  [CmdletBinding()]
+  [OutputType([System.Collections.Hashtable])]
+  param
+  (
+    [parameter(Mandatory = $true)]
+    [System.String]
+    $UserName
+  )
 
-#Write-Verbose "Use this cmdlet to deliver information about command processing."
+  #Write-Verbose "Use this cmdlet to deliver information about command processing."
 
-#Write-Debug "Use this cmdlet to write debug information while troubleshooting."
+  #Write-Debug "Use this cmdlet to write debug information while troubleshooting."
 
 
-<#
-$returnValue = @{
-UserName = [System.String]
-Ensure = [System.String]
-DomainAdminCredential = [System.Management.Automation.PSCredential]
-Password = [System.Management.Automation.PSCredential]
-}
+  <#
+  $returnValue = @{
+  UserName = [System.String]
+  Ensure = [System.String]
+  DomainAdminCredential = [System.Management.Automation.PSCredential]
+  Password = [System.Management.Automation.PSCredential]
+  }
 
-$returnValue
-#>
+  $returnValue
+  #>
 }
 
 
 function Set-TargetResource
 {
-[CmdletBinding()]
-param
-(
-[parameter(Mandatory = $true)]
-[System.String]
-$UserName,
+  [CmdletBinding()]
+  param
+  (
+    [parameter(Mandatory = $true)]
+    [System.String]
+    $UserName,
 
-[ValidateSet("Present","Absent")]
-[System.String]
-$Ensure,
+    [ValidateSet("Present","Absent")]
+    [System.String]
+    $Ensure,
 
-[System.Management.Automation.PSCredential]
-$DomainAdminCredential,
+    [System.Management.Automation.PSCredential]
+    $DomainAdminCredential,
 
-[System.Management.Automation.PSCredential]
-$Password
-)
+    [System.Management.Automation.PSCredential]
+    $Password
+  )
 
-#Write-Verbose "Use this cmdlet to deliver information about command processing."
+  #Write-Verbose "Use this cmdlet to deliver information about command processing."
 
-#Write-Debug "Use this cmdlet to write debug information while troubleshooting."
+  #Write-Debug "Use this cmdlet to write debug information while troubleshooting."
 
-#Include this line if the resource requires a system reboot.
-#$global:DSCMachineStatus = 1
+  #Include this line if the resource requires a system reboot.
+  #$global:DSCMachineStatus = 1
 
 
 }
@@ -122,35 +122,35 @@ $Password
 
 function Test-TargetResource
 {
-[CmdletBinding()]
-[OutputType([System.Boolean])]
-param
-(
-[parameter(Mandatory = $true)]
-[System.String]
-$UserName,
+  [CmdletBinding()]
+  [OutputType([System.Boolean])]
+  param
+  (
+    [parameter(Mandatory = $true)]
+    [System.String]
+    $UserName,
 
-[ValidateSet("Present","Absent")]
-[System.String]
-$Ensure,
+    [ValidateSet("Present","Absent")]
+    [System.String]
+    $Ensure,
 
-[System.Management.Automation.PSCredential]
-$DomainAdminCredential,
+    [System.Management.Automation.PSCredential]
+    $DomainAdminCredential,
 
-[System.Management.Automation.PSCredential]
-$Password
-)
+    [System.Management.Automation.PSCredential]
+    $Password
+  )
 
-#Write-Verbose "Use this cmdlet to deliver information about command processing."
+  #Write-Verbose "Use this cmdlet to deliver information about command processing."
 
-#Write-Debug "Use this cmdlet to write debug information while troubleshooting."
+  #Write-Debug "Use this cmdlet to write debug information while troubleshooting."
 
 
-<#
-$result = [System.Boolean]
+  <#
+  $result = [System.Boolean]
 
-$result
-#>
+  $result
+  #>
 }
 
 
@@ -164,8 +164,8 @@ If you need to add or modify the parameter list of the resource, you can call th
 For example, suppose you want to include the last log in time for the user in our resource. Rather than writing the resource again completely, you can call the **New-xDscResourceProperty** to create the new property, and then call **Update-xDscResource** and add your new property to the properties list.
 
 ```powershell
-PS C:\> $lastLogon = New-xDscResourceProperty –Name LastLogon –Type Hashtable –Attribute Write –Description “For mapping users to their last log on time”
-PS C:\> Update-xDscResource –Name ‘Demo_ADUser’ –Property $UserName, $Ensure, $DomainCredential, $Password, $lastLogon -Force
+$lastLogon = New-xDscResourceProperty –Name LastLogon –Type Hashtable –Attribute Write –Description “For mapping users to their last log on time”
+Update-xDscResource –Name ‘Demo_ADUser’ –Property $UserName, $Ensure, $DomainCredential, $Password, $lastLogon -Force
 ```
 
 ## Testing a resource schema
@@ -179,4 +179,3 @@ The Resource Designer tool exposes one more cmdlet that can be used to test the 
 
 #### Other Resources
 [xDscResourceDesigner Module](https://powershellgallery.com/packages/xDscResourceDesigner)
-


### PR DESCRIPTION
Removes PS C:\> from examples, adds indentation to functions to improve readability. 