### PR TITLE
Fix typo in Invoke-RestMethod.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -606,7 +606,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## Inputs
 
 ### System.Object
-You can pipe the body of a web request to `Invoke-Rest-Method`.
+You can pipe the body of a web request to `Invoke-RestMethod`.
 
 ## Outputs
 


### PR DESCRIPTION
Fixing an erroneous dash in the cmdlet name.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
