### PR TITLE
Add docs and examples for NoNewLine switch

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Out-String.md
@@ -73,22 +73,17 @@ If you omit the *Stream* parameter, the command displays all of the aliases, bec
 ```
 PS C:\> "a", "b" | Out-String -NoNewLine
 ab
-```
-Not using `-NoNewLine` would have resulted in an output like `a<newline>b<newline>`.
-It should be noted that `-NoNewLine` does not strip newlines embedded within a string but strips out embedded newlines from formatter-generated output. So while
-```
+
 PS C:\> @{key='value'} | Out-String
-```
-Would generate the following output
-```
 Name   Value
 ----   -----
 key    value
-```
-Using `-NoNewLine` would result in the newlines in this output being stripped, thus resulting in
-```
+
+PS C:\> @{key='value'} | Out-String -NoNewLine
 Name Value  -----  key value
 ```
+Not using `-NoNewLine` would have resulted in an output like `a<newline>b<newline>`.
+It should be noted that `-NoNewLine` does not strip newlines embedded within a string but strips out embedded newlines from formatter-generated output. Compare the second and third commands in this examples for clarity.
 
 ## PARAMETERS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Out-String.md
@@ -15,6 +15,13 @@ Sends objects to the host as a series of strings.
 
 ## SYNTAX
 
+### NoNewLineFormatting (Default)
+```
+Out-String [-NoNewLine] [-Width <Int32>] [-InputObject <PSObject>] [-InformationAction <ActionPreference>]
+ [-InformationVariable <String>] [<CommonParameters>]
+```
+
+### StreamFormatting
 ```
 Out-String [-Stream] [-Width <Int32>] [-InputObject <PSObject>] [-InformationAction <ActionPreference>]
  [-InformationVariable <String>] [<CommonParameters>]
@@ -61,6 +68,26 @@ It uses the *Stream* parameter of **Out-String** to send each string individuall
 Another pipeline operator sends the strings to the Select-String cmdlet, which selects the strings that include **Get-Command** anywhere in the string.
 
 If you omit the *Stream* parameter, the command displays all of the aliases, because **Select-String** finds **Get-Command** in the single string that **Out-String** returns, and the formatter displays the string as a table.
+
+### Example 4: Using NoNewLine
+```
+PS C:\> "a", "b" | Out-String -NoNewLine
+```
+This outputs `ab` while not using `-NoNewLine` would have resulted in an output like `a<newline>b<newline>`.
+It should be noted that `-NoNewLine` does not strip newlines embedded within a string but strips out embedded newlines from formatter-generated output. So while
+```
+PS C:\> @{key='value'} | Out-String
+```
+Would generate the following output
+```
+Name   Value
+----   -----
+key    value
+```
+Using `-NoNewLine` would result in the newlines in this output being stripped, thus resulting in
+```
+Name Value  -----  key value
+```
 
 ## PARAMETERS
 
@@ -115,7 +142,7 @@ To use the *Stream* parameter, type `-Stream` or its alias, `ost`.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: (All)
+Parameter Sets: StreamFormatting
 Aliases: 
 
 Required: False
@@ -134,6 +161,21 @@ The default value for the Windows PowerShell console is 80 (characters).
 ```yaml
 Type: Int32
 Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoNewline
+Removes all newlines from formatter generated output. Note that newlines present as part of string objects are preserved
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: NoNewLineFormatting
 Aliases: 
 
 Required: False

--- a/reference/6/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Out-String.md
@@ -72,8 +72,9 @@ If you omit the *Stream* parameter, the command displays all of the aliases, bec
 ### Example 4: Using NoNewLine
 ```
 PS C:\> "a", "b" | Out-String -NoNewLine
+ab
 ```
-This outputs `ab` while not using `-NoNewLine` would have resulted in an output like `a<newline>b<newline>`.
+Not using `-NoNewLine` would have resulted in an output like `a<newline>b<newline>`.
 It should be noted that `-NoNewLine` does not strip newlines embedded within a string but strips out embedded newlines from formatter-generated output. So while
 ```
 PS C:\> @{key='value'} | Out-String
@@ -92,7 +93,9 @@ Name Value  -----  key value
 ## PARAMETERS
 
 ### -InformationAction
-@{Text=}```yaml
+@{Text=}
+
+```yaml
 Type: ActionPreference
 Parameter Sets: (All)
 Aliases: infa
@@ -106,7 +109,9 @@ Accept wildcard characters: False
 ```
 
 ### -InformationVariable
-@{Text=}```yaml
+@{Text=}
+
+```yaml
 Type: String
 Parameter Sets: (All)
 Aliases: iv


### PR DESCRIPTION
Changes made to document functionality added via this [PR](https://github.com/raghav710/PowerShell/commit/cfd5ebd3afe6bf6a1d3aa72ae2b456bb75911cc5) 
* Updated syntax to list the two parameter sets
* Added examples to clarify the behaviour of NoNewLine
* Added parameter set info for -Stream switch
* added details about the -NoNewLine (adapted from Out-File description of the same)

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (v6.0.0-beta.8-17) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
