### PR TITLE
Update examples in about_Arithmetic_Operators.md (`-` operator)

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -36,8 +36,8 @@ PowerShell supports the following arithmetic operators:
 |Operator|Description|Example|
 |--------|-----------|-------|
 | + |Adds integers; concatenates strings,<br/> concatenates arrays, and hash tables.|`6 + 2`<br />`"file" + "name"`<br />`@(1, "one") + @(2.0, "two")`<br />`@{"one" = 1} + @{"two" = 2}`|
-| - |Subtracts one value from another value.|`6-2`<br />`(get-date).date - 1`|
-| - |Makes a number a negative number.|`-6`|
+| - | Subtracts one value from another value | `6 - 2` |
+| - | Makes a number a negative number | `-6`<br/>`(Get-Date).AddDays(-1)` |
 | * |Multiplies numbers, copies strings and<br/>arrays the specified number of times.|`6 * 2`<br />`"!" * 3`<br />`@("!") * 4`|
 | / |Divides two values.|`6 / 2`|
 | % |Returns the remainder of a division operation.|`7 % 2`|

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -36,8 +36,8 @@ PowerShell supports the following arithmetic operators:
 |Operator|Description|Example|
 |--------|-----------|-------|
 | + |Adds integers; concatenates strings,<br/> concatenates arrays, and hash tables.|`6 + 2`<br />`"file" + "name"`<br />`@(1, "one") + @(2.0, "two")`<br />`@{"one" = 1} + @{"two" = 2}`|
-| - |Subtracts one value from another value.|`6-2`<br />`(get-date).date - 1`|
-| - |Makes a number a negative number.|`-6`|
+| - | Subtracts one value from another value | `6 - 2` |
+| - | Makes a number a negative number | `-6`<br/>`(Get-Date).AddDays(-1)` |
 | * |Multiplies numbers, copies strings and<br/>arrays the specified number of times.|`6 * 2`<br />`"!" * 3`<br />`@("!") * 4`|
 | / |Divides two values.|`6 / 2`|
 | % |Returns the remainder of a division operation.|`7 % 2`|

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -36,8 +36,8 @@ PowerShell supports the following arithmetic operators:
 |Operator|Description|Example|
 |--------|-----------|-------|
 | + |Adds integers; concatenates strings,<br/> concatenates arrays, and hash tables.|`6 + 2`<br />`"file" + "name"`<br />`@(1, "one") + @(2.0, "two")`<br />`@{"one" = 1} + @{"two" = 2}`|
-| - |Subtracts one value from another value.|`6-2`<br />`(get-date).date - 1`|
-| - |Makes a number a negative number.|`-6`|
+| - | Subtracts one value from another value | `6 - 2` |
+| - | Makes a number a negative number | `-6`<br/>`(Get-Date).AddDays(-1)` |
 | * |Multiplies numbers, copies strings and<br/>arrays the specified number of times.|`6 * 2`<br />`"!" * 3`<br />`@("!") * 4`|
 | / |Divides two values.|`6 / 2`|
 | % |Returns the remainder of a division operation.|`7 % 2`|

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -36,8 +36,8 @@ PowerShell supports the following arithmetic operators:
 |Operator|Description|Example|
 |--------|-----------|-------|
 | + |Adds integers; concatenates strings,<br/> concatenates arrays, and hash tables.|`6 + 2`<br />`"file" + "name"`<br />`@(1, "one") + @(2.0, "two")`<br />`@{"one" = 1} + @{"two" = 2}`|
-| - |Subtracts one value from another value.|`6-2`<br />`(get-date).date - 1`|
-| - |Makes a number a negative number.|`-6`|
+| - | Subtracts one value from another value | `6 - 2` |
+| - | Makes a number a negative number | `-6`<br/>`(Get-Date).AddDays(-1)` |
 | * |Multiplies numbers, copies strings and<br/>arrays the specified number of times.|`6 * 2`<br />`"!" * 3`<br />`@("!") * 4`|
 | / |Divides two values.|`6 / 2`|
 | % |Returns the remainder of a division operation.|`7 % 2`|

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Arithmetic_Operators.md
@@ -36,8 +36,8 @@ PowerShell supports the following arithmetic operators:
 |Operator|Description|Example|
 |--------|-----------|-------|
 | + |Adds integers; concatenates strings,<br/> concatenates arrays, and hash tables.|`6 + 2`<br />`"file" + "name"`<br />`@(1, "one") + @(2.0, "two")`<br />`@{"one" = 1} + @{"two" = 2}`|
-| - |Subtracts one value from another value.|`6-2`<br />`(get-date).date - 1`|
-| - |Makes a number a negative number.|`-6`|
+| - | Subtracts one value from another value | `6 - 2` |
+| - | Makes a number a negative number | `-6`<br/>`(Get-Date).AddDays(-1)` |
 | * |Multiplies numbers, copies strings and<br/>arrays the specified number of times.|`6 * 2`<br />`"!" * 3`<br />`@("!") * 4`|
 | / |Divides two values.|`6 / 2`|
 | % |Returns the remainder of a division operation.|`7 % 2`|


### PR DESCRIPTION
Removed `(get-date).date - 1`, which causes error:

```powershell
PS> (get-date).date - 1
Multiple ambiguous overloads found for "op_Subtraction" and the argument count: "2".
At line:1 char:1
+ (get-date).date - 1
+ ~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodException
    + FullyQualifiedErrorId : MethodCountCouldNotFindBest
```

Instead of that, add a negative number example `(Get-Date).AddDays(-1)`

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
