### PR TITLE
Document new Encoding property on  BasicHtmlWebResponseObject and HtmlWebResponseObject

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -117,6 +117,21 @@ This command gets the links in a web page.
 It uses the **Invoke-WebRequest** cmdlet to get the web page content.
 Then it users the **Links** property of the **HtmlWebResponseObject** that **Invoke-WebRequest** returns, and the Href property of each link.
 
+### Example 4: Writes the response content to a file using the encoding defined in the requested page.
+```
+PS C:\> $response = Invoke-WebRequest -Uri "http://msdn.microsoft.com/en-us/library/aa973757(v=vs.85).aspx"
+PS C:\> $stream = [System.IO.StreamWriter]::new('.\msdnpage.html', $false, $response.Encoding)
+PS C:\> try {$stream.Write($response.Content)} finally {$stream.Dispose()}
+```
+
+This command uses the **Invoke-WebRequest** cmdlet to retrieve an msdn page.
+
+The first command retrieves the page and saves the response object in a variable.
+
+The second command creates a StreamWriter to use to write the response content to a file. The Encoding property of the response object is used to set the encoding for the file.
+
+The final command writes the Content property to the file then disposes the StreamWriter.
+
 ## PARAMETERS
 
 ### -Body

--- a/reference/6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -124,13 +124,15 @@ PS C:\> $stream = [System.IO.StreamWriter]::new('.\msdnpage.html', $false, $resp
 PS C:\> try {$stream.Write($response.Content)} finally {$stream.Dispose()}
 ```
 
-This command uses the **Invoke-WebRequest** cmdlet to retrieve an msdn page.
+This command uses the **Invoke-WebRequest** cmdlet to retrieve the web page content of an msdn page.
 
 The first command retrieves the page and saves the response object in a variable.
 
 The second command creates a StreamWriter to use to write the response content to a file. The Encoding property of the response object is used to set the encoding for the file.
 
 The final command writes the Content property to the file then disposes the StreamWriter.
+
+Note that the Encoding property will be null if the web request does not return text content.
 
 ## PARAMETERS
 


### PR DESCRIPTION
Document new Encoding property on  BasicHtmlWebResponseObject and HtmlWebResponseObject response objects returned by Invoke-WebRequest

See issue https://github.com/PowerShell/PowerShell/issues/3267 and PR https://github.com/PowerShell/PowerShell/pull/4338

Version(s) of document impacted
------------------------------
- [X ] Impacts 6 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (6) of PowerShell

