### PR TITLE
Update secureMOF.md

### DIFF
--- a/dsc/secureMOF.md
+++ b/dsc/secureMOF.md
@@ -153,7 +153,7 @@ $cert | Export-Certificate -FilePath "$env:temp\DscPublicKey.cer" -Force
 $cert | Remove-Item -Force
 Import-Certificate -FilePath "$env:temp\DscPublicKey.cer" -CertStoreLocation Cert:\LocalMachine\My
 ```
-Once exported, the ```DscPrivateKey.cer``` would need to be copied to the **Target Node**.
+Once exported, the ```DscPrivateKey.pfx``` would need to be copied to the **Target Node**.
 
 >Target Node: Windows Server 2012 R2/Windows 8.1 and earlier
 


### PR DESCRIPTION
Corrected .cer to .pfx at 'Once exported, the DscPrivateKey.cer would need to be copied to the Target Node'

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
