### PR TITLE
Remove errant $ sign from examples method call

### DIFF
--- a/reference/6/About/about_Hash_Tables.md
+++ b/reference/6/About/about_Hash_Tables.md
@@ -283,7 +283,7 @@ For example, to remove the Time\=Now key\/value pair from the hash table in the 
 
 
 ```
-$hash.$Remove("Time")
+$hash.Remove("Time")
 ```
 
 


### PR DESCRIPTION
Example code as is produced error, and was invalid syntax.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
