### PR TITLE
Fix the Example 1 in Register-ArgumentCompleter.md (unnecessary `)`)

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -42,7 +42,7 @@ PS C:\> Register-ArgumentCompleter -Native -CommandName powershell -ScriptBlock 
             Where-Object { $_ -like "$wordToComplete*" } |
             Sort-Object |
             ForEach-Object {
-                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_))
+                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
             }
 }
 PS C:\> Register-ArgumentCompleter -CommandName Get-Command -ParameterName Verb -ScriptBlock {

--- a/reference/5.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -42,7 +42,7 @@ PS C:\> Register-ArgumentCompleter -Native -CommandName powershell -ScriptBlock 
             Where-Object { $_ -like "$wordToComplete*" } |
             Sort-Object |
             ForEach-Object {
-                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_))
+                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
             }
 }
 PS C:\> Register-ArgumentCompleter -CommandName Get-Command -ParameterName Verb -ScriptBlock {

--- a/reference/6/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
+++ b/reference/6/Microsoft.PowerShell.Core/Register-ArgumentCompleter.md
@@ -42,7 +42,7 @@ PS C:\> Register-ArgumentCompleter -Native -CommandName powershell -ScriptBlock 
             Where-Object { $_ -like "$wordToComplete*" } |
             Sort-Object |
             ForEach-Object {
-                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_))
+                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
             }
 }
 PS C:\> Register-ArgumentCompleter -CommandName Get-Command -ParameterName Verb -ScriptBlock {


### PR DESCRIPTION
Removed `)` to avoid ParserError.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
