### PR TITLE
Documentation of Meta, Charset and Transitional parameter for ConvertTo-HTML

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -353,7 +353,7 @@ Specifies text to add to the opening \<meta\> tag.
 By default, there is no text in that position.
 
 ```yaml
-Type: String[]
+Type: Hashtable
 Parameter Sets: (Page)
 Aliases: 
 

--- a/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -18,7 +18,7 @@ Converts Microsoft .NET Framework objects into HTML that can be displayed in a W
 ### Page (Default)
 ```
 ConvertTo-Html [-InputObject <PSObject>] [[-Property] <Object[]>] [[-Body] <String[]>] [[-Head] <String[]>]
- [[-Title] <String>] [-As <String>] [-CssUri <Uri>] [-PostContent <String[]>] [-PreContent <String[]>]
+ [[-Title] <String>] [-As <String>] [-CssUri <Uri>] [-PostContent <String[]>] [-PreContent <String[]>] [-Meta <String[]>] [-Charset <String>] [-Transitional]
  [-InformationAction <ActionPreference>] [-InformationVariable <String>] [<CommonParameters>]
 ```
 
@@ -159,6 +159,20 @@ The command uses a pipeline operator (|) to send the results to the **ConvertTo-
 The command uses a redirection operator (\>) to send the output to the Services.htm file.
 
 A semicolon (;) ends the first command and starts a second command, which uses the Invoke-Item cmdlet (alias = "ii") to open the Services.htm file in the default browser.
+
+### Example 10: Set the Meta properties and Charset of the HTML
+```
+PS C:\> Get-Service | ConvertTo-HTML -Meta @{refresh=10;author="Author's Name";keywords="PowerShell, HTML, ConvertTo-HTML"} -Charset "UTF-8"
+```
+
+This command creates the HTML for a webpage with the meta tags for refresh, author, and keywords. The charset for the page is set to UTF-9
+
+### Example 10: Set the HTML to XHTML Transitional DTD
+```
+PS C:\> Get-Service | ConvertTo-HTML -Transitional
+```
+
+This command sets the DOCTYPE of the returned HTML to XHTML Transitional DTD
 
 ## PARAMETERS
 
@@ -325,6 +339,54 @@ By default, there is no text in that position.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Meta
+Specifies text to add to the opening \<meta\> tag.
+By default, there is no text in that position.
+
+```yaml
+Type: String[]
+Parameter Sets: (Page)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Charset
+Specifies text to add to the opening \<charset\> tag.
+By default, there is no text in that position.
+
+```yaml
+Type: String
+Parameter Sets: (Page)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Transitional
+Changes the DOCTYPE to XHTML Transitional DTD
+Default DOCTYPE is XHTML Strict DTD
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Page
 Aliases: 
 
 Required: False


### PR DESCRIPTION
Added documentation for use of Meta, Charset and Transitional parameters for ConvertTo-HTML. Reference [PowerShell #4184](https://github.com/PowerShell/PowerShell/pull/4184)

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version (6) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert issue here> tracks the remaining work
