### PR TITLE
Document multipart/form-data support for 6.0 Web Cmdlets

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -140,6 +140,8 @@ or
 Invoke-RestMethod http://website.com/service.aspx -Body $R.Forms[0]
 ```
 
+The *Body* parameter may also accept a `System.Net.Http.MultipartFormDataContent` object. This will facilitate `multipart/form-data` requests. When a `MultipartFormDataContent` object is supplied for *Body*, any Content related headers supplied to the *ContentType*, *Headers*, or *WebSession* parameters will be overridden by the Content headers of the `MultipartFormDataContent` object.
+
 ```yaml
 Type: Object
 Parameter Sets: (All)
@@ -198,6 +200,8 @@ Specifies the content type of the web request.
 If this parameter is omitted and the request method is POST, `Invoke-RestMethod` sets the content type to "application/x-www-form-urlencoded".
 Otherwise, the content type is not specified in the call.
 
+*ContentType* will be overridden when a `MultipartFormDataContent` object is supplied for *Body*.
+
 ```yaml
 Type: String
 Parameter Sets: (All)
@@ -251,6 +255,8 @@ Enter a hash table or dictionary.
 
 To set UserAgent headers, use the `-UserAgent` parameter.
 You cannot use this parameter to specify UserAgent or cookie headers.
+
+Content related headers, such as `Content-Type` will be overridden when a `MultipartFormDataContent` object is supplied for *Body*.
 
 ```yaml
 Type: IDictionary
@@ -725,7 +731,7 @@ Specifies a web request session.
 Enter the variable name, including the dollar sign (`$`).
 
 To override a value in the web request session, use a cmdlet parameter, such as `-UserAgent` or `-Credential`.
-Parameter values take precedence over values in the web request session.
+Parameter values take precedence over values in the web request session. Content related headers, such as `Content-Type`, will be also be overridden when a `MultipartFormDataContent` object is supplied for `-Body`.
 
 Unlike a remote session, the web request session is not a persistent connection.
 It is an object that contains information about the connection and the request, including cookies, credentials, the maximum redirection value, and the user agent string.


### PR DESCRIPTION
closes  #1650

Support for `MultipartFormDataConent` objects submitted to the `-Body` parameter of `Invoke-WebRequest` and `Invoke-RestMethod` was added in PowerShell/PowerShell#4782. This documents the new feature as well as its impact on the `-Headers`, `-ContentType`, and `-WebSession` parameters.

An example was added to `Invoke-WebRequest`, but not `Invoke-RestMethod` because most use-cases for this feature will return HTML and not an objet parsable by `Invoke-RestMethod`.

There were also some minor formatting issues with the `Invoke-WebRequest` document that was resulting in a large portion of the document to be treated as a code block. This appears to only affect the 6.0 version of the document.

Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document


Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version 6.0 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
