### PR TITLE
Fix examples in about_Functions.md (unnecessary `function`)

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -166,13 +166,17 @@ defined for the parameter.
 
 To use this function, type the following command:
 
-C:\PS> function Get-SmallFiles -Size 50
+```powershell
+Get-SmallFiles -Size 50
+```
 
 You can also enter a value for a named parameter without the parameter
 name. For example, the following command gives the same result as a
 command that names the Size parameter:
 
-C:\PS> function Get-SmallFiles 50
+```powershell
+Get-SmallFiles 50
+```
 
 To define a default value for a parameter, type an equal sign and the
 value after the parameter name, as shown in the following variation of

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -166,13 +166,17 @@ defined for the parameter.
 
 To use this function, type the following command:
 
-C:\PS> function Get-SmallFiles -Size 50
+```powershell
+Get-SmallFiles -Size 50
+```
 
 You can also enter a value for a named parameter without the parameter
 name. For example, the following command gives the same result as a
 command that names the Size parameter:
 
-C:\PS> function Get-SmallFiles 50
+```powershell
+Get-SmallFiles 50
+```
 
 To define a default value for a parameter, type an equal sign and the
 value after the parameter name, as shown in the following variation of

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -166,13 +166,17 @@ defined for the parameter.
 
 To use this function, type the following command:
 
-C:\PS> function Get-SmallFiles -Size 50
+```powershell
+Get-SmallFiles -Size 50
+```
 
 You can also enter a value for a named parameter without the parameter
 name. For example, the following command gives the same result as a
 command that names the Size parameter:
 
-C:\PS> function Get-SmallFiles 50
+```powershell
+Get-SmallFiles 50
+```
 
 To define a default value for a parameter, type an equal sign and the
 value after the parameter name, as shown in the following variation of

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -163,15 +163,19 @@ In the function, you can use the $size variable, which is the name
 defined for the parameter.
 
 To use this function, type the following command:
+
+```powershell
+Get-SmallFiles -Size 50
 ```
-C:\PS> function Get-SmallFiles -Size 50
-```
+
 You can also enter a value for a named parameter without the parameter
 name. For example, the following command gives the same result as a
 command that names the Size parameter:
+
+```powershell
+Get-SmallFiles 50
 ```
-C:\PS> function Get-SmallFiles 50
-```
+
 To define a default value for a parameter, type an equal sign and the
 value after the parameter name, as shown in the following variation of
 the Get-SmallFiles example:

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -163,15 +163,19 @@ In the function, you can use the $size variable, which is the name
 defined for the parameter.
 
 To use this function, type the following command:
+
+```powershell
+Get-SmallFiles -Size 50
 ```
-C:\PS> function Get-SmallFiles -Size 50
-```
+
 You can also enter a value for a named parameter without the parameter
 name. For example, the following command gives the same result as a
 command that names the Size parameter:
+
+```powershell
+Get-SmallFiles 50
 ```
-C:\PS> function Get-SmallFiles 50
-```
+
 To define a default value for a parameter, type an equal sign and the
 value after the parameter name, as shown in the following variation of
 the Get-SmallFiles example:


### PR DESCRIPTION
Removed `function` keyword to avoid exception:
```powershell
PS> function Get-SmallFiles -Size 50
At line:1 char:24
+ function Get-SmallFiles -Size 50
+                        ~
Missing function body in function declaration.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : MissingFunctionBody
```

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
