### PR TITLE
Fix the Example 4 of Get-PSDrive

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -91,14 +91,18 @@ Z          FileSystem    C:\Windows\System32
 
 This command gets all of the drives that are supported by the Windows PowerShell FileSystem provider.
 This includes fixed drives, logical partitions, mapped network drives, and temporary drives that you create by using the New-PSDrive cmdlet.
+
 ### Example 4
-```
-PS C:\> if (!(Get-PSDrive X)) {New-PSDrive -Name X -PSProvider Registry -Root HKLM:\Network}
-else { Write-Host "The X: drive is already in use." }
+```powershell
+if (Get-PSDrive X -ErrorAction SilentlyContinue) {
+	Write-Host 'The X: drive is already in use.'
+} else {
+	New-PSDrive -Name X -PSProvider Registry -Root HKLM:\SOFTWARE
+}
 ```
 
 This command checks to see whether the X drive is already in use as a Windows PowerShell drive name.
-If it is not, the command uses the New-PSDrive cmdlet to create a temporary drive that is mapped to the HKLM:\Network registry key.
+If it is not, the command uses the `New-PSDrive` cmdlet to create a temporary drive that is mapped to the HKLM:\SOFTWARE registry key.
 
 ### Example 5
 ```

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -96,13 +96,16 @@ This command gets all of the drives that are supported by the Windows PowerShell
 This includes fixed drives, logical partitions, mapped network drives, and temporary drives that you create by using the New-PSDrive cmdlet.
 
 ### Example 4
-```
-PS C:\> if (!(Get-PSDrive X)) {New-PSDrive -Name X -PSProvider Registry -Root HKLM:\Network}
-else { Write-Host "The X: drive is already in use." }
+```powershell
+if (Get-PSDrive X -ErrorAction SilentlyContinue) {
+	Write-Host 'The X: drive is already in use.'
+} else {
+	New-PSDrive -Name X -PSProvider Registry -Root HKLM:\SOFTWARE
+}
 ```
 
 This command checks to see whether the X drive is already in use as a Windows PowerShell drive name.
-If it is not, the command uses the New-PSDrive cmdlet to create a temporary drive that is mapped to the HKLM:\Network registry key.
+If it is not, the command uses the `New-PSDrive` cmdlet to create a temporary drive that is mapped to the HKLM:\SOFTWARE registry key.
 
 ### Example 5
 ```

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -84,12 +84,16 @@ This command gets all of the drives that are supported by the Windows PowerShell
 This includes fixed drives, logical partitions, mapped network drives, and temporary drives that you create by using the New-PSDrive cmdlet.
 
 ### Example 4: Check to see if a drive is in use as a Windows PowerShell drive name
-```
-PS C:\> if (!(Get-PSDrive X)) {New-PSDrive -Name X -PSProvider Registry -Root HKLM:\Network}else { Write-Host "The X: drive is already in use." }
+```powershell
+if (Get-PSDrive X -ErrorAction SilentlyContinue) {
+	Write-Host 'The X: drive is already in use.'
+} else {
+	New-PSDrive -Name X -PSProvider Registry -Root HKLM:\SOFTWARE
+}
 ```
 
 This command checks to see whether the X drive is already in use as a Windows PowerShell drive name.
-If it is not, the command uses the New-PSDrive cmdlet to create a temporary drive that is mapped to the HKLM:\Network registry key.
+If it is not, the command uses the `New-PSDrive` cmdlet to create a temporary drive that is mapped to the HKLM:\SOFTWARE registry key.
 
 ### Example 5: Compare the types of files system drives
 ```

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -95,15 +95,16 @@ This command gets all of the drives that are supported by the Windows PowerShell
 This includes fixed drives, logical partitions, mapped network drives, and temporary drives that you create by using the New-PSDrive cmdlet.
 
 ### Example 4: Check to see if a drive is in use as a Windows PowerShell drive name
-```
-PS C:\> if (!(Get-PSDrive X -ErrorAction SilentlyContinue))
-          {New-PSDrive -Name X -PSProvider Registry -Root HKLM:\Network}
-        else 
-          { Write-Host "The X: drive is already in use." }
+```powershell
+if (Get-PSDrive X -ErrorAction SilentlyContinue) {
+	Write-Host 'The X: drive is already in use.'
+} else {
+	New-PSDrive -Name X -PSProvider Registry -Root HKLM:\SOFTWARE
+}
 ```
 
 This command checks to see whether the X drive is already in use as a Windows PowerShell drive name.
-If it is not, the command uses the **New-PSDrive** cmdlet to create a temporary drive that is mapped to the HKLM:\Network registry key.
+If it is not, the command uses the `New-PSDrive` cmdlet to create a temporary drive that is mapped to the HKLM:\SOFTWARE registry key.
 
 ### Example 5: Compare the types of files system drives
 ```

--- a/reference/6/Microsoft.PowerShell.Management/Get-PSDrive.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-PSDrive.md
@@ -94,15 +94,16 @@ This command gets all of the drives that are supported by the Windows PowerShell
 This includes fixed drives, logical partitions, mapped network drives, and temporary drives that you create by using the New-PSDrive cmdlet.
 
 ### Example 4: Check to see if a drive is in use as a Windows PowerShell drive name
-```
-PS C:\> if (!(Get-PSDrive X -ErrorAction SilentlyContinue))
-          {New-PSDrive -Name X -PSProvider Registry -Root HKLM:\Network}
-        else 
-          { Write-Host "The X: drive is already in use." }
+```powershell
+if (Get-PSDrive X -ErrorAction SilentlyContinue) {
+	Write-Host 'The X: drive is already in use.'
+} else {
+	New-PSDrive -Name X -PSProvider Registry -Root HKLM:\SOFTWARE
+}
 ```
 
 This command checks to see whether the X drive is already in use as a Windows PowerShell drive name.
-If it is not, the command uses the **New-PSDrive** cmdlet to create a temporary drive that is mapped to the HKLM:\Network registry key.
+If it is not, the command uses the `New-PSDrive` cmdlet to create a temporary drive that is mapped to the HKLM:\SOFTWARE registry key.
 
 ### Example 5: Compare the types of files system drives
 ```


### PR DESCRIPTION
* Added `-ErrorAction SilentlyContinue` to avoid DriveNotFoundException
* Replaced 'HKLM:\Network' with 'HKLM:\SOFTWARE' to avoid ArgumentException
* Removed `!` for readability
* Removed `PS C:\>`
* Fixed formatting

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
