### PR TITLE
Fix typo: double hash

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
@@ -99,7 +99,7 @@ $hash = [ordered]@{ Number = 1; Shape = "Square"; Color = "Blue"}
 
 You can use ordered dictionaries in the same way that you use hash tables. Either type can be used as the value of parameters that take a hash table or dictionary (iDictionary).
 
-You cannot use the [ordered] attribute to convert or cast a hash hash table. If you place the ordered attribute before the variable name, the command fails with the following error message.
+You cannot use the [ordered] attribute to convert or cast a hash table. If you place the ordered attribute before the variable name, the command fails with the following error message.
 
 
 ```

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
@@ -99,7 +99,7 @@ $hash = [ordered]@{ Number = 1; Shape = "Square"; Color = "Blue"}
 
 You can use ordered dictionaries in the same way that you use hash tables. Either type can be used as the value of parameters that take a hash table or dictionary (iDictionary).
 
-You cannot use the [ordered] attribute to convert or cast a hash hash table. If you place the ordered attribute before the variable name, the command fails with the following error message.
+You cannot use the [ordered] attribute to convert or cast a hash table. If you place the ordered attribute before the variable name, the command fails with the following error message.
 
 
 ```

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
@@ -99,7 +99,7 @@ $hash = [ordered]@{ Number = 1; Shape = "Square"; Color = "Blue"}
 
 You can use ordered dictionaries in the same way that you use hash tables. Either type can be used as the value of parameters that take a hash table or dictionary (iDictionary).
 
-You cannot use the [ordered] attribute to convert or cast a hash hash table. If you place the ordered attribute before the variable name, the command fails with the following error message.
+You cannot use the [ordered] attribute to convert or cast a hash table. If you place the ordered attribute before the variable name, the command fails with the following error message.
 
 
 ```

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Hash_Tables.md
@@ -99,7 +99,7 @@ $hash = [ordered]@{ Number = 1; Shape = "Square"; Color = "Blue"}
 
 You can use ordered dictionaries in the same way that you use hash tables. Either type can be used as the value of parameters that take a hash table or dictionary (iDictionary).
 
-You cannot use the [ordered] attribute to convert or cast a hash hash table. If you place the ordered attribute before the variable name, the command fails with the following error message.
+You cannot use the [ordered] attribute to convert or cast a hash table. If you place the ordered attribute before the variable name, the command fails with the following error message.
 
 
 ```

--- a/reference/6/About/about_Hash_Tables.md
+++ b/reference/6/About/about_Hash_Tables.md
@@ -99,7 +99,7 @@ $hash = [ordered]@{ Number = 1; Shape = "Square"; Color = "Blue"}
 
 You can use ordered dictionaries in the same way that you use hash tables. Either type can be used as the value of parameters that take a hash table or dictionary (iDictionary).
 
-You cannot use the [ordered] attribute to convert or cast a hash hash table. If you place the ordered attribute before the variable name, the command fails with the following error message.
+You cannot use the [ordered] attribute to convert or cast a hash table. If you place the ordered attribute before the variable name, the command fails with the following error message.
 
 
 ```


### PR DESCRIPTION
Change instance of 'hash hash' to 'hash'

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->