### PR TITLE
Exclude scripting folder

### DIFF
--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -14,7 +14,7 @@ $ReferenceDocset = Join-Path $PSScriptRoot 'reference'
 $allErrors = @()
 
 # Go through all the directories in the reference folder
-Get-ChildItem $ReferenceDocset -Directory | ForEach-Object -Process {
+Get-ChildItem $ReferenceDocset -Directory -Exclude 'scripting' | ForEach-Object -Process {
     $Version = $_.Name
     $VersionFolder = $_.FullName
     # For each of the directories, go through each module folder


### PR DESCRIPTION
Exclude the scripting folder from appveyor script as it only has markdown files and hence does not need to be considered for PlatyPS conversion. 