### PR TITLE
Fixed casing of module landing pages and external help file names

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-PSBreakpoint.md
@@ -4,7 +4,7 @@ schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 online version:  http://go.microsoft.com/fwlink/?LinkId=821797
-external help file:  ISESteroids.dll-Help.xml
+external help file:  Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 title:  Get-PSBreakpoint
 ---
 
@@ -60,9 +60,9 @@ This command gets all breakpoints set on all scripts and functions in the curren
 ### Example 2: Get breakpoints by ID
 ```
 PS C:\> Get-PSBreakpoint -Id 2
-Function   : 
-IncrementAction     : 
-Enabled    : 
+Function   :
+IncrementAction     :
+Enabled    :
 TrueHitCount   : 0
 Id         : 2
 Script     : C:\ps-test\sample.ps1
@@ -134,7 +134,7 @@ If you omit the path, the default location is the current directory.
 ```yaml
 Type: String[]
 Parameter Sets: Script
-Aliases: 
+Aliases:
 
 Required: False
 Position: 0
@@ -146,7 +146,7 @@ Accept wildcard characters: False
 ```yaml
 Type: String[]
 Parameter Sets: Type, Command, Variable
-Aliases: 
+Aliases:
 
 Required: False
 Position: 0
@@ -162,7 +162,7 @@ Enter the variable names without dollar signs.
 ```yaml
 Type: String[]
 Parameter Sets: Variable
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -185,7 +185,7 @@ You can also pipe breakpoint types to **Get-PSBreakPoint**.
 ```yaml
 Type: BreakpointType[]
 Parameter Sets: Type
-Aliases: 
+Aliases:
 
 Required: True
 Position: 0
@@ -201,7 +201,7 @@ Enter the command names, such as the name of a cmdlet or function.
 ```yaml
 Type: String[]
 Parameter Sets: Command
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -218,7 +218,7 @@ You can also pipe breakpoint IDs to **Get-PSBreakpoint**.
 ```yaml
 Type: Int32[]
 Parameter Sets: Id
-Aliases: 
+Aliases:
 
 Required: True
 Position: 0

--- a/reference/6/Microsoft.PowerShell.Utility/Get-Verb.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Verb.md
@@ -4,7 +4,7 @@ schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 online version:  http://technet.microsoft.com/library/hh852690(v=wps.630).aspx
-external help file:  System.Management.Automation.dll-help.xml
+external help file:  Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 ---
 
 # Get-Verb
@@ -129,7 +129,7 @@ Wildcards are permitted.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 1
@@ -157,7 +157,7 @@ Windows PowerShell verbs are assigned to a group based on their most common use.
 The groups are designed to make the verbs easy to find and compare, not to restrict their use.
 You can use any approved verb for any type of command.
 
-Each Windows PowerShell verb is assigned to one of the following groups. 
+Each Windows PowerShell verb is assigned to one of the following groups.
 -- Common: Define generic actions that can apply to almost any cmdlet, such as Add.
 
 -- Communications:  Define actions that apply to communications, such as Connect.

--- a/reference/6/Microsoft.WSMan.Management/Microsoft.WSMan.Management.md
+++ b/reference/6/Microsoft.WSMan.Management/Microsoft.WSMan.Management.md
@@ -6,15 +6,15 @@ keywords:  powershell,cmdlet
 Help Version:  6.0
 Download Help Link:  https://go.microsoft.com/fwlink/?linkid=855961
 Module Guid:  766204a6-330e-4263-a7ab-46c87afc366c
-title:  Microsoft.WsMan.Management
-Module Name:  Microsoft.WsMan.Management
+title:  Microsoft.WSMan.Management
+Module Name:  Microsoft.WSMan.Management
 ---
 
-# Microsoft.WsMan.Management Module
+# Microsoft.WSMan.Management Module
 ## Description
 This section contains the help topics for the cmdlets that are installed with Windows PowerShell Microsoft.WSMan.Management module. The WSMan module contains cmdlets and providers that manage the WS-Management protocol in Windows PowerShell.
 
-## Microsoft.WsMan.Management Cmdlets
+## Microsoft.WSMan.Management Cmdlets
 ### [Connect-WSMan](Connect-WSMan.md)
 Connects to the WinRM service on a remote computer.
 

--- a/reference/6/PSReadLine/PSReadLine.md
+++ b/reference/6/PSReadLine/PSReadLine.md
@@ -6,15 +6,15 @@ keywords:  powershell,cmdlet
 Help Version:  6.0
 Download Help Link:  https://go.microsoft.com/fwlink/?linkid=855966
 Module Guid:  5714753b-2afd-4492-a5fd-01d9e2cff8b5
-title:  PSReadline
-Module Name:  PSReadline
+title:  PSReadLine
+Module Name:  PSReadLine
 ---
 
-# PSReadline Module
+# PSReadLine Module
 ## Description
 This section contains the help topics for the cmdlets that are installed with the Windows PowerShell® PSReadline module. The PSReadline module contains cmdlets that let you customize the command-line editing environment in Windows PowerShell.
 
-## PSReadline Cmdlets
+## PSReadLine Cmdlets
 ### [Get-PSReadlineKeyHandler](Get-PSReadlineKeyHandler.md)
 Gets the key bindings for the PSReadline module.
 


### PR DESCRIPTION
The casing has to be consistent with the module name since this is used to construct the help URI.
Some external help filenames were incorrect. Fixed them.
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
