### PR TITLE
Fix code style of Start-Sleep

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Start-Sleep.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Start-Sleep.md
@@ -14,29 +14,29 @@ Suspends the activity in a script or session for the specified period of time.
 ## SYNTAX
 
 ### Seconds (Default)
-```
+```powershell
 Start-Sleep [-Seconds] <Int32> [<CommonParameters>]
 ```
 
 ### Milliseconds
-```
+```powershell
 Start-Sleep -Milliseconds <Int32> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Start-Sleep cmdlet suspends the activity in a script or session for the specified period of time.
+The `Start-Sleep` cmdlet suspends the activity in a script or session for the specified period of time.
 You can use it for many tasks, such as waiting for an operation to complete or pausing before repeating an operation.
 ## EXAMPLES
 
 ### Example 1
-```
-PS C:\> Start-Sleep -s 15
+```powershell
+Start-Sleep -s 15
 ```
 
 This command makes all commands in the session sleep for 15 seconds.
 ### Example 2
-```
-PS C:\> Start-Sleep -m 500
+```powershell
+Start-Sleep -m 500
 ```
 
 This command makes all the commands in the session sleep for one-half of a second (500 milliseconds).
@@ -44,7 +44,7 @@ This command makes all the commands in the session sleep for one-half of a secon
 
 ### -Milliseconds
 Specifies how long the resource sleeps in milliseconds.
-The parameter can be abbreviated as "-m".
+The parameter can be abbreviated as **m**.
 
 ```yaml
 Type: Int32
@@ -60,7 +60,7 @@ Accept wildcard characters: False
 
 ### -Seconds
 Specifies how long the resource sleeps in seconds.
-You can omit the parameter name ("Seconds"), or you can abbreviate it as "-s".
+You can omit the parameter name (**Seconds**), or you can abbreviate it as **s**.
 
 ```yaml
 Type: Int32
@@ -76,17 +76,19 @@ Accept wildcard characters: False
 
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
 ## INPUTS
 
 ### System.Int32
-You can pipe the number of seconds to Start-Sleep.
+You can pipe the number of seconds to `Start-Sleep`.
+
 ## OUTPUTS
 
 ### None
 This cmdlet does not return any output.
-## NOTES
-* You can also refer to Start-Sleep by its built-in alias, "sleep". For more information, see about_Aliases.
 
-*
+## NOTES
+* You can also refer to Start-Sleep by its built-in alias, `sleep`. For more information, see about_Aliases.
+
 ## RELATED LINKS
 

--- a/reference/4.0/Microsoft.PowerShell.Utility/Start-Sleep.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Start-Sleep.md
@@ -16,31 +16,31 @@ Suspends the activity in a script or session for the specified period of time.
 ## SYNTAX
 
 ### Seconds (Default)
-```
+```powershell
 Start-Sleep [-Seconds] <Int32> [<CommonParameters>]
 ```
 
 ### Milliseconds
-```
+```powershell
 Start-Sleep -Milliseconds <Int32> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Start-Sleep cmdlet suspends the activity in a script or session for the specified period of time.
+The `Start-Sleep` cmdlet suspends the activity in a script or session for the specified period of time.
 You can use it for many tasks, such as waiting for an operation to complete or pausing before repeating an operation.
 
 ## EXAMPLES
 
 ### Example 1
-```
-PS C:\> Start-Sleep -s 15
+```powershell
+Start-Sleep -s 15
 ```
 
 This command makes all commands in the session sleep for 15 seconds.
 
 ### Example 2
-```
-PS C:\> Start-Sleep -m 500
+```powershell
+Start-Sleep -m 500
 ```
 
 This command makes all the commands in the session sleep for one-half of a second (500 milliseconds).
@@ -49,7 +49,7 @@ This command makes all the commands in the session sleep for one-half of a secon
 
 ### -Milliseconds
 Specifies how long the resource sleeps in milliseconds.
-The parameter can be abbreviated as "-m".
+The parameter can be abbreviated as **m**.
 
 ```yaml
 Type: Int32
@@ -65,7 +65,7 @@ Accept wildcard characters: False
 
 ### -Seconds
 Specifies how long the resource sleeps in seconds.
-You can omit the parameter name ("Seconds"), or you can abbreviate it as "-s".
+You can omit the parameter name (**Seconds**), or you can abbreviate it as **s**.
 
 ```yaml
 Type: Int32
@@ -85,7 +85,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.Int32
-You can pipe the number of seconds to Start-Sleep.
+You can pipe the number of seconds to `Start-Sleep`.
 
 ## OUTPUTS
 
@@ -93,9 +93,7 @@ You can pipe the number of seconds to Start-Sleep.
 This cmdlet does not return any output.
 
 ## NOTES
-* You can also refer to Start-Sleep by its built-in alias, "sleep". For more information, see about_Aliases.
-
-*
+* You can also refer to Start-Sleep by its built-in alias, `sleep`. For more information, see about_Aliases.
 
 ## RELATED LINKS
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/Start-Sleep.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Start-Sleep.md
@@ -16,31 +16,31 @@ Suspends the activity in a script or session for the specified period of time.
 ## SYNTAX
 
 ### Seconds (Default)
-```
+```powershell
 Start-Sleep [-Seconds] <Int32> [<CommonParameters>]
 ```
 
 ### Milliseconds
-```
+```powershell
 Start-Sleep -Milliseconds <Int32> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Start-Sleep** cmdlet suspends the activity in a script or session for the specified period of time.
+The `Start-Sleep` cmdlet suspends the activity in a script or session for the specified period of time.
 You can use it for many tasks, such as waiting for an operation to complete or pausing before repeating an operation.
 
 ## EXAMPLES
 
 ### Example 1: Sleep all commands for 15 seconds
-```
-PS C:\> Start-Sleep -s 15
+```powershell
+Start-Sleep -s 15
 ```
 
 This command makes all commands in the session sleep for 15 seconds.
 
 ### Example 2: Sleep all commands
-```
-PS C:\> Start-Sleep -m 500
+```powershell
+Start-Sleep -m 500
 ```
 
 This command makes all the commands in the session sleep for one-half of a second (500 milliseconds).
@@ -49,7 +49,7 @@ This command makes all the commands in the session sleep for one-half of a secon
 
 ### -Milliseconds
 Specifies how long the resource sleeps in milliseconds.
-The parameter can be abbreviated as *m*.
+The parameter can be abbreviated as **m**.
 
 ```yaml
 Type: Int32
@@ -65,7 +65,7 @@ Accept wildcard characters: False
 
 ### -Seconds
 Specifies how long the resource sleeps in seconds.
-You can omit the parameter name (*Seconds*), or you can abbreviate it as *s*.
+You can omit the parameter name (**Seconds**), or you can abbreviate it as **s**.
 
 ```yaml
 Type: Int32
@@ -85,7 +85,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.Int32
-You can pipe the number of seconds to **Start-Sleep**.
+You can pipe the number of seconds to `Start-Sleep`.
 
 ## OUTPUTS
 
@@ -93,9 +93,7 @@ You can pipe the number of seconds to **Start-Sleep**.
 This cmdlet does not return any output.
 
 ## NOTES
-* You can also refer to **Start-Sleep** by its built-in alias, **sleep**. For more information, see about_Aliases.
-
-*
+* You can also refer to `Start-Sleep` by its built-in alias, `sleep`. For more information, see about_Aliases.
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Start-Sleep.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Start-Sleep.md
@@ -16,31 +16,31 @@ Suspends the activity in a script or session for the specified period of time.
 ## SYNTAX
 
 ### Seconds (Default)
-```
+```powershell
 Start-Sleep [-Seconds] <Int32> [<CommonParameters>]
 ```
 
 ### Milliseconds
-```
+```powershell
 Start-Sleep -Milliseconds <Int32> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Start-Sleep** cmdlet suspends the activity in a script or session for the specified period of time.
+The `Start-Sleep` cmdlet suspends the activity in a script or session for the specified period of time.
 You can use it for many tasks, such as waiting for an operation to complete or pausing before repeating an operation.
 
 ## EXAMPLES
 
 ### Example 1: Sleep all commands for 15 seconds
-```
-PS C:\> Start-Sleep -s 15
+```powershell
+Start-Sleep -s 15
 ```
 
 This command makes all commands in the session sleep for 15 seconds.
 
 ### Example 2: Sleep all commands
-```
-PS C:\> Start-Sleep -m 500
+```powershell
+Start-Sleep -m 500
 ```
 
 This command makes all the commands in the session sleep for one-half of a second (500 milliseconds).
@@ -49,7 +49,7 @@ This command makes all the commands in the session sleep for one-half of a secon
 
 ### -Milliseconds
 Specifies how long the resource sleeps in milliseconds.
-The parameter can be abbreviated as *m*.
+The parameter can be abbreviated as **m**.
 
 ```yaml
 Type: Int32
@@ -65,7 +65,7 @@ Accept wildcard characters: False
 
 ### -Seconds
 Specifies how long the resource sleeps in seconds.
-You can omit the parameter name (*Seconds*), or you can abbreviate it as *s*.
+You can omit the parameter name (**Seconds**), or you can abbreviate it as **s**.
 
 ```yaml
 Type: Int32
@@ -85,7 +85,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.Int32
-You can pipe the number of seconds to **Start-Sleep**.
+You can pipe the number of seconds to `Start-Sleep`.
 
 ## OUTPUTS
 
@@ -93,9 +93,7 @@ You can pipe the number of seconds to **Start-Sleep**.
 This cmdlet does not return any output.
 
 ## NOTES
-* You can also refer to **Start-Sleep** by its built-in alias, **sleep**. For more information, see about_Aliases.
-
-*
+* You can also refer to `Start-Sleep` by its built-in alias, `sleep`. For more information, see about_Aliases.
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Start-Sleep.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Start-Sleep.md
@@ -16,69 +16,40 @@ Suspends the activity in a script or session for the specified period of time.
 ## SYNTAX
 
 ### Seconds (Default)
-```
-Start-Sleep [-Seconds] <Int32> [-InformationAction <ActionPreference>] [-InformationVariable <String>]
- [<CommonParameters>]
+```powershell
+Start-Sleep [-Seconds] <Int32> [<CommonParameters>]
 ```
 
 ### Milliseconds
-```
-Start-Sleep -Milliseconds <Int32> [-InformationAction <ActionPreference>] [-InformationVariable <String>]
- [<CommonParameters>]
+```powershell
+Start-Sleep -Milliseconds <Int32> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Start-Sleep** cmdlet suspends the activity in a script or session for the specified period of time.
+The `Start-Sleep` cmdlet suspends the activity in a script or session for the specified period of time.
 You can use it for many tasks, such as waiting for an operation to complete or pausing before repeating an operation.
 
 ## EXAMPLES
 
 ### Example 1: Sleep all commands for 15 seconds
-```
-PS C:\> Start-Sleep -s 15
+```powershell
+Start-Sleep -s 15
 ```
 
 This command makes all commands in the session sleep for 15 seconds.
 
 ### Example 2: Sleep all commands
-```
-PS C:\> Start-Sleep -m 500
+```powershell
+Start-Sleep -m 500
 ```
 
 This command makes all the commands in the session sleep for one-half of a second (500 milliseconds).
 
 ## PARAMETERS
 
-### -InformationAction
-@{Text=}```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
-@{Text=}```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Milliseconds
 Specifies how long the resource sleeps in milliseconds.
-The parameter can be abbreviated as *m*.
+The parameter can be abbreviated as **m**.
 
 ```yaml
 Type: Int32
@@ -94,7 +65,7 @@ Accept wildcard characters: False
 
 ### -Seconds
 Specifies how long the resource sleeps in seconds.
-You can omit the parameter name (*Seconds*), or you can abbreviate it as *s*.
+You can omit the parameter name (**Seconds**), or you can abbreviate it as **s**.
 
 ```yaml
 Type: Int32
@@ -114,7 +85,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.Int32
-You can pipe the number of seconds to **Start-Sleep**.
+You can pipe the number of seconds to `Start-Sleep`.
 
 ## OUTPUTS
 
@@ -122,9 +93,7 @@ You can pipe the number of seconds to **Start-Sleep**.
 This cmdlet does not return any output.
 
 ## NOTES
-* You can also refer to **Start-Sleep** by its built-in alias, **sleep**. For more information, see about_Aliases.
-
-*
+* You can also refer to `Start-Sleep` by its built-in alias, `sleep`. For more information, see about_Aliases.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
Following the [style guide](https://github.com/PowerShell/PowerShell-Docs/blob/339b28cce36de091302c002d1829cb2289419ae8/STYLE.md):
* \`\`\` -> \`\`\`powershell
* \*\*cmdlet\*\* -> \`cmdlet\`
* \*parameter\* -> \*\*parameter\*\*
* "-parameter" -> \*\*parameter\*\*
* Remove 'PS C:> '
* Remove meaningless InformationAction/InformationVariable

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document
