### PR TITLE
Updated Division and Rounding

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -101,8 +101,8 @@ $b[$a] = $tmp
 ## DIVISION AND ROUNDING
 
 When the quotient of a division operation is an integer, Windows PowerShell
-rounds the value to the nearest integer. This is because powershell implements Bankers’ Rounding.
-When the value is `.5`, it rounds to the nearest even integer.
+rounds the value to the nearest integer.
+When the value is `.5`, it rounds to the nearest even integer. This rounding system is called Bankers' Rounding.
 
 The following example shows the effect of rounding to the nearest even
 integer.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -101,7 +101,7 @@ $b[$a] = $tmp
 ## DIVISION AND ROUNDING
 
 When the quotient of a division operation is an integer, Windows PowerShell
-rounds the value to the nearest integer.
+rounds the value to the nearest integer. This is because powershell implements Bankers’ Rounding.
 When the value is `.5`, it rounds to the nearest even integer.
 
 The following example shows the effect of rounding to the nearest even


### PR DESCRIPTION
Update to explain that Bankers’ Rounding is used in rounding during division.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
