### PR TITLE
Fix $NULL as a placeholder example in about_Automatic_Variables.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -148,37 +148,26 @@ Hello
 
 As a result, you cannot use $null to mean "no parameter value." A parameter value of $null overrides the default parameter value.
 
-However, because  Windows PowerShell treats the $null variable as a placeholder, you can use it scripts like the following one, which would not work if $null were ignored.
+However, because PowerShell treats the $null variable as a placeholder,
+you can use it in scripts like the following one, which would not work if
+$null were ignored.
 
-
-```
-$calendar = @($null, $null, “Meeting”, $null, $null, “Team Lunch”, $null)  
-$days = Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"  
+```powershell
+$calendar = @($null, $null, "Meeting", $null, $null, "Team Lunch", $null)
+$days = "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
 $currentDay = 0
-```
-
-
-
-```
-foreach($day in $calendar)  
-{  
-    if($day -ne $null)  
-    {  
-        "Appointment on $($days[$currentDay]): $day"  
-    }  
-  
-    $currentDay++  
+foreach ($day in $calendar) {
+	if ($day -ne $null) {
+		"Appointment on $($days[$currentDay]): $day"
+	}
+	$currentDay++
 }
 ```
 
-
-
-```
+```output
 Appointment on Tuesday: Meeting  
 Appointment on Friday: Team lunch
 ```
-
-
 
 ### $OFS
 $OFS is a special variable that stores a string that you want to use as an output field separator. Use this variable when you are converting an array to a string. By default, the value of $OFS is " ", but you can change the value of $OFS in your session, by typing $OFS\="<value>". If you are expecting the default value of " " in your script, module, or configuration output, be careful that the $OFS default value has not been changed elsewhere in your code.

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -148,37 +148,26 @@ Hello
 
 As a result, you cannot use $null to mean "no parameter value." A parameter value of $null overrides the default parameter value.
 
-However, because  Windows PowerShell treats the $null variable as a placeholder, you can use it scripts like the following one, which would not work if $null were ignored.
+However, because PowerShell treats the $null variable as a placeholder,
+you can use it in scripts like the following one, which would not work if
+$null were ignored.
 
-
-```
-$calendar = @($null, $null, “Meeting”, $null, $null, “Team Lunch”, $null)  
-$days = Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"  
+```powershell
+$calendar = @($null, $null, "Meeting", $null, $null, "Team Lunch", $null)
+$days = "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
 $currentDay = 0
-```
-
-
-
-```
-foreach($day in $calendar)  
-{  
-    if($day -ne $null)  
-    {  
-        "Appointment on $($days[$currentDay]): $day"  
-    }  
-  
-    $currentDay++  
+foreach ($day in $calendar) {
+	if ($day -ne $null) {
+		"Appointment on $($days[$currentDay]): $day"
+	}
+	$currentDay++
 }
 ```
 
-
-
-```
+```output
 Appointment on Tuesday: Meeting  
 Appointment on Friday: Team lunch
 ```
-
-
 
 ### $OFS
 $OFS is a special variable that stores a string that you want to use as an output field separator. Use this variable when you are converting an array to a string. By default, the value of $OFS is " ", but you can change the value of $OFS in your session, by typing $OFS\="<value>". If you are expecting the default value of " " in your script, module, or configuration output, be careful that the $OFS default value has not been changed elsewhere in your code.

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -255,17 +255,14 @@ you can use it in scripts like the following one, which would not work if
 $null were ignored.
 
 ```powershell
-$calendar = @($null, $null, “Meeting”, $null, $null, “Team Lunch”, $null)  
-$days = Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"  
+$calendar = @($null, $null, "Meeting", $null, $null, "Team Lunch", $null)
+$days = "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
 $currentDay = 0
-foreach($day in $calendar)
-{  
-    if($day -ne $null)  
-    {  
-        "Appointment on $($days[$currentDay]): $day"  
-    }  
-  
-    $currentDay++  
+foreach ($day in $calendar) {
+	if ($day -ne $null) {
+		"Appointment on $($days[$currentDay]): $day"
+	}
+	$currentDay++
 }
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -255,17 +255,14 @@ you can use it in scripts like the following one, which would not work if
 $null were ignored.
 
 ```powershell
-$calendar = @($null, $null, “Meeting”, $null, $null, “Team Lunch”, $null)  
-$days = Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"  
+$calendar = @($null, $null, "Meeting", $null, $null, "Team Lunch", $null)
+$days = "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
 $currentDay = 0
-foreach($day in $calendar)
-{  
-    if($day -ne $null)  
-    {  
-        "Appointment on $($days[$currentDay]): $day"  
-    }  
-  
-    $currentDay++  
+foreach ($day in $calendar) {
+	if ($day -ne $null) {
+		"Appointment on $($days[$currentDay]): $day"
+	}
+	$currentDay++
 }
 ```
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -255,17 +255,14 @@ you can use it in scripts like the following one, which would not work if
 $null were ignored.
 
 ```powershell
-$calendar = @($null, $null, “Meeting”, $null, $null, “Team Lunch”, $null)  
-$days = Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"  
+$calendar = @($null, $null, "Meeting", $null, $null, "Team Lunch", $null)
+$days = "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
 $currentDay = 0
-foreach($day in $calendar)
-{  
-    if($day -ne $null)  
-    {  
-        "Appointment on $($days[$currentDay]): $day"  
-    }  
-  
-    $currentDay++  
+foreach ($day in $calendar) {
+	if ($day -ne $null) {
+		"Appointment on $($days[$currentDay]): $day"
+	}
+	$currentDay++
 }
 ```
 


### PR DESCRIPTION
The example does not work because of a missing double quotation mark:
x `$days = Sunday", ...`
o `$days = "Sunday", ...`

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
