### PR TITLE
Fix code style of Export/Import-Alias

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -14,84 +14,72 @@ Exports information about currently defined aliases to a file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
+```powershell
 Export-Alias [-Path] <String> [[-Name] <String[]>] [-PassThru] [-As <ExportAliasFormat>] [-Append] [-Force]
  [-NoClobber] [-Description <String>] [-Scope <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```powershell
 Export-Alias -LiteralPath <String> [[-Name] <String[]>] [-PassThru] [-As <ExportAliasFormat>] [-Append]
  [-Force] [-NoClobber] [-Description <String>] [-Scope <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Export-Alias cmdlet exports the aliases in the current session to a file. 
+The `Export-Alias` cmdlet exports the aliases in the current session to a file. 
 If the output file does not exist, the cmdlet will create it.
 
 Export-Alias can export the aliases in a particular scope or all scopes, it can generate the data in CSV format or as a series of Set-Alias commands that you can add to a session or to a Windows PowerShell profile.
 ## EXAMPLES
 
 ### Example 1
+```powershell
+Export-Alias -Path alias.csv
 ```
-C:\PS>export-alias -path alias.csv
-```
-
-Description
-
------------
 
 This command exports current alias information to a file named Alias.csv in the current directory.
+
 ### Example 2
+```powershell
+Export-Alias -Path alias.csv -NoClobber
 ```
-C:\PS>export-alias -path alias.csv -noclobber
-```
-
-Description
-
------------
 
 This command exports the aliases in the current session to an Alias.csv file.
 
-Because the NoClobber parameter is specified, the command will fail if an Alias.csv file already exists in the current directory.
+Because the **NoClobber** parameter is specified, the command will fail if an Alias.csv file already exists in the current directory.
+
 ### Example 3
+```powershell
+Export-Alias -Path alias.csv -Append -Description "Appended Aliases" -force
 ```
-C:\PS>export-alias -path alias.csv -append -description "Appended Aliases" -force
-```
-
-Description
-
------------
 
 This command appends the aliases in the current session to the Alias.csv file.
 
-The command uses the Description parameter to add a description to the comments at the top of the file.
+The command uses the **Description** parameter to add a description to the comments at the top of the file.
 
-The command also uses the Force parameter to overwrite any existing Alias.csv files, even if they have the read-only attribute.
+The command also uses the **Force** parameter to overwrite any existing Alias.csv files, even if they have the read-only attribute.
+
 ### Example 4
+```powershell
+Export-Alias -Path alias.ps1 -As Script
+Add-Content -Path $profile -Value (Get-Content alias.ps1)
+$s = New-PSSession -ComputerName Server01
+Invoke-Command -Session $s -FilePath .\alias.ps1
 ```
-C:\PS>export-alias -path alias.ps1 -as script
-PS C:\> add-content -path $profile -value (get-content alias.ps1)
-PS C:\> $s = new-pssession -computername Server01
-PS C:\> invoke-command -session $s -filepath .\alias.ps1
-```
-
-Description
-
------------
 
 This example shows how to use the script file format that Export-Alias generates.
 
 The first command exports the aliases in the session to the Alias.ps1 file.
-It uses the As parameter with a value of Script to generate a file that contains a Set-Alias command for each alias.
+It uses the **As** parameter with a value of Script to generate a file that contains a Set-Alias command for each alias.
 
 The second command adds the aliases in the Alias.ps1 file to the CurrentUser-CurrentHost profile.
-(The path to the profile is saved in the $profile variable.) The command uses the Get-Content cmdlet to get the aliases from the Alias.ps1 file and the Add-Content cmdlet to add them to the profile.
+(The path to the profile is saved in the $profile variable.) The command uses the `Get-Content` cmdlet to get the aliases from the Alias.ps1 file and the `Add-Content` cmdlet to add them to the profile.
 For more information, see about_Profiles.
 
 The third and fourth commands add the aliases in the Alias.ps1 file to a  remote session on the Server01 computer.
-The third command uses the New-PSSession cmdlet to create the session.
-The fourth command uses the FilePath parameter of the Invoke-Command cmdlet to run the Alias.ps1 file in the new session.
+The third command uses the `New-PSSession` cmdlet to create the session.
+The fourth command uses the **FilePath** parameter of the `Invoke-Command` cmdlet to run the Alias.ps1 file in the new session.
+
 ## PARAMETERS
 
 ### -Append
@@ -149,10 +137,10 @@ Accept wildcard characters: False
 ### -Force
 Overwrites the output file, even if the read-only attribute is set on the file.
 
-By default, Export-Alias overwrites files without warning, unless the read-only or hidden attribute is set or the NoClobber parameter is used in the command.
-The NoClobber parameter takes precedence over the Force parameter when both are used in a command.
+By default, `Export-Alias` overwrites files without warning, unless the read-only or hidden attribute is set or the **NoClobber** parameter is used in the command.
+The **NoClobber** parameter takes precedence over the **Force** parameter when both are used in a command.
 
-The Force parameter cannot force Export-Alias to overwrite files with the hidden attribute.
+The **Force** parameter cannot force Export-Alias to overwrite files with the hidden attribute.
 
 ```yaml
 Type: SwitchParameter
@@ -189,7 +177,7 @@ Accept wildcard characters: False
 Specifies the names of the aliases to export.
 Wildcards are permitted.
 
-By default, Export-Alias exports all aliases in the session or scope.
+By default, `Export-Alias` exports all aliases in the session or scope.
 
 ```yaml
 Type: String[]
@@ -204,12 +192,12 @@ Accept wildcard characters: False
 ```
 
 ### -NoClobber
-Prevents Export-Alias from overwriting any files, even if the Force parameter is used in the command.
+Prevents Export-Alias from overwriting any files, even if the **Force** parameter is used in the command.
 
-If the NoClobber parameter is omitted, Export-Alias will overwrite an existing file without warning, unless the read-only attribute is set on the file.
-NoClobber takes precedence over the Force parameter, which permits Export-Alias to overwrite a file with the read-only attribute.
+If the **NoClobber** parameter is omitted, `Export-Alias` will overwrite an existing file without warning, unless the read-only attribute is set on the file.
+NoClobber takes precedence over the **Force** parameter, which permits Export-Alias to overwrite a file with the read-only attribute.
 
-NoClobber does not prevent the Append parameter from adding content to an existing file.
+NoClobber does not prevent the **Append** parameter from adding content to an existing file.
 
 ```yaml
 Type: SwitchParameter
@@ -315,7 +303,7 @@ You cannot pipe objects to this cmdlet.
 ## OUTPUTS
 
 ### None or System.Management.Automation.AliasInfo
-When you use the Passthru parameter, Export-Alias returns a System.Management.Automation.AliasInfo object that represents the alias.
+When you use the **Passthru** parameter, `Export-Alias` returns a System.Management.Automation.AliasInfo object that represents the alias.
 Otherwise, this cmdlet does not generate any output.
 ## NOTES
 * You can only Export-Aliases to a file.

--- a/reference/3.0/Microsoft.PowerShell.Utility/Import-Alias.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Import-Alias.md
@@ -14,36 +14,37 @@ Imports an alias list from a file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
+```powershell
 Import-Alias [-Path] <String> [-Scope <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```powershell
 Import-Alias -LiteralPath <String> [-Scope <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Import-Alias** cmdlet imports an alias list from a file.
+The `Import-Alias` cmdlet imports an alias list from a file.
 
-Beginning in Windows PowerShell 3.0, as a security feature, **Import-Alias** does not overwrite existing aliases by default.
+Beginning in Windows PowerShell 3.0, as a security feature, `Import-Alias` does not overwrite existing aliases by default.
 To overwrite an existing alias, after assuring that the contents of the alias file is safe, use the **Force** parameter.
 ## EXAMPLES
 
 ### Example 1
-```
-PS C:\> import-alias test.txt
+```powershell
+Import-Alias test.txt
 ```
 
 This command imports alias information from a file named test.txt.
+
 ## PARAMETERS
 
 ### -Force
 Allows the cmdlet to import an alias that is already defined or is read only.
 You can use the following command to display information about the currently-defined aliases:
 
-`get-alias | select-object name,Options`
+`Get-Alias | Select-Object Name, Options`
 
 If the corresponding alias is read-only, it will be displayed in the value of the **Options** property.
 
@@ -164,11 +165,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains a path to Import-Alias.
+You can pipe a string that contains a path to `Import-Alias`.
 ## OUTPUTS
 
 ### None or System.Management.Automation.AliasInfo
-When you use the **Passthru** parameter, **Import-Alias** returns a **System.Management.Automation.AliasInfo** object that represents the alias.
+When you use the **Passthru** parameter, `Import-Alias` returns a **System.Management.Automation.AliasInfo** object that represents the alias.
 Otherwise, this cmdlet does not generate any output.
 ## NOTES
 

--- a/reference/4.0/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -16,19 +16,19 @@ Exports information about currently defined aliases to a file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
+```powershell
 Export-Alias [-Path] <String> [[-Name] <String[]>] [-PassThru] [-As <ExportAliasFormat>] [-Append] [-Force]
  [-NoClobber] [-Description <String>] [-Scope <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```powershell
 Export-Alias -LiteralPath <String> [[-Name] <String[]>] [-PassThru] [-As <ExportAliasFormat>] [-Append]
  [-Force] [-NoClobber] [-Description <String>] [-Scope <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Export-Alias cmdlet exports the aliases in the current session to a file. 
+The `Export-Alias` cmdlet exports the aliases in the current session to a file. 
 If the output file does not exist, the cmdlet will create it.
 
 Export-Alias can export the aliases in a particular scope or all scopes, it can generate the data in CSV format or as a series of Set-Alias commands that you can add to a session or to a Windows PowerShell profile.
@@ -36,68 +36,52 @@ Export-Alias can export the aliases in a particular scope or all scopes, it can 
 ## EXAMPLES
 
 ### Example 1
+```powershell
+Export-Alias -Path alias.csv
 ```
-PS C:\> export-alias -path alias.csv
-```
-
-Description
-
------------
 
 This command exports current alias information to a file named Alias.csv in the current directory.
 
 ### Example 2
+```powershell
+Export-Alias -Path alias.csv -NoClobber
 ```
-PS C:\> export-alias -path alias.csv -noclobber
-```
-
-Description
-
------------
 
 This command exports the aliases in the current session to an Alias.csv file.
 
-Because the NoClobber parameter is specified, the command will fail if an Alias.csv file already exists in the current directory.
+Because the **NoClobber** parameter is specified, the command will fail if an Alias.csv file already exists in the current directory.
 
 ### Example 3
+```powershell
+Export-Alias -Path alias.csv -Append -Description "Appended Aliases" -force
 ```
-PS C:\> export-alias -path alias.csv -append -description "Appended Aliases" -force
-```
-
-Description
-
------------
 
 This command appends the aliases in the current session to the Alias.csv file.
 
-The command uses the Description parameter to add a description to the comments at the top of the file.
+The command uses the **Description** parameter to add a description to the comments at the top of the file.
 
-The command also uses the Force parameter to overwrite any existing Alias.csv files, even if they have the read-only attribute.
+The command also uses the **Force** parameter to overwrite any existing Alias.csv files, even if they have the read-only attribute.
 
 ### Example 4
+```powershell
+Export-Alias -Path alias.ps1 -As Script
+Add-Content -Path $profile -Value (Get-Content alias.ps1)
+$s = New-PSSession -ComputerName Server01
+Invoke-Command -Session $s -FilePath .\alias.ps1
 ```
-PS C:\> export-alias -path alias.ps1 -as script
-PS C:\> add-content -path $profile -value (get-content alias.ps1)
-PS C:\> $s = new-pssession -computername Server01
-PS C:\> invoke-command -session $s -filepath .\alias.ps1
-```
-
-Description
-
------------
 
 This example shows how to use the script file format that Export-Alias generates.
 
 The first command exports the aliases in the session to the Alias.ps1 file.
-It uses the As parameter with a value of Script to generate a file that contains a Set-Alias command for each alias.
+It uses the **As** parameter with a value of Script to generate a file that contains a Set-Alias command for each alias.
 
 The second command adds the aliases in the Alias.ps1 file to the CurrentUser-CurrentHost profile.
-(The path to the profile is saved in the $profile variable.) The command uses the Get-Content cmdlet to get the aliases from the Alias.ps1 file and the Add-Content cmdlet to add them to the profile.
+(The path to the profile is saved in the $profile variable.) The command uses the `Get-Content` cmdlet to get the aliases from the Alias.ps1 file and the `Add-Content` cmdlet to add them to the profile.
 For more information, see about_Profiles.
 
 The third and fourth commands add the aliases in the Alias.ps1 file to a  remote session on the Server01 computer.
-The third command uses the New-PSSession cmdlet to create the session.
-The fourth command uses the FilePath parameter of the Invoke-Command cmdlet to run the Alias.ps1 file in the new session.
+The third command uses the `New-PSSession` cmdlet to create the session.
+The fourth command uses the **FilePath** parameter of the `Invoke-Command` cmdlet to run the Alias.ps1 file in the new session.
 
 ## PARAMETERS
 
@@ -156,10 +140,10 @@ Accept wildcard characters: False
 ### -Force
 Overwrites the output file, even if the read-only attribute is set on the file.
 
-By default, Export-Alias overwrites files without warning, unless the read-only or hidden attribute is set or the NoClobber parameter is used in the command.
-The NoClobber parameter takes precedence over the Force parameter when both are used in a command.
+By default, `Export-Alias` overwrites files without warning, unless the read-only or hidden attribute is set or the **NoClobber** parameter is used in the command.
+The **NoClobber** parameter takes precedence over the **Force** parameter when both are used in a command.
 
-The Force parameter cannot force Export-Alias to overwrite files with the hidden attribute.
+The **Force** parameter cannot force Export-Alias to overwrite files with the hidden attribute.
 
 ```yaml
 Type: SwitchParameter
@@ -196,7 +180,7 @@ Accept wildcard characters: False
 Specifies the names of the aliases to export.
 Wildcards are permitted.
 
-By default, Export-Alias exports all aliases in the session or scope.
+By default, `Export-Alias` exports all aliases in the session or scope.
 
 ```yaml
 Type: String[]
@@ -211,12 +195,12 @@ Accept wildcard characters: False
 ```
 
 ### -NoClobber
-Prevents Export-Alias from overwriting any files, even if the Force parameter is used in the command.
+Prevents Export-Alias from overwriting any files, even if the **Force** parameter is used in the command.
 
-If the NoClobber parameter is omitted, Export-Alias will overwrite an existing file without warning, unless the read-only attribute is set on the file.
-NoClobber takes precedence over the Force parameter, which permits Export-Alias to overwrite a file with the read-only attribute.
+If the **NoClobber** parameter is omitted, `Export-Alias` will overwrite an existing file without warning, unless the read-only attribute is set on the file.
+NoClobber takes precedence over the **Force** parameter, which permits Export-Alias to overwrite a file with the read-only attribute.
 
-NoClobber does not prevent the Append parameter from adding content to an existing file.
+NoClobber does not prevent the **Append** parameter from adding content to an existing file.
 
 ```yaml
 Type: SwitchParameter
@@ -324,7 +308,7 @@ You cannot pipe objects to this cmdlet.
 ## OUTPUTS
 
 ### None or System.Management.Automation.AliasInfo
-When you use the Passthru parameter, Export-Alias returns a System.Management.Automation.AliasInfo object that represents the alias.
+When you use the **Passthru** parameter, `Export-Alias` returns a System.Management.Automation.AliasInfo object that represents the alias.
 Otherwise, this cmdlet does not generate any output.
 
 ## NOTES

--- a/reference/4.0/Microsoft.PowerShell.Utility/Import-Alias.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Import-Alias.md
@@ -16,27 +16,27 @@ Imports an alias list from a file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
+```powershell
 Import-Alias [-Path] <String> [-Scope <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```powershell
 Import-Alias -LiteralPath <String> [-Scope <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Import-Alias** cmdlet imports an alias list from a file.
+The `Import-Alias` cmdlet imports an alias list from a file.
 
-Beginning in Windows PowerShell 3.0, as a security feature, **Import-Alias** does not overwrite existing aliases by default.
+Beginning in Windows PowerShell 3.0, as a security feature, `Import-Alias` does not overwrite existing aliases by default.
 To overwrite an existing alias, after assuring that the contents of the alias file is safe, use the **Force** parameter.
 
 ## EXAMPLES
 
 ### Example 1
-```
-PS C:\> import-alias test.txt
+```powershell
+Import-Alias test.txt
 ```
 
 This command imports alias information from a file named test.txt.
@@ -47,7 +47,7 @@ This command imports alias information from a file named test.txt.
 Allows the cmdlet to import an alias that is already defined or is read only.
 You can use the following command to display information about the currently-defined aliases:
 
-`get-alias | select-object name,Options`
+`Get-Alias | Select-Object Name, Options`
 
 If the corresponding alias is read-only, it will be displayed in the value of the **Options** property.
 
@@ -169,12 +169,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains a path to Import-Alias.
+You can pipe a string that contains a path to `Import-Alias`.
 
 ## OUTPUTS
 
 ### None or System.Management.Automation.AliasInfo
-When you use the **Passthru** parameter, **Import-Alias** returns a **System.Management.Automation.AliasInfo** object that represents the alias.
+When you use the **Passthru** parameter, `Import-Alias` returns a **System.Management.Automation.AliasInfo** object that represents the alias.
 Otherwise, this cmdlet does not generate any output.
 
 ## NOTES

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -178,7 +178,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies the path to the output file.
-Unlike *Path*, the value of the **LiteralPath** parameter is used exactly as it is typed.
+Unlike **Path**, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -16,73 +16,73 @@ Exports information about currently defined aliases to a file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
+```powershell
 Export-Alias [-Path] <String> [[-Name] <String[]>] [-PassThru] [-As <ExportAliasFormat>] [-Append] [-Force]
  [-NoClobber] [-Description <String>] [-Scope <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```powershell
 Export-Alias -LiteralPath <String> [[-Name] <String[]>] [-PassThru] [-As <ExportAliasFormat>] [-Append]
  [-Force] [-NoClobber] [-Description <String>] [-Scope <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Export-Alias** cmdlet exports the aliases in the current session to a file.
+The `Export-Alias` cmdlet exports the aliases in the current session to a file.
 If the output file does not exist, the cmdlet will create it.
 
-**Export-Alias** can export the aliases in a particular scope or all scopes, it can generate the data in CSV format or as a series of Set-Alias commands that you can add to a session or to a Windows PowerShell profile.
+`Export-Alias` can export the aliases in a particular scope or all scopes, it can generate the data in CSV format or as a series of Set-Alias commands that you can add to a session or to a Windows PowerShell profile.
 
 ## EXAMPLES
 
 ### Example 1: Export an alias
-```
-PS C:\> Export-Alias -Path "alias.csv"
+```powershell
+Export-Alias -Path "alias.csv"
 ```
 
 This command exports current alias information to a file named Alias.csv in the current directory.
 
 ### Example 2: Export an alias unless the export file already exists
-```
-PS C:\> Export-Alias -Path "alias.csv" -NoClobber
+```powershell
+Export-Alias -Path "alias.csv" -NoClobber
 ```
 
 This command exports the aliases in the current session to an Alias.csv file.
 
-Because the *NoClobber* parameter is specified, the command will fail if an Alias.csv file already exists in the current directory.
+Because the **NoClobber** parameter is specified, the command will fail if an Alias.csv file already exists in the current directory.
 
 ### Example 3: Append aliases to a file
-```
-PS C:\> Export-Alias -Path "alias.csv" -Append -Description "Appended Aliases" -Force
+```powershell
+Export-Alias -Path "alias.csv" -Append -Description "Appended Aliases" -Force
 ```
 
 This command appends the aliases in the current session to the Alias.csv file.
 
-The command uses the *Description* parameter to add a description to the comments at the top of the file.
+The command uses the **Description** parameter to add a description to the comments at the top of the file.
 
-The command also uses the *Force* parameter to overwrite any existing Alias.csv files, even if they have the read-only attribute.
+The command also uses the **Force** parameter to overwrite any existing Alias.csv files, even if they have the read-only attribute.
 
 ### Example 4: Export aliases as a script
-```
-PS C:\> Export-Alias -Path "alias.ps1" -As Script
-PS C:\> Add-Content -Path $Profile -Value (Get-Content alias.ps1)
-PS C:\> $S = New-PSSession -ComputerName Server01
-PS C:\> Invoke-Command -Session $S -FilePath .\alias.ps1
+```powershell
+Export-Alias -Path "alias.ps1" -As Script
+Add-Content -Path $Profile -Value (Get-Content alias.ps1)
+$S = New-PSSession -ComputerName Server01
+Invoke-Command -Session $S -FilePath .\alias.ps1
 ```
 
-This example shows how to use the script file format that **Export-Alias** generates.
+This example shows how to use the script file format that `Export-Alias` generates.
 
 The first command exports the aliases in the session to the Alias.ps1 file.
-It uses the *As* parameter with a value of Script to generate a file that contains a Set-Alias command for each alias.
+It uses the **As** parameter with a value of Script to generate a file that contains a Set-Alias command for each alias.
 
 The second command adds the aliases in the Alias.ps1 file to the CurrentUser-CurrentHost profile.
 The path to the profile is saved in the $Profile variable.
-The command uses the Get-Content cmdlet to get the aliases from the Alias.ps1 file and the Add-Content cmdlet to add them to the profile.
+The command uses the `Get-Content` cmdlet to get the aliases from the Alias.ps1 file and the `Add-Content` cmdlet to add them to the profile.
 For more information, see about_Profiles.
 
 The third and fourth commands add the aliases in the Alias.ps1 file to a remote session on the Server01 computer.
-The third command uses the New-PSSession cmdlet to create the session.
-The fourth command uses the *FilePath* parameter of the Invoke-Command cmdlet to run the Alias.ps1 file in the new session.
+The third command uses the `New-PSSession` cmdlet to create the session.
+The fourth command uses the **FilePath** parameter of the `Invoke-Command` cmdlet to run the Alias.ps1 file in the new session.
 
 ## PARAMETERS
 
@@ -109,7 +109,7 @@ The acceptable values for this parameter are:
 - CSV.
 Comma-separated value (CSV) format. 
 - Script.
-Creates a **Set-Alias** command for each exported alias.
+Creates a `Set-Alias` command for each exported alias.
 If you name the output file with a .ps1 file name extension, you can run it as a script to add the aliases to any session.
 
 ```yaml
@@ -159,10 +159,10 @@ Accept wildcard characters: False
 ### -Force
 Forces the command to run without asking for user confirmation.
 
-By default, **Export-Alias** overwrites files without warning, unless the read-only or hidden attribute is set or the *NoClobber* parameter is used in the command.
-The *NoClobber* parameter takes precedence over the *Force* parameter when both are used in a command.
+By default, `Export-Alias` overwrites files without warning, unless the read-only or hidden attribute is set or the **NoClobber** parameter is used in the command.
+The **NoClobber** parameter takes precedence over the **Force** parameter when both are used in a command.
 
-The *Force* parameter cannot force **Export-Alias** to overwrite files with the hidden attribute.
+The **Force** parameter cannot force `Export-Alias` to overwrite files with the hidden attribute.
 
 ```yaml
 Type: SwitchParameter
@@ -178,7 +178,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies the path to the output file.
-Unlike *Path*, the value of the *LiteralPath* parameter is used exactly as it is typed.
+Unlike *Path*, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
@@ -199,7 +199,7 @@ Accept wildcard characters: False
 Specifies the names as an array of the aliases to export.
 Wildcards are permitted.
 
-By default, **Export-Alias** exports all aliases in the session or scope.
+By default, `Export-Alias` exports all aliases in the session or scope.
 
 ```yaml
 Type: String[]
@@ -214,12 +214,12 @@ Accept wildcard characters: False
 ```
 
 ### -NoClobber
-Indicates that this cmdlet prevents **Export-Alias** from overwriting any files, even if the *Force* parameter is used in the command.
+Indicates that this cmdlet prevents `Export-Alias` from overwriting any files, even if the **Force** parameter is used in the command.
 
-If the *NoClobber* parameter is omitted, **Export-Alias** will overwrite an existing file without warning, unless the read-only attribute is set on the file.
-*NoClobber* takes precedence over the *Force* parameter, which permits **Export-Alias** to overwrite a file with the read-only attribute.
+If the **NoClobber** parameter is omitted, `Export-Alias` will overwrite an existing file without warning, unless the read-only attribute is set on the file.
+*NoClobber* takes precedence over the **Force** parameter, which permits `Export-Alias` to overwrite a file with the read-only attribute.
 
-*NoClobber* does not prevent the *Append* parameter from adding content to an existing file.
+*NoClobber* does not prevent the **Append** parameter from adding content to an existing file.
 
 ```yaml
 Type: SwitchParameter
@@ -316,7 +316,7 @@ You cannot pipe objects to this cmdlet.
 ## OUTPUTS
 
 ### None or System.Management.Automation.AliasInfo
-When you use the *Passthru* parameter, **Export-Alias** returns a **System.Management.Automation.AliasInfo** object that represents the alias.
+When you use the **Passthru** parameter, `Export-Alias` returns a **System.Management.Automation.AliasInfo** object that represents the alias.
 Otherwise, this cmdlet does not generate any output.
 
 ## NOTES

--- a/reference/5.0/Microsoft.PowerShell.Utility/Import-Alias.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Import-Alias.md
@@ -16,27 +16,27 @@ Imports an alias list from a file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
+```powershell
 Import-Alias [-Path] <String> [-Scope <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```powershell
 Import-Alias -LiteralPath <String> [-Scope <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Import-Alias** cmdlet imports an alias list from a file.
+The `Import-Alias` cmdlet imports an alias list from a file.
 
-Beginning in Windows PowerShell 3.0, as a security feature, **Import-Alias** does not overwrite existing aliases by default.
-To overwrite an existing alias, after assuring that the contents of the alias file is safe, use the *Force* parameter.
+Beginning in Windows PowerShell 3.0, as a security feature, `Import-Alias` does not overwrite existing aliases by default.
+To overwrite an existing alias, after assuring that the contents of the alias file is safe, use the **Force** parameter.
 
 ## EXAMPLES
 
 ### Example 1: Import aliases from a file
-```
-PS C:\> Import-Alias test.txt
+```powershell
+Import-Alias test.txt
 ```
 
 This command imports alias information from a file named test.txt.
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 Allows the cmdlet to import an alias that is already defined or is read only.
 You can use the following command to display information about the currently-defined aliases:
 
-`Get-Alias | Select-Object name,Options`
+`Get-Alias | Select-Object Name, Options`
 
 If the corresponding alias is read-only, it will be displayed in the value of the **Options** property.
 
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies the path to a file that includes exported alias information.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is typed.
+Unlike the **Path** parameter, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
@@ -175,12 +175,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains a path to **Import-Alias**.
+You can pipe a string that contains a path to `Import-Alias`.
 
 ## OUTPUTS
 
 ### None or System.Management.Automation.AliasInfo
-When you use the *Passthru* parameter, **Import-Alias** returns a **System.Management.Automation.AliasInfo** object that represents the alias.
+When you use the **Passthru** parameter, `Import-Alias` returns a **System.Management.Automation.AliasInfo** object that represents the alias.
 Otherwise, this cmdlet does not generate any output.
 
 ## NOTES

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -179,7 +179,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies the path to the output file.
-Unlike *Path*, the value of the **LiteralPath** parameter is used exactly as it is typed.
+Unlike **Path**, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -16,72 +16,72 @@ Exports information about currently defined aliases to a file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
+```powershell
 Export-Alias [-Path] <String> [[-Name] <String[]>] [-PassThru] [-As <ExportAliasFormat>] [-Append] [-Force]
  [-NoClobber] [-Description <String>] [-Scope <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```powershell
 Export-Alias -LiteralPath <String> [[-Name] <String[]>] [-PassThru] [-As <ExportAliasFormat>] [-Append]
  [-Force] [-NoClobber] [-Description <String>] [-Scope <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Export-Alias** cmdlet exports the aliases in the current session to a file.
+The `Export-Alias` cmdlet exports the aliases in the current session to a file.
 If the output file does not exist, the cmdlet will create it.
 
-**Export-Alias** can export the aliases in a particular scope or all scopes, it can generate the data in CSV format or as a series of Set-Alias commands that you can add to a session or to a Windows PowerShell profile.
+`Export-Alias` can export the aliases in a particular scope or all scopes, it can generate the data in CSV format or as a series of Set-Alias commands that you can add to a session or to a Windows PowerShell profile.
 
 ## EXAMPLES
 
 ### Example 1: Export an alias
-```
-PS C:\> Export-Alias -Path "alias.csv"
+```powershell
+Export-Alias -Path "alias.csv"
 ```
 
 This command exports current alias information to a file named Alias.csv in the current directory.
 
 ### Example 2: Export an alias unless the export file already exists
-```
-PS C:\> Export-Alias -Path "alias.csv" -NoClobber
+```powershell
+Export-Alias -Path "alias.csv" -NoClobber
 ```
 
 This command exports the aliases in the current session to an Alias.csv file.
 
-Because the *NoClobber* parameter is specified, the command will fail if an Alias.csv file already exists in the current directory.
+Because the **NoClobber** parameter is specified, the command will fail if an Alias.csv file already exists in the current directory.
 
 ### Example 3: Append aliases to a file
-```
-PS C:\> Export-Alias -Path "alias.csv" -Append -Description "Appended Aliases" -Force
+```powershell
+Export-Alias -Path "alias.csv" -Append -Description "Appended Aliases" -Force
 ```
 
 This command appends the aliases in the current session to the Alias.csv file.
 
-The command uses the *Description* parameter to add a description to the comments at the top of the file.
+The command uses the **Description** parameter to add a description to the comments at the top of the file.
 
-The command also uses the *Force* parameter to overwrite any existing Alias.csv files, even if they have the read-only attribute.
+The command also uses the **Force** parameter to overwrite any existing Alias.csv files, even if they have the read-only attribute.
 
 ### Example 4: Export aliases as a script
-```
-PS C:\> Export-Alias -Path "alias.ps1" -As Script
-PS C:\> Add-Content -Path $Profile -Value (Get-Content alias.ps1)
-PS C:\> $S = New-PSSession -ComputerName Server01
-PS C:\> Invoke-Command -Session $S -FilePath .\alias.ps1
+```powershell
+Export-Alias -Path "alias.ps1" -As Script
+Add-Content -Path $Profile -Value (Get-Content alias.ps1)
+$S = New-PSSession -ComputerName Server01
+Invoke-Command -Session $S -FilePath .\alias.ps1
 ```
 
-This example shows how to use the script file format that **Export-Alias** generates.
+This example shows how to use the script file format that `Export-Alias` generates.
 
 The first command exports the aliases in the session to the Alias.ps1 file.
-It uses the *As* parameter with a value of Script to generate a file that contains a Set-Alias command for each alias.
+It uses the **As** parameter with a value of Script to generate a file that contains a Set-Alias command for each alias.
 
 The second command adds the aliases in the Alias.ps1 file to the CurrentUser-CurrentHost profile.
-(The path to the profile is saved in the $Profile variable.) The command uses the Get-Content cmdlet to get the aliases from the Alias.ps1 file and the Add-Content cmdlet to add them to the profile.
+(The path to the profile is saved in the $Profile variable.) The command uses the `Get-Content` cmdlet to get the aliases from the Alias.ps1 file and the `Add-Content` cmdlet to add them to the profile.
 For more information, see about_Profiles.
 
 The third and fourth commands add the aliases in the Alias.ps1 file to a remote session on the Server01 computer.
-The third command uses the New-PSSession cmdlet to create the session.
-The fourth command uses the *FilePath* parameter of the Invoke-Command cmdlet to run the Alias.ps1 file in the new session.
+The third command uses the `New-PSSession` cmdlet to create the session.
+The fourth command uses the **FilePath** parameter of the `Invoke-Command` cmdlet to run the Alias.ps1 file in the new session.
 
 ## PARAMETERS
 
@@ -108,7 +108,7 @@ The acceptable values for this parameter are:
 - CSV.
 Comma-separated value (CSV) format. 
 - Script.
-Creates a **Set-Alias** command for each exported alias.
+Creates a `Set-Alias` command for each exported alias.
 If you name the output file with a .ps1 file name extension, you can run it as a script to add the aliases to any session.
 
 ```yaml
@@ -160,10 +160,10 @@ Forces the command to run without asking for user confirmation.
 
 Overwrites the output file, even if the read-only attribute is set on the file.
 
-By default, **Export-Alias** overwrites files without warning, unless the read-only or hidden attribute is set or the *NoClobber* parameter is used in the command.
-The *NoClobber* parameter takes precedence over the *Force* parameter when both are used in a command.
+By default, `Export-Alias` overwrites files without warning, unless the read-only or hidden attribute is set or the **NoClobber** parameter is used in the command.
+The **NoClobber** parameter takes precedence over the **Force** parameter when both are used in a command.
 
-The *Force* parameter cannot force **Export-Alias** to overwrite files with the hidden attribute.
+The **Force** parameter cannot force `Export-Alias` to overwrite files with the hidden attribute.
 
 ```yaml
 Type: SwitchParameter
@@ -179,7 +179,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies the path to the output file.
-Unlike *Path*, the value of the *LiteralPath* parameter is used exactly as it is typed.
+Unlike *Path*, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
@@ -200,7 +200,7 @@ Accept wildcard characters: False
 Specifies the names as an array of the aliases to export.
 Wildcards are permitted.
 
-By default, **Export-Alias** exports all aliases in the session or scope.
+By default, `Export-Alias` exports all aliases in the session or scope.
 
 ```yaml
 Type: String[]
@@ -215,12 +215,12 @@ Accept wildcard characters: False
 ```
 
 ### -NoClobber
-Indicates that this cmdlet prevents **Export-Alias** from overwriting any files, even if the *Force* parameter is used in the command.
+Indicates that this cmdlet prevents `Export-Alias` from overwriting any files, even if the **Force** parameter is used in the command.
 
-If the *NoClobber* parameter is omitted, **Export-Alias** will overwrite an existing file without warning, unless the read-only attribute is set on the file.
-*NoClobber* takes precedence over the *Force* parameter, which permits **Export-Alias** to overwrite a file with the read-only attribute.
+If the **NoClobber** parameter is omitted, `Export-Alias` will overwrite an existing file without warning, unless the read-only attribute is set on the file.
+*NoClobber* takes precedence over the **Force** parameter, which permits `Export-Alias` to overwrite a file with the read-only attribute.
 
-*NoClobber* does not prevent the *Append* parameter from adding content to an existing file.
+*NoClobber* does not prevent the **Append** parameter from adding content to an existing file.
 
 ```yaml
 Type: SwitchParameter
@@ -317,7 +317,7 @@ You cannot pipe objects to this cmdlet.
 ## OUTPUTS
 
 ### None or System.Management.Automation.AliasInfo
-When you use the *Passthru* parameter, **Export-Alias** returns a **System.Management.Automation.AliasInfo** object that represents the alias.
+When you use the **Passthru** parameter, `Export-Alias` returns a **System.Management.Automation.AliasInfo** object that represents the alias.
 Otherwise, this cmdlet does not generate any output.
 
 ## NOTES

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-Alias.md
@@ -16,27 +16,27 @@ Imports an alias list from a file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
+```powershell
 Import-Alias [-Path] <String> [-Scope <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```powershell
 Import-Alias -LiteralPath <String> [-Scope <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Import-Alias** cmdlet imports an alias list from a file.
+The `Import-Alias` cmdlet imports an alias list from a file.
 
-Beginning in Windows PowerShell 3.0, as a security feature, **Import-Alias** does not overwrite existing aliases by default.
-To overwrite an existing alias, after assuring that the contents of the alias file is safe, use the *Force* parameter.
+Beginning in Windows PowerShell 3.0, as a security feature, `Import-Alias` does not overwrite existing aliases by default.
+To overwrite an existing alias, after assuring that the contents of the alias file is safe, use the **Force** parameter.
 
 ## EXAMPLES
 
 ### Example 1: Import aliases from a file
-```
-PS C:\> Import-Alias test.txt
+```powershell
+Import-Alias test.txt
 ```
 
 This command imports alias information from a file named test.txt.
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 Allows the cmdlet to import an alias that is already defined or is read only.
 You can use the following command to display information about the currently-defined aliases:
 
-`Get-Alias | Select-Object name,Options`
+`Get-Alias | Select-Object Name, Options`
 
 If the corresponding alias is read-only, it will be displayed in the value of the **Options** property.
 
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies the path to a file that includes exported alias information.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is typed.
+Unlike the **Path** parameter, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
@@ -175,12 +175,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains a path to **Import-Alias**.
+You can pipe a string that contains a path to `Import-Alias`.
 
 ## OUTPUTS
 
 ### None or System.Management.Automation.AliasInfo
-When you use the *Passthru* parameter, **Import-Alias** returns a **System.Management.Automation.AliasInfo** object that represents the alias.
+When you use the **Passthru** parameter, `Import-Alias` returns a **System.Management.Automation.AliasInfo** object that represents the alias.
 Otherwise, this cmdlet does not generate any output.
 
 ## NOTES

--- a/reference/6/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -164,7 +164,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies the path to the output file.
-Unlike *Path*, the value of the **LiteralPath** parameter is used exactly as it is typed.
+Unlike **Path**, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.

--- a/reference/6/Microsoft.PowerShell.Utility/Export-Alias.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-Alias.md
@@ -16,74 +16,72 @@ Exports information about currently defined aliases to a file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
+```powershell
 Export-Alias [-Path] <String> [[-Name] <String[]>] [-PassThru] [-As <ExportAliasFormat>] [-Append] [-Force]
- [-NoClobber] [-Description <String>] [-Scope <String>] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-NoClobber] [-Description <String>] [-Scope <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```powershell
 Export-Alias -LiteralPath <String> [[-Name] <String[]>] [-PassThru] [-As <ExportAliasFormat>] [-Append]
- [-Force] [-NoClobber] [-Description <String>] [-Scope <String>] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Force] [-NoClobber] [-Description <String>] [-Scope <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Export-Alias** cmdlet exports the aliases in the current session to a file.
+The `Export-Alias` cmdlet exports the aliases in the current session to a file.
 If the output file does not exist, the cmdlet will create it.
 
-**Export-Alias** can export the aliases in a particular scope or all scopes, it can generate the data in CSV format or as a series of Set-Alias commands that you can add to a session or to a Windows PowerShell profile.
+`Export-Alias` can export the aliases in a particular scope or all scopes, it can generate the data in CSV format or as a series of Set-Alias commands that you can add to a session or to a Windows PowerShell profile.
 
 ## EXAMPLES
 
 ### Example 1: Export an alias
-```
-PS C:\> Export-Alias -Path "alias.csv"
+```powershell
+Export-Alias -Path "alias.csv"
 ```
 
 This command exports current alias information to a file named Alias.csv in the current directory.
 
 ### Example 2: Export an alias unless the export file already exists
-```
-PS C:\> Export-Alias -Path "alias.csv" -NoClobber
+```powershell
+Export-Alias -Path "alias.csv" -NoClobber
 ```
 
 This command exports the aliases in the current session to an Alias.csv file.
 
-Because the *NoClobber* parameter is specified, the command will fail if an Alias.csv file already exists in the current directory.
+Because the **NoClobber** parameter is specified, the command will fail if an Alias.csv file already exists in the current directory.
 
 ### Example 3: Append aliases to a file
-```
-PS C:\> Export-Alias -Path "alias.csv" -Append -Description "Appended Aliases" -Force
+```powershell
+Export-Alias -Path "alias.csv" -Append -Description "Appended Aliases" -Force
 ```
 
 This command appends the aliases in the current session to the Alias.csv file.
 
-The command uses the *Description* parameter to add a description to the comments at the top of the file.
+The command uses the **Description** parameter to add a description to the comments at the top of the file.
 
-The command also uses the *Force* parameter to overwrite any existing Alias.csv files, even if they have the read-only attribute.
+The command also uses the **Force** parameter to overwrite any existing Alias.csv files, even if they have the read-only attribute.
 
 ### Example 4: Export aliases as a script
-```
-PS C:\> Export-Alias -Path "alias.ps1" -As Script
-PS C:\> Add-Content -Path $Profile -Value (Get-Content alias.ps1)
-PS C:\> $S = New-PSSession -ComputerName Server01
-PS C:\> Invoke-Command -Session $S -FilePath .\alias.ps1
+```powershell
+Export-Alias -Path "alias.ps1" -As Script
+Add-Content -Path $Profile -Value (Get-Content alias.ps1)
+$S = New-PSSession -ComputerName Server01
+Invoke-Command -Session $S -FilePath .\alias.ps1
 ```
 
-This example shows how to use the script file format that **Export-Alias** generates.
+This example shows how to use the script file format that `Export-Alias` generates.
 
 The first command exports the aliases in the session to the Alias.ps1 file.
-It uses the *As* parameter with a value of Script to generate a file that contains a Set-Alias command for each alias.
+It uses the **As** parameter with a value of Script to generate a file that contains a Set-Alias command for each alias.
 
 The second command adds the aliases in the Alias.ps1 file to the CurrentUser-CurrentHost profile.
-(The path to the profile is saved in the $Profile variable.) The command uses the Get-Content cmdlet to get the aliases from the Alias.ps1 file and the Add-Content cmdlet to add them to the profile.
+(The path to the profile is saved in the $Profile variable.) The command uses the `Get-Content` cmdlet to get the aliases from the Alias.ps1 file and the `Add-Content` cmdlet to add them to the profile.
 For more information, see about_Profiles.
 
 The third and fourth commands add the aliases in the Alias.ps1 file to a remote session on the Server01 computer.
-The third command uses the New-PSSession cmdlet to create the session.
-The fourth command uses the *FilePath* parameter of the Invoke-Command cmdlet to run the Alias.ps1 file in the new session.
+The third command uses the `New-PSSession` cmdlet to create the session.
+The fourth command uses the **FilePath** parameter of the `Invoke-Command` cmdlet to run the Alias.ps1 file in the new session.
 
 ## PARAMETERS
 
@@ -110,7 +108,7 @@ The acceptable values for this parameter are:
 - CSV.
 Comma-separated value (CSV) format. 
 - Script.
-Creates a **Set-Alias** command for each exported alias.
+Creates a `Set-Alias` command for each exported alias.
 If you name the output file with a .ps1 file name extension, you can run it as a script to add the aliases to any session.
 
 ```yaml
@@ -147,10 +145,10 @@ Forces the command to run without asking for user confirmation.
 
 Overwrites the output file, even if the read-only attribute is set on the file.
 
-By default, **Export-Alias** overwrites files without warning, unless the read-only or hidden attribute is set or the *NoClobber* parameter is used in the command.
-The *NoClobber* parameter takes precedence over the *Force* parameter when both are used in a command.
+By default, `Export-Alias` overwrites files without warning, unless the read-only or hidden attribute is set or the **NoClobber** parameter is used in the command.
+The **NoClobber** parameter takes precedence over the **Force** parameter when both are used in a command.
 
-The *Force* parameter cannot force **Export-Alias** to overwrite files with the hidden attribute.
+The **Force** parameter cannot force `Export-Alias` to overwrite files with the hidden attribute.
 
 ```yaml
 Type: SwitchParameter
@@ -164,36 +162,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -InformationAction
-@{Text=}```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
-@{Text=}```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -LiteralPath
 Specifies the path to the output file.
-Unlike *Path*, the value of the *LiteralPath* parameter is used exactly as it is typed.
+Unlike *Path*, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
@@ -214,7 +185,7 @@ Accept wildcard characters: False
 Specifies the names as an array of the aliases to export.
 Wildcards are permitted.
 
-By default, **Export-Alias** exports all aliases in the session or scope.
+By default, `Export-Alias` exports all aliases in the session or scope.
 
 ```yaml
 Type: String[]
@@ -229,12 +200,12 @@ Accept wildcard characters: False
 ```
 
 ### -NoClobber
-Indicates that this cmdlet prevents **Export-Alias** from overwriting any files, even if the *Force* parameter is used in the command.
+Indicates that this cmdlet prevents `Export-Alias` from overwriting any files, even if the **Force** parameter is used in the command.
 
-If the *NoClobber* parameter is omitted, **Export-Alias** will overwrite an existing file without warning, unless the read-only attribute is set on the file.
-*NoClobber* takes precedence over the *Force* parameter, which permits **Export-Alias** to overwrite a file with the read-only attribute.
+If the **NoClobber** parameter is omitted, `Export-Alias` will overwrite an existing file without warning, unless the read-only attribute is set on the file.
+*NoClobber* takes precedence over the **Force** parameter, which permits `Export-Alias` to overwrite a file with the read-only attribute.
 
-*NoClobber* does not prevent the *Append* parameter from adding content to an existing file.
+*NoClobber* does not prevent the **Append** parameter from adding content to an existing file.
 
 ```yaml
 Type: SwitchParameter
@@ -346,7 +317,7 @@ You cannot pipe objects to this cmdlet.
 ## OUTPUTS
 
 ### None or System.Management.Automation.AliasInfo
-When you use the *Passthru* parameter, **Export-Alias** returns a **System.Management.Automation.AliasInfo** object that represents the alias.
+When you use the **Passthru** parameter, `Export-Alias` returns a **System.Management.Automation.AliasInfo** object that represents the alias.
 Otherwise, this cmdlet does not generate any output.
 
 ## NOTES

--- a/reference/6/Microsoft.PowerShell.Utility/Import-Alias.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Import-Alias.md
@@ -16,29 +16,26 @@ Imports an alias list from a file.
 ## SYNTAX
 
 ### ByPath (Default)
-```
-Import-Alias [-Path] <String> [-Scope <String>] [-PassThru] [-Force] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```powershell
+Import-Alias [-Path] <String> [-Scope <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
-Import-Alias -LiteralPath <String> [-Scope <String>] [-PassThru] [-Force]
- [-InformationAction <ActionPreference>] [-InformationVariable <String>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+```powershell
+Import-Alias -LiteralPath <String> [-Scope <String>] [-PassThru] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Import-Alias** cmdlet imports an alias list from a file.
+The `Import-Alias` cmdlet imports an alias list from a file.
 
-Beginning in Windows PowerShell 3.0, as a security feature, **Import-Alias** does not overwrite existing aliases by default.
-To overwrite an existing alias, after assuring that the contents of the alias file is safe, use the *Force* parameter.
+Beginning in Windows PowerShell 3.0, as a security feature, `Import-Alias` does not overwrite existing aliases by default.
+To overwrite an existing alias, after assuring that the contents of the alias file is safe, use the **Force** parameter.
 
 ## EXAMPLES
 
 ### Example 1: Import aliases from a file
-```
-PS C:\> Import-Alias test.txt
+```powershell
+Import-Alias test.txt
 ```
 
 This command imports alias information from a file named test.txt.
@@ -49,7 +46,7 @@ This command imports alias information from a file named test.txt.
 Allows the cmdlet to import an alias that is already defined or is read only.
 You can use the following command to display information about the currently-defined aliases:
 
-`Get-Alias | Select-Object name,Options`
+`Get-Alias | Select-Object Name, Options`
 
 If the corresponding alias is read-only, it will be displayed in the value of the **Options** property.
 
@@ -57,37 +54,6 @@ If the corresponding alias is read-only, it will be displayed in the value of th
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: 
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationAction
-get-alias | select-object name,Options
-
-If the corresponding alias is read-only, it will be displayed in the value of the Options property.```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
-get-alias | select-object name,Options
-
-If the corresponding alias is read-only, it will be displayed in the value of the Options property.```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
 
 Required: False
 Position: Named
@@ -154,7 +120,7 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 Specifies the path to a file that includes exported alias information.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is typed.
+Unlike the **Path** parameter, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
@@ -208,12 +174,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains a path to **Import-Alias**.
+You can pipe a string that contains a path to `Import-Alias`.
 
 ## OUTPUTS
 
 ### None or System.Management.Automation.AliasInfo
-When you use the *Passthru* parameter, **Import-Alias** returns a **System.Management.Automation.AliasInfo** object that represents the alias.
+When you use the **Passthru** parameter, `Import-Alias` returns a **System.Management.Automation.AliasInfo** object that represents the alias.
 Otherwise, this cmdlet does not generate any output.
 
 ## NOTES


### PR DESCRIPTION
Following the [style guide](https://github.com/PowerShell/PowerShell-Docs/blob/112dbd871a120e87a0ea4cdfd2b7d92df218a7e9/STYLE.md):
* \`\`\` -> \`\`\`powershell
* \*\*cmdlet\*\* -> \`cmdlet\`
* cmdlet -> \`cmdlet\`
* \*parameter\* -> \*\*parameter\*\*
* parameter -> \*\*parameter\*\*
* Remove 'PS C:> '
* Remove 'C:\PS>'
* PascalCase
* Remove meaningless InformationAction/InformationVariable (#1415)

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document
