### PR TITLE
Update Compress-Archive.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/5.1/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -63,13 +63,17 @@ This is a limitation of the underlying API.
 
 ### Example 1: Create an archive file
 ```powershell
-Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip
+Compress-Archive -Path C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip
+```
+### Example 2: Create an archive file (using LiteralPath)
+```powershell
+Compress-Archive -LiteralPath "C:\Reference\Draft Doc.docx", "C:\Reference\Images\Diagram 2.vsd"  -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip
 ```
 
 This command creates a new archive file, Draft.zip, by compressing two files, Draftdoc.docx and diagram2.vsd, specified by the **LiteralPath** parameter.
 The compression level specified for this operation is Optimal.
 
-### Example 2: Create an archive with wildcard characters
+### Example 3: Create an archive with wildcard characters
 ```powershell
 Compress-Archive -Path C:\Reference\* -CompressionLevel Fastest -DestinationPath C:\Archives\Draft
 ```
@@ -79,7 +83,7 @@ Note that though the file name extension .zip was not added to the value of the 
 The new archive file contains every file in the C:\Reference folder, because a wildcard character was used in place of specific file names in the **Path** parameter.
 The specified compression level is Fastest, which might result in a larger output file, but compresses a large number of files faster.
 
-### Example 3: Update an existing archive file
+### Example 4: Update an existing archive file
 ```powershell
 Compress-Archive -Path C:\Reference\* -Update -DestinationPath C:\Archives\Draft.Zip
 ```
@@ -87,7 +91,7 @@ Compress-Archive -Path C:\Reference\* -Update -DestinationPath C:\Archives\Draft
 This command updates an existing archive file, Draft.Zip, in the C:\Archives folder.
 The command is run to update Draft.Zip with newer versions of existing files that came from the C:\Reference folder, and also to add new files that have been added to C:\Reference since Draft.Zip was initially created.
 
-### Example 4: Create an archive from an entire folder
+### Example 5: Create an archive from an entire folder
 ```powershell
 Compress-Archive -Path C:\Reference -DestinationPath C:\Archives\Draft
 ```


### PR DESCRIPTION
1. Changed the first example to use Path rather than Literalpath as the existing example really did not show off the value of literalpath (i.e. to have spaces in the file names).
2. Added a new example so properly show literal path with files that have spaces in the file name.
3. Renumbered the examples.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
