### PR TITLE
Joining configuration code blocks

### DIFF
--- a/dsc/pullServer.md
+++ b/dsc/pullServer.md
@@ -45,8 +45,7 @@ The easiest way to set up a web pull server is to use the xWebService resource, 
                 [ValidateNotNullOrEmpty()]
                 [string] $RegistrationKey 
          ) 
-
-
+         
          Import-DSCResource -ModuleName xPSDesiredStateConfiguration
          Import-DSCResource –ModuleName PSDesiredStateConfiguration
 


### PR DESCRIPTION
After indenting the code blocks to have the numbering continue on the production site (https://docs.microsoft.com/en-us/powershell/dsc/pullserver) the code block got broken into two pieces.  It looks fine on github but not the production site.  I added spaces to align the empty line with the indentation of the surrounding code block to join them together.