### PR TITLE
Updating WorkingDirectory path details

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Start-Process.md
@@ -365,7 +365,7 @@ Accept wildcard characters: False
 
 ### -WorkingDirectory
 Specifies the location of the executable file or document that runs in the process.
-The default is the current folder.
+The default is the folder for the new process.
 
 ```yaml
 Type: String


### PR DESCRIPTION
Change from: 
The default is the current folder.

Change to:
WorkingDirectory specifies the working directory for the new process.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
