### PR TITLE
Remove wrong command from the Example 5 of Get-PSDrive

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -98,10 +98,10 @@ else { Write-Host "The X: drive is already in use." }
 
 This command checks to see whether the X drive is already in use as a Windows PowerShell drive name.
 If it is not, the command uses the New-PSDrive cmdlet to create a temporary drive that is mapped to the HKLM:\Network registry key.
+
 ### Example 5
 ```
 PS C:\> Get-PSDrive -PSProvider FileSystem
-PS C:\> Get-PSDrive -provider FileSystem
 
 Name       Provider      Root
 ----       --------      ----
@@ -110,6 +110,7 @@ D          FileSystem    D:\
 X          FileSystem    X:\
 Y          FileSystem    \\Server01\Public
 Z          FileSystem    C:\Windows\System32
+
 PS C:\> net use
 New connections will be remembered.
 
@@ -117,7 +118,7 @@ Status       Local     Remote                    Network
 -------------------------------------------------------------------------------
 X:        \\Server01\Public         Microsoft Windows Network
 
-PS C:\> [System.IO.DriveInfo]::getdrives()
+PS C:\> [System.IO.DriveInfo]::GetDrives()
 
 Name               : C:\
 DriveType          : Fixed
@@ -147,7 +148,7 @@ TotalSize          : 36413280256
 RootDirectory      : X:\
 VolumeLabel        : D_Drive
 
-PS C:\> get-wmiobject win32_logicaldisk
+PS C:\> Get-WmiObject Win32_LogicalDisk
 
 DeviceID     : C:
 DriveType    : 3
@@ -168,7 +169,7 @@ FreeSpace    : 36340559872
 Size         : 36413280256
 VolumeName   : D_Drive
 
-PS C:\> get-wmiobject win32_networkconnection
+PS C:\> Get-WmiObject Win32_NetworkConnection
 
 LocalName                     RemoteName
 --------------               ------------
@@ -193,6 +194,7 @@ It returns the C:, D:, and X: drives, but not the temporary drives created by **
 
 The last command uses the Get-WmiObject cmdlet to display the instances of the **Win32_NetworkConnection** class.
 Like "net use", it returns only the persistent X: drive that was created by **New-PSDrive**.
+
 ## PARAMETERS
 
 ### -LiteralName

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -108,7 +108,6 @@ If it is not, the command uses the New-PSDrive cmdlet to create a temporary driv
 ### Example 5
 ```
 PS C:\> Get-PSDrive -PSProvider FileSystem
-PS C:\> Get-PSDrive -provider FileSystem
 
 Name       Provider      Root
 ----       --------      ----
@@ -117,6 +116,7 @@ D          FileSystem    D:\
 X          FileSystem    X:\
 Y          FileSystem    \\Server01\Public
 Z          FileSystem    C:\Windows\System32
+
 PS C:\> net use
 New connections will be remembered.
 
@@ -124,7 +124,7 @@ Status       Local     Remote                    Network
 -------------------------------------------------------------------------------
 X:        \\Server01\Public         Microsoft Windows Network
 
-PS C:\> [System.IO.DriveInfo]::getdrives()
+PS C:\> [System.IO.DriveInfo]::GetDrives()
 
 Name               : C:\
 DriveType          : Fixed
@@ -154,7 +154,7 @@ TotalSize          : 36413280256
 RootDirectory      : X:\
 VolumeLabel        : D_Drive
 
-PS C:\> get-wmiobject win32_logicaldisk
+PS C:\> Get-WmiObject Win32_LogicalDisk
 
 DeviceID     : C:
 DriveType    : 3
@@ -175,7 +175,7 @@ FreeSpace    : 36340559872
 Size         : 36413280256
 VolumeName   : D_Drive
 
-PS C:\> get-wmiobject win32_networkconnection
+PS C:\> Get-WmiObject Win32_NetworkConnection
 
 LocalName                     RemoteName
 --------------               ------------

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -81,7 +81,79 @@ If it is not, the command uses the New-PSDrive cmdlet to create a temporary driv
 
 ### Example 5: Compare the types of files system drives
 ```
-PS C:\> Get-PSDrive -PSProvider FileSystemPS C:\> Get-PSDrive -provider FileSystemName       Provider      Root----       --------      ----C          FileSystem    C:\D          FileSystem    D:\X          FileSystem    X:\Y          FileSystem    \\Server01\PublicZ          FileSystem    C:\Windows\System32PS C:\> net useNew connections will be remembered.Status       Local     Remote                    Network-------------------------------------------------------------------------------X:        \\Server01\Public         Microsoft Windows NetworkPS C:\> [System.IO.DriveInfo]::getdrives()Name               : C:\DriveType          : FixedDriveFormat        : NTFSIsReady            : TrueAvailableFreeSpace : 39831498752TotalFreeSpace     : 39831498752TotalSize          : 79900368896RootDirectory      : C:\VolumeLabel        :Name               : D:\DriveType          : CDRomDriveFormat        :IsReady            : FalseAvailableFreeSpace :TotalFreeSpace     :TotalSize          :RootDirectory      : D:\VolumeLabel        :Name               : X:\DriveType          : NetworkDriveFormat        : NTFSIsReady            : TrueAvailableFreeSpace : 36340559872TotalFreeSpace     : 36340559872TotalSize          : 36413280256RootDirectory      : X:\VolumeLabel        : D_DrivePS C:\> get-wmiobject win32_logicaldiskDeviceID     : C:DriveType    : 3ProviderName :FreeSpace    : 39831252992Size         : 79900368896VolumeName   :DeviceID     : D:DriveType    : 5ProviderName :FreeSpace    :Size         :VolumeName   :DeviceID     : X:DriveType    : 4ProviderName : \\server01\publicFreeSpace    : 36340559872Size         : 36413280256VolumeName   : D_DrivePS C:\> get-wmiobject win32_networkconnectionLocalName                     RemoteName--------------               ------------x:                            \\server01\public
+PS C:\> Get-PSDrive -PSProvider FileSystem
+
+Name       Provider      Root
+----       --------      ----
+C          FileSystem    C:\
+D          FileSystem    D:\
+X          FileSystem    X:\
+Y          FileSystem    \\Server01\Public
+Z          FileSystem    C:\Windows\System32
+
+PS C:\> net use
+New connections will be remembered.
+
+Status       Local     Remote                    Network
+-------------------------------------------------------------------------------
+X:        \\Server01\Public         Microsoft Windows Network
+
+PS C:\> [System.IO.DriveInfo]::GetDrives()
+
+Name               : C:\
+DriveType          : Fixed
+DriveFormat        : NTFS
+IsReady            : True
+AvailableFreeSpace : 39831498752
+TotalFreeSpace     : 39831498752
+TotalSize          : 79900368896
+RootDirectory      : C:\
+VolumeLabel        :
+Name               : D:\
+DriveType          : CDRom
+DriveFormat        :
+IsReady            : False
+AvailableFreeSpace :
+TotalFreeSpace     :
+TotalSize          :
+RootDirectory      : D:\
+VolumeLabel        :
+Name               : X:\
+DriveType          : Network
+DriveFormat        : NTFS
+IsReady            : True
+AvailableFreeSpace : 36340559872
+TotalFreeSpace     : 36340559872
+TotalSize          : 36413280256
+RootDirectory      : X:\
+VolumeLabel        : D_Drive
+
+PS C:\> Get-WmiObject Win32_LogicalDisk
+
+DeviceID     : C:
+DriveType    : 3
+ProviderName :
+FreeSpace    : 39831252992
+Size         : 79900368896
+VolumeName   :
+DeviceID     : D:
+DriveType    : 5
+ProviderName :
+FreeSpace    :
+Size         :
+VolumeName   :
+DeviceID     : X:
+DriveType    : 4
+ProviderName : \\server01\public
+FreeSpace    : 36340559872
+Size         : 36413280256
+VolumeName   : D_Drive
+
+PS C:\> Get-WmiObject Win32_NetworkConnection
+
+LocalName                     RemoteName
+--------------               ------------
+x:                            \\server01\public
 ```
 
 This example compares the types of file system drives that are displayed by **Get-PSDrive** to those displayed by using other methods.


### PR DESCRIPTION
Removed `Get-PSDrive -provider FileSystem` because it throws exception:
```
PS C:\> Get-PSDrive -provider FileSystem
Get-PSDrive : A parameter cannot be found that matches parameter name 'provider'.
At line:1 char:13
+ Get-PSDrive -provider FileSystem
+             ~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Get-PSDrive], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Microsoft.PowerShell.Commands.GetPSDriveCommand
```
Besides, fixed some line breaks and PascalCase.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
