### PR TITLE
Fix link for Win32_QuickFixEngineering class

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Management/Get-HotFix.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-HotFix.md
@@ -144,12 +144,12 @@ You cannot pipe input to Get-HotFix.
 
 ### System.Management.ManagementObject#root\CIMV2\Win32_QuickFixEngineering
 Get-Hotfix returns objects that represent the hotfixes on the computer.
+
 ## NOTES
-* This cmdlet uses the Win32_QuickFixEngineering WMI class, which represents small system-wide updates of the operating system. Starting with Windows Vista, this class returns only the updates supplied by Microsoft Windows Installer (MSI), Windows Update, Microsoft Update, or Windows Server Update Services. It does not include updates that are supplied by Component Based Servicing (CBS), or other non-hotfix programs or apps. For more information, see the Win32_QuickFixEngineering class topic in the Microsoft .NET Framework SDK at http://go.microsoft.com/fwlink/?LinkID=145071.
+* This cmdlet uses the Win32_QuickFixEngineering WMI class, which represents small system-wide updates of the operating system. Starting with Windows Vista, this class returns only the updates supplied by Microsoft Windows Installer (MSI), Windows Update, Microsoft Update, or Windows Server Update Services. It does not include updates that are supplied by Component Based Servicing (CBS), or other non-hotfix programs or apps. For more information, see [Win32_QuickFixEngineering class](https://go.microsoft.com/fwlink/?LinkID=145071) in the MSDN library.
 
   The output of this cmdlet might be different on different operating systems.
 
-*
 ## RELATED LINKS
 
 [Get-ComputerRestorePoint](Get-ComputerRestorePoint.md)

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-HotFix.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-HotFix.md
@@ -155,11 +155,9 @@ You cannot pipe input to Get-HotFix.
 Get-Hotfix returns objects that represent the hotfixes on the computer.
 
 ## NOTES
-* This cmdlet uses the Win32_QuickFixEngineering WMI class, which represents small system-wide updates of the operating system. Starting with Windows Vista, this class returns only the updates supplied by Microsoft Windows Installer (MSI), Windows Update, Microsoft Update, or Windows Server Update Services. It does not include updates that are supplied by Component Based Servicing (CBS), or other non-hotfix programs or apps. For more information, see the Win32_QuickFixEngineering class topic in the Microsoft .NET Framework SDK at http://go.microsoft.com/fwlink/?LinkID=145071.
+* This cmdlet uses the Win32_QuickFixEngineering WMI class, which represents small system-wide updates of the operating system. Starting with Windows Vista, this class returns only the updates supplied by Microsoft Windows Installer (MSI), Windows Update, Microsoft Update, or Windows Server Update Services. It does not include updates that are supplied by Component Based Servicing (CBS), or other non-hotfix programs or apps. For more information, see [Win32_QuickFixEngineering class](https://go.microsoft.com/fwlink/?LinkID=145071) in the MSDN library.
 
   The output of this cmdlet might be different on different operating systems.
-
-*
 
 ## RELATED LINKS
 

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-HotFix.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-HotFix.md
@@ -155,15 +155,13 @@ You cannot pipe input to this cmdlet.
 This cmdlet returns objects that represent the hotfixes on the computer.
 
 ## NOTES
-* This cmdlet uses the Win32_QuickFixEngineering WMI class, which represents small system-wide updates of the operating system. Starting with Windows Vista, this class returns only the updates supplied by Microsoft Windows Installer, Windows Update, Microsoft Update, or Windows Server Update Services. It does not include updates that are supplied by Component Based Servicing (CBS), or other non-hotfix programs or apps. For more information, see the Win32_QuickFixEngineeringhttp://go.microsoft.com/fwlink/?LinkID=145071 class topic in the Microsoft .NET Framework SDK at http://go.microsoft.com/fwlink/?LinkID=145071.
+* This cmdlet uses the Win32_QuickFixEngineering WMI class, which represents small system-wide updates of the operating system. Starting with Windows Vista, this class returns only the updates supplied by Microsoft Windows Installer, Windows Update, Microsoft Update, or Windows Server Update Services. It does not include updates that are supplied by Component Based Servicing (CBS), or other non-hotfix programs or apps. For more information, see [Win32_QuickFixEngineering class](https://go.microsoft.com/fwlink/?LinkID=145071) in the MSDN library.
 
   The output of this cmdlet might be different on different operating systems.
 
-*
-
 ## RELATED LINKS
 
-[Win32_QuickFixEngineering](http://go.microsoft.com/fwlink/?LinkID=145071)
+[Win32_QuickFixEngineering class](https://go.microsoft.com/fwlink/?LinkID=145071)
 
 [Get-ComputerRestorePoint](Get-ComputerRestorePoint.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-HotFix.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-HotFix.md
@@ -155,15 +155,13 @@ You cannot pipe input to this cmdlet.
 This cmdlet returns objects that represent the hotfixes on the computer.
 
 ## NOTES
-* This cmdlet uses the Win32_QuickFixEngineering WMI class, which represents small system-wide updates of the operating system. Starting with Windows Vista, this class returns only the updates supplied by Microsoft Windows Installer, Windows Update, Microsoft Update, or Windows Server Update Services. It does not include updates that are supplied by Component Based Servicing (CBS), or other non-hotfix programs or apps. For more information, see the Win32_QuickFixEngineeringhttp://go.microsoft.com/fwlink/?LinkID=145071 class topic in the Microsoft .NET Framework SDK at http://go.microsoft.com/fwlink/?LinkID=145071.
+* This cmdlet uses the Win32_QuickFixEngineering WMI class, which represents small system-wide updates of the operating system. Starting with Windows Vista, this class returns only the updates supplied by Microsoft Windows Installer, Windows Update, Microsoft Update, or Windows Server Update Services. It does not include updates that are supplied by Component Based Servicing (CBS), or other non-hotfix programs or apps. For more information, see [Win32_QuickFixEngineering class](https://go.microsoft.com/fwlink/?LinkID=145071) in the MSDN library.
 
   The output of this cmdlet might be different on different operating systems.
 
-*
-
 ## RELATED LINKS
 
-[Win32_QuickFixEngineering](http://go.microsoft.com/fwlink/?LinkID=145071)
+[Win32_QuickFixEngineering class](https://go.microsoft.com/fwlink/?LinkID=145071)
 
 [Get-ComputerRestorePoint](Get-ComputerRestorePoint.md)
 


### PR DESCRIPTION
Fixed url, formatting, and minor differences in wording.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
