### PR TITLE
Remove-Service documentation added.

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Get-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-Service.md
@@ -428,3 +428,4 @@ The sort is based on the integer value, not the name.
 
 [Suspend-Service](Suspend-Service.md)
 
+[Remove-Service](Remove-Service.md)

--- a/reference/6/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/New-Service.md
@@ -59,17 +59,6 @@ Status    : OK
 This command uses **Get-WmiObject** to get the **Win32_Service** object for the new service.
 This object includes the start mode and the service description.
 
-### Example 4: Delete a service
-```
-PS C:\> sc.exe delete TestService
-- or -
-PS C:\> (Get-WmiObject win32_service -Filter "name='TestService'").delete()
-```
-
-This example shows two ways to delete the TestService service.
-The first command uses the delete option of Sc.exe.
-The second command uses the **Delete** method of the Win32_Service objects that **Get-WmiObject** returns.
-
 ## PARAMETERS
 
 ### -BinaryPathName
@@ -268,7 +257,6 @@ This cmdlet returns an object that represents the new service.
 
 ## NOTES
 * To run this cmdlet on Windows Vista and later versions of the Windows operating system, start Windows PowerShell by using the Run as administrator option.
-* To delete a service, use Sc.exe, or use the Get-WmiObject cmdlet to get the **Win32_Service** object that represents the service and then use the **Delete** method to delete the service. The object that Get-Service returns does not have a delete method.
 
 ## RELATED LINKS
 
@@ -286,3 +274,4 @@ This cmdlet returns an object that represents the new service.
 
 [Suspend-Service](Suspend-Service.md)
 
+[Remove-Service](Remove-Service.md)

--- a/reference/6/Microsoft.PowerShell.Management/Remove-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/Remove-Service.md
@@ -1,0 +1,173 @@
+---
+ms.date:  2017-06-09
+schema:  2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+online version:  http://go.microsoft.com/fwlink/?LinkId=821608
+external help file:  Microsoft.PowerShell.Commands.Management.dll-Help.xml
+title:  Remove-Service
+---
+
+# Remove-Service
+
+## SYNOPSIS
+Removes a Windows service.
+
+## SYNTAX
+
+### Name
+```
+Remove-Service [-Name] <String> 
+ [-InformationAction <ActionPreference>] [-InformationVariable <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+### InputObject (Default)
+```
+Remove-Service [-InputObject] <ServiceController[]> 
+ [-InformationAction <ActionPreference>] [-InformationVariable <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+The **Remove-Service** cmdlet removes a Windows service in the registry and in the service database.
+
+## EXAMPLES
+
+### Example 1: Remove a service
+```
+PS C:\> Remove-Service -Name "TestService"
+```
+
+This command removes a service named TestService.
+
+### Example 2: Remove a service using the display name
+```
+PS C:\> Get-Service -DisplayName "Test Service" | Remove-Service
+```
+
+This command creates a service named TestService.
+The command uses **Get-Service** to get an object that represents the TestService service using the display name.
+The pipeline operator (|) pipes the object to **Remove-Service**, which removes the service.
+
+## PARAMETERS
+
+### -InformationAction
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: infa
+Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InformationVariable
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: iv
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+### -InputObject
+Specifies **ServiceController** objects that represent the services to stop.
+Enter a variable that contains the objects, or type a command or expression that gets the objects.
+
+```yaml
+Type: ServiceController[]
+Parameter Sets: InputObject
+Aliases: 
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Name
+Specifies the service names of the services to stop.
+Wildcard characters are permitted.
+
+```yaml
+Type: String[]
+Parameter Sets: Default
+Aliases: ServiceName
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.ServiceProcess.ServiceController, System.String
+You can pipe a service object or a string that contains the name of a service to this cmdlet.
+
+## OUTPUTS
+
+### None
+This cmdlet does not return any output.
+
+## NOTES
+* To run this cmdlet on Windows Vista and later versions of the Windows operating system, start Windows PowerShell by using the Run as administrator option.
+
+## RELATED LINKS
+
+[Get-Service](Get-Service.md)
+
+[Restart-Service](Restart-Service.md)
+
+[Resume-Service](Resume-Service.md)
+
+[Set-Service](Set-Service.md)
+
+[Start-Service](Start-Service.md)
+
+[Stop-Service](Stop-Service.md)
+
+[Suspend-Service](Suspend-Service.md)
+

--- a/reference/6/Microsoft.PowerShell.Management/Restart-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/Restart-Service.md
@@ -278,3 +278,4 @@ Otherwise, this cmdlet does not generate any output.
 
 [Suspend-Service](Suspend-Service.md)
 
+[Remove-Service](Remove-Service.md)

--- a/reference/6/Microsoft.PowerShell.Management/Resume-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/Resume-Service.md
@@ -259,3 +259,4 @@ Otherwise, this cmdlet does not generate any output.
 
 [Suspend-Service](Suspend-Service.md)
 
+[Remove-Service](Remove-Service.md)

--- a/reference/6/Microsoft.PowerShell.Management/Set-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/Set-Service.md
@@ -398,3 +398,4 @@ This cmdlet does not return any objects.
 
 [Suspend-Service](Suspend-Service.md)
 
+[Remove-Service](Remove-Service.md)

--- a/reference/6/Microsoft.PowerShell.Management/Start-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/Start-Service.md
@@ -305,3 +305,4 @@ Otherwise, this cmdlet does not generate any output.
 
 [Suspend-Service](Suspend-Service.md)
 
+[Remove-Service](Remove-Service.md)

--- a/reference/6/Microsoft.PowerShell.Management/Stop-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/Stop-Service.md
@@ -307,3 +307,4 @@ The service names appear in the **Name** column and the display names appear in 
 
 [Suspend-Service](Suspend-Service.md)
 
+[Remove-Service](Remove-Service.md)

--- a/reference/6/Microsoft.PowerShell.Management/Suspend-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/Suspend-Service.md
@@ -275,3 +275,4 @@ Otherwise, this cmdlet does not generate any output.
 
 [Stop-Service](Stop-Service.md)
 
+[Remove-Service](Remove-Service.md)


### PR DESCRIPTION
Added documentation for `Remove-Service` which was added in PowerShell/PowerShell#4858

I'm guessing properties like `online version` needs to be changed, but I'm not sure on how/what.
The `Remove-Service` command was added in v6.0.0-beta.8

Version(s) of document impacted
------------------------------
- [ x ] Impacts 6 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ x ] The documented feature was introduced in version (v6.0.0-beta.8) of PowerShell