### PR TITLE
Fixing minor typo on "Viewing Object Structure (Get-Member) "

### DIFF
--- a/reference/docs-conceptual/getting-started/cookbooks/Viewing-Object-Structure--Get-Member-.md
+++ b/reference/docs-conceptual/getting-started/cookbooks/Viewing-Object-Structure--Get-Member-.md
@@ -61,7 +61,7 @@ Path                       ScriptProperty System.Object Path {get=$this.Main...
 There are over 60 properties for a process. The reason Windows PowerShell often shows only a handful of properties for any well-known object is that showing all of them would produce an unmanageable amount of information.
 
 > [!NOTE]
-> Windows PowerShell determines how to display an object type by using information stored in XML files that have names ending in .format.ps1xml. The formatting data for process objects, which are .NET System.Diagnostics.Process objects, is stored in PowerShellCore.format.ps1xml.
+> Windows PowerShell determines how to display an object type by using information stored in XML files that have names ending in .format.ps1xml. The formatting data for process objects, which are .NET System.Diagnostics.Process objects, is stored in DotNetTypes.format.ps1xml.
 
 If you need to look at properties other than those that Windows PowerShell displays by default, you will need to format the output data yourself. This can be done by using the format cmdlets.
 

--- a/reference/docs-conceptual/getting-started/cookbooks/Viewing-Object-Structure--Get-Member-.md
+++ b/reference/docs-conceptual/getting-started/cookbooks/Viewing-Object-Structure--Get-Member-.md
@@ -33,7 +33,7 @@ add_Disposed                   Method         System.Void add_Disposed(Event...
 ...
 ```
 
-We can make this long list of information more usable by filtering for elements we want to see. The **Get-Member** command lets you list only members that are properties. There are several forms of properties. The cmdlet displays properties of any type if we set the **Get-MemberMemberType** parameter to the value **Properties**. The resulting list is still very long, but a bit more manageable:
+We can make this long list of information more usable by filtering for elements we want to see. The **Get-Member** command lets you list only members that are properties. There are several forms of properties. The cmdlet displays properties of any type if we set the **Get-Member MemberType** parameter to the value **Properties**. The resulting list is still very long, but a bit more manageable:
 
 ```
 PS> Get-Process | Get-Member -MemberType Properties


### PR DESCRIPTION
A missing space betwen the cmdlet name and the paramater name - fixed to reduce confusion.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
