### PR TITLE
Add behavior if LocalAccountTokenFilterPolicy registry is not set

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/Enable-PSRemoting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Enable-PSRemoting.md
@@ -181,6 +181,9 @@ This cmdlet returns strings that describe its results.
 To create a firewall rule for public networks that allows remote access from the same local subnet, use the *SkipNetworkProfileCheck* parameter.
 
   On client or server versions of the Windows operating system, to create a firewall rule for public networks that removes the local subnet restriction and allows remote access , use the **Set-NetFirewallRule** cmdlet in the NetSecurity module to run the following command: `Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP-PUBLIC" -RemoteAddress Any`
+  
+  Document Registry information
+
 
 * In Windows PowerShell 2.0, **Enable-PSRemoting** creates the following firewall exceptions for WS-Management communications.
 


### PR DESCRIPTION
If you run the Enable-PSRemoting cmdlet on the server OS on which Windows Management Framework 5.1 is installed, nothing is displayed on the console and the value of the LocalAccountTokenFilterPolicy registry is not set to 1.

This is because the behavior of the Enable-PSRemoting cmdlet has been changed so that the configuration of the WinRM service is skipped if the following settings are made.

1. The status of WinRM service is set to "Running".
2. The startup type of the WinRM service is "Automatic".
3. A value is set in the setting information in the WinRM service.
4. Firewall rules for WinRM service are enabled.

Workaround 1:
1. Execute the command prompt as "administrator".
2. Do one of the following:

Winrm Quickconfig

Workaround 2:
1. Run "PowerShell as administrator".
2. Do one of the following:

Set-WSManQuickConfig-Force

Remedy:
1. Run PowerShell as an administrator.
2. Do the following and change the LocalAccountTokenFilterPolicy registry value to 1:
New-ItemProperty -Name LocalAccountTokenFilterPolicy -path HKLM: \ SOFTWARE \ Microsoft \ Windows \ CurrentVersion
More information on - https://blogs.msdn.microsoft.com/wmi/2009/07/24/powershell-remoting-between-two-workgroup-machines/

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
