### PR TITLE
Fix link for ModuleSpecification Constructor

### DIFF
--- a/reference/4.0/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Get-Module.md
@@ -428,7 +428,7 @@ Accept wildcard characters: False
 ```
 
 ### -FullyQualifiedName
-Gets modules with names that are specified in the form of ModuleSpecification objects (described by the Remarks section of ModuleSpecification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx on MSDN).
+Gets modules with names that are specified in the form of ModuleSpecification objects (described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library).
 For example, the FullyQualifiedName parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-Command.md
@@ -300,7 +300,7 @@ Accept wildcard characters: False
 ```
 
 ### -FullyQualifiedModule
-Specifies modules with names that are specified in the form of ModuleSpecification objects, described by the Remarks section of Module Specification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx on the Microsoft Developer Network (MSDN).
+Specifies modules with names that are specified in the form of ModuleSpecification objects, described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library.
 For example, the FullyQualifiedModule parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-Module.md
@@ -374,7 +374,7 @@ Accept wildcard characters: False
 
 ### -FullyQualifiedName
 Specifies names of modules in the form of **ModuleSpecification** objects.
-These objects are described in the Remarks section of ModuleSpecification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx (http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx) in the Microsoft Developer Network (MSDN) library.
+These objects are described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library.
 For example, the *FullyQualifiedName* parameter accepts a module name that is specified in the following formats: 
 
 @{ModuleName = "modulename"; ModuleVersion = "version_number"}

--- a/reference/5.0/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Save-Help.md
@@ -221,7 +221,7 @@ Accept wildcard characters: False
 
 ### -FullyQualifiedModule
 Specifies modules with names that are specified in the form of ModuleSpecification objects.
-This is described in the Remarks section of Module Specification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx (http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx) on the Microsoft Developer Network (MSDN).
+This is described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library.
 For example, the *FullyQualifiedModule* parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/5.0/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Update-Help.md
@@ -274,7 +274,7 @@ Accept wildcard characters: False
 
 ### -FullyQualifiedModule
 Specifies modules with names that are specified in the form of **ModuleSpecification** objects.
-These are described in the Remarks section of Module Specification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx (http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx) in the Microsoft Developer Network (MSDN).
+These are described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library.
 For example, the FullyQualifiedModule parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -319,7 +319,7 @@ Accept wildcard characters: False
 ```
 
 ### -FullyQualifiedModule
-Specifies modules with names that are specified in the form of **ModuleSpecification** objects (described by the Remarks section of ModuleSpecification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx on MSDN).
+Specifies modules with names that are specified in the form of **ModuleSpecification** objects (described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library).
 For example, the FullyQualifiedModule parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/Import-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Import-PSSession.md
@@ -417,7 +417,7 @@ Accept wildcard characters: False
 ```
 
 ### -FullyQualifiedModule
-Specifies modules with names that are specified in the form of **ModuleSpecification** objects (described by the Remarks section of Module Specification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx on MSDN).
+Specifies modules with names that are specified in the form of **ModuleSpecification** objects (described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library).
 For example, the *FullyQualifiedModule* parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-Command.md
@@ -300,7 +300,7 @@ Accept wildcard characters: False
 ```
 
 ### -FullyQualifiedModule
-Specifies modules with names that are specified in the form of ModuleSpecification objects, described by the Remarks section of Module Specification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx on the Microsoft Developer Network (MSDN).
+Specifies modules with names that are specified in the form of ModuleSpecification objects, described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library.
 For example, the FullyQualifiedModule parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-Module.md
@@ -374,7 +374,7 @@ Accept wildcard characters: False
 
 ### -FullyQualifiedName
 Specifies names of modules in the form of **ModuleSpecification** objects.
-These objects are described in the Remarks section of ModuleSpecification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx (http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx) in the Microsoft Developer Network (MSDN) library.
+These objects are described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library.
 For example, the *FullyQualifiedName* parameter accepts a module name that is specified in the following formats: 
 
 @{ModuleName = "modulename"; ModuleVersion = "version_number"}

--- a/reference/5.1/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Save-Help.md
@@ -221,7 +221,7 @@ Accept wildcard characters: False
 
 ### -FullyQualifiedModule
 Specifies modules with names that are specified in the form of ModuleSpecification objects.
-This is described in the Remarks section of Module Specification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx (http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx) on the Microsoft Developer Network (MSDN).
+This is described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library.
 For example, the *FullyQualifiedModule* parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Update-Help.md
@@ -274,7 +274,7 @@ Accept wildcard characters: False
 
 ### -FullyQualifiedModule
 Specifies modules with names that are specified in the form of **ModuleSpecification** objects.
-These are described in the Remarks section of Module Specification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx (http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx) in the Microsoft Developer Network (MSDN).
+These are described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library.
 For example, the FullyQualifiedModule parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -319,7 +319,7 @@ Accept wildcard characters: False
 ```
 
 ### -FullyQualifiedModule
-Specifies modules with names that are specified in the form of **ModuleSpecification** objects (described by the Remarks section of ModuleSpecification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx on MSDN).
+Specifies modules with names that are specified in the form of **ModuleSpecification** objects (described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library).
 For example, the FullyQualifiedModule parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Import-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Import-PSSession.md
@@ -417,7 +417,7 @@ Accept wildcard characters: False
 ```
 
 ### -FullyQualifiedModule
-Specifies modules with names that are specified in the form of **ModuleSpecification** objects (described by the Remarks section of Module Specification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx on MSDN).
+Specifies modules with names that are specified in the form of **ModuleSpecification** objects (described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library).
 For example, the *FullyQualifiedModule* parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/6/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Command.md
@@ -300,7 +300,7 @@ Accept wildcard characters: False
 ```
 
 ### -FullyQualifiedModule
-Specifies modules with names that are specified in the form of ModuleSpecification objects, described by the Remarks section of Module Specification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx on the Microsoft Developer Network (MSDN).
+Specifies modules with names that are specified in the form of ModuleSpecification objects, described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library.
 For example, the FullyQualifiedModule parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/6/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Module.md
@@ -374,7 +374,7 @@ Accept wildcard characters: False
 
 ### -FullyQualifiedName
 Specifies names of modules in the form of **ModuleSpecification** objects.
-These objects are described in the Remarks section of ModuleSpecification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx (http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx) in the Microsoft Developer Network (MSDN) library.
+These objects are described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library.
 For example, the *FullyQualifiedName* parameter accepts a module name that is specified in the following formats: 
 
 @{ModuleName = "modulename"; ModuleVersion = "version_number"}

--- a/reference/6/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/6/Microsoft.PowerShell.Core/Save-Help.md
@@ -221,7 +221,7 @@ Accept wildcard characters: False
 
 ### -FullyQualifiedModule
 Specifies modules with names that are specified in the form of ModuleSpecification objects.
-This is described in the Remarks section of Module Specification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx (http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx) on the Microsoft Developer Network (MSDN).
+This is described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library.
 For example, the *FullyQualifiedModule* parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/6/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/6/Microsoft.PowerShell.Core/Update-Help.md
@@ -272,7 +272,7 @@ Accept wildcard characters: False
 
 ### -FullyQualifiedModule
 Specifies modules with names that are specified in the form of **ModuleSpecification** objects.
-These are described in the Remarks section of Module Specification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx (http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx) in the Microsoft Developer Network (MSDN).
+These are described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library.
 For example, the FullyQualifiedModule parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/6/Microsoft.PowerShell.Utility/Export-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-PSSession.md
@@ -301,7 +301,7 @@ Accept wildcard characters: False
 ```
 
 ### -FullyQualifiedModule
-Specifies modules with names that are specified in the form of **ModuleSpecification** objects (described by the Remarks section of ModuleSpecification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx on MSDN).
+Specifies modules with names that are specified in the form of **ModuleSpecification** objects (described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library).
 For example, the FullyQualifiedModule parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/reference/6/Microsoft.PowerShell.Utility/Import-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Import-PSSession.md
@@ -398,7 +398,7 @@ Accept wildcard characters: False
 ```
 
 ### -FullyQualifiedModule
-Specifies modules with names that are specified in the form of **ModuleSpecification** objects (described by the Remarks section of Module Specification Constructor (Hashtable)http://msdn.microsoft.com/library/windows/desktop/jj136290(v=vs.85).aspx on MSDN).
+Specifies modules with names that are specified in the form of **ModuleSpecification** objects (described in the Remarks section of [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290) in the MSDN library).
 For example, the *FullyQualifiedModule* parameter accepts a module name that is specified in the format @{ModuleName = "modulename"; ModuleVersion = "version_number"} or @{ModuleName = "modulename"; ModuleVersion = "version_number"; Guid = "GUID"}.
 **ModuleName** and **ModuleVersion** are required, but **Guid** is optional.
 

--- a/wmf/5.1/scenarios-features.md
+++ b/wmf/5.1/scenarios-features.md
@@ -113,7 +113,7 @@ Previously, you had no way to specify a particular module version; if there were
 
 In WMF 5.1:
 
-* You can use `ModuleSpecification` [hash table](https://msdn.microsoft.com/en-us/library/jj136290(v=vs.85).aspx). 
+* You can use [ModuleSpecification Constructor (Hashtable)](https://msdn.microsoft.com/library/jj136290). 
 This hash table has the same format as `Get-Module -FullyQualifiedName`.
 
 **Example:** `using module @{ModuleName = 'PSReadLine'; RequiredVersion = '1.1'}`


### PR DESCRIPTION
Fixed url, formatting, and minor differences in wording.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
