### PR TITLE
Update .openpublishing.redirection.json

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -11052,532 +11052,532 @@
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Aliases.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Aliases.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Aliases?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Arithmetic_Operators.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Arithmetic_Operators.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Arithmetic_Operators?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Arrays.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Arrays.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Arrays?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Assignment_Operators.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Assignment_Operators.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Assignment_Operators?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Automatic_Variables.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Automatic_Variables.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Automatic_Variables?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Break.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Break.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Break?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Classes.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Classes.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Classes?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Command_Precedence.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Command_Precedence.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Command_Precedence?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Command_Syntax.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Command_Syntax.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Command_Syntax?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Comment_Based_Help.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Comment_Based_Help.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Comment_Based_Help?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_CommonParameters.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_CommonParameters.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_CommonParameters?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Comparison_Operators.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Comparison_Operators.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Comparison_Operators?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Continue.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Continue.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Continue?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Core_Commands.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Core_Commands.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Core_Commands?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Data_Sections.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Data_Sections.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Data_Sections?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Debuggers.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Debuggers.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Debuggers?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Do.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Do.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Do?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Enum.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Enum.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Enum?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Environment_Variables.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Environment_Variables.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Environment_Variables?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Escape_Characters.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Escape_Characters.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Escape_Characters?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Eventlogs.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Eventlogs.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Eventlogs?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Execution_Policies.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Execution_Policies.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Execution_Policies?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_For.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_For.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_For?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Foreach.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Foreach.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Foreach?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Format.ps1xml.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Format.ps1xml.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Format.ps1xml?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Functions.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Functions.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Functions?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Functions_Advanced.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Functions_Advanced.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Functions_Advanced?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Functions_Advanced_Methods.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Functions_Advanced_Methods.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Functions_Advanced_Methods?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Functions_Advanced_Parameters.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Functions_Advanced_Parameters.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Functions_Advanced_Parameters?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Functions_CmdletBindingAttribute.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Functions_CmdletBindingAttribute.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Functions_CmdletBindingAttribute?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Functions_OutputTypeAttribute.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Functions_OutputTypeAttribute.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Functions_OutputTypeAttribute?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Group_Policy_Settings.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Group_Policy_Settings.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Group_Policy_Settings?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Hash_Tables.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Hash_Tables.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Hash_Tables?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_History.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_History.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_History?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_If.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_If.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_If?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Jobs.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Jobs.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Jobs?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Job_Details.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Job_Details.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Job_Details?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Join.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Join.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Join?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Language_Keywords.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Language_Keywords.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Language_Keywords?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Language_Modes.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Language_Modes.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Language_Modes?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Line_Editing.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Line_Editing.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Line_Editing?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Methods.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Methods.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Methods?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Modules.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Modules.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Modules?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Objects.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Objects.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Objects?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Object_Creation.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Object_Creation.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Object_Creation?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Operators.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Operators.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Operators?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Operator_Precedence.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Operator_Precedence.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Operator_Precedence?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_PackageManagement.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_PackageManagement.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_PackageManagement?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Parameters.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Parameters.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Parameters?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Parameters_Default_Values.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Parameters_Default_Values.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Parameters_Default_Values?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Parsing.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Parsing.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Parsing?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Path_Syntax.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Path_Syntax.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Path_Syntax?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_pipelines.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_pipelines.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_pipelines?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_PowerShell_exe.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_PowerShell_exe.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_PowerShell_exe?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_PowerShell_Ise_exe.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_PowerShell_Ise_exe.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_PowerShell_Ise_exe?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Preference_Variables.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Preference_Variables.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Preference_Variables?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Profiles.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Profiles.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Profiles?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Prompts.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Prompts.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Prompts?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Properties.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Properties.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Properties?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Providers.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Providers.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Providers?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_PSSessions.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_PSSessions.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_PSSessions?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_PSSession_Details.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_PSSession_Details.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_PSSession_Details?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_PSSnapins.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_PSSnapins.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_PSSnapins?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Quoting_Rules.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Quoting_Rules.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Quoting_Rules?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Redirection.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Redirection.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Redirection?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Ref.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Ref.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Ref?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Regular_Expressions.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Regular_Expressions.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Regular_Expressions?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Remote.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Remote.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Remote?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Remote_Disconnected_Sessions.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Remote_Disconnected_Sessions.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Remote_Disconnected_Sessions?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Remote_FAQ.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Remote_FAQ.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Remote_FAQ?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Remote_Jobs.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Remote_Jobs.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Remote_Jobs?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Remote_Output.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Remote_Output.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Remote_Output?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Remote_Requirements.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Remote_Requirements.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Remote_Requirements?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Remote_Troubleshooting.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Remote_Troubleshooting.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Remote_Troubleshooting?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Remote_Variables.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Remote_Variables.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Remote_Variables?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Requires.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Requires.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Requires?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Reserved_Words.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Reserved_Words.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Reserved_Words?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Return.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Return.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Return?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Run_With_PowerShell.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Run_With_PowerShell.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Run_With_PowerShell?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Scopes.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Scopes.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Scopes?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Scripts.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Scripts.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Scripts?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Script_Blocks.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Script_Blocks.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Script_Blocks?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Script_Internationalization.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Script_Internationalization.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Script_Internationalization?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Session_Configurations.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Session_Configurations.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Session_Configurations?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Session_Configuration_Files.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Session_Configuration_Files.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Session_Configuration_Files?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Signing.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Signing.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Signing?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Special_Characters.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Special_Characters.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Special_Characters?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Splatting.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Splatting.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Splatting?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Split.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Split.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Split?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Switch.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Switch.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Switch?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Throw.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Throw.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Throw?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Transactions.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Transactions.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Transactions?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Trap.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Trap.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Trap?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Try_Catch_Finally.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Try_Catch_Finally.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Try_Catch_Finally?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Types.ps1xml.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Types.ps1xml.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Types.ps1xml?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Type_Operators.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Type_Operators.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Type_Operators?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Updatable_Help.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Updatable_Help.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Updatable_Help?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Variables.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Variables.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Variables?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_While.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_While.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_While?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Wildcards.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Wildcards.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Wildcards?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Windows_PowerShell_ISE.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Windows_PowerShell_ISE.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Windows_PowerShell_ISE?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_Windows_RT.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_Windows_RT.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_Windows_RT?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_WMI.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_WMI.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_WMI?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_WMI_Cmdlets.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_WMI_Cmdlets.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_WMI_Cmdlets?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_WQL.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_WQL.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_WQL?view=powershell-6",
     "redirect_document_id": "False"
    },
    {
-     "source_path": "reference/virtual-directory-module/6/microsoft.powershell.core/about/about_WS-Management_Cmdlets.md",
+     "source_path": "reference/virtual-directory-module/6/about/about_WS-Management_Cmdlets.md",
      "redirect_url": "/powershell/module/microsoft.powershell.core/about_WS-Management_Cmdlets?view=powershell-6",
     "redirect_document_id": "False"
    },


### PR DESCRIPTION
Deleting module name from V6 redirections for about topics

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
