### PR TITLE
updating reference docfx for bread crumb

### DIFF
--- a/reference/docfx.json
+++ b/reference/docfx.json
@@ -3,7 +3,7 @@
     "content": [
       {
         "files": [
-          "toc.yml"
+          "bread/toc.yml"
         ],
         "src": "powershell-3.0/docs-conceptual",
         "version":"powershell-3.0",
@@ -223,21 +223,21 @@
     "overwrite": [],
     "externalReference": [],
     "globalMetadata": {
-     "breadcrumb_path": "/powershell/bread/toc.json",
+      "breadcrumb_path": "/powershell/bread/toc.json",
       "showPowerShellPicker": "true",
-     "apiPlatform": "powershell",
+      "apiPlatform": "powershell",
       "ms.devlang": "powershell",
-       "ROBOTS": "INDEX, FOLLOW",
-            "ms.prod": "powershell",
-            "ms.technology": "powershell",
-            "ms.topic": "reference",
-            "manager": "carmonm",
-            "ms.tgt_pltfr": "windows, macos, linux",
-            "author": "juanpablojofre",
-            "ms.author": "jpjofre"
+      "ROBOTS": "INDEX, FOLLOW",
+      "ms.prod": "powershell",
+      "ms.technology": "powershell",
+      "ms.topic": "reference",
+      "manager": "carmonm",
+      "ms.tgt_pltfr": "windows, macos, linux",
+      "author": "juanpablojofre",
+      "ms.author": "jpjofre"
     },
     "fileMetadata": {},
     "template": [],
-    "dest": "Powershell/reference"
+    "dest": "pscore-reference"
   }
 }


### PR DESCRIPTION
<!--
Tweak needed to make bread crumb work for reference and scripting on docs
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
