### PR TITLE
Fix typo in Add-History documentation

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Core/Add-History.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Add-History.md
@@ -41,7 +41,7 @@ The second command is typed at the command line of a different session.
 It uses the **Import-Csv** cmdlet to import the objects in the History.csv file.
 The pipeline operator (|) passes the objects to the **Add-History** cmdlet, which adds the objects representing the commands in the History.csv file to the current session history.
 
-### Example 2: Import and turn commands
+### Example 2: Import and run commands
 ```
 PS C:\> Import-Clixml c:\temp\history.xml | Add-History -PassThru | ForEach-Object -Process {Invoke-History}
 ```

--- a/reference/5.1/Microsoft.PowerShell.Core/Add-History.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Add-History.md
@@ -41,7 +41,7 @@ The second command is typed at the command line of a different session.
 It uses the **Import-Csv** cmdlet to import the objects in the History.csv file.
 The pipeline operator (|) passes the objects to the **Add-History** cmdlet, which adds the objects representing the commands in the History.csv file to the current session history.
 
-### Example 2: Import and turn commands
+### Example 2: Import and run commands
 ```
 PS C:\> Import-Clixml c:\temp\history.xml | Add-History -PassThru | ForEach-Object -Process {Invoke-History}
 ```

--- a/reference/6/Microsoft.PowerShell.Core/Add-History.md
+++ b/reference/6/Microsoft.PowerShell.Core/Add-History.md
@@ -41,7 +41,7 @@ The second command is typed at the command line of a different session.
 It uses the **Import-Csv** cmdlet to import the objects in the History.csv file.
 The pipeline operator (|) passes the objects to the **Add-History** cmdlet, which adds the objects representing the commands in the History.csv file to the current session history.
 
-### Example 2: Import and turn commands
+### Example 2: Import and run commands
 ```
 PS C:\> Import-Clixml c:\temp\history.xml | Add-History -PassThru | ForEach-Object -Process {Invoke-History}
 ```


### PR DESCRIPTION
Fix typo in Add-History documentation

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (5.0, 5.1, 6) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
