### PR TITLE
Add wildcard characters to the examples in about_Wildcards.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -50,17 +50,22 @@ to create a word pattern that represents property values. For example, the
 following command gets services in which the ServiceType property value
 includes "Interactive".
 
-Get-Service | Where-Object {$_.ServiceType -like "Interactive"}
+```powershell
+Get-Service | Where-Object { $_.ServiceType -like "*Interactive*" }
+```
 
 In the following example, wildcard characters are used to find property values
 in the conditions of an If statement. In this command, if the Description of a
 restore point includes "PowerShell", the command adds the value of the CreationTime
 property of the restore point to a log file.
 
-$p = Get-ComputerRestorePoint
-foreach ($point in $p)
-{if ($point.description -like "PowerShell")
-{add-content -path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"}}
+```powershell
+foreach ($point in Get-ComputerRestorePoint) {
+	if ($point.Description -like "*PowerShell*") {
+		Add-Content -Path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
+	}
+}
+```
 
 # SEE ALSO
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -50,17 +50,22 @@ to create a word pattern that represents property values. For example, the
 following command gets services in which the ServiceType property value
 includes "Interactive".
 
-Get-Service | Where-Object {$_.ServiceType -like "Interactive"}
+```powershell
+Get-Service | Where-Object { $_.ServiceType -like "*Interactive*" }
+```
 
 In the following example, wildcard characters are used to find property values
 in the conditions of an If statement. In this command, if the Description of a
 restore point includes "PowerShell", the command adds the value of the CreationTime
 property of the restore point to a log file.
 
-$p = Get-ComputerRestorePoint
-foreach ($point in $p)
-{if ($point.description -like "PowerShell")
-{add-content -path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"}}
+```powershell
+foreach ($point in Get-ComputerRestorePoint) {
+	if ($point.Description -like "*PowerShell*") {
+		Add-Content -Path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
+	}
+}
+```
 
 # SEE ALSO
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -50,17 +50,22 @@ to create a word pattern that represents property values. For example, the
 following command gets services in which the ServiceType property value
 includes "Interactive".
 
-Get-Service | Where-Object {$_.ServiceType -like "Interactive"}
+```powershell
+Get-Service | Where-Object { $_.ServiceType -like "*Interactive*" }
+```
 
 In the following example, wildcard characters are used to find property values
 in the conditions of an If statement. In this command, if the Description of a
 restore point includes "PowerShell", the command adds the value of the CreationTime
 property of the restore point to a log file.
 
-$p = Get-ComputerRestorePoint
-foreach ($point in $p)
-{if ($point.description -like "PowerShell")
-{add-content -path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"}}
+```powershell
+foreach ($point in Get-ComputerRestorePoint) {
+	if ($point.Description -like "*PowerShell*") {
+		Add-Content -Path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
+	}
+}
+```
 
 # SEE ALSO
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -50,17 +50,22 @@ to create a word pattern that represents property values. For example, the
 following command gets services in which the ServiceType property value
 includes "Interactive".
 
-Get-Service | Where-Object {$_.ServiceType -like "Interactive"}
+```powershell
+Get-Service | Where-Object { $_.ServiceType -like "*Interactive*" }
+```
 
 In the following example, wildcard characters are used to find property values
 in the conditions of an If statement. In this command, if the Description of a
 restore point includes "PowerShell", the command adds the value of the CreationTime
 property of the restore point to a log file.
 
-$p = Get-ComputerRestorePoint
-foreach ($point in $p)
-{if ($point.description -like "PowerShell")
-{add-content -path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"}}
+```powershell
+foreach ($point in Get-ComputerRestorePoint) {
+	if ($point.Description -like "*PowerShell*") {
+		Add-Content -Path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
+	}
+}
+```
 
 # SEE ALSO
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -50,17 +50,22 @@ to create a word pattern that represents property values. For example, the
 following command gets services in which the ServiceType property value
 includes "Interactive".
 
-Get-Service | Where-Object {$_.ServiceType -like "Interactive"}
+```powershell
+Get-Service | Where-Object { $_.ServiceType -like "*Interactive*" }
+```
 
 In the following example, wildcard characters are used to find property values
 in the conditions of an If statement. In this command, if the Description of a
 restore point includes "PowerShell", the command adds the value of the CreationTime
 property of the restore point to a log file.
 
-$p = Get-ComputerRestorePoint
-foreach ($point in $p)
-{if ($point.description -like "PowerShell")
-{add-content -path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"}}
+```powershell
+foreach ($point in Get-ComputerRestorePoint) {
+	if ($point.Description -like "*PowerShell*") {
+		Add-Content -Path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
+	}
+}
+```
 
 # SEE ALSO
 


### PR DESCRIPTION
The description says "In the following example, wildcard characters are used", but the example does not use any wildcard characters.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
