### PR TITLE
fixing incorrect related links format in cmdlets reference

### DIFF
--- a/reference/6/Pester/Context.md
+++ b/reference/6/Pester/Context.md
@@ -95,4 +95,16 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
+[Describe](Describe.md)
 
+[It](It.md)
+
+[BeforeEach](BeforeEach.md)
+
+[AfterEach](AfterEach.md)
+
+[about_Should]()
+
+[about_Mocking]()
+
+[about_TestDrive]()

--- a/reference/6/Pester/Context.md
+++ b/reference/6/Pester/Context.md
@@ -95,11 +95,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[Describe
-It
-BeforeEach
-AfterEach
-about_Should
-about_Mocking
-about_TestDrive]()
 

--- a/reference/6/Pester/Describe.md
+++ b/reference/6/Pester/Describe.md
@@ -121,3 +121,14 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
+[It](It.md)
+
+[Context](Context.md)
+
+[Invoke-Pester](Invoke-Pester.md)
+
+[about_Should]()
+
+[about_Mocking]()
+
+[about_TestDrive]()

--- a/reference/6/Pester/Describe.md
+++ b/reference/6/Pester/Describe.md
@@ -121,10 +121,3 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[It
-Context
-Invoke-Pester
-about_Should
-about_Mocking
-about_TestDrive]()
-

--- a/reference/6/Pester/InModuleScope.md
+++ b/reference/6/Pester/InModuleScope.md
@@ -46,7 +46,7 @@ function PrivateFunction
 
 Export-ModuleMember -Function PublicFunction
 
-# The test script:
+The test script:
 
 Import-Module MyModule
 

--- a/reference/6/Pester/It.md
+++ b/reference/6/Pester/It.md
@@ -202,7 +202,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[Describe
-Context
-about_should]()
 

--- a/reference/6/Pester/It.md
+++ b/reference/6/Pester/It.md
@@ -202,4 +202,8 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
+[Describe](Describe.md)
 
+[Context](Context.md)
+
+[about_Should]()

--- a/reference/6/Pester/Mock.md
+++ b/reference/6/Pester/Mock.md
@@ -272,11 +272,4 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[Assert-MockCalled
-Assert-VerifiableMocks
-Describe
-Context
-It
-about_Should
-about_Mocking]()
 

--- a/reference/6/Pester/Mock.md
+++ b/reference/6/Pester/Mock.md
@@ -272,4 +272,16 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
+[Assert-MockCalled](Assert-MockCalled.md)
 
+[Assert-VerifiableMocks](Assert-VerifiableMocks.md)
+
+[Describe](Describe.md)
+
+[Context](Context.md)
+
+[It](It.md)
+
+[about_Should]()
+
+[about_Mocking]()


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
