### PR TITLE
Edit Invoke-History Example 5

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/Invoke-History.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Invoke-History.md
@@ -59,7 +59,7 @@ PS C:\> Get-History -Id 255 -Count 7 | ForEach {Invoke-History -Id $_.Id}
 
 This command runs the 7 commands in the history that end with command 255 (typically 249 through 255).
 It uses the Get-History cmdlet to retrieve the commands.
-The pipeline operator (|) passes the commands to **Invoke-History**, which executes them.
+Because you can list only one ID value, the command uses the ForEach-Object cmdlet to run the **Invoke-History** command once for each ID value.
 ## PARAMETERS
 
 ### -Id

--- a/reference/3.0/Microsoft.PowerShell.Core/Invoke-History.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Invoke-History.md
@@ -54,7 +54,7 @@ This command runs commands 16 through 24.
 Because you can list only one ID value, the command uses the ForEach-Object cmdlet to run the **Invoke-History** command once for each ID value.
 ### Example 5
 ```
-PS C:\> Get-History -Id 255 -Count 7 | Invoke-History
+PS C:\> Get-History -Id 255 -Count 7 | ForEach {Invoke-History -Id $_.Id}
 ```
 
 This command runs the 7 commands in the history that end with command 255 (typically 249 through 255).

--- a/reference/4.0/Microsoft.PowerShell.Core/Invoke-History.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Invoke-History.md
@@ -61,12 +61,12 @@ Because you can list only one ID value, the command uses the ForEach-Object cmdl
 
 ### Example 5
 ```
-PS C:\> Get-History -Id 255 -Count 7 | Invoke-History
+PS C:\> Get-History -Id 255 -Count 7 | ForEach {Invoke-History -Id $_.Id}
 ```
 
 This command runs the 7 commands in the history that end with command 255 (typically 249 through 255).
 It uses the Get-History cmdlet to retrieve the commands.
-The pipeline operator (|) passes the commands to **Invoke-History**, which executes them.
+Because you can list only one ID value, the command uses the ForEach-Object cmdlet to run the **Invoke-History** command once for each ID value.
 
 ## PARAMETERS
 

--- a/reference/5.0/Microsoft.PowerShell.Core/Invoke-History.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Invoke-History.md
@@ -58,14 +58,14 @@ PS C:\> 16..24 | ForEach {Invoke-History -Id $_ }
 This command runs commands 16 through 24.
 Because you can list only one ID value, the command uses the ForEach-Object cmdlet to run the **Invoke-History** command one time for each ID value.
 
-### Example 5: Run several commands by using Get-History
+### Example 5
 ```
-PS C:\> Get-History -Id 255 -Count 7 | Invoke-History
+PS C:\> Get-History -Id 255 -Count 7 | ForEach {Invoke-History -Id $_.Id}
 ```
 
-This command runs the 7 commands in the history that end with command 255, typically 249 through 255.
+This command runs the 7 commands in the history that end with command 255 (typically 249 through 255).
 It uses the Get-History cmdlet to retrieve the commands.
-The pipeline operator (|) passes the commands to **Invoke-History**, which runs them.
+Because you can list only one ID value, the command uses the ForEach-Object cmdlet to run the **Invoke-History** command once for each ID value.
 
 ## PARAMETERS
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Invoke-History.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Invoke-History.md
@@ -58,14 +58,14 @@ PS C:\> 16..24 | ForEach {Invoke-History -Id $_ }
 This command runs commands 16 through 24.
 Because you can list only one ID value, the command uses the ForEach-Object cmdlet to run the **Invoke-History** command one time for each ID value.
 
-### Example 5: Run several commands by using Get-History
+### Example 5
 ```
-PS C:\> Get-History -Id 255 -Count 7 | Invoke-History
+PS C:\> Get-History -Id 255 -Count 7 | ForEach {Invoke-History -Id $_.Id}
 ```
 
-This command runs the 7 commands in the history that end with command 255, typically 249 through 255.
+This command runs the 7 commands in the history that end with command 255 (typically 249 through 255).
 It uses the Get-History cmdlet to retrieve the commands.
-The pipeline operator (|) passes the commands to **Invoke-History**, which runs them.
+Because you can list only one ID value, the command uses the ForEach-Object cmdlet to run the **Invoke-History** command once for each ID value.
 
 ## PARAMETERS
 

--- a/reference/6/Microsoft.PowerShell.Core/Invoke-History.md
+++ b/reference/6/Microsoft.PowerShell.Core/Invoke-History.md
@@ -58,14 +58,14 @@ PS C:\> 16..24 | ForEach {Invoke-History -Id $_ }
 This command runs commands 16 through 24.
 Because you can list only one ID value, the command uses the ForEach-Object cmdlet to run the **Invoke-History** command one time for each ID value.
 
-### Example 5: Run several commands by using Get-History
+### Example 5
 ```
-PS C:\> Get-History -Id 255 -Count 7 | Invoke-History
+PS C:\> Get-History -Id 255 -Count 7 | ForEach {Invoke-History -Id $_.Id}
 ```
 
-This command runs the 7 commands in the history that end with command 255, typically 249 through 255.
+This command runs the 7 commands in the history that end with command 255 (typically 249 through 255).
 It uses the Get-History cmdlet to retrieve the commands.
-The pipeline operator (|) passes the commands to **Invoke-History**, which runs them.
+Because you can list only one ID value, the command uses the ForEach-Object cmdlet to run the **Invoke-History** command once for each ID value.
 
 ## PARAMETERS
 


### PR DESCRIPTION
Fixes #1708. Previously this line of code would throw an error stating that Invoke-History cannot process multiple history commands and that you can only run a single command by using Invoke-History.

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
