### PR TITLE
Add ResponseHeadersVariable Parameter Documentation

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -594,6 +594,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ResponseHeadersVariable
+Creates a Response Headers Dictionary and saves it in the value of the specified variable. The the keys of the dictionary will contain the field names of the Response Header returned by the web server and the values will be the respective field values. 
+
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: RHV
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+
+```
+
 ### -SessionVariable
 Creates a web request session and saves it in the value of the specified variable.
 Enter a variable name without the dollar sign (`$`) symbol.


### PR DESCRIPTION
Documents PowerShell/PowerShell#4888 wherein a new `-ResponseHeadersVariable` parameter was added to `Invoke-RestMethod`.

Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version 6.0.0 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
