### PR TITLE
Remove InformationAction/InformationVariable from *-Location.md

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Get-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-Location.md
@@ -17,14 +17,12 @@ Gets information about the current working location or a location stack.
 
 ### Location (Default)
 ```
-Get-Location [-PSProvider <String[]>] [-PSDrive <String[]>] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [-UseTransaction] [<CommonParameters>]
+Get-Location [-PSProvider <String[]>] [-PSDrive <String[]>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### Stack
 ```
-Get-Location [-Stack] [-StackName <String[]>] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [-UseTransaction] [<CommonParameters>]
+Get-Location [-Stack] [-StackName <String[]>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -169,33 +167,6 @@ To append the current location, it uses a **Get-Location** command, which runs w
 The prompt ends with the string "\> ".
 
 ## PARAMETERS
-
-### -InformationAction
-For example, if you are in the Certificate: drive, you can use this parameter to find your current location in the C: drive.```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
-For example, if you are in the Certificate: drive, you can use this parameter to find your current location in the C: drive.```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### -PSDrive
 Specifies the current location in the specified Windows PowerShell drive that this cmdlet gets in the operation.

--- a/reference/6/Microsoft.PowerShell.Management/Pop-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Pop-Location.md
@@ -16,8 +16,7 @@ Changes the current location to the location most recently pushed onto the stack
 ## SYNTAX
 
 ```
-Pop-Location [-PassThru] [-StackName <String>] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [-UseTransaction] [<CommonParameters>]
+Pop-Location [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -62,33 +61,6 @@ The last two commands pop those locations off the stack.
 The first **popd** command returns to the Registry drive, and the second command returns to the file system drive.
 
 ## PARAMETERS
-
-### -InformationAction
-@{Text=}```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
-@{Text=}```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### -PassThru
 Passes an object that represents the location to the pipeline.

--- a/reference/6/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Push-Location.md
@@ -17,14 +17,12 @@ Adds the current location to the top of a location stack.
 
 ### Path (Default)
 ```
-Push-Location [[-Path] <String>] [-PassThru] [-StackName <String>] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [-UseTransaction] [<CommonParameters>]
+Push-Location [[-Path] <String>] [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### LiteralPath
 ```
-Push-Location [-LiteralPath <String>] [-PassThru] [-StackName <String>] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [-UseTransaction] [<CommonParameters>]
+Push-Location [-LiteralPath <String>] [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -82,33 +80,6 @@ PS C:\> Get-Location -Stack
 This commmand shows the current location stack.
 
 ## PARAMETERS
-
-### -InformationAction
-@{Text=}```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
-@{Text=}```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### -LiteralPath
 Specifies the path of the new location.

--- a/reference/6/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Set-Location.md
@@ -17,20 +17,17 @@ Sets the current working location to a specified location.
 
 ### Path (Default)
 ```
-Set-Location [[-Path] <String>] [-PassThru] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [-UseTransaction] [<CommonParameters>]
+Set-Location [[-Path] <String>] [-PassThru] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### LiteralPath
 ```
-Set-Location -LiteralPath <String> [-PassThru] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [-UseTransaction] [<CommonParameters>]
+Set-Location -LiteralPath <String> [-PassThru] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### Stack
 ```
-Set-Location [-PassThru] [-StackName <String>] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [-UseTransaction] [<CommonParameters>]
+Set-Location [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -81,33 +78,6 @@ The location cmdlets use the current location stack unless a different location 
 For information about location stacks, see the Notes.
 
 ## PARAMETERS
-
-### -InformationAction
-@{Text=}```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
-@{Text=}```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### -LiteralPath
 Specifies a path of the location.


### PR DESCRIPTION
* InformationAction and InformationVariable are referred to in CommonParameters section
* The text does not make sense (it might be a copy/paste error or auto-gen text)

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
