### PR TITLE
Modules not Snap-Ins

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -67,7 +67,7 @@ Get-PSProvider
 # INSTALLING AND REMOVING PROVIDERS
 
 Windows PowerShell providers are delivered to you in Windows PowerShell
-snap-ins, which are .NET Framework-based programs that are compiled
+modules, which are .NET Framework-based programs that are compiled
 into .dll files. The snap-ins can include providers and cmdlets.
 
 Before you use the provider features, you have to install the snap-in and


### PR DESCRIPTION
LINE: 69-70: says "Windows PowerShell providers are delivered to you in Windows PowerShell snap-ins" but should read "Windows PowerShell providers are delivered to you in Windows PowerShell modules". This must be true for two reasons: (1) snap-ins are a very old technology, (2) to create a snap-in, one must derive from ' CustomPSSnapIn ', but Providers derive from 'CmdletProvider', 'ItemCmdletProvider ', 'ContainerCmdletProvider', or 'NavigationCmdletProvider '.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
