### PR TITLE
Fix link for ErrorCategory Enumeration

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Write-Error.md
@@ -86,7 +86,7 @@ The value of the Exception parameter is the Exception object in the $e variable.
 Specifies the category of the error.
 The default value is **NotSpecified**.
 
-For information about the error categories, see "ErrorCategory Enumeration" in the MSDN (Microsoft Developer Network) library at http://go.microsoft.com/fwlink/?LinkId=143600.
+For information about the error categories, see [ErrorCategory Enumeration](http://go.microsoft.com/fwlink/?LinkId=143600) in the MSDN library.
 
 ```yaml
 Type: ErrorCategory

--- a/reference/4.0/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Write-Error.md
@@ -93,7 +93,7 @@ The value of the Exception parameter is the Exception object in the $e variable.
 Specifies the category of the error.
 The default value is **NotSpecified**.
 
-For information about the error categories, see "ErrorCategory Enumeration" in the MSDN (Microsoft Developer Network) library at http://go.microsoft.com/fwlink/?LinkId=143600.
+For information about the error categories, see [ErrorCategory Enumeration](http://go.microsoft.com/fwlink/?LinkId=143600) in the MSDN library.
 
 ```yaml
 Type: ErrorCategory

--- a/reference/5.0/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Write-Error.md
@@ -127,7 +127,7 @@ The acceptable values for this parameter are:
 - QuotaExceeded
 - NotEnabled
 
-For information about the error categories, see ErrorCategory Enumerationhttp://go.microsoft.com/fwlink/?LinkId=143600 (http://go.microsoft.com/fwlink/?LinkId=143600) in MSDN.
+For information about the error categories, see [ErrorCategory Enumeration](http://go.microsoft.com/fwlink/?LinkId=143600) in the MSDN library.
 
 ```yaml
 Type: ErrorCategory

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Error.md
@@ -127,7 +127,7 @@ The acceptable values for this parameter are:
 - QuotaExceeded
 - NotEnabled
 
-For information about the error categories, see ErrorCategory Enumerationhttp://go.microsoft.com/fwlink/?LinkId=143600 (http://go.microsoft.com/fwlink/?LinkId=143600) in MSDN.
+For information about the error categories, see [ErrorCategory Enumeration](http://go.microsoft.com/fwlink/?LinkId=143600) in the MSDN library.
 
 ```yaml
 Type: ErrorCategory

--- a/reference/6/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Write-Error.md
@@ -19,23 +19,23 @@ Writes an object to the error stream.
 ```
 Write-Error [-Message] <String> [-Category <ErrorCategory>] [-ErrorId <String>] [-TargetObject <Object>]
  [-RecommendedAction <String>] [-CategoryActivity <String>] [-CategoryReason <String>]
- [-CategoryTargetName <String>] [-CategoryTargetType <String>] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [<CommonParameters>]
+ [-CategoryTargetName <String>] [-CategoryTargetType <String>]
+ [<CommonParameters>]
 ```
 
 ### WithException
 ```
 Write-Error -Exception <Exception> [[-Message] <String>] [-Category <ErrorCategory>] [-ErrorId <String>]
  [-TargetObject <Object>] [-RecommendedAction <String>] [-CategoryActivity <String>] [-CategoryReason <String>]
- [-CategoryTargetName <String>] [-CategoryTargetType <String>] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [<CommonParameters>]
+ [-CategoryTargetName <String>] [-CategoryTargetType <String>]
+ [<CommonParameters>]
 ```
 
 ### ErrorRecord
 ```
 Write-Error -ErrorRecord <ErrorRecord> [-RecommendedAction <String>] [-CategoryActivity <String>]
  [-CategoryReason <String>] [-CategoryTargetName <String>] [-CategoryTargetType <String>]
- [-InformationAction <ActionPreference>] [-InformationVariable <String>] [<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -130,7 +130,7 @@ The acceptable values for this parameter are:
 - QuotaExceeded
 - NotEnabled
 
-For information about the error categories, see ErrorCategory Enumerationhttp://go.microsoft.com/fwlink/?LinkId=143600 (http://go.microsoft.com/fwlink/?LinkId=143600) in MSDN.
+For information about the error categories, see [ErrorCategory Enumeration](http://go.microsoft.com/fwlink/?LinkId=143600) in the MSDN library.
 
 ```yaml
 Type: ErrorCategory
@@ -251,33 +251,6 @@ Parameter Sets: WithException
 Aliases: 
 
 Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationAction
-For information about the error categories, see "ErrorCategory Enumeration" in the MSDN (Microsoft Developer Network) library at http://go.microsoft.com/fwlink/?LinkId=143600.```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
-For information about the error categories, see "ErrorCategory Enumeration" in the MSDN (Microsoft Developer Network) library at http://go.microsoft.com/fwlink/?LinkId=143600.```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
-
-Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
* Fixed url, formatting, and minor differences in wording
* Removed meaningless InformationAction/InformationVariable containing the link

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document
