### PR TITLE
Add aliases to CommonParameters list

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -40,24 +40,23 @@ In addition to the common parameters, many cmdlets offer the WhatIf and
 Confirm risk mitigation parameters. Cmdlets that involve risk to the system
 or to user data usually offer these parameters.
 
-The following list displays the common parameters. Their aliases are listed
-in parentheses.
-
--Debug (db)
--ErrorAction (ea)
--ErrorVariable (ev)
--InformationAction
--InformationVariable
--OutVariable (ov)
--OutBuffer (ob)
--PipelineVariable (pv)
--Verbose (vb)
--WarningAction (wa)
--WarningVariable (wv)
+The following list displays the common parameters.
+Their aliases are listed in parentheses.
+* Debug (db)
+* ErrorAction (ea)
+* ErrorVariable (ev)
+* InformationAction (infa)
+* InformationVariable (iv)
+* OutVariable (ov)
+* OutBuffer (ob)
+* PipelineVariable (pv)
+* Verbose (vb)
+* WarningAction (wa)
+* WarningVariable (wv)
 
 The risk mitigation parameters are:
--WhatIf (wi)
--Confirm (cf)
+* WhatIf (wi)
+* Confirm (cf)
 
 For more information about preference variables, type:
 help about_Preference_Variables

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -40,24 +40,23 @@ In addition to the common parameters, many cmdlets offer the WhatIf and
 Confirm risk mitigation parameters. Cmdlets that involve risk to the system
 or to user data usually offer these parameters.
 
-The following list displays the common parameters. Their aliases are listed
-in parentheses.
-
--Debug (db)
--ErrorAction (ea)
--ErrorVariable (ev)
--InformationAction
--InformationVariable
--OutVariable (ov)
--OutBuffer (ob)
--PipelineVariable (pv)
--Verbose (vb)
--WarningAction (wa)
--WarningVariable (wv
+The following list displays the common parameters.
+Their aliases are listed in parentheses.
+* Debug (db)
+* ErrorAction (ea)
+* ErrorVariable (ev)
+* InformationAction (infa)
+* InformationVariable (iv)
+* OutVariable (ov)
+* OutBuffer (ob)
+* PipelineVariable (pv)
+* Verbose (vb)
+* WarningAction (wa)
+* WarningVariable (wv)
 
 The risk mitigation parameters are:
--WhatIf (wi)
--Confirm (cf)
+* WhatIf (wi)
+* Confirm (cf)
 
 For more information about preference variables, type:
 help about_Preference_Variables

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -40,24 +40,23 @@ In addition to the common parameters, many cmdlets offer the WhatIf and
 Confirm risk mitigation parameters. Cmdlets that involve risk to the system
 or to user data usually offer these parameters.
 
-The following list displays the common parameters. Their aliases are listed
-in parentheses.
-
--Debug (db)
--ErrorAction (ea)
--ErrorVariable (ev)
--InformationAction
--InformationVariable
--OutVariable (ov)
--OutBuffer (ob)
--PipelineVariable (pv)
--Verbose (vb)
--WarningAction (wa)
--WarningVariable (wv
+The following list displays the common parameters.
+Their aliases are listed in parentheses.
+* Debug (db)
+* ErrorAction (ea)
+* ErrorVariable (ev)
+* InformationAction (infa)
+* InformationVariable (iv)
+* OutVariable (ov)
+* OutBuffer (ob)
+* PipelineVariable (pv)
+* Verbose (vb)
+* WarningAction (wa)
+* WarningVariable (wv)
 
 The risk mitigation parameters are:
--WhatIf (wi)
--Confirm (cf)
+* WhatIf (wi)
+* Confirm (cf)
 
 For more information about preference variables, type:
 help about_Preference_Variables

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -40,24 +40,23 @@ In addition to the common parameters, many cmdlets offer the WhatIf and
 Confirm risk mitigation parameters. Cmdlets that involve risk to the system
 or to user data usually offer these parameters.
 
-The following list displays the common parameters. Their aliases are listed
-in parentheses.
-
--Debug (db)
--ErrorAction (ea)
--ErrorVariable (ev)
--InformationAction
--InformationVariable
--OutVariable (ov)
--OutBuffer (ob)
--PipelineVariable (pv)
--Verbose (vb)
--WarningAction (wa)
--WarningVariable (wv
+The following list displays the common parameters.
+Their aliases are listed in parentheses.
+* Debug (db)
+* ErrorAction (ea)
+* ErrorVariable (ev)
+* InformationAction (infa)
+* InformationVariable (iv)
+* OutVariable (ov)
+* OutBuffer (ob)
+* PipelineVariable (pv)
+* Verbose (vb)
+* WarningAction (wa)
+* WarningVariable (wv)
 
 The risk mitigation parameters are:
--WhatIf (wi)
--Confirm (cf)
+* WhatIf (wi)
+* Confirm (cf)
 
 For more information about preference variables, type:
 help about_Preference_Variables

--- a/reference/6/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -40,24 +40,23 @@ In addition to the common parameters, many cmdlets offer the WhatIf and
 Confirm risk mitigation parameters. Cmdlets that involve risk to the system
 or to user data usually offer these parameters.
 
-The following list displays the common parameters. Their aliases are listed
-in parentheses.
-
--Debug (db)
--ErrorAction (ea)
--ErrorVariable (ev)
--InformationAction
--InformationVariable
--OutVariable (ov)
--OutBuffer (ob)
--PipelineVariable (pv)
--Verbose (vb)
--WarningAction (wa)
--WarningVariable (wv
+The following list displays the common parameters.
+Their aliases are listed in parentheses.
+* Debug (db)
+* ErrorAction (ea)
+* ErrorVariable (ev)
+* InformationAction (infa)
+* InformationVariable (iv)
+* OutVariable (ov)
+* OutBuffer (ob)
+* PipelineVariable (pv)
+* Verbose (vb)
+* WarningAction (wa)
+* WarningVariable (wv)
 
 The risk mitigation parameters are:
--WhatIf (wi)
--Confirm (cf)
+* WhatIf (wi)
+* Confirm (cf)
 
 For more information about preference variables, type:
 help about_Preference_Variables


### PR DESCRIPTION
Added "infa" and "iv". And fixed formatting.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
