### PR TITLE
Fix reference build post-Docs

### DIFF
--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -14,7 +14,7 @@ $ReferenceDocset = Join-Path $PSScriptRoot 'reference'
 $allErrors = @()
 
 # Go through all the directories in the reference folder
-Get-ChildItem $ReferenceDocset -Directory -Exclude 'scripting' | ForEach-Object -Process {
+Get-ChildItem $ReferenceDocset -Directory -Exclude 'docs-conceptual','mapping' | ForEach-Object -Process {
     $Version = $_.Name
     $VersionFolder = $_.FullName
     # For each of the directories, go through each module folder


### PR DESCRIPTION
@adityapatwardhan it turns out that the `scripting` folder got renamed when it was placed into `reference`. @sankethka and company also added an additional `mapping` folder, so I added that to the `-Exclude`. 

If it looks good to you, @adityapatwardhan, feel free to merge. 