### PR TITLE
Fix example of about_Remote.md (missing '_')

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote.md
@@ -89,10 +89,15 @@ the Server01 remote computer:
 Get-Service -ComputerName Server01
 
 Typically, cmdlets that support remoting without special configuration
-have a ComputerName parameter and do not have a Session parameter. To
-find these cmdlets in your session, type:
+have a **ComputerName** parameter and do not have a **Session** parameter.
+To find these cmdlets in your session, type:
 
-Get-Command | where { $.Parameters.Keys -contains "ComputerName" -and $.Parameters.Keys -NotContains "Session"}
+```powershell
+Get-Command | Where-Object {
+	$_.Parameters.Keys -contains 'ComputerName' -and
+	$_.Parameters.Keys -notcontains 'Session'
+}
+```
 
 # HOW TO RUN A REMOTE COMMAND
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote.md
@@ -89,10 +89,15 @@ the Server01 remote computer:
 Get-Service -ComputerName Server01
 
 Typically, cmdlets that support remoting without special configuration
-have a ComputerName parameter and do not have a Session parameter. To
-find these cmdlets in your session, type:
+have a **ComputerName** parameter and do not have a **Session** parameter.
+To find these cmdlets in your session, type:
 
-Get-Command | where { $.Parameters.Keys -contains "ComputerName" -and $.Parameters.Keys -NotContains "Session"}
+```powershell
+Get-Command | Where-Object {
+	$_.Parameters.Keys -contains 'ComputerName' -and
+	$_.Parameters.Keys -notcontains 'Session'
+}
+```
 
 # HOW TO RUN A REMOTE COMMAND
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote.md
@@ -89,10 +89,15 @@ the Server01 remote computer:
 Get-Service -ComputerName Server01
 
 Typically, cmdlets that support remoting without special configuration
-have a ComputerName parameter and do not have a Session parameter. To
-find these cmdlets in your session, type:
+have a **ComputerName** parameter and do not have a **Session** parameter.
+To find these cmdlets in your session, type:
 
-Get-Command | where { $.Parameters.Keys -contains "ComputerName" -and $.Parameters.Keys -NotContains "Session"}
+```powershell
+Get-Command | Where-Object {
+	$_.Parameters.Keys -contains 'ComputerName' -and
+	$_.Parameters.Keys -notcontains 'Session'
+}
+```
 
 # HOW TO RUN A REMOTE COMMAND
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote.md
@@ -89,10 +89,15 @@ the Server01 remote computer:
 Get-Service -ComputerName Server01
 
 Typically, cmdlets that support remoting without special configuration
-have a ComputerName parameter and do not have a Session parameter. To
-find these cmdlets in your session, type:
+have a **ComputerName** parameter and do not have a **Session** parameter.
+To find these cmdlets in your session, type:
 
-Get-Command | where { $.Parameters.Keys -contains "ComputerName" -and $.Parameters.Keys -NotContains "Session"}
+```powershell
+Get-Command | Where-Object {
+	$_.Parameters.Keys -contains 'ComputerName' -and
+	$_.Parameters.Keys -notcontains 'Session'
+}
+```
 
 # HOW TO RUN A REMOTE COMMAND
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote.md
@@ -89,10 +89,15 @@ the Server01 remote computer:
 Get-Service -ComputerName Server01
 
 Typically, cmdlets that support remoting without special configuration
-have a ComputerName parameter and do not have a Session parameter. To
-find these cmdlets in your session, type:
+have a **ComputerName** parameter and do not have a **Session** parameter.
+To find these cmdlets in your session, type:
 
-Get-Command | where { $.Parameters.Keys -contains "ComputerName" -and $.Parameters.Keys -NotContains "Session"}
+```powershell
+Get-Command | Where-Object {
+	$_.Parameters.Keys -contains 'ComputerName' -and
+	$_.Parameters.Keys -notcontains 'Session'
+}
+```
 
 # HOW TO RUN A REMOTE COMMAND
 


### PR DESCRIPTION
x `$.Parameters.Keys`
o `$_.Parameters.Keys`
```powershell
PS> Get-Command | where { $.Parameters.Keys -contains "ComputerName" -and $.Parameters.Keys -NotContains "Session"}
$.Parameters.Keys : The term '$.Parameters.Keys' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:23
+ Get-Command | where { $.Parameters.Keys -contains "ComputerName" -and ...
+                       ~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: ($.Parameters.Keys:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
