### PR TITLE
Fix example in about_Eventlogs.md (wildcard)

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Eventlogs.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Eventlogs.md
@@ -66,7 +66,9 @@ Get-WmiObject Win32_NTEventLogFile | where `
 
 To find the Win32 event-related WMI classes, type:
 
-Get-WmiObject -List | where {$_.Name -like "win32event"}
+```powershell
+Get-WmiObject -List | where Name -Like "win32*event*"
+```
 
 For more information, type "Get-Help Get-EventLog" and
 "Get-Help Get-WmiObject".

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Eventlogs.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Eventlogs.md
@@ -66,7 +66,9 @@ Get-WmiObject Win32_NTEventLogFile | where `
 
 To find the Win32 event-related WMI classes, type:
 
-Get-WmiObject -List | where {$_.Name -like "win32event"}
+```powershell
+Get-WmiObject -List | where Name -Like "win32*event*"
+```
 
 For more information, type "Get-Help Get-EventLog" and
 "Get-Help Get-WmiObject".

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Eventlogs.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Eventlogs.md
@@ -66,7 +66,9 @@ Get-WmiObject Win32_NTEventLogFile | where `
 
 To find the Win32 event-related WMI classes, type:
 
-Get-WmiObject -List | where {$_.Name -like "win32event"}
+```powershell
+Get-WmiObject -List | where Name -Like "win32*event*"
+```
 
 For more information, type "Get-Help Get-EventLog" and
 "Get-Help Get-WmiObject".

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Eventlogs.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Eventlogs.md
@@ -66,7 +66,9 @@ Get-WmiObject Win32_NTEventLogFile | where `
 
 To find the Win32 event-related WMI classes, type:
 
-Get-WmiObject -List | where {$_.Name -like "win32event"}
+```powershell
+Get-WmiObject -List | where Name -Like "win32*event*"
+```
 
 For more information, type "Get-Help Get-EventLog" and
 "Get-Help Get-WmiObject".

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Eventlogs.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Eventlogs.md
@@ -66,7 +66,9 @@ Get-WmiObject Win32_NTEventLogFile | where `
 
 To find the Win32 event-related WMI classes, type:
 
-Get-WmiObject -List | where {$_.Name -like "win32event"}
+```powershell
+Get-WmiObject -List | where Name -Like "win32*event*"
+```
 
 For more information, type "Get-Help Get-EventLog" and
 "Get-Help Get-WmiObject".


### PR DESCRIPTION
`Get-WmiObject -List | where {$_.Name -like "win32event"}` returns nothing.

Fixed it as follows:

```powershell
PS> Get-WmiObject -List | where Name -Like "win32*event*"


   NameSpace: ROOT\cimv2

Name                                Methods              Properties
----                                -------              ----------
Win32_DeviceChangeEvent             {}                   {EventType, SECURITY_DESCRIPTOR, TIME...
Win32_SystemConfigurationChangeE... {}                   {EventType, SECURITY_DESCRIPTOR, TIME...
Win32_VolumeChangeEvent             {}                   {DriveName, EventType, SECURITY_DESCR...
Win32_PowerManagementEvent          {}                   {EventType, OEMEventCode, SECURITY_DE...
Win32_ComputerSystemEvent           {}                   {MachineName, SECURITY_DESCRIPTOR, TI...
Win32_ComputerShutdownEvent         {}                   {MachineName, SECURITY_DESCRIPTOR, TI...
Win32_IP4RouteTableEvent            {}                   {SECURITY_DESCRIPTOR, TIME_CREATED}
Win32_NTLogEvent                    {}                   {Category, CategoryString, ComputerNa...
Win32_NTEventlogFile                {TakeOwnerShip, C... {AccessMask, Archive, Caption, Compre...
Win32_NTLogEventLog                 {}                   {Log, Record}
Win32_NTLogEventUser                {}                   {Record, User}
Win32_NTLogEventComputer            {}                   {Computer, Record}
Win32_PerfFormattedData_Counters... {}                   {Caption, Description, Frequency_Obje...
Win32_PerfRawData_Counters_Event... {}                   {Caption, Description, Frequency_Obje...
Win32_PerfFormattedData_Counters... {}                   {BufferMemoryUsageNonPagedPool, Buffe...
Win32_PerfRawData_Counters_Event... {}                   {BufferMemoryUsageNonPagedPool, Buffe...
```

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
