### PR TITLE
Remove errant $ sign from method call

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
@@ -283,7 +283,7 @@ For example, to remove the Time\=Now key\/value pair from the hash table in the 
 
 
 ```
-$hash.$Remove("Time")
+$hash.Remove("Time")
 ```
 
 


### PR DESCRIPTION
Code as is produced error, and was invalid syntax.

