### PR TITLE
Fix markdown formatting of about_special_characters.

### DIFF
--- a/reference/6/About/about_Special_Characters.md
+++ b/reference/6/About/about_Special_Characters.md
@@ -26,6 +26,7 @@ character, also known as the grave accent (ASCII 96).
 
 The following special characters are recognized by Windows PowerShell:
 
+```
 `0    Null
 `a    Alert
 `b    Backspace
@@ -37,10 +38,11 @@ The following special characters are recognized by Windows PowerShell:
 `u{x} Unicode escape sequence
 `v    Vertical tab
 --%   Stop parsing
+```
 
 These characters are case-sensitive.
 
-# NULL (`0)
+## NULL (`0)
 
 Windows PowerShell recognizes a null special character (`0) and represents
 it with a character code of 0. It appears as an empty space in the
@@ -49,26 +51,30 @@ read and process text files that use null characters, such as string
 termination or record termination indicators. The null special character
 is not equivalent to the $null variable, which stores a value of NULL.
 
-ALERT (`a)
+## ALERT (`a)
 The alert (`a) character sends a beep signal to the computer's speaker.
 You can use this to warn a user about an impending action. The following
 command sends two beep signals to the local computer's speaker:
 
 for ($i = 0; $i -le 1; $i++){"`a"}
 
-BACKSPACE (`b)
+## BACKSPACE (`b)
 The backspace character (`b) moves the cursor back one character, but it
 does not delete any characters. The following command writes the word
 "backup", moves the cursor back twice, and then writes the word "out"
 (preceded by a space and starting at the new position):
 
+```
 "backup`b`b out"
+```
 
 The output from this command is as follows:
 
+```
 back out
+```
 
-ESCAPE (`e)
+## ESCAPE (`e)
 The escape character is most commonly used to specify a virtual terminal
 sequence (ANSI escape sequence) that modifies the color of text and other
 text attributes such as bolding and underlining.  These sequences can also
@@ -78,47 +84,59 @@ and higher with the boolean property $Host.UI.SupportsVirtualTerminal.
 
 The following command outputs Green text.
 
+```
 $fgColor = 32 # green - see http://en.wikipedia.org/wiki/ANSI_escape_code
 "`e[${fgColor}mGreen text`e[0m"
+```
 
 The output from this command is the following text with a Green foreground
 color:
 
+```
 Green text
+```
 
-FORM FEED (`f)
+## FORM FEED (`f)
 The form feed character (`f) is a print instruction that ejects the
 current page and continues printing on the next page. This character
 affects printed documents only; it does not affect screen output.
 
-NEW LINE (`n)
+## NEW LINE (`n)
 The new line character (`n) inserts a line break immediately after the
 character.
 
 The following example shows how to use the new line character in a
 Write-Host command:
 
+```
 "There are two line breaks`n`nhere."
+```
 
 The output from this command is as follows:
 
+```
 There are two line breaks
 
 here.
+```
 
-CARRIAGE RETURN (`r)
-The carriage return character (`r) eliminates the entire line prior
+## CARRIAGE RETURN (`r)
+The carriage return character ``(`r)`` eliminates the entire line prior
 to the `r character, as though the prior text were on a different line.
 
 For example:
 
+```
 Write-Host "Let's not move`rDelete everything before this point."
+```
 
 The output from this command is:
 
+```
 Delete everything before this point.
+```
 
-HORIZONTAL TAB (`t)
+## HORIZONTAL TAB (`t)
 The horizontal tab character (`t) advances to the next tab stop and
 continues writing at that point. By default, the Windows PowerShell
 console has a tab stop at every eighth space.
@@ -126,34 +144,36 @@ console has a tab stop at every eighth space.
 For example, the following command inserts two tabs between each
 column.
 
+```
 "Column1`t`tColumn2`t`tColumn3"
+```
 
 The output from this command is:
 
+```
 Column1         Column2         Column3
+```
 
-UNICODE CHARACTER (`u{x})
+## UNICODE CHARACTER (`u{x})
 The Unicode escape sequence allows you to specify any Unicode character
 by the hexadecimal representation of its code point. This includes Unicode
 characters above the Basic Multilingual Plane (> 0xFFFF) which includes
-emoji characters e.g. `u{1F44D}. The Unicode escape sequence requires at
-least one hex digit and supports up to six hex digits. The maximum value
-for the sequence is `u{10FFFF}.
+emoji characters e.g. `` `u{1F44D}``. The Unicode escape sequence requires
+at least one hex digit and supports up to six hex digits. The maximum hex
+value for the sequence is 10FFFF.
 
 The following command outputs the character '↕':
 
+```
 "`u{2195}"
+```
 
-The output from this command is:
-
-↕
-
-VERTICAL TAB (`v)
+## VERTICAL TAB (`v)
 The horizontal tab character (`t) advances to the next vertical tab stop
 and writes all subsequent output beginning at that point. This character
 affects printed documents only. It does not affect screen output.
 
-STOP PARSING  (--%)
+## STOP PARSING  (--%)
 The stop-parsing symbol (--%) prevents Windows PowerShell from
 interpreting arguments in program calls as Windows PowerShell
 commands and expressions.
@@ -163,10 +183,16 @@ program arguments that might cause errors.
 
 For example, the following Icacls command uses the stop-parsing
 symbol.
+
+```
 icacls X:\VMS --% /grant Dom\HVAdmin:(CI)(OI)F
+```
 
 Windows PowerShell sends the following command to Icacls.
+
+```
 X:\VMS /grant Dom\HVAdmin:(CI)(OI)F
+```
 
 For more information about the stop-parsing symbol, see
 about_Parsing.


### PR DESCRIPTION
After looking at this page - https://msdn.microsoft.com/en-us/powershell/reference/6/about/about_special_characters - it is obvious we need to inject a bit more markdown formatting to display the escape list better, to use some headers on each special char (not just NULL) and to use triple-backtick on commands/output.

The only thing I'm not sure about is if your processor that converts this markdown file to the plain text equivalent will handle the escape of backticks e.g. `{double-backtick}` `` `u{1F44D}`` `{double-backtick}`.  Hopefully it will remove the leading and trailing double-backtick.

Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature will be introduced in version 6.0 Beta4 (hopefully - waiting on PR that implements this feature to be accepted) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
