### PR TITLE
Fix link for DateTime Methods and TimeSpan Methods

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Set-Date.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Set-Date.md
@@ -184,11 +184,12 @@ You can pipe a date to Set-Date.
 
 ### System.DateTime
 Set-Date returns an object that represents the date that it set.
+
 ## NOTES
 * Use this cmdlet cautiously. Changing the date and time on the computer. The change might prevent the computer from receiving system-wide events and updates that are triggered by a date or time. Use the -WhatIf and -Confirm parameters to avoid errors.
 
-  You can use standard .NET methods with the DateTime and TimeSpan objects used with Set-Date, such as AddDays, AddMonths and FromFileTime.
-For more information, see "DateTime Methods" and "TimeSpan Methods."
+  You can use standard .NET methods with the DateTime and TimeSpan objects used with Set-Date, such as AddDays, AddMonths and FromFileTime. For more information, see [DateTime Methods](https://msdn.microsoft.com/library/system.datetime_methods) and [TimeSpan Methods](https://msdn.microsoft.com/library/system.timespan_methods) in the MSDN library.
+
 ## RELATED LINKS
 
 [Get-Date](Get-Date.md)

--- a/reference/4.0/Microsoft.PowerShell.Utility/Set-Date.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Set-Date.md
@@ -197,8 +197,7 @@ Set-Date returns an object that represents the date that it set.
 ## NOTES
 * Use this cmdlet cautiously. Changing the date and time on the computer. The change might prevent the computer from receiving system-wide events and updates that are triggered by a date or time. Use the -WhatIf and -Confirm parameters to avoid errors.
 
-  You can use standard .NET methods with the DateTime and TimeSpan objects used with Set-Date, such as AddDays, AddMonths and FromFileTime.
-For more information, see "DateTime Methods" and "TimeSpan Methods."
+  You can use standard .NET methods with the DateTime and TimeSpan objects used with Set-Date, such as AddDays, AddMonths and FromFileTime. For more information, see [DateTime Methods](https://msdn.microsoft.com/library/system.datetime_methods) and [TimeSpan Methods](https://msdn.microsoft.com/library/system.timespan_methods) in the MSDN library.
 
 ## RELATED LINKS
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/Set-Date.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Set-Date.md
@@ -183,7 +183,7 @@ You can pipe a date to **Set-Date**.
 
 ## NOTES
 * Use this cmdlet cautiously when changing the date and time on the computer. The change might prevent the computer from receiving system-wide events and updates that are triggered by a date or time. Use the *WhatIf* and *Confirm* parameters to avoid errors.
-* You can use standard .NET methods with the **DateTime** and **TimeSpan** objects used with **Set-Date**, such as **AddDays**, **AddMonths**, and **FromFileTime**. For more information, see DateTime Methodshttps://msdn.microsoft.com/en-us/library/system.datetime_methods(v=vs.110).aspx and TimeSpan Methodshttps://msdn.microsoft.com/en-us/library/system.timespan_methods(v=vs.110).aspx.
+* You can use standard .NET methods with the **DateTime** and **TimeSpan** objects used with **Set-Date**, such as **AddDays**, **AddMonths**, and **FromFileTime**. For more information, see [DateTime Methods](https://msdn.microsoft.com/library/system.datetime_methods) and [TimeSpan Methods](https://msdn.microsoft.com/library/system.timespan_methods) in the MSDN library.
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Set-Date.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Set-Date.md
@@ -182,7 +182,7 @@ You can pipe a date to **Set-Date**.
 
 ## NOTES
 * Use this cmdlet cautiously when changing the date and time on the computer. The change might prevent the computer from receiving system-wide events and updates that are triggered by a date or time. Use the *WhatIf* and *Confirm* parameters to avoid errors.
-* You can use standard .NET methods with the **DateTime** and **TimeSpan** objects used with **Set-Date**, such as **AddDays**, **AddMonths**, and **FromFileTime**. For more information, see DateTime Methodshttps://msdn.microsoft.com/en-us/library/system.datetime_methods(v=vs.110).aspx and TimeSpan Methodshttps://msdn.microsoft.com/en-us/library/system.timespan_methods(v=vs.110).aspx.
+* You can use standard .NET methods with the **DateTime** and **TimeSpan** objects used with **Set-Date**, such as **AddDays**, **AddMonths**, and **FromFileTime**. For more information, see [DateTime Methods](https://msdn.microsoft.com/library/system.datetime_methods) and [TimeSpan Methods](https://msdn.microsoft.com/library/system.timespan_methods) in the MSDN library.
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Set-Date.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Set-Date.md
@@ -211,7 +211,7 @@ You can pipe a date to **Set-Date**.
 
 ## NOTES
 * Use this cmdlet cautiously when changing the date and time on the computer. The change might prevent the computer from receiving system-wide events and updates that are triggered by a date or time. Use the *WhatIf* and *Confirm* parameters to avoid errors.
-* You can use standard .NET methods with the **DateTime** and **TimeSpan** objects used with **Set-Date**, such as **AddDays**, **AddMonths**, and **FromFileTime**. For more information, see DateTime Methodshttps://msdn.microsoft.com/en-us/library/system.datetime_methods(v=vs.110).aspx and TimeSpan Methodshttps://msdn.microsoft.com/en-us/library/system.timespan_methods(v=vs.110).aspx.
+* You can use standard .NET methods with the **DateTime** and **TimeSpan** objects used with **Set-Date**, such as **AddDays**, **AddMonths**, and **FromFileTime**. For more information, see [DateTime Methods](https://msdn.microsoft.com/library/system.datetime_methods) and [TimeSpan Methods](https://msdn.microsoft.com/library/system.timespan_methods) in the MSDN library.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
Fixed url, formatting, and minor differences in wording.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
