### PR TITLE
Incorrect cmdlet name on Get-ScheduledJobOption documentation

### DIFF
--- a/reference/5.1/PSScheduledJob/Get-ScheduledJobOption.md
+++ b/reference/5.1/PSScheduledJob/Get-ScheduledJobOption.md
@@ -86,13 +86,13 @@ The results show the job options object that **Get-ScheduledJobOption** returned
 
 ### Example 2: Get all job options
 ```
-PS C:\> Get-ScheduledJob | Get-ScheduledJobOptions
+PS C:\> Get-ScheduledJob | Get-ScheduledJobOption
 ```
 
 This command gets the job options of all scheduled jobs on the local computer.
 
 It uses the Get-ScheduledJob cmdlet to get the scheduled jobs on the local computer.
-A pipeline operator (|) sends the scheduled jobs to the **Get-ScheduledJobOptions** cmdlet, which gets the job options of each scheduled job.
+A pipeline operator (|) sends the scheduled jobs to the **Get-ScheduledJobOption** cmdlet, which gets the job options of each scheduled job.
 
 ### Example 3: Get selected job options
 ```
@@ -145,9 +145,9 @@ PS C:\> $Opts = Get-ScheduledJobOption -Name "BackupTestLogs"
 PS C:\> Register-ScheduledJob -Name "Archive-Scripts" -FilePath "\\Srv01\Scripts\ArchiveScripts.ps1" -ScheduledJobOption $Opts
 ```
 
-This example shows how to use the job options that Get-ScheduledJobOptions gets in a new scheduled job.
+This example shows how to use the job options that Get-ScheduledJobOption gets in a new scheduled job.
 
-The first command uses **Get-ScheduledJobOptions** to get the jobs options of the BackupTestLogs scheduled job.
+The first command uses **Get-ScheduledJobOption** to get the jobs options of the BackupTestLogs scheduled job.
 The command saves the options in the $Opts variable.
 
 The second command uses Register-ScheduledJob cmdlet to create a new scheduled job.


### PR DESCRIPTION
Four times in the document it said Get-ScheduledJobOptions with an S instead of Get-ScheduledJobOption.  I corrected the mistake in all four cases.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] This issue only shows up in version (3, 4, 5, and 5.1) of the document.  Version 6 does not exist.