### PR TITLE
Fix link for OutputAssemblyType Enumeration

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Add-Type.md
@@ -461,7 +461,7 @@ Accept wildcard characters: False
 ### -OutputType
 Specifies the output type of the output assembly.
 Valid values are **Library**, **ConsoleApplication**, and **WindowsApplication**.
-For more information about the values, see "OutputAssemblyType Enumeration" in MSDN.
+For more information about the values, see [OutputAssemblyType Enumeration](https://msdn.microsoft.com/library/microsoft.powershell.commands.outputassemblytype) in the MSDN library.
 
 By default, no output type is specified.
 

--- a/reference/4.0/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Add-Type.md
@@ -457,7 +457,7 @@ Accept wildcard characters: False
 ### -OutputType
 Specifies the output type of the output assembly.
 Valid values are **Library**, **ConsoleApplication**, and **WindowsApplication**.
-For more information about the values, see "OutputAssemblyType Enumeration" in MSDN.
+For more information about the values, see [OutputAssemblyType Enumeration](https://msdn.microsoft.com/library/microsoft.powershell.commands.outputassemblytype) in the MSDN library.
 
 By default, no output type is specified.
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Add-Type.md
@@ -465,7 +465,7 @@ The acceptable values for this parameter are:
 - ConsoleApplication
 - WindowsApplication
 
-For more information about the values, see OutputAssemblyType Enumerationhttps://msdn.microsoft.com/en-us/library/microsoft.powershell.commands.outputassemblytype(v=vs.85).aspx (https://msdn.microsoft.com/en-us/library/microsoft.powershell.commands.outputassemblytype(v=vs.85).aspx)in MSDN.
+For more information about the values, see [OutputAssemblyType Enumeration](https://msdn.microsoft.com/library/microsoft.powershell.commands.outputassemblytype) in the MSDN library.
 
 By default, no output type is specified.
 
@@ -603,7 +603,7 @@ Otherwise, this cmdlet does not generate any output.
 
 ## RELATED LINKS
 
-[OutputAssemblyType Enumeration](https://msdn.microsoft.com/en-us/library/microsoft.powershell.commands.outputassemblytype(v=vs.85).aspx)
+[OutputAssemblyType Enumeration](https://msdn.microsoft.com/library/microsoft.powershell.commands.outputassemblytype)
 
 [Add-Member](Add-Member.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Add-Type.md
@@ -463,7 +463,7 @@ The acceptable values for this parameter are:
 - ConsoleApplication
 - WindowsApplication
 
-For more information about the values, see OutputAssemblyType Enumerationhttps://msdn.microsoft.com/en-us/library/microsoft.powershell.commands.outputassemblytype(v=vs.85).aspx in MSDN.
+For more information about the values, see [OutputAssemblyType Enumeration](https://msdn.microsoft.com/library/microsoft.powershell.commands.outputassemblytype) in the MSDN library.
 
 By default, no output type is specified.
 

--- a/reference/6/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Add-Type.md
@@ -495,7 +495,7 @@ The acceptable values for this parameter are:
 - ConsoleApplication
 - WindowsApplication
 
-For more information about the values, see OutputAssemblyType Enumerationhttps://msdn.microsoft.com/en-us/library/microsoft.powershell.commands.outputassemblytype(v=vs.85).aspx in MSDN.
+For more information about the values, see [OutputAssemblyType Enumeration](https://msdn.microsoft.com/library/microsoft.powershell.commands.outputassemblytype) in the MSDN library.
 
 By default, no output type is specified.
 


### PR DESCRIPTION
Fixed url, formatting and minor differences in wording.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
