### PR TITLE
Undo PR #1781-#1785: about_Wildcards.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -27,19 +27,12 @@ that appear before the .ppt file name extension.
 
 PowerShell supports the following wildcard characters.
 
-|Wildcard|Description               |Example |Match        |No Match|
-|--------|--------------------------|--------|-------------|--------|
-|*       |Matches zero or more      |a*      |aA, ag, Apple|banana  |
-|        |characters                |        |             |        |
-|        |                          |        |             |        |
-|?       |Matches exactly one       |?n      |an, in, on   |ran     |
-|        |character in that position|        |             |        |
-|        |                          |        |             |        |
-|[ ]     |Matches a range of        |[a-l]ook|book, cook,  |took    |
-|        |characters                |        | look        |        |
-|        |                          |        |             |        |
-|[ ]     |Matches the specified     |[bc]ook |book, cook   |hook    |
-|        |characters                |        |             |        |
+| Wildcard | Description             | Example  | Match            | No match |
+| -------- | ----------------------- | -------- | ---------------- | -------- |
+| *        | Zero or more characters | a*       | aA, ag, Apple    | banana   |
+| ?        | Exactly one character   | ?n       | an, in, on       | ran      |
+| [ ]      | A range of characters   | [a-l]ook | book, cook, look | took     |
+| [ ]      | Specified characters    | [bc]ook  | book, cook       | hook     |
 
 You can include multiple wildcard characters in the same word pattern.
 For example, to find text files whose names begin with the letters "a"
@@ -60,7 +53,7 @@ following command gets services in which the ServiceType property value
 includes "Interactive".
 
 ```powershell
-Get-Service | Where-Object {$_.ServiceType -like "Interactive"}
+Get-Service | Where-Object { $_.ServiceType -like "*Interactive*" }
 ```
 
 In the following example, wildcard characters are used to find property
@@ -69,16 +62,17 @@ Description of a restore point includes "PowerShell", the command adds the
 value of the CreationTime property of the restore point to a log file.
 
 ```powershell
-$p = Get-ComputerRestorePoint
-foreach ($point in $p) {
-  if ($point.description -like "PowerShell") {
-    add-content -path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
-  }
+foreach ($point in Get-ComputerRestorePoint) {
+	if ($point.Description -like "*PowerShell*") {
+		Add-Content -Path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
+	}
 }
 ```
 
 ## SEE ALSO
 
-- [about_Language_Keywords](about_Language_Keywords.md)
-- [about_If](about_If.md)
-- [about_Script_Blocks](about_Script_Blocks.md)
+[about_Language_Keywords](about_Language_Keywords.md)
+
+[about_If](about_If.md)
+
+[about_Script_Blocks](about_Script_Blocks.md)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -27,19 +27,12 @@ that appear before the .ppt file name extension.
 
 PowerShell supports the following wildcard characters.
 
-|Wildcard|Description               |Example |Match        |No Match|
-|--------|--------------------------|--------|-------------|--------|
-|*       |Matches zero or more      |a*      |aA, ag, Apple|banana  |
-|        |characters                |        |             |        |
-|        |                          |        |             |        |
-|?       |Matches exactly one       |?n      |an, in, on   |ran     |
-|        |character in that position|        |             |        |
-|        |                          |        |             |        |
-|[ ]     |Matches a range of        |[a-l]ook|book, cook,  |took    |
-|        |characters                |        | look        |        |
-|        |                          |        |             |        |
-|[ ]     |Matches the specified     |[bc]ook |book, cook   |hook    |
-|        |characters                |        |             |        |
+| Wildcard | Description             | Example  | Match            | No match |
+| -------- | ----------------------- | -------- | ---------------- | -------- |
+| *        | Zero or more characters | a*       | aA, ag, Apple    | banana   |
+| ?        | Exactly one character   | ?n       | an, in, on       | ran      |
+| [ ]      | A range of characters   | [a-l]ook | book, cook, look | took     |
+| [ ]      | Specified characters    | [bc]ook  | book, cook       | hook     |
 
 You can include multiple wildcard characters in the same word pattern.
 For example, to find text files whose names begin with the letters "a"
@@ -60,7 +53,7 @@ following command gets services in which the ServiceType property value
 includes "Interactive".
 
 ```powershell
-Get-Service | Where-Object {$_.ServiceType -like "Interactive"}
+Get-Service | Where-Object { $_.ServiceType -like "*Interactive*" }
 ```
 
 In the following example, wildcard characters are used to find property
@@ -69,16 +62,17 @@ Description of a restore point includes "PowerShell", the command adds the
 value of the CreationTime property of the restore point to a log file.
 
 ```powershell
-$p = Get-ComputerRestorePoint
-foreach ($point in $p) {
-  if ($point.description -like "PowerShell") {
-    add-content -path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
-  }
+foreach ($point in Get-ComputerRestorePoint) {
+	if ($point.Description -like "*PowerShell*") {
+		Add-Content -Path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
+	}
 }
 ```
 
 ## SEE ALSO
 
-- [about_Language_Keywords](about_Language_Keywords.md)
-- [about_If](about_If.md)
-- [about_Script_Blocks](about_Script_Blocks.md)
+[about_Language_Keywords](about_Language_Keywords.md)
+
+[about_If](about_If.md)
+
+[about_Script_Blocks](about_Script_Blocks.md)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -27,19 +27,12 @@ that appear before the .ppt file name extension.
 
 PowerShell supports the following wildcard characters.
 
-|Wildcard|Description               |Example |Match        |No Match|
-|--------|--------------------------|--------|-------------|--------|
-|*       |Matches zero or more      |a*      |aA, ag, Apple|banana  |
-|        |characters                |        |             |        |
-|        |                          |        |             |        |
-|?       |Matches exactly one       |?n      |an, in, on   |ran     |
-|        |character in that position|        |             |        |
-|        |                          |        |             |        |
-|[ ]     |Matches a range of        |[a-l]ook|book, cook,  |took    |
-|        |characters                |        | look        |        |
-|        |                          |        |             |        |
-|[ ]     |Matches the specified     |[bc]ook |book, cook   |hook    |
-|        |characters                |        |             |        |
+| Wildcard | Description             | Example  | Match            | No match |
+| -------- | ----------------------- | -------- | ---------------- | -------- |
+| *        | Zero or more characters | a*       | aA, ag, Apple    | banana   |
+| ?        | Exactly one character   | ?n       | an, in, on       | ran      |
+| [ ]      | A range of characters   | [a-l]ook | book, cook, look | took     |
+| [ ]      | Specified characters    | [bc]ook  | book, cook       | hook     |
 
 You can include multiple wildcard characters in the same word pattern.
 For example, to find text files whose names begin with the letters "a"
@@ -60,7 +53,7 @@ following command gets services in which the ServiceType property value
 includes "Interactive".
 
 ```powershell
-Get-Service | Where-Object {$_.ServiceType -like "Interactive"}
+Get-Service | Where-Object { $_.ServiceType -like "*Interactive*" }
 ```
 
 In the following example, wildcard characters are used to find property
@@ -69,16 +62,17 @@ Description of a restore point includes "PowerShell", the command adds the
 value of the CreationTime property of the restore point to a log file.
 
 ```powershell
-$p = Get-ComputerRestorePoint
-foreach ($point in $p) {
-  if ($point.description -like "PowerShell") {
-    add-content -path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
-  }
+foreach ($point in Get-ComputerRestorePoint) {
+	if ($point.Description -like "*PowerShell*") {
+		Add-Content -Path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
+	}
 }
 ```
 
 ## SEE ALSO
 
-- [about_Language_Keywords](about_Language_Keywords.md)
-- [about_If](about_If.md)
-- [about_Script_Blocks](about_Script_Blocks.md)
+[about_Language_Keywords](about_Language_Keywords.md)
+
+[about_If](about_If.md)
+
+[about_Script_Blocks](about_Script_Blocks.md)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -27,19 +27,12 @@ that appear before the .ppt file name extension.
 
 PowerShell supports the following wildcard characters.
 
-|Wildcard|Description               |Example |Match        |No Match|
-|--------|--------------------------|--------|-------------|--------|
-|*       |Matches zero or more      |a*      |aA, ag, Apple|banana  |
-|        |characters                |        |             |        |
-|        |                          |        |             |        |
-|?       |Matches exactly one       |?n      |an, in, on   |ran     |
-|        |character in that position|        |             |        |
-|        |                          |        |             |        |
-|[ ]     |Matches a range of        |[a-l]ook|book, cook,  |took    |
-|        |characters                |        | look        |        |
-|        |                          |        |             |        |
-|[ ]     |Matches the specified     |[bc]ook |book, cook   |hook    |
-|        |characters                |        |             |        |
+| Wildcard | Description             | Example  | Match            | No match |
+| -------- | ----------------------- | -------- | ---------------- | -------- |
+| *        | Zero or more characters | a*       | aA, ag, Apple    | banana   |
+| ?        | Exactly one character   | ?n       | an, in, on       | ran      |
+| [ ]      | A range of characters   | [a-l]ook | book, cook, look | took     |
+| [ ]      | Specified characters    | [bc]ook  | book, cook       | hook     |
 
 You can include multiple wildcard characters in the same word pattern.
 For example, to find text files whose names begin with the letters "a"
@@ -60,7 +53,7 @@ following command gets services in which the ServiceType property value
 includes "Interactive".
 
 ```powershell
-Get-Service | Where-Object {$_.ServiceType -like "Interactive"}
+Get-Service | Where-Object { $_.ServiceType -like "*Interactive*" }
 ```
 
 In the following example, wildcard characters are used to find property
@@ -69,16 +62,17 @@ Description of a restore point includes "PowerShell", the command adds the
 value of the CreationTime property of the restore point to a log file.
 
 ```powershell
-$p = Get-ComputerRestorePoint
-foreach ($point in $p) {
-  if ($point.description -like "PowerShell") {
-    add-content -path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
-  }
+foreach ($point in Get-ComputerRestorePoint) {
+	if ($point.Description -like "*PowerShell*") {
+		Add-Content -Path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
+	}
 }
 ```
 
 ## SEE ALSO
 
-- [about_Language_Keywords](about_Language_Keywords.md)
-- [about_If](about_If.md)
-- [about_Script_Blocks](about_Script_Blocks.md)
+[about_Language_Keywords](about_Language_Keywords.md)
+
+[about_If](about_If.md)
+
+[about_Script_Blocks](about_Script_Blocks.md)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -27,19 +27,12 @@ that appear before the .ppt file name extension.
 
 PowerShell supports the following wildcard characters.
 
-|Wildcard|Description               |Example |Match        |No Match|
-|--------|--------------------------|--------|-------------|--------|
-|*       |Matches zero or more      |a*      |aA, ag, Apple|banana  |
-|        |characters                |        |             |        |
-|        |                          |        |             |        |
-|?       |Matches exactly one       |?n      |an, in, on   |ran     |
-|        |character in that position|        |             |        |
-|        |                          |        |             |        |
-|[ ]     |Matches a range of        |[a-l]ook|book, cook,  |took    |
-|        |characters                |        | look        |        |
-|        |                          |        |             |        |
-|[ ]     |Matches the specified     |[bc]ook |book, cook   |hook    |
-|        |characters                |        |             |        |
+| Wildcard | Description             | Example  | Match            | No match |
+| -------- | ----------------------- | -------- | ---------------- | -------- |
+| *        | Zero or more characters | a*       | aA, ag, Apple    | banana   |
+| ?        | Exactly one character   | ?n       | an, in, on       | ran      |
+| [ ]      | A range of characters   | [a-l]ook | book, cook, look | took     |
+| [ ]      | Specified characters    | [bc]ook  | book, cook       | hook     |
 
 You can include multiple wildcard characters in the same word pattern.
 For example, to find text files whose names begin with the letters "a"
@@ -60,7 +53,7 @@ following command gets services in which the ServiceType property value
 includes "Interactive".
 
 ```powershell
-Get-Service | Where-Object {$_.ServiceType -like "Interactive"}
+Get-Service | Where-Object { $_.ServiceType -like "*Interactive*" }
 ```
 
 In the following example, wildcard characters are used to find property
@@ -69,16 +62,17 @@ Description of a restore point includes "PowerShell", the command adds the
 value of the CreationTime property of the restore point to a log file.
 
 ```powershell
-$p = Get-ComputerRestorePoint
-foreach ($point in $p) {
-  if ($point.description -like "PowerShell") {
-    add-content -path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
-  }
+foreach ($point in Get-ComputerRestorePoint) {
+	if ($point.Description -like "*PowerShell*") {
+		Add-Content -Path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
+	}
 }
 ```
 
 ## SEE ALSO
 
-- [about_Language_Keywords](about_Language_Keywords.md)
-- [about_If](about_If.md)
-- [about_Script_Blocks](about_Script_Blocks.md)
+[about_Language_Keywords](about_Language_Keywords.md)
+
+[about_If](about_If.md)
+
+[about_Script_Blocks](about_Script_Blocks.md)


### PR DESCRIPTION
PR #1781 #1782 #1783 #1784 #1785 have issues as follows:
* Broke table appearance (See [Microsoft Docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_wildcards?view=powershell-6))
* Applied list style to "See Also" links.
  It is different from many other "See Also" links (e.g. about_Profiles.md)
* Restored the issue fixed by #1733

I have rolled back them to the previous version.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
