### PR TITLE
Remove leftover pronoun

### DIFF
--- a/dsc/enactingConfigurations.md
+++ b/dsc/enactingConfigurations.md
@@ -32,7 +32,7 @@ you would apply it to the local machine with the following command: `Start-DscCo
 
 In pull mode, pull clients are configured to get their desired state configurations from a remote pull server. Likewise, the pull server has been set up to host the DSC service, and 
 has been provisioned with the configurations and resources that are required by the pull clients. Each one of the pull clients has a scheduled task that performs a periodic compliance 
-check on the configuration of the node. When the event is triggered the first time, it the Local Configuration Manager (LCM) on the pull client makes a request to the pull server to get the 
+check on the configuration of the node. When the event is triggered the first time, the Local Configuration Manager (LCM) on the pull client makes a request to the pull server to get the 
 configuration specified in the LCM. If that configuration exists on the pull server, and it passes initial validation checks, the configuration is transmitted to the pull client, where it is then 
 executed by the LCM.
 


### PR DESCRIPTION
Removed "it", which seemed to be a left-over pronoun for "the Local Configuration Manager".