### PR TITLE
Adding Index.md to WMF 5.1, and fixing SIL wording in Release-Notes

### DIFF
--- a/wmf/5.1/Index.md
+++ b/wmf/5.1/Index.md
@@ -1,0 +1,36 @@
+---
+ms.date:  2017-08-12
+author:  JKeithB
+ms.topic:  reference
+keywords:  wmf,powershell,setup
+title:  WMF 5.1 Release Notes
+---
+
+# Windows Management Framework (WMF) 5.1 #
+
+WMF provides users with the ability to update existing Windows systems to the versions of PowerShell, WMI, WinRM, and Software Inventory Logging (SIL) components that were released with Windows Server 2016. 
+
+WMF 5.1 can be installed on Windows 7, Windows 8.1, Windows Server 2008 R2, 2012, and 2012 R2, and provides a number of improvements over WMF 5.0 RTM including:
+
+- New cmdlets: local users and groups; Get-ComputerInfo
+- PowerShellGet improvements include enforcing signed modules, and installing JEA modules
+- PackageManagement added support for Containers, CBS Setup, EXE-based setup, CAB packages
+- Debugging improvements for DSC and PowerShell classes
+- Security enhancements including enforcement of catalog-signed modules coming from the Pull Server and when using PowerShellGet cmdlets
+- Responses to a number of user requests and issues
+
+To learn about what is new in this release, browse the topics listed under [New Scenarios and Features](https://docs.microsoft.com/en-us/powershell/wmf/5.1/scenarios-features). 
+
+The [Install and Configure](https://docs.microsoft.com/en-us/powershell/wmf/5.1/install-configure) topic lists the requirements and provides installation instructions for WMF. 
+
+The [Compatibility](https://docs.microsoft.com/en-us/powershell/wmf/5.1/compatibility) topic lists which versions of WMF may be installed on which Windows releases. 
+
+[Product Compatibility](https://docs.microsoft.com/en-us/powershell/wmf/5.1/productincompat) lists the Microsoft applications that have not approved WMF 5.1 for use at this time. 
+
+Details for the components of WMF will be found in MSDN documentation:
+
+- [PowerShell 5.1](https://docs.microsoft.com/en-us/powershell/) 
+- [WMI](https://msdn.microsoft.com/en-us/library/jj152383(v=vs.85).aspx)
+- [WinRM](https://msdn.microsoft.com/en-us/library/aa384426(v=vs.85).aspx)
+- [Software Inventory Logging](https://technet.microsoft.com/en-us/library/dn383584(v=ws.11).aspx)
+

--- a/wmf/5.1/release-notes.md
+++ b/wmf/5.1/release-notes.md
@@ -8,7 +8,7 @@ title:  WMF 5.1 Release Notes
 
 # Windows Management Framework (WMF) 5.1 Release Notes #
 
-WMF 5.1 includes the PowerShell, WMI, WinRM, and Software Inventory and Licensing (SIL) components that were released with Windows Server 2016.
+WMF 5.1 includes the PowerShell, WMI, WinRM, and Software Inventory Logging (SIL) components that were released with Windows Server 2016.
 WMF 5.1 can be installed on Windows 7, Windows 8.1, Windows Server 2008 R2, 2012, and 2012 R2, and provides a number of improvements over WMF 5.0 RTM including:
 
 - New cmdlets: local users and groups; Get-ComputerInfo


### PR DESCRIPTION
Complying with doc team requirements to have an Index.MD file in the doc set. 
Took content from release-notes, added links to WMF topics and pointers to primary content for the apps included in WMF.
Also, fixed SIL to be Software Inventory Logging (which is the correct name). 