### PR TITLE
updated supported versions for Debian and Ubuntu

### DIFF
--- a/dsc/lnxGettingStarted.md
+++ b/dsc/lnxGettingStarted.md
@@ -14,11 +14,11 @@ This topic explains how to get started using PowerShell Desired State Configurat
 
 The following Linux operating system versions are supported for DSC for Linux.
 - CentOS 5, 6, and 7 (x86/x64)
-- Debian GNU/Linux 6 and 7 (x86/x64)
+- Debian GNU/Linux 6, 7 and 8 (x86/x64)
 - Oracle Linux 5, 6 and 7 (x86/x64)
 - Red Hat Enterprise Linux Server 5, 6 and 7 (x86/x64)
 - SUSE Linux Enterprise Server 10, 11 and 12 (x86/x64)
-- Ubuntu Server 12.04 LTS and 14.04 LTS (x86/x64)
+- Ubuntu Server 12.04 LTS, 14.04 LTS and 16.04 LTS (x86/x64)
 
 The following table describes the required package dependencies for DSC for Linux.
 


### PR DESCRIPTION
As per the release notes https://github.com/Microsoft/PowerShell-DSC-for-Linux/releases Debian 8 and Ubuntu 16.04LTS are supported.