### PR TITLE
Undo PR #1781-#1785: about_Automatic_Variables.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -121,7 +121,7 @@ information, see [about_ForEach](about_ForEach.md).
 
 Contains the full path of the user's home directory. This variable is the
 equivalent of the `%homedrive%%homepath%` Windows environment variables,
-typically C:\\Users\\<UserName>.
+typically C:\Users\<UserName>.
 
 ### $HOST
 
@@ -172,15 +172,10 @@ is particularly useful for finding the name of the current script.
 Beginning in PowerShell 3.0, $MyInvocation has the following new
 properties.
 
-| Property      | Description                                         |
-| ------------- | --------------------------------------------------- |
-| PSScriptRoot  | Contains the full path to the script that invoked   |
-|               | the current command. The value of this property is  |
-|               | populated only when the caller is a script.         |
-| PSCommandPath | Contains the full path and file name of the script  |
-|               | that invoked the current command. The value of this |
-|               | property is populated only when the caller is a     |
-|               | script.                                             |
+Property | Description
+-- | --
+PSScriptRoot | Contains the full path to the script that invoked the current<br>command. The value of this property is populated only when the<br>caller is a script.
+PSCommandPath | Contains the full path and file name of the script that<br>invoked the current command. The value of this property<br>is populated only when the caller is a script.
 
 Unlike the $PSScriptRoot and $PSCommandPath automatic variables, the
 PSScriptRoot and PSCommandPath properties of the $MyInvocation automatic
@@ -250,17 +245,14 @@ can use it in scripts like the following one, which would not work if $null
 were ignored.
 
 ```powershell
-$calendar = @($null, $null, “Meeting”, $null, $null, “Team Lunch”, $null)
-$days = Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"
+$calendar = @($null, $null, "Meeting", $null, $null, "Team Lunch", $null)
+$days = "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
 $currentDay = 0
-foreach($day in $calendar)
-{
-    if($day -ne $null)
-    {
-        "Appointment on $($days[$currentDay]): $day"
-    }
-
-    $currentDay++
+foreach ($day in $calendar) {
+	if ($day -ne $null) {
+		"Appointment on $($days[$currentDay]): $day"
+	}
+	$currentDay++
 }
 ```
 
@@ -453,25 +445,17 @@ Contains a read-only hash table that displays details about the version of
 PowerShell that is running in the current session. The table includes the
 following items:
 
-| Property                  | Description                                   |
-| ------------------------- | --------------------------------------------- |
-| BuildVersion              | The build number of the current version       |
-| CLRVersion                | The version of the common language runtime    |
-|                           | (CLR)                                         |
-| GitCommitId               | The commit Id of the source files, in GitHub, |
-|                           | used in this version of PowerShell            |
-| PSCompatibleVersions      | Versions of PowerShell that are compatible    |
-|                           | with the current version                      |
-| PSEdition                 | This property has the value of 'Desktop', for |
-|                           | Windows Server and Windows client versions.   |
-|                           | This property has the value of 'Core' for     |
-|                           | PowerShell running under Nano Server or       |
-|                           | Windows IOT.                                  |
-| PSRemotingProtocolVersion | The version of the PowerShell remote          |
-|                           | management protocol.                          |
-| PSVersion                 | The PowerShell version number                 |
-| SerializationVersion      | The version of the serialization method       |
-| WSManStackVersion         | The version number of the WS-Management stack |
+Property | Description
+-- | --
+BuildVersion              | The build number of the current version
+CLRVersion                | The version of the common language runtime (CLR)
+GitCommitId               | The commit Id of the source files, in GitHub,<br>used in this version of PowerShell
+PSCompatibleVersions      | Versions of PowerShell that are compatible with<br>the current version
+PSEdition                 | This property has the value of 'Desktop', for<br>Windows Server and Windows client versions.<br>This property has the value of 'Core' for<br>PowerShell running under Nano Server or<br>Windows IOT.
+PSRemotingProtocolVersion | The version of the PowerShell remote management<br>protocol
+PSVersion                 | The PowerShell version number
+SerializationVersion      | The version of the serialization method
+WSManStackVersion         | The version number of the WS-Management stack
 
 ### $PWD
 
@@ -514,6 +498,8 @@ scripts.
 
 ## SEE ALSO
 
-- [about_Hash_Tables](about_Hash_Tables.md)
-- [about_Preference_Variables](about_Preference_Variables.md)
-- [about_Variables](about_Variables.md)
+[about_Hash_Tables](about_Hash_Tables.md)
+
+[about_Preference_Variables](about_Preference_Variables.md)
+
+[about_Variables](about_Variables.md)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -121,7 +121,7 @@ information, see [about_ForEach](about_ForEach.md).
 
 Contains the full path of the user's home directory. This variable is the
 equivalent of the `%homedrive%%homepath%` Windows environment variables,
-typically C:\\Users\\<UserName>.
+typically C:\Users\<UserName>.
 
 ### $HOST
 
@@ -172,15 +172,10 @@ is particularly useful for finding the name of the current script.
 Beginning in PowerShell 3.0, $MyInvocation has the following new
 properties.
 
-| Property      | Description                                         |
-| ------------- | --------------------------------------------------- |
-| PSScriptRoot  | Contains the full path to the script that invoked   |
-|               | the current command. The value of this property is  |
-|               | populated only when the caller is a script.         |
-| PSCommandPath | Contains the full path and file name of the script  |
-|               | that invoked the current command. The value of this |
-|               | property is populated only when the caller is a     |
-|               | script.                                             |
+Property | Description
+-- | --
+PSScriptRoot | Contains the full path to the script that invoked the current<br>command. The value of this property is populated only when the<br>caller is a script.
+PSCommandPath | Contains the full path and file name of the script that<br>invoked the current command. The value of this property<br>is populated only when the caller is a script.
 
 Unlike the $PSScriptRoot and $PSCommandPath automatic variables, the
 PSScriptRoot and PSCommandPath properties of the $MyInvocation automatic
@@ -250,17 +245,14 @@ can use it in scripts like the following one, which would not work if $null
 were ignored.
 
 ```powershell
-$calendar = @($null, $null, “Meeting”, $null, $null, “Team Lunch”, $null)
-$days = Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"
+$calendar = @($null, $null, "Meeting", $null, $null, "Team Lunch", $null)
+$days = "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
 $currentDay = 0
-foreach($day in $calendar)
-{
-    if($day -ne $null)
-    {
-        "Appointment on $($days[$currentDay]): $day"
-    }
-
-    $currentDay++
+foreach ($day in $calendar) {
+	if ($day -ne $null) {
+		"Appointment on $($days[$currentDay]): $day"
+	}
+	$currentDay++
 }
 ```
 
@@ -453,25 +445,17 @@ Contains a read-only hash table that displays details about the version of
 PowerShell that is running in the current session. The table includes the
 following items:
 
-| Property                  | Description                                   |
-| ------------------------- | --------------------------------------------- |
-| BuildVersion              | The build number of the current version       |
-| CLRVersion                | The version of the common language runtime    |
-|                           | (CLR)                                         |
-| GitCommitId               | The commit Id of the source files, in GitHub, |
-|                           | used in this version of PowerShell            |
-| PSCompatibleVersions      | Versions of PowerShell that are compatible    |
-|                           | with the current version                      |
-| PSEdition                 | This property has the value of 'Desktop', for |
-|                           | Windows Server and Windows client versions.   |
-|                           | This property has the value of 'Core' for     |
-|                           | PowerShell running under Nano Server or       |
-|                           | Windows IOT.                                  |
-| PSRemotingProtocolVersion | The version of the PowerShell remote          |
-|                           | management protocol.                          |
-| PSVersion                 | The PowerShell version number                 |
-| SerializationVersion      | The version of the serialization method       |
-| WSManStackVersion         | The version number of the WS-Management stack |
+Property | Description
+-- | --
+BuildVersion              | The build number of the current version
+CLRVersion                | The version of the common language runtime (CLR)
+GitCommitId               | The commit Id of the source files, in GitHub,<br>used in this version of PowerShell
+PSCompatibleVersions      | Versions of PowerShell that are compatible with<br>the current version
+PSEdition                 | This property has the value of 'Desktop', for<br>Windows Server and Windows client versions.<br>This property has the value of 'Core' for<br>PowerShell running under Nano Server or<br>Windows IOT.
+PSRemotingProtocolVersion | The version of the PowerShell remote management<br>protocol
+PSVersion                 | The PowerShell version number
+SerializationVersion      | The version of the serialization method
+WSManStackVersion         | The version number of the WS-Management stack
 
 ### $PWD
 
@@ -514,6 +498,8 @@ scripts.
 
 ## SEE ALSO
 
-- [about_Hash_Tables](about_Hash_Tables.md)
-- [about_Preference_Variables](about_Preference_Variables.md)
-- [about_Variables](about_Variables.md)
+[about_Hash_Tables](about_Hash_Tables.md)
+
+[about_Preference_Variables](about_Preference_Variables.md)
+
+[about_Variables](about_Variables.md)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -121,7 +121,7 @@ information, see [about_ForEach](about_ForEach.md).
 
 Contains the full path of the user's home directory. This variable is the
 equivalent of the `%homedrive%%homepath%` Windows environment variables,
-typically C:\\Users\\<UserName>.
+typically C:\Users\<UserName>.
 
 ### $HOST
 
@@ -172,15 +172,10 @@ is particularly useful for finding the name of the current script.
 Beginning in PowerShell 3.0, $MyInvocation has the following new
 properties.
 
-| Property      | Description                                         |
-| ------------- | --------------------------------------------------- |
-| PSScriptRoot  | Contains the full path to the script that invoked   |
-|               | the current command. The value of this property is  |
-|               | populated only when the caller is a script.         |
-| PSCommandPath | Contains the full path and file name of the script  |
-|               | that invoked the current command. The value of this |
-|               | property is populated only when the caller is a     |
-|               | script.                                             |
+Property | Description
+-- | --
+PSScriptRoot | Contains the full path to the script that invoked the current<br>command. The value of this property is populated only when the<br>caller is a script.
+PSCommandPath | Contains the full path and file name of the script that<br>invoked the current command. The value of this property<br>is populated only when the caller is a script.
 
 Unlike the $PSScriptRoot and $PSCommandPath automatic variables, the
 PSScriptRoot and PSCommandPath properties of the $MyInvocation automatic
@@ -250,17 +245,14 @@ can use it in scripts like the following one, which would not work if $null
 were ignored.
 
 ```powershell
-$calendar = @($null, $null, “Meeting”, $null, $null, “Team Lunch”, $null)
-$days = Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"
+$calendar = @($null, $null, "Meeting", $null, $null, "Team Lunch", $null)
+$days = "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
 $currentDay = 0
-foreach($day in $calendar)
-{
-    if($day -ne $null)
-    {
-        "Appointment on $($days[$currentDay]): $day"
-    }
-
-    $currentDay++
+foreach ($day in $calendar) {
+	if ($day -ne $null) {
+		"Appointment on $($days[$currentDay]): $day"
+	}
+	$currentDay++
 }
 ```
 
@@ -453,25 +445,17 @@ Contains a read-only hash table that displays details about the version of
 PowerShell that is running in the current session. The table includes the
 following items:
 
-| Property                  | Description                                   |
-| ------------------------- | --------------------------------------------- |
-| BuildVersion              | The build number of the current version       |
-| CLRVersion                | The version of the common language runtime    |
-|                           | (CLR)                                         |
-| GitCommitId               | The commit Id of the source files, in GitHub, |
-|                           | used in this version of PowerShell            |
-| PSCompatibleVersions      | Versions of PowerShell that are compatible    |
-|                           | with the current version                      |
-| PSEdition                 | This property has the value of 'Desktop', for |
-|                           | Windows Server and Windows client versions.   |
-|                           | This property has the value of 'Core' for     |
-|                           | PowerShell running under Nano Server or       |
-|                           | Windows IOT.                                  |
-| PSRemotingProtocolVersion | The version of the PowerShell remote          |
-|                           | management protocol.                          |
-| PSVersion                 | The PowerShell version number                 |
-| SerializationVersion      | The version of the serialization method       |
-| WSManStackVersion         | The version number of the WS-Management stack |
+Property | Description
+-- | --
+BuildVersion              | The build number of the current version
+CLRVersion                | The version of the common language runtime (CLR)
+GitCommitId               | The commit Id of the source files, in GitHub,<br>used in this version of PowerShell
+PSCompatibleVersions      | Versions of PowerShell that are compatible with<br>the current version
+PSEdition                 | This property has the value of 'Desktop', for<br>Windows Server and Windows client versions.<br>This property has the value of 'Core' for<br>PowerShell running under Nano Server or<br>Windows IOT.
+PSRemotingProtocolVersion | The version of the PowerShell remote management<br>protocol
+PSVersion                 | The PowerShell version number
+SerializationVersion      | The version of the serialization method
+WSManStackVersion         | The version number of the WS-Management stack
 
 ### $PWD
 
@@ -514,6 +498,8 @@ scripts.
 
 ## SEE ALSO
 
-- [about_Hash_Tables](about_Hash_Tables.md)
-- [about_Preference_Variables](about_Preference_Variables.md)
-- [about_Variables](about_Variables.md)
+[about_Hash_Tables](about_Hash_Tables.md)
+
+[about_Preference_Variables](about_Preference_Variables.md)
+
+[about_Variables](about_Variables.md)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -121,7 +121,7 @@ information, see [about_ForEach](about_ForEach.md).
 
 Contains the full path of the user's home directory. This variable is the
 equivalent of the `%homedrive%%homepath%` Windows environment variables,
-typically C:\\Users\\<UserName>.
+typically C:\Users\<UserName>.
 
 ### $HOST
 
@@ -172,15 +172,10 @@ is particularly useful for finding the name of the current script.
 Beginning in PowerShell 3.0, $MyInvocation has the following new
 properties.
 
-| Property      | Description                                         |
-| ------------- | --------------------------------------------------- |
-| PSScriptRoot  | Contains the full path to the script that invoked   |
-|               | the current command. The value of this property is  |
-|               | populated only when the caller is a script.         |
-| PSCommandPath | Contains the full path and file name of the script  |
-|               | that invoked the current command. The value of this |
-|               | property is populated only when the caller is a     |
-|               | script.                                             |
+Property | Description
+-- | --
+PSScriptRoot | Contains the full path to the script that invoked the current<br>command. The value of this property is populated only when the<br>caller is a script.
+PSCommandPath | Contains the full path and file name of the script that<br>invoked the current command. The value of this property<br>is populated only when the caller is a script.
 
 Unlike the $PSScriptRoot and $PSCommandPath automatic variables, the
 PSScriptRoot and PSCommandPath properties of the $MyInvocation automatic
@@ -250,17 +245,14 @@ can use it in scripts like the following one, which would not work if $null
 were ignored.
 
 ```powershell
-$calendar = @($null, $null, “Meeting”, $null, $null, “Team Lunch”, $null)
-$days = Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"
+$calendar = @($null, $null, "Meeting", $null, $null, "Team Lunch", $null)
+$days = "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
 $currentDay = 0
-foreach($day in $calendar)
-{
-    if($day -ne $null)
-    {
-        "Appointment on $($days[$currentDay]): $day"
-    }
-
-    $currentDay++
+foreach ($day in $calendar) {
+	if ($day -ne $null) {
+		"Appointment on $($days[$currentDay]): $day"
+	}
+	$currentDay++
 }
 ```
 
@@ -453,25 +445,17 @@ Contains a read-only hash table that displays details about the version of
 PowerShell that is running in the current session. The table includes the
 following items:
 
-| Property                  | Description                                   |
-| ------------------------- | --------------------------------------------- |
-| BuildVersion              | The build number of the current version       |
-| CLRVersion                | The version of the common language runtime    |
-|                           | (CLR)                                         |
-| GitCommitId               | The commit Id of the source files, in GitHub, |
-|                           | used in this version of PowerShell            |
-| PSCompatibleVersions      | Versions of PowerShell that are compatible    |
-|                           | with the current version                      |
-| PSEdition                 | This property has the value of 'Desktop', for |
-|                           | Windows Server and Windows client versions.   |
-|                           | This property has the value of 'Core' for     |
-|                           | PowerShell running under Nano Server or       |
-|                           | Windows IOT.                                  |
-| PSRemotingProtocolVersion | The version of the PowerShell remote          |
-|                           | management protocol.                          |
-| PSVersion                 | The PowerShell version number                 |
-| SerializationVersion      | The version of the serialization method       |
-| WSManStackVersion         | The version number of the WS-Management stack |
+Property | Description
+-- | --
+BuildVersion              | The build number of the current version
+CLRVersion                | The version of the common language runtime (CLR)
+GitCommitId               | The commit Id of the source files, in GitHub,<br>used in this version of PowerShell
+PSCompatibleVersions      | Versions of PowerShell that are compatible with<br>the current version
+PSEdition                 | This property has the value of 'Desktop', for<br>Windows Server and Windows client versions.<br>This property has the value of 'Core' for<br>PowerShell running under Nano Server or<br>Windows IOT.
+PSRemotingProtocolVersion | The version of the PowerShell remote management<br>protocol
+PSVersion                 | The PowerShell version number
+SerializationVersion      | The version of the serialization method
+WSManStackVersion         | The version number of the WS-Management stack
 
 ### $PWD
 
@@ -514,6 +498,8 @@ scripts.
 
 ## SEE ALSO
 
-- [about_Hash_Tables](about_Hash_Tables.md)
-- [about_Preference_Variables](about_Preference_Variables.md)
-- [about_Variables](about_Variables.md)
+[about_Hash_Tables](about_Hash_Tables.md)
+
+[about_Preference_Variables](about_Preference_Variables.md)
+
+[about_Variables](about_Variables.md)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -121,7 +121,7 @@ information, see [about_ForEach](about_ForEach.md).
 
 Contains the full path of the user's home directory. This variable is the
 equivalent of the `%homedrive%%homepath%` Windows environment variables,
-typically C:\\Users\\<UserName>.
+typically C:\Users\<UserName>.
 
 ### $HOST
 
@@ -172,15 +172,10 @@ is particularly useful for finding the name of the current script.
 Beginning in PowerShell 3.0, $MyInvocation has the following new
 properties.
 
-| Property      | Description                                         |
-| ------------- | --------------------------------------------------- |
-| PSScriptRoot  | Contains the full path to the script that invoked   |
-|               | the current command. The value of this property is  |
-|               | populated only when the caller is a script.         |
-| PSCommandPath | Contains the full path and file name of the script  |
-|               | that invoked the current command. The value of this |
-|               | property is populated only when the caller is a     |
-|               | script.                                             |
+Property | Description
+-- | --
+PSScriptRoot | Contains the full path to the script that invoked the current<br>command. The value of this property is populated only when the<br>caller is a script.
+PSCommandPath | Contains the full path and file name of the script that<br>invoked the current command. The value of this property<br>is populated only when the caller is a script.
 
 Unlike the $PSScriptRoot and $PSCommandPath automatic variables, the
 PSScriptRoot and PSCommandPath properties of the $MyInvocation automatic
@@ -250,17 +245,14 @@ can use it in scripts like the following one, which would not work if $null
 were ignored.
 
 ```powershell
-$calendar = @($null, $null, “Meeting”, $null, $null, “Team Lunch”, $null)
-$days = Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"
+$calendar = @($null, $null, "Meeting", $null, $null, "Team Lunch", $null)
+$days = "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
 $currentDay = 0
-foreach($day in $calendar)
-{
-    if($day -ne $null)
-    {
-        "Appointment on $($days[$currentDay]): $day"
-    }
-
-    $currentDay++
+foreach ($day in $calendar) {
+	if ($day -ne $null) {
+		"Appointment on $($days[$currentDay]): $day"
+	}
+	$currentDay++
 }
 ```
 
@@ -453,25 +445,17 @@ Contains a read-only hash table that displays details about the version of
 PowerShell that is running in the current session. The table includes the
 following items:
 
-| Property                  | Description                                   |
-| ------------------------- | --------------------------------------------- |
-| BuildVersion              | The build number of the current version       |
-| CLRVersion                | The version of the common language runtime    |
-|                           | (CLR)                                         |
-| GitCommitId               | The commit Id of the source files, in GitHub, |
-|                           | used in this version of PowerShell            |
-| PSCompatibleVersions      | Versions of PowerShell that are compatible    |
-|                           | with the current version                      |
-| PSEdition                 | This property has the value of 'Desktop', for |
-|                           | Windows Server and Windows client versions.   |
-|                           | This property has the value of 'Core' for     |
-|                           | PowerShell running under Nano Server or       |
-|                           | Windows IOT.                                  |
-| PSRemotingProtocolVersion | The version of the PowerShell remote          |
-|                           | management protocol.                          |
-| PSVersion                 | The PowerShell version number                 |
-| SerializationVersion      | The version of the serialization method       |
-| WSManStackVersion         | The version number of the WS-Management stack |
+Property | Description
+-- | --
+BuildVersion              | The build number of the current version
+CLRVersion                | The version of the common language runtime (CLR)
+GitCommitId               | The commit Id of the source files, in GitHub,<br>used in this version of PowerShell
+PSCompatibleVersions      | Versions of PowerShell that are compatible with<br>the current version
+PSEdition                 | This property has the value of 'Desktop', for<br>Windows Server and Windows client versions.<br>This property has the value of 'Core' for<br>PowerShell running under Nano Server or<br>Windows IOT.
+PSRemotingProtocolVersion | The version of the PowerShell remote management<br>protocol
+PSVersion                 | The PowerShell version number
+SerializationVersion      | The version of the serialization method
+WSManStackVersion         | The version number of the WS-Management stack
 
 ### $PWD
 
@@ -514,6 +498,8 @@ scripts.
 
 ## SEE ALSO
 
-- [about_Hash_Tables](about_Hash_Tables.md)
-- [about_Preference_Variables](about_Preference_Variables.md)
-- [about_Variables](about_Variables.md)
+[about_Hash_Tables](about_Hash_Tables.md)
+
+[about_Preference_Variables](about_Preference_Variables.md)
+
+[about_Variables](about_Variables.md)


### PR DESCRIPTION
PR #1781 #1782 #1783 #1784 #1785 have issues as follows:
* Broke table appearance (See [Microsoft Docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-6))
* Added unnecessary `\`
* Applied list style to "See Also" links.
  It is different from many other "See Also" links (e.g. about_Profiles.md)
* Restored the issue fixed by #1703

I have rolled back them to the previous version.

@juanpablojofre It seems that the PR #1781-#1785 have many issues. I think they should be rolled back or reviewed again.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
