### PR TITLE
Remove misformatted PS1 prompts from examples

### DIFF
--- a/wmf/5.0/psget_modulesxsinstall.md
+++ b/wmf/5.0/psget_modulesxsinstall.md
@@ -12,14 +12,16 @@ Also, we have added a -RequiredVersion parameter to the Publish-Module cmdlet to
 
 **Install-Module examples:**
 ```powershell
-PS C:\\windows\\system32&gt; Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.1.0 -Repository PSGallery
-PS C:\\windows\\system32&gt; Get-Module -ListAvailable -Name PSScriptAnalyzer | Format-List Name,Version,ModuleBase
+Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.1.0 -Repository PSGallery
+Get-Module -ListAvailable -Name PSScriptAnalyzer | Format-List Name,Version,ModuleBase
+
 Name : PSScriptAnalyzer
 Version : 1.1.0
 ModuleBase : C:\Program Files\WindowsPowerShell\Modules\PSScriptAnalyzer\1.1.0
 
-PS C:\\windows\\system32&gt; Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.1.1 -Repository PSGallery
-PS C:\\windows\\system32&gt; Get-Module -ListAvailable -Name PSScriptAnalyzer | Format-List Name,Version,ModuleBase
+Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.1.1 -Repository PSGallery
+Get-Module -ListAvailable -Name PSScriptAnalyzer | Format-List Name,Version,ModuleBase
+
 Name       : PSScriptAnalyzer 
 Version    : 1.1.1
 ModuleBase : C:\Program Files\WindowsPowerShell\Modules\PSScriptAnalyzer\1.1.1
@@ -27,7 +29,8 @@ Name       : PSScriptAnalyzer
 Version    : 1.1.0
 ModuleBase : C:\Program Files\WindowsPowerShell\Modules\PSScriptAnalyzer\1.1.0
 
-PS C:\\windows\\system32&gt; Get-InstalledModule -Name PSScriptAnalyzer -AllVersions
+Get-InstalledModule -Name PSScriptAnalyzer -AllVersions
+
 Version    Name                                Type       Repository           Description            
 -------    ----                                ----       ----------           -----------            
 1.1.0      PSScriptAnalyzer                    Module     PSGallery            PSScriptAnalyzer provides script analysis... 


### PR DESCRIPTION
Examples had PS1 prompts with unescaped characters.  Fixed formatting to be consistent with [other articles](https://docs.microsoft.com/en-us/powershell/gallery/psget/module/psget_install-module#side-by-side-version-support-on-powershell-50-or-newer).