### PR TITLE
Placeholder and rough outline for DSC Roadmap

### DIFF
--- a/dsc/dsc_roadmap.md
+++ b/dsc/dsc_roadmap.md
@@ -1,0 +1,8 @@
+# Desired State Configuration Roadmap
+
+| Release Name | Planned Features | Alpha | Beta | RTM |
+| ---- | -------- | :-------: | :-------:| :-----: |
+| Downloadable package | <ul><li> TBD</li></ul> | TBD | TBD | TBD |
+| On-Prem Pull Server | <ul><li> TBD</li></ul> | TBD | TBD | TBD |
+
+*Note: This table is currently just a placeholder. We will be updating it in the coming months and will keep it up to date as we progress with our plans.* 

--- a/dsc/dsc_roadmap.md
+++ b/dsc/dsc_roadmap.md
@@ -3,6 +3,6 @@
 | Release Name | Planned Features | Alpha | Beta | RTM |
 | ---- | -------- | :-------: | :-------:| :-----: |
 | Downloadable package | <ul><li> TBD</li></ul> | TBD | TBD | TBD |
-| On-Prem Pull Server | <ul><li> TBD</li></ul> | TBD | TBD | TBD |
+| TBD | <ul><li> TBD</li></ul> | TBD | TBD | TBD |
 
 *Note: This table is currently just a placeholder. We will be updating it in the coming months and will keep it up to date as we progress with our plans.* 


### PR DESCRIPTION
This document provides a placeholder for a living roadmap for DSC that we will keep up to date as we flush out our plans for DSC. I discussed this with Eric and Zach. 

We will be linking to this from a blog post that we are putting out today.
