### PR TITLE
Add a missing "workflow" command type

### DIFF
--- a/reference/docs-conceptual/Windows-PowerShell-Glossary.md
+++ b/reference/docs-conceptual/Windows-PowerShell-Glossary.md
@@ -11,7 +11,7 @@ ms.assetid:  b0f88cbe-cb83-4912-a301-184534cb35c7
 |Term|Definition|
 |--------|--------------|
 |binary module|A Windows PowerShell module whose root module is a binary module file (.dll). A binary module may or may not include a module manifest.|
-|common parameter|A parameter that is added to all cmdlets and advanced functions by the Windows PowerShell engine.|
+|common parameter|A parameter that is added to all cmdlets, advanced functions, and workflows by the Windows PowerShell engine.|
 |dot source|In Windows PowerShell, to start a command by typing a dot and a space before the command. Commands that are dot sourced run in the current scope instead of in a new scope. Any variables, aliases, functions, or drives that command creates are created in the current scope and are available to users when the command is completed.|
 |dynamic module|A module that exists only in memory. The New-Module and Import-PSSession cmdlets create dynamic modules.|
 |dynamic parameter|A parameter that is added to a Windows PowerShell cmdlet, function, or script under certain conditions. Cmdlets, functions, providers, and scripts can add dynamic parameters.|


### PR DESCRIPTION
A "workflow" command type also gets common parameters.
"Workflow common parameters" could also be mentioned as a new entry.


