### PR TITLE
minor formatting error

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -86,8 +86,7 @@ $false (-Debug:$false). Suppresses the display of debugging
 messages when the value of the $DebugPreference is not
 SilentlyContinue (the default).
 
-#### -ErrorAction[:{Continue | Ignore | Inquire | SilentlyContinue | Stop |
-Suspend }]
+#### -ErrorAction[:{Continue | Ignore | Inquire | SilentlyContinue | Stop | Suspend }]
 Alias: ea
 
 Determines how the cmdlet responds to a non-terminating error


### PR DESCRIPTION
LINE 89: The carriage return prevented the "Suspend" parameter enum from being bold.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
