### PR TITLE
Fix .gitingore for maml and updateablehelp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ obj/
 _site/
 Tools/NuGet/
 _site/
-out_cab/
-out_maml/
+maml/
+updateablehelp/
 
 
 .openpublishing.build.mdproj


### PR DESCRIPTION
The `.gitignore` was still using the old `out_maml` and `out_cab` folders, so `maml` and `updateablehelp` were showing up as untracked files whenever I ran `appveyor.ps1` locally. 