### PR TITLE
Fix Import-Module Example 5

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Import-Module.md
@@ -134,44 +134,34 @@ This command uses an explicit path to identify the module to import.
 
 It also uses the **Verbose** common parameter to get a list of the items imported from the module.
 Without the **Verbose**, **PassThru**, or **AsCustomObject** parameter, **Import-Module** does not generate any output when it imports a module.
+
 ### Example 5
 ```
-PS C:\> Import-Module BitsTransfer -cmdlet Add-BitsTransferFile, Get-BitsTransfer
-PS C:\> Get-Module BitsTransfer
+PS C:\> Import-Module BitsTransfer -Cmdlet Add-BitsFile, Get-BitsTransfer
+PS C:\> (Get-Module BitsTransfer).ExportedCmdlets
 
-Name              : BitsTransfer
-Path              : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\BitsTransfer\BitsTransfer.psd1
-Description       :
-Guid              : 8fa5064b-8479-4c5c-86ea-0d311fe48875
-Version           : 1.0.0.0
-ModuleBase        : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\BitsTransfer
-ModuleType        : Manifest
-PrivateData       :
-AccessMode        : ReadWrite
-ExportedAliases   : {}
-ExportedCmdlets   : {[Add-BitsTransfer, Add-BitsTransfer], [Complete-BitsTransfer, Complete-BitsTransfer],
- [Get-BitsTransfer, Get-BitsTransfer], [Remove-BitsTransfer, Remove-BitsTransfer]...}
-ExportedFunctions : {}
-ExportedVariables : {}
-NestedModules     : {Microsoft.BackgroundIntelligentTransfer.Management}
+Key                   Value
+---                   -----
+Add-BitsFile          Add-BitsFile
+Complete-BitsTransfer Complete-BitsTransfer
+Get-BitsTransfer      Get-BitsTransfer
+Remove-BitsTransfer   Remove-BitsTransfer
+Resume-BitsTransfer   Resume-BitsTransfer
+Set-BitsTransfer      Set-BitsTransfer
+Start-BitsTransfer    Start-BitsTransfer
+Suspend-BitsTransfer  Suspend-BitsTransfer
 
 PS C:\> Get-Command -Module BitsTransfer
 
-CommandType     Name                                               ModuleName
------------     ----                                               ----------
-Cmdlet          Add-BitsFile                                       bitstransfer
-Cmdlet          Complete-BitsTransfer                              bitstransfer
-Cmdlet          Get-BitsTransfer                                   bitstransfer
-Cmdlet          Remove-BitsTransfer                                bitstransfer
-Cmdlet          Resume-BitsTransfer                                bitstransfer
-Cmdlet          Set-BitsTransfer                                   bitstransfer
-Cmdlet          Start-BitsTransfer                                 bitstransfer
-Cmdlet          Suspend-BitsTransfer                               bitstransfer
+CommandType Name             Version Source
+----------- ----             ------- ------
+Cmdlet      Add-BitsFile     2.0.0.0 BitsTransfer
+Cmdlet      Get-BitsTransfer 2.0.0.0 BitsTransfer
 ```
 
 This example shows how to restrict the module members that are imported into the session and the effect of this command on the session.
 
-The first command imports only the **Add-BitsTransfer** and **Get-BitsTransfer** cmdlets from the **BitsTransfer** module.
+The first command imports only the **Add-BitsFile** and **Get-BitsTransfer** cmdlets from the **BitsTransfer** module.
 The command uses the **Cmdlet** parameter to restrict the cmdlets that the module imports.
 You can also use the **Alias**, **Variable**, and **Function** parameters to restrict other members that a module imports.
 
@@ -179,7 +169,8 @@ The second command uses the Get-Module cmdlet to get the object that represents 
 The **ExportedCmdlets** property lists all of the cmdlets that the module exports, even when they were not all imported.
 
 The third command uses the **Module** parameter of the Get-Command cmdlet to get the commands that were imported from the **BitsTransfer** module.
-The results confirm that only the **Add-BitsTransfer** and **Get-BitsTransfer** cmdlets were imported.
+The results confirm that only the **Add-BitsFile** and **Get-BitsTransfer** cmdlets were imported.
+
 ### Example 6
 ```
 PS C:\> Import-Module BitsTransfer -Prefix PS -PassThru

--- a/reference/4.0/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Import-Module.md
@@ -143,42 +143,31 @@ Without the **Verbose**, **PassThru**, or **AsCustomObject** parameter, **Import
 
 ### Example 5
 ```
-PS C:\> Import-Module BitsTransfer -cmdlet Add-BitsTransferFile, Get-BitsTransfer
-PS C:\> Get-Module BitsTransfer
+PS C:\> Import-Module BitsTransfer -Cmdlet Add-BitsFile, Get-BitsTransfer
+PS C:\> (Get-Module BitsTransfer).ExportedCmdlets
 
-Name              : BitsTransfer
-Path              : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\BitsTransfer\BitsTransfer.psd1
-Description       :
-Guid              : 8fa5064b-8479-4c5c-86ea-0d311fe48875
-Version           : 1.0.0.0
-ModuleBase        : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\BitsTransfer
-ModuleType        : Manifest
-PrivateData       :
-AccessMode        : ReadWrite
-ExportedAliases   : {}
-ExportedCmdlets   : {[Add-BitsTransfer, Add-BitsTransfer], [Complete-BitsTransfer, Complete-BitsTransfer],
- [Get-BitsTransfer, Get-BitsTransfer], [Remove-BitsTransfer, Remove-BitsTransfer]...}
-ExportedFunctions : {}
-ExportedVariables : {}
-NestedModules     : {Microsoft.BackgroundIntelligentTransfer.Management}
+Key                   Value
+---                   -----
+Add-BitsFile          Add-BitsFile
+Complete-BitsTransfer Complete-BitsTransfer
+Get-BitsTransfer      Get-BitsTransfer
+Remove-BitsTransfer   Remove-BitsTransfer
+Resume-BitsTransfer   Resume-BitsTransfer
+Set-BitsTransfer      Set-BitsTransfer
+Start-BitsTransfer    Start-BitsTransfer
+Suspend-BitsTransfer  Suspend-BitsTransfer
 
 PS C:\> Get-Command -Module BitsTransfer
 
-CommandType     Name                                               ModuleName
------------     ----                                               ----------
-Cmdlet          Add-BitsFile                                       bitstransfer
-Cmdlet          Complete-BitsTransfer                              bitstransfer
-Cmdlet          Get-BitsTransfer                                   bitstransfer
-Cmdlet          Remove-BitsTransfer                                bitstransfer
-Cmdlet          Resume-BitsTransfer                                bitstransfer
-Cmdlet          Set-BitsTransfer                                   bitstransfer
-Cmdlet          Start-BitsTransfer                                 bitstransfer
-Cmdlet          Suspend-BitsTransfer                               bitstransfer
+CommandType Name             Version Source
+----------- ----             ------- ------
+Cmdlet      Add-BitsFile     2.0.0.0 BitsTransfer
+Cmdlet      Get-BitsTransfer 2.0.0.0 BitsTransfer
 ```
 
 This example shows how to restrict the module members that are imported into the session and the effect of this command on the session.
 
-The first command imports only the **Add-BitsTransfer** and **Get-BitsTransfer** cmdlets from the **BitsTransfer** module.
+The first command imports only the **Add-BitsFile** and **Get-BitsTransfer** cmdlets from the **BitsTransfer** module.
 The command uses the **Cmdlet** parameter to restrict the cmdlets that the module imports.
 You can also use the **Alias**, **Variable**, and **Function** parameters to restrict other members that a module imports.
 
@@ -186,7 +175,7 @@ The second command uses the Get-Module cmdlet to get the object that represents 
 The **ExportedCmdlets** property lists all of the cmdlets that the module exports, even when they were not all imported.
 
 The third command uses the **Module** parameter of the Get-Command cmdlet to get the commands that were imported from the **BitsTransfer** module.
-The results confirm that only the **Add-BitsTransfer** and **Get-BitsTransfer** cmdlets were imported.
+The results confirm that only the **Add-BitsFile** and **Get-BitsTransfer** cmdlets were imported.
 
 ### Example 6
 ```

--- a/reference/5.0/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Import-Module.md
@@ -159,42 +159,31 @@ Without the *Verbose*, *PassThru*, or *AsCustomObject* parameter, **Import-Modul
 
 ### Example 5: Restrict module members imported into a session
 ```
-PS C:\> Import-Module BitsTransfer -cmdlet Add-BitsTransferFile, Get-BitsTransfer
-PS C:\> Get-Module BitsTransfer
+PS C:\> Import-Module BitsTransfer -Cmdlet Add-BitsFile, Get-BitsTransfer
+PS C:\> (Get-Module BitsTransfer).ExportedCmdlets
 
-Name              : BitsTransfer
-Path              : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\BitsTransfer\BitsTransfer.psd1
-Description       :
-Guid              : 8fa5064b-8479-4c5c-86ea-0d311fe48875
-Version           : 1.0.0.0
-ModuleBase        : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\BitsTransfer
-ModuleType        : Manifest
-PrivateData       :
-AccessMode        : ReadWrite
-ExportedAliases   : {}
-ExportedCmdlets   : {[Add-BitsTransfer, Add-BitsTransfer], [Complete-BitsTransfer, Complete-BitsTransfer],
- [Get-BitsTransfer, Get-BitsTransfer], [Remove-BitsTransfer, Remove-BitsTransfer]...}
-ExportedFunctions : {}
-ExportedVariables : {}
-NestedModules     : {Microsoft.BackgroundIntelligentTransfer.Management}
+Key                   Value
+---                   -----
+Add-BitsFile          Add-BitsFile
+Complete-BitsTransfer Complete-BitsTransfer
+Get-BitsTransfer      Get-BitsTransfer
+Remove-BitsTransfer   Remove-BitsTransfer
+Resume-BitsTransfer   Resume-BitsTransfer
+Set-BitsTransfer      Set-BitsTransfer
+Start-BitsTransfer    Start-BitsTransfer
+Suspend-BitsTransfer  Suspend-BitsTransfer
 
 PS C:\> Get-Command -Module BitsTransfer
 
-CommandType     Name                                               ModuleName
------------     ----                                               ----------
-Cmdlet          Add-BitsFile                                       bitstransfer
-Cmdlet          Complete-BitsTransfer                              bitstransfer
-Cmdlet          Get-BitsTransfer                                   bitstransfer
-Cmdlet          Remove-BitsTransfer                                bitstransfer
-Cmdlet          Resume-BitsTransfer                                bitstransfer
-Cmdlet          Set-BitsTransfer                                   bitstransfer
-Cmdlet          Start-BitsTransfer                                 bitstransfer
-Cmdlet          Suspend-BitsTransfer                               bitstransfer
+CommandType Name             Version Source
+----------- ----             ------- ------
+Cmdlet      Add-BitsFile     2.0.0.0 BitsTransfer
+Cmdlet      Get-BitsTransfer 2.0.0.0 BitsTransfer
 ```
 
 This example shows how to restrict the module members that are imported into the session and the effect of this command on the session.
 
-The first command imports only the **Add-BitsTransfer** and **Get-BitsTransfer** cmdlets from the **BitsTransfer** module.
+The first command imports only the **Add-BitsFile** and **Get-BitsTransfer** cmdlets from the **BitsTransfer** module.
 The command uses the *Cmdlet* parameter to restrict the cmdlets that the module imports.
 You can also use the *Alias*, *Variable*, and *Function* parameters to restrict other members that a module imports.
 
@@ -202,7 +191,7 @@ The second command uses the Get-Module cmdlet to get the object that represents 
 The **ExportedCmdlets** property lists all of the cmdlets that the module exports, even when they were not all imported.
 
 The third command uses the *Module* parameter of the Get-Command cmdlet to get the commands that were imported from the **BitsTransfer** module.
-The results confirm that only the **Add-BitsTransfer** and **Get-BitsTransfer** cmdlets were imported.
+The results confirm that only the **Add-BitsFile** and **Get-BitsTransfer** cmdlets were imported.
 
 ### Example 6: Import the members of a module and add a prefix
 ```

--- a/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
@@ -160,42 +160,31 @@ Without the *Verbose*, *PassThru*, or *AsCustomObject* parameter, **Import-Modul
 
 ### Example 5: Restrict module members imported into a session
 ```
-PS C:\> Import-Module BitsTransfer -cmdlet Add-BitsTransferFile, Get-BitsTransfer
-PS C:\> Get-Module BitsTransfer
+PS C:\> Import-Module BitsTransfer -Cmdlet Add-BitsFile, Get-BitsTransfer
+PS C:\> (Get-Module BitsTransfer).ExportedCmdlets
 
-Name              : BitsTransfer
-Path              : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\BitsTransfer\BitsTransfer.psd1
-Description       :
-Guid              : 8fa5064b-8479-4c5c-86ea-0d311fe48875
-Version           : 1.0.0.0
-ModuleBase        : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\BitsTransfer
-ModuleType        : Manifest
-PrivateData       :
-AccessMode        : ReadWrite
-ExportedAliases   : {}
-ExportedCmdlets   : {[Add-BitsTransfer, Add-BitsTransfer], [Complete-BitsTransfer, Complete-BitsTransfer],
- [Get-BitsTransfer, Get-BitsTransfer], [Remove-BitsTransfer, Remove-BitsTransfer]...}
-ExportedFunctions : {}
-ExportedVariables : {}
-NestedModules     : {Microsoft.BackgroundIntelligentTransfer.Management}
+Key                   Value
+---                   -----
+Add-BitsFile          Add-BitsFile
+Complete-BitsTransfer Complete-BitsTransfer
+Get-BitsTransfer      Get-BitsTransfer
+Remove-BitsTransfer   Remove-BitsTransfer
+Resume-BitsTransfer   Resume-BitsTransfer
+Set-BitsTransfer      Set-BitsTransfer
+Start-BitsTransfer    Start-BitsTransfer
+Suspend-BitsTransfer  Suspend-BitsTransfer
 
 PS C:\> Get-Command -Module BitsTransfer
 
-CommandType     Name                                               ModuleName
------------     ----                                               ----------
-Cmdlet          Add-BitsFile                                       bitstransfer
-Cmdlet          Complete-BitsTransfer                              bitstransfer
-Cmdlet          Get-BitsTransfer                                   bitstransfer
-Cmdlet          Remove-BitsTransfer                                bitstransfer
-Cmdlet          Resume-BitsTransfer                                bitstransfer
-Cmdlet          Set-BitsTransfer                                   bitstransfer
-Cmdlet          Start-BitsTransfer                                 bitstransfer
-Cmdlet          Suspend-BitsTransfer                               bitstransfer
+CommandType Name             Version Source
+----------- ----             ------- ------
+Cmdlet      Add-BitsFile     2.0.0.0 BitsTransfer
+Cmdlet      Get-BitsTransfer 2.0.0.0 BitsTransfer
 ```
 
 This example shows how to restrict the module members that are imported into the session and the effect of this command on the session.
 
-The first command imports only the **Add-BitsTransfer** and **Get-BitsTransfer** cmdlets from the **BitsTransfer** module.
+The first command imports only the **Add-BitsFile** and **Get-BitsTransfer** cmdlets from the **BitsTransfer** module.
 The command uses the *Cmdlet* parameter to restrict the cmdlets that the module imports.
 You can also use the *Alias*, *Variable*, and *Function* parameters to restrict other members that a module imports.
 
@@ -203,7 +192,7 @@ The second command uses the Get-Module cmdlet to get the object that represents 
 The **ExportedCmdlets** property lists all of the cmdlets that the module exports, even when they were not all imported.
 
 The third command uses the *Module* parameter of the Get-Command cmdlet to get the commands that were imported from the **BitsTransfer** module.
-The results confirm that only the **Add-BitsTransfer** and **Get-BitsTransfer** cmdlets were imported.
+The results confirm that only the **Add-BitsFile** and **Get-BitsTransfer** cmdlets were imported.
 
 ### Example 6: Import the members of a module and add a prefix
 ```

--- a/reference/6/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Import-Module.md
@@ -160,42 +160,31 @@ Without the *Verbose*, *PassThru*, or *AsCustomObject* parameter, **Import-Modul
 
 ### Example 5: Restrict module members imported into a session
 ```
-PS C:\> Import-Module BitsTransfer -cmdlet Add-BitsTransferFile, Get-BitsTransfer
-PS C:\> Get-Module BitsTransfer
+PS C:\> Import-Module BitsTransfer -Cmdlet Add-BitsFile, Get-BitsTransfer
+PS C:\> (Get-Module BitsTransfer).ExportedCmdlets
 
-Name              : BitsTransfer
-Path              : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\BitsTransfer\BitsTransfer.psd1
-Description       :
-Guid              : 8fa5064b-8479-4c5c-86ea-0d311fe48875
-Version           : 1.0.0.0
-ModuleBase        : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\BitsTransfer
-ModuleType        : Manifest
-PrivateData       :
-AccessMode        : ReadWrite
-ExportedAliases   : {}
-ExportedCmdlets   : {[Add-BitsTransfer, Add-BitsTransfer], [Complete-BitsTransfer, Complete-BitsTransfer],
- [Get-BitsTransfer, Get-BitsTransfer], [Remove-BitsTransfer, Remove-BitsTransfer]...}
-ExportedFunctions : {}
-ExportedVariables : {}
-NestedModules     : {Microsoft.BackgroundIntelligentTransfer.Management}
+Key                   Value
+---                   -----
+Add-BitsFile          Add-BitsFile
+Complete-BitsTransfer Complete-BitsTransfer
+Get-BitsTransfer      Get-BitsTransfer
+Remove-BitsTransfer   Remove-BitsTransfer
+Resume-BitsTransfer   Resume-BitsTransfer
+Set-BitsTransfer      Set-BitsTransfer
+Start-BitsTransfer    Start-BitsTransfer
+Suspend-BitsTransfer  Suspend-BitsTransfer
 
 PS C:\> Get-Command -Module BitsTransfer
 
-CommandType     Name                                               ModuleName
------------     ----                                               ----------
-Cmdlet          Add-BitsFile                                       bitstransfer
-Cmdlet          Complete-BitsTransfer                              bitstransfer
-Cmdlet          Get-BitsTransfer                                   bitstransfer
-Cmdlet          Remove-BitsTransfer                                bitstransfer
-Cmdlet          Resume-BitsTransfer                                bitstransfer
-Cmdlet          Set-BitsTransfer                                   bitstransfer
-Cmdlet          Start-BitsTransfer                                 bitstransfer
-Cmdlet          Suspend-BitsTransfer                               bitstransfer
+CommandType Name             Version Source
+----------- ----             ------- ------
+Cmdlet      Add-BitsFile     2.0.0.0 BitsTransfer
+Cmdlet      Get-BitsTransfer 2.0.0.0 BitsTransfer
 ```
 
 This example shows how to restrict the module members that are imported into the session and the effect of this command on the session.
 
-The first command imports only the **Add-BitsTransfer** and **Get-BitsTransfer** cmdlets from the **BitsTransfer** module.
+The first command imports only the **Add-BitsFile** and **Get-BitsTransfer** cmdlets from the **BitsTransfer** module.
 The command uses the *Cmdlet* parameter to restrict the cmdlets that the module imports.
 You can also use the *Alias*, *Variable*, and *Function* parameters to restrict other members that a module imports.
 
@@ -203,7 +192,7 @@ The second command uses the Get-Module cmdlet to get the object that represents 
 The **ExportedCmdlets** property lists all of the cmdlets that the module exports, even when they were not all imported.
 
 The third command uses the *Module* parameter of the Get-Command cmdlet to get the commands that were imported from the **BitsTransfer** module.
-The results confirm that only the **Add-BitsTransfer** and **Get-BitsTransfer** cmdlets were imported.
+The results confirm that only the **Add-BitsFile** and **Get-BitsTransfer** cmdlets were imported.
 
 ### Example 6: Import the members of a module and add a prefix
 ```


### PR DESCRIPTION
Fixed three problems as follows:

1. Cmdlet name
x Add-BitsTransferFile
x Add-BitsTransfer
o Add-BitsFile

2. `Get-Module BitsTransfer` results
The results include not only `ExportedCmdlets` but also unrelated properties.

3. `Get-Command -Module BitsTransfer` results
The description says "The results confirm that only the Add-BitsTransfer and Get-BitsTransfer cmdlets were imported."
But the results include not only the imported cmdlets but also the others.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document