### PR TITLE
Fix the beginning characters "0. " in about_Assignment_Operators.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -106,8 +106,8 @@ the following example:
 $a = if ($b -lt 0) { 0 } else { $b }
 ```
 
-This example assigns 0 to the $a variable if the value of $b is less than
-0. It assigns the value of $b to $a if the value of $b is not less than
+This example assigns zero to the $a variable if the value of $b is less than
+zero. It assigns the value of $b to $a if the value of $b is not less than
 zero.
 
 ### THE ASSIGNMENT OPERATOR

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -106,8 +106,8 @@ the following example:
 $a = if ($b -lt 0) { 0 } else { $b }
 ```
 
-This example assigns 0 to the $a variable if the value of $b is less than
-0. It assigns the value of $b to $a if the value of $b is not less than
+This example assigns zero to the $a variable if the value of $b is less than
+zero. It assigns the value of $b to $a if the value of $b is not less than
 zero.
 
 ### THE ASSIGNMENT OPERATOR

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -106,8 +106,8 @@ the following example:
 $a = if ($b -lt 0) { 0 } else { $b }
 ```
 
-This example assigns 0 to the $a variable if the value of $b is less than
-0. It assigns the value of $b to $a if the value of $b is not less than
+This example assigns zero to the $a variable if the value of $b is less than
+zero. It assigns the value of $b to $a if the value of $b is not less than
 zero.
 
 ### THE ASSIGNMENT OPERATOR

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -106,8 +106,8 @@ the following example:
 $a = if ($b -lt 0) { 0 } else { $b }
 ```
 
-This example assigns 0 to the $a variable if the value of $b is less than
-0. It assigns the value of $b to $a if the value of $b is not less than
+This example assigns zero to the $a variable if the value of $b is less than
+zero. It assigns the value of $b to $a if the value of $b is not less than
 zero.
 
 ### THE ASSIGNMENT OPERATOR

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -106,8 +106,8 @@ the following example:
 $a = if ($b -lt 0) { 0 } else { $b }
 ```
 
-This example assigns 0 to the $a variable if the value of $b is less than
-0. It assigns the value of $b to $a if the value of $b is not less than
+This example assigns zero to the $a variable if the value of $b is less than
+zero. It assigns the value of $b to $a if the value of $b is not less than
 zero.
 
 ### THE ASSIGNMENT OPERATOR


### PR DESCRIPTION
Markdown:
> This example assigns 0 to the $a variable if the value of $b is less than
> 0. It assigns the value of $b to $a if the value of $b is not less than
> zero.

[Microsoft Docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_assignment_operators?view=powershell-6):
> This example assigns 0 to the $a variable if the value of $b is less than
> 
>   1. It assigns the value of $b to $a if the value of $b is not less than zero.

Because the beginning characters "0. " stand for numbered list.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
