### PR TITLE
Fix examples in about_Functions.md (missing `_`)

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -154,10 +154,12 @@ has a $size parameter. The function displays all the files that are
 smaller than the value of the $size parameter, and it excludes
 directories:
 
+```powershell
 function Get-SmallFiles {
-param ($size)
-Get-ChildItem c:\ | where {$.Length -lt $Size -and !$.PSIsContainer}
+	Param($Size)
+	Get-ChildItem $HOME | where { $_.Length -lt $Size -and !$_.PSIsContainer }
 }
+```
 
 In the function, you can use the $size variable, which is the name
 defined for the parameter.
@@ -176,9 +178,11 @@ To define a default value for a parameter, type an equal sign and the
 value after the parameter name, as shown in the following variation of
 the Get-SmallFiles example:
 
-function Get-SmallFiles ($size = 100) {
-Get-ChildItem c:\ | where {$.Length -lt $Size -and !$.PSIsContainer}
+```powershell
+function Get-SmallFiles ($Size = 100) {
+	Get-ChildItem $HOME | where { $_.Length -lt $Size -and !$_.PSIsContainer }
 }
+```
 
 If you type "Get-SmallFiles" without a value, the function assigns 100 to
 $size. If you provide a value, the function uses that value.

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -154,10 +154,12 @@ has a $size parameter. The function displays all the files that are
 smaller than the value of the $size parameter, and it excludes
 directories:
 
+```powershell
 function Get-SmallFiles {
-param ($size)
-Get-ChildItem c:\ | where {$.Length -lt $Size -and !$.PSIsContainer}
+	Param($Size)
+	Get-ChildItem $HOME | where { $_.Length -lt $Size -and !$_.PSIsContainer }
 }
+```
 
 In the function, you can use the $size variable, which is the name
 defined for the parameter.
@@ -176,9 +178,11 @@ To define a default value for a parameter, type an equal sign and the
 value after the parameter name, as shown in the following variation of
 the Get-SmallFiles example:
 
-function Get-SmallFiles ($size = 100) {
-Get-ChildItem c:\ | where {$.Length -lt $Size -and !$.PSIsContainer}
+```powershell
+function Get-SmallFiles ($Size = 100) {
+	Get-ChildItem $HOME | where { $_.Length -lt $Size -and !$_.PSIsContainer }
 }
+```
 
 If you type "Get-SmallFiles" without a value, the function assigns 100 to
 $size. If you provide a value, the function uses that value.

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -154,10 +154,12 @@ has a $size parameter. The function displays all the files that are
 smaller than the value of the $size parameter, and it excludes
 directories:
 
+```powershell
 function Get-SmallFiles {
-param ($size)
-Get-ChildItem c:\ | where {$.Length -lt $Size -and !$.PSIsContainer}
+	Param($Size)
+	Get-ChildItem $HOME | where { $_.Length -lt $Size -and !$_.PSIsContainer }
 }
+```
 
 In the function, you can use the $size variable, which is the name
 defined for the parameter.
@@ -176,9 +178,11 @@ To define a default value for a parameter, type an equal sign and the
 value after the parameter name, as shown in the following variation of
 the Get-SmallFiles example:
 
-function Get-SmallFiles ($size = 100) {
-Get-ChildItem c:\ | where {$.Length -lt $Size -and !$.PSIsContainer}
+```powershell
+function Get-SmallFiles ($Size = 100) {
+	Get-ChildItem $HOME | where { $_.Length -lt $Size -and !$_.PSIsContainer }
 }
+```
 
 If you type "Get-SmallFiles" without a value, the function assigns 100 to
 $size. If you provide a value, the function uses that value.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -151,12 +151,14 @@ The following example is a function called Get-SmallFiles. This function
 has a $size parameter. The function displays all the files that are
 smaller than the value of the $size parameter, and it excludes
 directories:
-```
+
+```powershell
 function Get-SmallFiles {
-  param ($size)
-  Get-ChildItem c:\ | where {$.Length -lt $Size -and !$.PSIsContainer}
+	Param($Size)
+	Get-ChildItem $HOME | where { $_.Length -lt $Size -and !$_.PSIsContainer }
 }
 ```
+
 In the function, you can use the $size variable, which is the name
 defined for the parameter.
 
@@ -173,11 +175,13 @@ C:\PS> function Get-SmallFiles 50
 To define a default value for a parameter, type an equal sign and the
 value after the parameter name, as shown in the following variation of
 the Get-SmallFiles example:
-```
-function Get-SmallFiles ($size = 100) {
-  Get-ChildItem c:\ | where {$.Length -lt $Size -and !$.PSIsContainer}
+
+```powershell
+function Get-SmallFiles ($Size = 100) {
+	Get-ChildItem $HOME | where { $_.Length -lt $Size -and !$_.PSIsContainer }
 }
 ```
+
 If you type "Get-SmallFiles" without a value, the function assigns 100 to
 $size. If you provide a value, the function uses that value.
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -151,12 +151,14 @@ The following example is a function called Get-SmallFiles. This function
 has a $size parameter. The function displays all the files that are
 smaller than the value of the $size parameter, and it excludes
 directories:
-```
+
+```powershell
 function Get-SmallFiles {
-  param ($size)
-  Get-ChildItem c:\ | where {$.Length -lt $Size -and !$.PSIsContainer}
+	Param($Size)
+	Get-ChildItem $HOME | where { $_.Length -lt $Size -and !$_.PSIsContainer }
 }
 ```
+
 In the function, you can use the $size variable, which is the name
 defined for the parameter.
 
@@ -173,11 +175,13 @@ C:\PS> function Get-SmallFiles 50
 To define a default value for a parameter, type an equal sign and the
 value after the parameter name, as shown in the following variation of
 the Get-SmallFiles example:
-```
-function Get-SmallFiles ($size = 100) {
-  Get-ChildItem c:\ | where {$.Length -lt $Size -and !$.PSIsContainer}
+
+```powershell
+function Get-SmallFiles ($Size = 100) {
+	Get-ChildItem $HOME | where { $_.Length -lt $Size -and !$_.PSIsContainer }
 }
 ```
+
 If you type "Get-SmallFiles" without a value, the function assigns 100 to
 $size. If you provide a value, the function uses that value.
 


### PR DESCRIPTION
* `$` -> `$_` (to avoid error)
* `C:\` -> `$HOME` (it is likely that users can not find many small files in `C:\`)

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
