### PR TITLE
Edit to About_Arrays

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -467,7 +467,7 @@ $a.ForEach({ $_ * $_})
 C:\ >
 ```
 
-The `Where` method can be used to swiftly cast
+The `ForEach` method can be used to swiftly cast
 the elements to a different type;
 the following example shows how to convert
 a list of string dates to `[DateTime]` type.


### PR DESCRIPTION
LINE 470: The Line says "The `Where` method can be used to swiftly cast" but it should read "The `ForEach` method can be used to swiftly cast". That is the method in the example.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
