### PR TITLE
Mispelled or misused word (used)

### DIFF
--- a/reference/docs-conceptual/setup/PS-remoting-second-hop.md
+++ b/reference/docs-conceptual/setup/PS-remoting-second-hop.md
@@ -41,7 +41,7 @@ For an example of how to enable and use CredSSP for PowerShell remoting, see
 
 ## Kerberos delegation (unconstrained)
 
-You can also used Kerberos unconstrained delegation to make the second hop. However, this method provides no control of where delegated credentials are used.
+You can also use Kerberos unconstrained delegation to make the second hop. However, this method provides no control of where delegated credentials are used.
 
 >**Note:** Active Directory accounts that have the **Account is sensitive and cannot be delegated** property set cannot be delegated. For more information, see 
 >[Security Focus: Analysing 'Account is sensitive and cannot be delegated' for Privileged Accounts](https://blogs.technet.microsoft.com/poshchap/2015/05/01/security-focus-analysing-account-is-sensitive-and-cannot-be-delegated-for-privileged-accounts/)


### PR DESCRIPTION
Should be use instead. Statement under Kerberos says "You can also used Kerberos" and it should use not used.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
