### PR TITLE
Fix formatting: about_Regular_Expressions.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -7,140 +7,64 @@ title:  about_Regular_Expressions
 ---
 
 # About Regular Expressions
-## about_Regular_Expressions
 
-
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Describes regular expressions in Windows PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Windows PowerShell supports the following regular expression characters.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-value    Matches exact characters         "book" -match "oo"
-anywhere in the original value.
-
-.        Matches any single character.    "copy" -match "c..y"
-
-[value]  Matches at least one of the      "big" -match "b[iou]g"
-characters in the brackets.
-
-[range]  Matches at least one of the      "and" -match "[a-e]nd"
-characters within the range.
-The use of a hyphen (-) allows
-you to specify an adjacent
-character.
-
-[^]      Matches any characters except    "and" -match "[^brt]nd"
-those in brackets.
-
-^        Matches the beginning            "book" -match "^bo"
-characters.
-
-$        Matches the end characters.      "book" -match "ok$"
-
-Matches any instances            "baggy" -match "g"
-of the preceding character.
-
-?        Matches zero or one instance     "baggy" -match "g?"
-of the preceding character.
-
-\        Matches the character that       "Try$" -match "Try\$"
-follows as an escaped character.
+| Format  | Logic | Example |
+| ------- | ----- | ------- |
+| value   | Matches exact characters anywhere in the original value. | "book" -match "oo" |
+| .       | Matches any single character. | "copy" -match "c..y" |
+| [value] | Matches at least one of the characters in the brackets. | "big" -match "b[iou]g" |
+| [range] | Matches at least one of the characters within the range. The use of a hyphen (-) allows you to specify an adjacent character. | "and" -match "[a-e]nd" |
+| [^]     | Matches any characters except those in brackets. | "and" -match "[^brt]nd" |
+| ^       | Matches the beginning characters. | "book" -match "^bo" |
+| $       | Matches the end characters. | "book" -match "ok$" |
+| *       | Matches any instances of the preceding character. | "baggy" -match "g*" |
+| ?       | Matches zero or one instance of the preceding character. | "baggy" -match "g?" |
+| \       | Matches the character that follows as an escaped character. | "Try$" -match "Try\\$" |
 
 Windows PowerShell supports the character classes available in
 Microsoft .NET Framework regular expressions.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-\p{name} Matches any character in the     "abcd defg" -match "\p{Ll}+"
-named character class specified
-by {name}. Supported names are
-Unicode groups and block
-ranges such as Ll, Nd,
-Z, IsGreek, and IsBoxDrawing.
-
-\P{name} Matches text not included in     1234 -match "\P{Ll}+"
-the groups and block ranges
-specified in {name}.
-
-\w       Matches any word character.      "abcd defg" -match "\w+"
-Equivalent to the Unicode        (this matches abcd)
-character categories [\p{Ll}
-\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}].
-If ECMAScript-compliant behavior
-is specified with the ECMAScript
-option, \w is equivalent to
-[a-zA-Z_0-9].
-
-\W       Matches any nonword character.   "abcd defg" -match "\W+"
-Equivalent to the Unicode        (This matches the space)
-categories [^\p{Ll}\p{Lu}\p{Lt}
-\p{Lo}\p{Nd}\p{Pc}].
-
-\s       Matches any white-space          "abcd defg" -match "\s+"
-character.  Equivalent to the
-Unicode character categories
-[\f\n\r\t\v\x85\p{Z}].
-
-\S       Matches any non-white-space      "abcd defg" -match "\S+"
-character. Equivalent to the
-Unicode character categories
-[^\f\n\r\t\v\x85\p{Z}].
-
-\d       Matches any decimal digit.       12345 -match "\d+"
-Equivalent to \p{Nd} for
-Unicode and [0-9] for non-
-Unicode behavior.
-
-\D       Matches any nondigit.            "abcd" -match "\D+"
-Equivalent  to \P{Nd} for
-Unicode and [^0-9] for non-
-Unicode behavior.
+| Format   | Logic | Example |
+| -------- | ----- | ------- |
+| \p{name} | Matches any character in the named character class specified by {name}. Supported names are Unicode groups and block ranges such as Ll, Nd, Z, IsGreek, and IsBoxDrawing. | "abcd defg" -match "\p{Ll}+" |
+| \P{name} | Matches text not included in the groups and block ranges specified in {name}. | 1234 -match "\P{Ll}+" |
+| \w       | Matches any word character. Equivalent to the Unicode character categories [\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}]. If ECMAScript-compliant behavior is specified with the ECMAScript option, \w is equivalent to [a-zA-Z_0-9]. | "abcd defg" -match "\w+" (this matches abcd) |
+| \W       | Matches any nonword character. Equivalent to the Unicode categories [^\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}]. | "abcd defg" -match "\W+" (this matches the space) |
+| \s       | Matches any white-space character. Equivalent to the Unicode character categories [\f\n\r\t\v\x85\p{Z}]. | "abcd defg" -match "\s+" |
+| \S       | Matches any non-white-space character. Equivalent to the Unicode character categories [^\f\n\r\t\v\x85\p{Z}]. | "abcd defg" -match "\S+" |
+| \d       | Matches any decimal digit. Equivalent to \p{Nd} for Unicode and [0-9] for non-Unicode behavior. | 12345 -match "\d+" |
+| \D       | Matches any nondigit. Equivalent to \P{Nd} for Unicode and [^0-9] for non-Unicode behavior. | "abcd" -match "\D+" |
 
 Windows PowerShell supports the quantifiers available in .NET Framework
 regular expressions. The following are some examples of quantifiers.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-Specifies zero or more matches;  "abc" -match "\w"
-for example, \wor (abc).
-Equivalent to {0,}.
-
-+        Matches repeating instances of   "xyxyxy" -match "xy+"
-the preceding characters.
-
-?        Specifies zero or one matches;   "abc" -match "\w?"
-for example, \w? or (abc)?.
-Equivalent to {0,1}.
-
-{n}      Specifies exactly n matches;     "abc" -match "\w{2}"
-for example, (pizza){2}.
-
-{n,}     Specifies at least n matches;    "abc" -match "\w{2,}"
-for example, (abc){2,}.
-
-{n,m}    Specifies at least n, but no     "abc" -match "\w{2,3}"
-more than m, matches.
+| Format | Logic | Example |
+| ------ | ----- | ------- |
+| *      | Specifies zero or more matches; for example, \wor (abc). Equivalent to {0,}. | "abc" -match "\w*" |
+| +      | Matches repeating instances of the preceding characters. | "xyxyxy" -match "xy+" |
+| ?      | Specifies zero or one matches; for example, \w? or (abc)?. Equivalent to {0,1}. | "abc" -match "\w?" |
+| {n}    | Specifies exactly n matches; for example, (pizza){2}. | "abc" -match "\w{2}" |
+| {n,}   | Specifies at least n matches; for example, (abc){2,}. | "abc" -match "\w{2,}" |
+| {n,m}  | Specifies at least n, but no more than m, matches. | "abc" -match "\w{2,3}" |
 
 All the comparisons shown in the preceding table evaluate to true.
 
-Notice that the escape character for regular expressions, a backslash (),
+Notice that the escape character for regular expressions, a backslash (\\),
 is different from the escape character for Windows PowerShell. The
-escape character for Windows PowerShell is the backtick character (`)
-# (ASCII 96).
+escape character for Windows PowerShell is the backtick character (`) (ASCII 96).
 
+For more information, see [Regular Expression Language - Quick Reference](https://go.microsoft.com/fwlink/?LinkId=133231).
 
-For more information, see the "Regular Expression Language Elements" topic
-in the Microsoft Developer Network (MSDN) library
-at http://go.microsoft.com/fwlink/?LinkId=133231.
-
-# SEE ALSO
+## SEE ALSO
 
 [about_Comparison_Operators](about_Comparison_Operators.md)
 
 [about_Operators](about_Operators.md)
-

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -7,140 +7,64 @@ title:  about_Regular_Expressions
 ---
 
 # About Regular Expressions
-## about_Regular_Expressions
 
-
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Describes regular expressions in Windows PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Windows PowerShell supports the following regular expression characters.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-value    Matches exact characters         "book" -match "oo"
-anywhere in the original value.
-
-.        Matches any single character.    "copy" -match "c..y"
-
-[value]  Matches at least one of the      "big" -match "b[iou]g"
-characters in the brackets.
-
-[range]  Matches at least one of the      "and" -match "[a-e]nd"
-characters within the range.
-The use of a hyphen (-) allows
-you to specify an adjacent
-character.
-
-[^]      Matches any characters except    "and" -match "[^brt]nd"
-those in brackets.
-
-^        Matches the beginning            "book" -match "^bo"
-characters.
-
-$        Matches the end characters.      "book" -match "ok$"
-
-Matches any instances            "baggy" -match "g"
-of the preceding character.
-
-?        Matches zero or one instance     "baggy" -match "g?"
-of the preceding character.
-
-\        Matches the character that       "Try$" -match "Try\$"
-follows as an escaped character.
+| Format  | Logic | Example |
+| ------- | ----- | ------- |
+| value   | Matches exact characters anywhere in the original value. | "book" -match "oo" |
+| .       | Matches any single character. | "copy" -match "c..y" |
+| [value] | Matches at least one of the characters in the brackets. | "big" -match "b[iou]g" |
+| [range] | Matches at least one of the characters within the range. The use of a hyphen (-) allows you to specify an adjacent character. | "and" -match "[a-e]nd" |
+| [^]     | Matches any characters except those in brackets. | "and" -match "[^brt]nd" |
+| ^       | Matches the beginning characters. | "book" -match "^bo" |
+| $       | Matches the end characters. | "book" -match "ok$" |
+| *       | Matches any instances of the preceding character. | "baggy" -match "g*" |
+| ?       | Matches zero or one instance of the preceding character. | "baggy" -match "g?" |
+| \       | Matches the character that follows as an escaped character. | "Try$" -match "Try\\$" |
 
 Windows PowerShell supports the character classes available in
 Microsoft .NET Framework regular expressions.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-\p{name} Matches any character in the     "abcd defg" -match "\p{Ll}+"
-named character class specified
-by {name}. Supported names are
-Unicode groups and block
-ranges such as Ll, Nd,
-Z, IsGreek, and IsBoxDrawing.
-
-\P{name} Matches text not included in     1234 -match "\P{Ll}+"
-the groups and block ranges
-specified in {name}.
-
-\w       Matches any word character.      "abcd defg" -match "\w+"
-Equivalent to the Unicode        (this matches abcd)
-character categories [\p{Ll}
-\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}].
-If ECMAScript-compliant behavior
-is specified with the ECMAScript
-option, \w is equivalent to
-[a-zA-Z_0-9].
-
-\W       Matches any nonword character.   "abcd defg" -match "\W+"
-Equivalent to the Unicode        (This matches the space)
-categories [^\p{Ll}\p{Lu}\p{Lt}
-\p{Lo}\p{Nd}\p{Pc}].
-
-\s       Matches any white-space          "abcd defg" -match "\s+"
-character.  Equivalent to the
-Unicode character categories
-[\f\n\r\t\v\x85\p{Z}].
-
-\S       Matches any non-white-space      "abcd defg" -match "\S+"
-character. Equivalent to the
-Unicode character categories
-[^\f\n\r\t\v\x85\p{Z}].
-
-\d       Matches any decimal digit.       12345 -match "\d+"
-Equivalent to \p{Nd} for
-Unicode and [0-9] for non-
-Unicode behavior.
-
-\D       Matches any nondigit.            "abcd" -match "\D+"
-Equivalent  to \P{Nd} for
-Unicode and [^0-9] for non-
-Unicode behavior.
+| Format   | Logic | Example |
+| -------- | ----- | ------- |
+| \p{name} | Matches any character in the named character class specified by {name}. Supported names are Unicode groups and block ranges such as Ll, Nd, Z, IsGreek, and IsBoxDrawing. | "abcd defg" -match "\p{Ll}+" |
+| \P{name} | Matches text not included in the groups and block ranges specified in {name}. | 1234 -match "\P{Ll}+" |
+| \w       | Matches any word character. Equivalent to the Unicode character categories [\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}]. If ECMAScript-compliant behavior is specified with the ECMAScript option, \w is equivalent to [a-zA-Z_0-9]. | "abcd defg" -match "\w+" (this matches abcd) |
+| \W       | Matches any nonword character. Equivalent to the Unicode categories [^\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}]. | "abcd defg" -match "\W+" (this matches the space) |
+| \s       | Matches any white-space character. Equivalent to the Unicode character categories [\f\n\r\t\v\x85\p{Z}]. | "abcd defg" -match "\s+" |
+| \S       | Matches any non-white-space character. Equivalent to the Unicode character categories [^\f\n\r\t\v\x85\p{Z}]. | "abcd defg" -match "\S+" |
+| \d       | Matches any decimal digit. Equivalent to \p{Nd} for Unicode and [0-9] for non-Unicode behavior. | 12345 -match "\d+" |
+| \D       | Matches any nondigit. Equivalent to \P{Nd} for Unicode and [^0-9] for non-Unicode behavior. | "abcd" -match "\D+" |
 
 Windows PowerShell supports the quantifiers available in .NET Framework
 regular expressions. The following are some examples of quantifiers.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-Specifies zero or more matches;  "abc" -match "\w"
-for example, \wor (abc).
-Equivalent to {0,}.
-
-+        Matches repeating instances of   "xyxyxy" -match "xy+"
-the preceding characters.
-
-?        Specifies zero or one matches;   "abc" -match "\w?"
-for example, \w? or (abc)?.
-Equivalent to {0,1}.
-
-{n}      Specifies exactly n matches;     "abc" -match "\w{2}"
-for example, (pizza){2}.
-
-{n,}     Specifies at least n matches;    "abc" -match "\w{2,}"
-for example, (abc){2,}.
-
-{n,m}    Specifies at least n, but no     "abc" -match "\w{2,3}"
-more than m, matches.
+| Format | Logic | Example |
+| ------ | ----- | ------- |
+| *      | Specifies zero or more matches; for example, \wor (abc). Equivalent to {0,}. | "abc" -match "\w*" |
+| +      | Matches repeating instances of the preceding characters. | "xyxyxy" -match "xy+" |
+| ?      | Specifies zero or one matches; for example, \w? or (abc)?. Equivalent to {0,1}. | "abc" -match "\w?" |
+| {n}    | Specifies exactly n matches; for example, (pizza){2}. | "abc" -match "\w{2}" |
+| {n,}   | Specifies at least n matches; for example, (abc){2,}. | "abc" -match "\w{2,}" |
+| {n,m}  | Specifies at least n, but no more than m, matches. | "abc" -match "\w{2,3}" |
 
 All the comparisons shown in the preceding table evaluate to true.
 
-Notice that the escape character for regular expressions, a backslash (),
+Notice that the escape character for regular expressions, a backslash (\\),
 is different from the escape character for Windows PowerShell. The
-escape character for Windows PowerShell is the backtick character (`)
-# (ASCII 96).
+escape character for Windows PowerShell is the backtick character (`) (ASCII 96).
 
+For more information, see [Regular Expression Language - Quick Reference](https://go.microsoft.com/fwlink/?LinkId=133231).
 
-For more information, see the "Regular Expression Language Elements" topic
-in the Microsoft Developer Network (MSDN) library
-at http://go.microsoft.com/fwlink/?LinkId=133231.
-
-# SEE ALSO
+## SEE ALSO
 
 [about_Comparison_Operators](about_Comparison_Operators.md)
 
 [about_Operators](about_Operators.md)
-

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -7,140 +7,64 @@ title:  about_Regular_Expressions
 ---
 
 # About Regular Expressions
-## about_Regular_Expressions
 
-
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Describes regular expressions in Windows PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Windows PowerShell supports the following regular expression characters.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-value    Matches exact characters         "book" -match "oo"
-anywhere in the original value.
-
-.        Matches any single character.    "copy" -match "c..y"
-
-[value]  Matches at least one of the      "big" -match "b[iou]g"
-characters in the brackets.
-
-[range]  Matches at least one of the      "and" -match "[a-e]nd"
-characters within the range.
-The use of a hyphen (-) allows
-you to specify an adjacent
-character.
-
-[^]      Matches any characters except    "and" -match "[^brt]nd"
-those in brackets.
-
-^        Matches the beginning            "book" -match "^bo"
-characters.
-
-$        Matches the end characters.      "book" -match "ok$"
-
-Matches any instances            "baggy" -match "g"
-of the preceding character.
-
-?        Matches zero or one instance     "baggy" -match "g?"
-of the preceding character.
-
-\        Matches the character that       "Try$" -match "Try\$"
-follows as an escaped character.
+| Format  | Logic | Example |
+| ------- | ----- | ------- |
+| value   | Matches exact characters anywhere in the original value. | "book" -match "oo" |
+| .       | Matches any single character. | "copy" -match "c..y" |
+| [value] | Matches at least one of the characters in the brackets. | "big" -match "b[iou]g" |
+| [range] | Matches at least one of the characters within the range. The use of a hyphen (-) allows you to specify an adjacent character. | "and" -match "[a-e]nd" |
+| [^]     | Matches any characters except those in brackets. | "and" -match "[^brt]nd" |
+| ^       | Matches the beginning characters. | "book" -match "^bo" |
+| $       | Matches the end characters. | "book" -match "ok$" |
+| *       | Matches any instances of the preceding character. | "baggy" -match "g*" |
+| ?       | Matches zero or one instance of the preceding character. | "baggy" -match "g?" |
+| \       | Matches the character that follows as an escaped character. | "Try$" -match "Try\\$" |
 
 Windows PowerShell supports the character classes available in
 Microsoft .NET Framework regular expressions.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-\p{name} Matches any character in the     "abcd defg" -match "\p{Ll}+"
-named character class specified
-by {name}. Supported names are
-Unicode groups and block
-ranges such as Ll, Nd,
-Z, IsGreek, and IsBoxDrawing.
-
-\P{name} Matches text not included in     1234 -match "\P{Ll}+"
-the groups and block ranges
-specified in {name}.
-
-\w       Matches any word character.      "abcd defg" -match "\w+"
-Equivalent to the Unicode        (this matches abcd)
-character categories [\p{Ll}
-\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}].
-If ECMAScript-compliant behavior
-is specified with the ECMAScript
-option, \w is equivalent to
-[a-zA-Z_0-9].
-
-\W       Matches any nonword character.   "abcd defg" -match "\W+"
-Equivalent to the Unicode        (This matches the space)
-categories [^\p{Ll}\p{Lu}\p{Lt}
-\p{Lo}\p{Nd}\p{Pc}].
-
-\s       Matches any white-space          "abcd defg" -match "\s+"
-character.  Equivalent to the
-Unicode character categories
-[\f\n\r\t\v\x85\p{Z}].
-
-\S       Matches any non-white-space      "abcd defg" -match "\S+"
-character. Equivalent to the
-Unicode character categories
-[^\f\n\r\t\v\x85\p{Z}].
-
-\d       Matches any decimal digit.       12345 -match "\d+"
-Equivalent to \p{Nd} for
-Unicode and [0-9] for non-
-Unicode behavior.
-
-\D       Matches any nondigit.            "abcd" -match "\D+"
-Equivalent  to \P{Nd} for
-Unicode and [^0-9] for non-
-Unicode behavior.
+| Format   | Logic | Example |
+| -------- | ----- | ------- |
+| \p{name} | Matches any character in the named character class specified by {name}. Supported names are Unicode groups and block ranges such as Ll, Nd, Z, IsGreek, and IsBoxDrawing. | "abcd defg" -match "\p{Ll}+" |
+| \P{name} | Matches text not included in the groups and block ranges specified in {name}. | 1234 -match "\P{Ll}+" |
+| \w       | Matches any word character. Equivalent to the Unicode character categories [\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}]. If ECMAScript-compliant behavior is specified with the ECMAScript option, \w is equivalent to [a-zA-Z_0-9]. | "abcd defg" -match "\w+" (this matches abcd) |
+| \W       | Matches any nonword character. Equivalent to the Unicode categories [^\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}]. | "abcd defg" -match "\W+" (this matches the space) |
+| \s       | Matches any white-space character. Equivalent to the Unicode character categories [\f\n\r\t\v\x85\p{Z}]. | "abcd defg" -match "\s+" |
+| \S       | Matches any non-white-space character. Equivalent to the Unicode character categories [^\f\n\r\t\v\x85\p{Z}]. | "abcd defg" -match "\S+" |
+| \d       | Matches any decimal digit. Equivalent to \p{Nd} for Unicode and [0-9] for non-Unicode behavior. | 12345 -match "\d+" |
+| \D       | Matches any nondigit. Equivalent to \P{Nd} for Unicode and [^0-9] for non-Unicode behavior. | "abcd" -match "\D+" |
 
 Windows PowerShell supports the quantifiers available in .NET Framework
 regular expressions. The following are some examples of quantifiers.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-Specifies zero or more matches;  "abc" -match "\w"
-for example, \wor (abc).
-Equivalent to {0,}.
-
-+        Matches repeating instances of   "xyxyxy" -match "xy+"
-the preceding characters.
-
-?        Specifies zero or one matches;   "abc" -match "\w?"
-for example, \w? or (abc)?.
-Equivalent to {0,1}.
-
-{n}      Specifies exactly n matches;     "abc" -match "\w{2}"
-for example, (pizza){2}.
-
-{n,}     Specifies at least n matches;    "abc" -match "\w{2,}"
-for example, (abc){2,}.
-
-{n,m}    Specifies at least n, but no     "abc" -match "\w{2,3}"
-more than m, matches.
+| Format | Logic | Example |
+| ------ | ----- | ------- |
+| *      | Specifies zero or more matches; for example, \wor (abc). Equivalent to {0,}. | "abc" -match "\w*" |
+| +      | Matches repeating instances of the preceding characters. | "xyxyxy" -match "xy+" |
+| ?      | Specifies zero or one matches; for example, \w? or (abc)?. Equivalent to {0,1}. | "abc" -match "\w?" |
+| {n}    | Specifies exactly n matches; for example, (pizza){2}. | "abc" -match "\w{2}" |
+| {n,}   | Specifies at least n matches; for example, (abc){2,}. | "abc" -match "\w{2,}" |
+| {n,m}  | Specifies at least n, but no more than m, matches. | "abc" -match "\w{2,3}" |
 
 All the comparisons shown in the preceding table evaluate to true.
 
-Notice that the escape character for regular expressions, a backslash (),
+Notice that the escape character for regular expressions, a backslash (\\),
 is different from the escape character for Windows PowerShell. The
-escape character for Windows PowerShell is the backtick character (`)
-# (ASCII 96).
+escape character for Windows PowerShell is the backtick character (`) (ASCII 96).
 
+For more information, see [Regular Expression Language - Quick Reference](https://go.microsoft.com/fwlink/?LinkId=133231).
 
-For more information, see the "Regular Expression Language Elements" topic
-in the Microsoft Developer Network (MSDN) library
-at http://go.microsoft.com/fwlink/?LinkId=133231.
-
-# SEE ALSO
+## SEE ALSO
 
 [about_Comparison_Operators](about_Comparison_Operators.md)
 
 [about_Operators](about_Operators.md)
-

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -7,140 +7,64 @@ title:  about_Regular_Expressions
 ---
 
 # About Regular Expressions
-## about_Regular_Expressions
 
-
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Describes regular expressions in Windows PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Windows PowerShell supports the following regular expression characters.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-value    Matches exact characters         "book" -match "oo"
-anywhere in the original value.
-
-.        Matches any single character.    "copy" -match "c..y"
-
-[value]  Matches at least one of the      "big" -match "b[iou]g"
-characters in the brackets.
-
-[range]  Matches at least one of the      "and" -match "[a-e]nd"
-characters within the range.
-The use of a hyphen (-) allows
-you to specify an adjacent
-character.
-
-[^]      Matches any characters except    "and" -match "[^brt]nd"
-those in brackets.
-
-^        Matches the beginning            "book" -match "^bo"
-characters.
-
-$        Matches the end characters.      "book" -match "ok$"
-
-Matches any instances            "baggy" -match "g"
-of the preceding character.
-
-?        Matches zero or one instance     "baggy" -match "g?"
-of the preceding character.
-
-\        Matches the character that       "Try$" -match "Try\$"
-follows as an escaped character.
+| Format  | Logic | Example |
+| ------- | ----- | ------- |
+| value   | Matches exact characters anywhere in the original value. | "book" -match "oo" |
+| .       | Matches any single character. | "copy" -match "c..y" |
+| [value] | Matches at least one of the characters in the brackets. | "big" -match "b[iou]g" |
+| [range] | Matches at least one of the characters within the range. The use of a hyphen (-) allows you to specify an adjacent character. | "and" -match "[a-e]nd" |
+| [^]     | Matches any characters except those in brackets. | "and" -match "[^brt]nd" |
+| ^       | Matches the beginning characters. | "book" -match "^bo" |
+| $       | Matches the end characters. | "book" -match "ok$" |
+| *       | Matches any instances of the preceding character. | "baggy" -match "g*" |
+| ?       | Matches zero or one instance of the preceding character. | "baggy" -match "g?" |
+| \       | Matches the character that follows as an escaped character. | "Try$" -match "Try\\$" |
 
 Windows PowerShell supports the character classes available in
 Microsoft .NET Framework regular expressions.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-\p{name} Matches any character in the     "abcd defg" -match "\p{Ll}+"
-named character class specified
-by {name}. Supported names are
-Unicode groups and block
-ranges such as Ll, Nd,
-Z, IsGreek, and IsBoxDrawing.
-
-\P{name} Matches text not included in     1234 -match "\P{Ll}+"
-the groups and block ranges
-specified in {name}.
-
-\w       Matches any word character.      "abcd defg" -match "\w+"
-Equivalent to the Unicode        (this matches abcd)
-character categories [\p{Ll}
-\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}].
-If ECMAScript-compliant behavior
-is specified with the ECMAScript
-option, \w is equivalent to
-[a-zA-Z_0-9].
-
-\W       Matches any nonword character.   "abcd defg" -match "\W+"
-Equivalent to the Unicode        (This matches the space)
-categories [^\p{Ll}\p{Lu}\p{Lt}
-\p{Lo}\p{Nd}\p{Pc}].
-
-\s       Matches any white-space          "abcd defg" -match "\s+"
-character.  Equivalent to the
-Unicode character categories
-[\f\n\r\t\v\x85\p{Z}].
-
-\S       Matches any non-white-space      "abcd defg" -match "\S+"
-character. Equivalent to the
-Unicode character categories
-[^\f\n\r\t\v\x85\p{Z}].
-
-\d       Matches any decimal digit.       12345 -match "\d+"
-Equivalent to \p{Nd} for
-Unicode and [0-9] for non-
-Unicode behavior.
-
-\D       Matches any nondigit.            "abcd" -match "\D+"
-Equivalent  to \P{Nd} for
-Unicode and [^0-9] for non-
-Unicode behavior.
+| Format   | Logic | Example |
+| -------- | ----- | ------- |
+| \p{name} | Matches any character in the named character class specified by {name}. Supported names are Unicode groups and block ranges such as Ll, Nd, Z, IsGreek, and IsBoxDrawing. | "abcd defg" -match "\p{Ll}+" |
+| \P{name} | Matches text not included in the groups and block ranges specified in {name}. | 1234 -match "\P{Ll}+" |
+| \w       | Matches any word character. Equivalent to the Unicode character categories [\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}]. If ECMAScript-compliant behavior is specified with the ECMAScript option, \w is equivalent to [a-zA-Z_0-9]. | "abcd defg" -match "\w+" (this matches abcd) |
+| \W       | Matches any nonword character. Equivalent to the Unicode categories [^\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}]. | "abcd defg" -match "\W+" (this matches the space) |
+| \s       | Matches any white-space character. Equivalent to the Unicode character categories [\f\n\r\t\v\x85\p{Z}]. | "abcd defg" -match "\s+" |
+| \S       | Matches any non-white-space character. Equivalent to the Unicode character categories [^\f\n\r\t\v\x85\p{Z}]. | "abcd defg" -match "\S+" |
+| \d       | Matches any decimal digit. Equivalent to \p{Nd} for Unicode and [0-9] for non-Unicode behavior. | 12345 -match "\d+" |
+| \D       | Matches any nondigit. Equivalent to \P{Nd} for Unicode and [^0-9] for non-Unicode behavior. | "abcd" -match "\D+" |
 
 Windows PowerShell supports the quantifiers available in .NET Framework
 regular expressions. The following are some examples of quantifiers.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-Specifies zero or more matches;  "abc" -match "\w"
-for example, \wor (abc).
-Equivalent to {0,}.
-
-+        Matches repeating instances of   "xyxyxy" -match "xy+"
-the preceding characters.
-
-?        Specifies zero or one matches;   "abc" -match "\w?"
-for example, \w? or (abc)?.
-Equivalent to {0,1}.
-
-{n}      Specifies exactly n matches;     "abc" -match "\w{2}"
-for example, (pizza){2}.
-
-{n,}     Specifies at least n matches;    "abc" -match "\w{2,}"
-for example, (abc){2,}.
-
-{n,m}    Specifies at least n, but no     "abc" -match "\w{2,3}"
-more than m, matches.
+| Format | Logic | Example |
+| ------ | ----- | ------- |
+| *      | Specifies zero or more matches; for example, \wor (abc). Equivalent to {0,}. | "abc" -match "\w*" |
+| +      | Matches repeating instances of the preceding characters. | "xyxyxy" -match "xy+" |
+| ?      | Specifies zero or one matches; for example, \w? or (abc)?. Equivalent to {0,1}. | "abc" -match "\w?" |
+| {n}    | Specifies exactly n matches; for example, (pizza){2}. | "abc" -match "\w{2}" |
+| {n,}   | Specifies at least n matches; for example, (abc){2,}. | "abc" -match "\w{2,}" |
+| {n,m}  | Specifies at least n, but no more than m, matches. | "abc" -match "\w{2,3}" |
 
 All the comparisons shown in the preceding table evaluate to true.
 
-Notice that the escape character for regular expressions, a backslash (),
+Notice that the escape character for regular expressions, a backslash (\\),
 is different from the escape character for Windows PowerShell. The
-escape character for Windows PowerShell is the backtick character (`)
-# (ASCII 96).
+escape character for Windows PowerShell is the backtick character (`) (ASCII 96).
 
+For more information, see [Regular Expression Language - Quick Reference](https://go.microsoft.com/fwlink/?LinkId=133231).
 
-For more information, see the "Regular Expression Language Elements" topic
-in the Microsoft Developer Network (MSDN) library
-at http://go.microsoft.com/fwlink/?LinkId=133231.
-
-# SEE ALSO
+## SEE ALSO
 
 [about_Comparison_Operators](about_Comparison_Operators.md)
 
 [about_Operators](about_Operators.md)
-

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Regular_Expressions.md
@@ -7,140 +7,64 @@ title:  about_Regular_Expressions
 ---
 
 # About Regular Expressions
-## about_Regular_Expressions
 
-
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Describes regular expressions in Windows PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Windows PowerShell supports the following regular expression characters.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-value    Matches exact characters         "book" -match "oo"
-anywhere in the original value.
-
-.        Matches any single character.    "copy" -match "c..y"
-
-[value]  Matches at least one of the      "big" -match "b[iou]g"
-characters in the brackets.
-
-[range]  Matches at least one of the      "and" -match "[a-e]nd"
-characters within the range.
-The use of a hyphen (-) allows
-you to specify an adjacent
-character.
-
-[^]      Matches any characters except    "and" -match "[^brt]nd"
-those in brackets.
-
-^        Matches the beginning            "book" -match "^bo"
-characters.
-
-$        Matches the end characters.      "book" -match "ok$"
-
-Matches any instances            "baggy" -match "g"
-of the preceding character.
-
-?        Matches zero or one instance     "baggy" -match "g?"
-of the preceding character.
-
-\        Matches the character that       "Try$" -match "Try\$"
-follows as an escaped character.
+| Format  | Logic | Example |
+| ------- | ----- | ------- |
+| value   | Matches exact characters anywhere in the original value. | "book" -match "oo" |
+| .       | Matches any single character. | "copy" -match "c..y" |
+| [value] | Matches at least one of the characters in the brackets. | "big" -match "b[iou]g" |
+| [range] | Matches at least one of the characters within the range. The use of a hyphen (-) allows you to specify an adjacent character. | "and" -match "[a-e]nd" |
+| [^]     | Matches any characters except those in brackets. | "and" -match "[^brt]nd" |
+| ^       | Matches the beginning characters. | "book" -match "^bo" |
+| $       | Matches the end characters. | "book" -match "ok$" |
+| *       | Matches any instances of the preceding character. | "baggy" -match "g*" |
+| ?       | Matches zero or one instance of the preceding character. | "baggy" -match "g?" |
+| \       | Matches the character that follows as an escaped character. | "Try$" -match "Try\\$" |
 
 Windows PowerShell supports the character classes available in
 Microsoft .NET Framework regular expressions.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-\p{name} Matches any character in the     "abcd defg" -match "\p{Ll}+"
-named character class specified
-by {name}. Supported names are
-Unicode groups and block
-ranges such as Ll, Nd,
-Z, IsGreek, and IsBoxDrawing.
-
-\P{name} Matches text not included in     1234 -match "\P{Ll}+"
-the groups and block ranges
-specified in {name}.
-
-\w       Matches any word character.      "abcd defg" -match "\w+"
-Equivalent to the Unicode        (this matches abcd)
-character categories [\p{Ll}
-\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}].
-If ECMAScript-compliant behavior
-is specified with the ECMAScript
-option, \w is equivalent to
-[a-zA-Z_0-9].
-
-\W       Matches any nonword character.   "abcd defg" -match "\W+"
-Equivalent to the Unicode        (This matches the space)
-categories [^\p{Ll}\p{Lu}\p{Lt}
-\p{Lo}\p{Nd}\p{Pc}].
-
-\s       Matches any white-space          "abcd defg" -match "\s+"
-character.  Equivalent to the
-Unicode character categories
-[\f\n\r\t\v\x85\p{Z}].
-
-\S       Matches any non-white-space      "abcd defg" -match "\S+"
-character. Equivalent to the
-Unicode character categories
-[^\f\n\r\t\v\x85\p{Z}].
-
-\d       Matches any decimal digit.       12345 -match "\d+"
-Equivalent to \p{Nd} for
-Unicode and [0-9] for non-
-Unicode behavior.
-
-\D       Matches any nondigit.            "abcd" -match "\D+"
-Equivalent  to \P{Nd} for
-Unicode and [^0-9] for non-
-Unicode behavior.
+| Format   | Logic | Example |
+| -------- | ----- | ------- |
+| \p{name} | Matches any character in the named character class specified by {name}. Supported names are Unicode groups and block ranges such as Ll, Nd, Z, IsGreek, and IsBoxDrawing. | "abcd defg" -match "\p{Ll}+" |
+| \P{name} | Matches text not included in the groups and block ranges specified in {name}. | 1234 -match "\P{Ll}+" |
+| \w       | Matches any word character. Equivalent to the Unicode character categories [\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}]. If ECMAScript-compliant behavior is specified with the ECMAScript option, \w is equivalent to [a-zA-Z_0-9]. | "abcd defg" -match "\w+" (this matches abcd) |
+| \W       | Matches any nonword character. Equivalent to the Unicode categories [^\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Nd}\p{Pc}]. | "abcd defg" -match "\W+" (this matches the space) |
+| \s       | Matches any white-space character. Equivalent to the Unicode character categories [\f\n\r\t\v\x85\p{Z}]. | "abcd defg" -match "\s+" |
+| \S       | Matches any non-white-space character. Equivalent to the Unicode character categories [^\f\n\r\t\v\x85\p{Z}]. | "abcd defg" -match "\S+" |
+| \d       | Matches any decimal digit. Equivalent to \p{Nd} for Unicode and [0-9] for non-Unicode behavior. | 12345 -match "\d+" |
+| \D       | Matches any nondigit. Equivalent to \P{Nd} for Unicode and [^0-9] for non-Unicode behavior. | "abcd" -match "\D+" |
 
 Windows PowerShell supports the quantifiers available in .NET Framework
 regular expressions. The following are some examples of quantifiers.
 
-Format   Logic                            Example
--------- -------------------------------  -----------------------
-Specifies zero or more matches;  "abc" -match "\w"
-for example, \wor (abc).
-Equivalent to {0,}.
-
-+        Matches repeating instances of   "xyxyxy" -match "xy+"
-the preceding characters.
-
-?        Specifies zero or one matches;   "abc" -match "\w?"
-for example, \w? or (abc)?.
-Equivalent to {0,1}.
-
-{n}      Specifies exactly n matches;     "abc" -match "\w{2}"
-for example, (pizza){2}.
-
-{n,}     Specifies at least n matches;    "abc" -match "\w{2,}"
-for example, (abc){2,}.
-
-{n,m}    Specifies at least n, but no     "abc" -match "\w{2,3}"
-more than m, matches.
+| Format | Logic | Example |
+| ------ | ----- | ------- |
+| *      | Specifies zero or more matches; for example, \wor (abc). Equivalent to {0,}. | "abc" -match "\w*" |
+| +      | Matches repeating instances of the preceding characters. | "xyxyxy" -match "xy+" |
+| ?      | Specifies zero or one matches; for example, \w? or (abc)?. Equivalent to {0,1}. | "abc" -match "\w?" |
+| {n}    | Specifies exactly n matches; for example, (pizza){2}. | "abc" -match "\w{2}" |
+| {n,}   | Specifies at least n matches; for example, (abc){2,}. | "abc" -match "\w{2,}" |
+| {n,m}  | Specifies at least n, but no more than m, matches. | "abc" -match "\w{2,3}" |
 
 All the comparisons shown in the preceding table evaluate to true.
 
-Notice that the escape character for regular expressions, a backslash (),
+Notice that the escape character for regular expressions, a backslash (\\),
 is different from the escape character for Windows PowerShell. The
-escape character for Windows PowerShell is the backtick character (`)
-# (ASCII 96).
+escape character for Windows PowerShell is the backtick character (`) (ASCII 96).
 
+For more information, see [Regular Expression Language - Quick Reference](https://go.microsoft.com/fwlink/?LinkId=133231).
 
-For more information, see the "Regular Expression Language Elements" topic
-in the Microsoft Developer Network (MSDN) library
-at http://go.microsoft.com/fwlink/?LinkId=133231.
-
-# SEE ALSO
+## SEE ALSO
 
 [about_Comparison_Operators](about_Comparison_Operators.md)
 
 [about_Operators](about_Operators.md)
-


### PR DESCRIPTION
Fixed header level, table, escape character, link, etc.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
