### PR TITLE
Fix example 3 in Get-ExecutionPolicy.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
+++ b/reference/3.0/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
@@ -47,16 +47,16 @@ These commands set a new user preference for the execution policy and then displ
 The commands are separated by a semicolon (;).
 In this example, because there is no Group Policy setting, the user preference is the effective policy for the computer.
 ### Example 3
-```
-PS C:\> Get-ExecutionPolicy -list
+```powershell
+PS C:\> Get-ExecutionPolicy -List
 
-Scope  ExecutionPolicy
------  ---------------
+Scope          ExecutionPolicy
+-----          ---------------
 MachinePolicy  Undefined
-UserPolicy  Undefined
-Process  Undefined
-CurrentUser  AllSigned
-LocalMachine  RemoteSigned
+UserPolicy     Undefined
+Process        Undefined
+CurrentUser    AllSigned
+LocalMachine   RemoteSigned
 
 PS C:\> Get-ExecutionPolicy
 AllSigned
@@ -68,6 +68,7 @@ The first command gets all execution policies that affect the current session.
 The policies are listed in precedence order.
 
 The second command gets only the effective execution policy, which is the one set in the CurrentUser scope.
+
 ### Example 4
 ```
 The first command uses the **Get-ExecutionPolicy** cmdlet to get the effective execution policy in the current session.

--- a/reference/4.0/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
+++ b/reference/4.0/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
@@ -52,16 +52,16 @@ The commands are separated by a semicolon (;).
 In this example, because there is no Group Policy setting, the user preference is the effective policy for the computer.
 
 ### Example 3
-```
-PS C:\> Get-ExecutionPolicy -list
+```powershell
+PS C:\> Get-ExecutionPolicy -List
 
-Scope  ExecutionPolicy
------  ---------------
+Scope          ExecutionPolicy
+-----          ---------------
 MachinePolicy  Undefined
-UserPolicy  Undefined
-Process  Undefined
-CurrentUser  AllSigned
-LocalMachine  RemoteSigned
+UserPolicy     Undefined
+Process        Undefined
+CurrentUser    AllSigned
+LocalMachine   RemoteSigned
 
 PS C:\> Get-ExecutionPolicy
 AllSigned

--- a/reference/5.0/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
+++ b/reference/5.0/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
@@ -51,15 +51,18 @@ These commands set a new user preference for the execution policy and then displ
 In this example, because there is no Group Policy setting, the user preference is the effective policy for the computer.
 
 ### Example 3: Get all execution policies for the current session
-```
+```powershell
 PS C:\> Get-ExecutionPolicy -List
+
 Scope          ExecutionPolicy
 -----          ---------------
 MachinePolicy  Undefined
 UserPolicy     Undefined
 Process        Undefined
 CurrentUser    AllSigned
-LocalMachine   RemoteSigned PS C:\> Get-ExecutionPolicy
+LocalMachine   RemoteSigned
+
+PS C:\> Get-ExecutionPolicy
 AllSigned
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
@@ -53,13 +53,15 @@ In this example, because there is no Group Policy setting, the user preference i
 ### Example 3: Get all execution policies for the current session
 ```powershell
 PS C:\> Get-ExecutionPolicy -List
+
 Scope          ExecutionPolicy
 -----          ---------------
 MachinePolicy  Undefined
 UserPolicy     Undefined
 Process        Undefined
 CurrentUser    AllSigned
-LocalMachine   RemoteSigned 
+LocalMachine   RemoteSigned
+
 PS C:\> Get-ExecutionPolicy
 AllSigned
 ```

--- a/reference/6/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
+++ b/reference/6/Microsoft.PowerShell.Security/Get-ExecutionPolicy.md
@@ -51,15 +51,18 @@ These commands set a new user preference for the execution policy and then displ
 In this example, because there is no Group Policy setting, the user preference is the effective policy for the computer.
 
 ### Example 3: Get all execution policies for the current session
-```
+```powershell
 PS C:\> Get-ExecutionPolicy -List
+
 Scope          ExecutionPolicy
 -----          ---------------
 MachinePolicy  Undefined
 UserPolicy     Undefined
 Process        Undefined
 CurrentUser    AllSigned
-LocalMachine   RemoteSigned PS C:\> Get-ExecutionPolicy
+LocalMachine   RemoteSigned
+
+PS C:\> Get-ExecutionPolicy
 AllSigned
 ```
 


### PR DESCRIPTION
Added line break to `LocalMachine   RemoteSigned PS C:\> Get-ExecutionPolicy`.
And fixed some formatting issues.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
