### PR TITLE
Remove 'Windows' from PowerShell for 6.0 doc

### DIFF
--- a/reference/docs-conceptual/core-powershell/console/PowerShell.exe-Command-Line-Help.md
+++ b/reference/docs-conceptual/core-powershell/console/PowerShell.exe-Command-Line-Help.md
@@ -6,7 +6,7 @@ ms.assetid:  1ab7b93b-6785-42c6-a1c9-35ff686a958f
 ---
 
 # PowerShell.exe Command-Line Help
-Starts a Windows PowerShell session. You can use PowerShell.exe to start a Windows PowerShell session from the command line of another tool, such as Cmd.exe, or use it at the Windows PowerShell command line to start a new session. Use the parameters to customize the session.
+a Windows PowerShell session. You can use PowerShell.exe to start a PowerShell session from the command line of another tool, such as Cmd.exe, or use it at the PowerShell command line to start a new session. Use the parameters to customize the session.
 
 ## Syntax
 
@@ -24,7 +24,7 @@ PowerShell[.exe]
        [-NonInteractive] 
        [-NoProfile] 
        [-OutputFormat {Text | XML}] 
-       [-PSConsoleFile <FilePath> | -Version <Windows PowerShell version>]
+       [-PSConsoleFile <FilePath> | -Version <PowerShell version>]
        [-Sta]
        [-WindowStyle <style>]
         
@@ -35,10 +35,10 @@ PowerShell[.exe] -Help | -? | /?
 ## Parameters
 
 ### -EncodedCommand <Base64EncodedCommand>
-Accepts a base-64-encoded string version of a command. Use this parameter to submit commands to Windows PowerShell that require complex quotation marks or curly braces.
+Accepts a base-64-encoded string version of a command. Use this parameter to submit commands to PowerShell that require complex quotation marks or curly braces.
 
 ### -ExecutionPolicy <ExecutionPolicy>
-Sets the default execution policy for the current session and saves it in the $env:PSExecutionPolicyPreference environment variable. This parameter does not change the Windows PowerShell execution policy that is set in the registry. For information about Windows PowerShell execution policies, including a list of valid values, see about_Execution_Policies (http://go.microsoft.com/fwlink/?LinkID=135170).
+Sets the default execution policy for the current session and saves it in the $env:PSExecutionPolicyPreference environment variable. This parameter does not change the PowerShell execution policy that is set in the registry. For information about PowerShell execution policies, including a list of valid values, see about_Execution_Policies (http://go.microsoft.com/fwlink/?LinkID=135170).
 
 ### -File <FilePath> \[<Parameters>]
 Runs the specified script in the local scope ("dot-sourced"), so that the functions and variables that the script creates are available in the current session. Enter the script file path and any parameters. **File** must be the last parameter in the command, because all characters typed after the **File** parameter name are interpreted as the script file path followed by the script parameters and their values.
@@ -51,10 +51,10 @@ If you were to use PowerShell syntax, then in this example your script would rec
 Typically, the switch parameters of a script are either included or omitted. For example, the following command uses the **All** parameter of the Get-Script.ps1 script file: `-File .\Get-Script.ps1 -All`
 
 ### \-InputFormat {Text | XML}
-Describes the format of data sent to Windows PowerShell. Valid values are "Text" (text strings) or "XML" (serialized CLIXML format).
+Describes the format of data sent to PowerShell. Valid values are "Text" (text strings) or "XML" (serialized CLIXML format).
 
 ### -Mta
-Starts Windows PowerShell using a multi-threaded apartment. This parameter is introduced in Windows PowerShell 3.0. In Windows PowerShell 3.0, single-threaded apartment (STA) is the default. In Windows PowerShell 2.0, multi-threaded apartment (MTA) is the default.
+Starts PowerShell using a multi-threaded apartment. This parameter is introduced in PowerShell 3.0. In PowerShell 3.0, single-threaded apartment (STA) is the default. In PowerShell 2.0, multi-threaded apartment (MTA) is the default.
 
 ### -NoExit
 Does not exit after running startup commands.
@@ -66,38 +66,38 @@ Hides the copyright banner at startup.
 Does not present an interactive prompt to the user.
 
 ### -NoProfile
-Does not load the Windows PowerShell profile.
+Does not load the PowerShell profile.
 
 ### -OutputFormat {Text | XML}
-Determines how output from Windows PowerShell is formatted. Valid values are "Text" (text strings) or "XML" (serialized CLIXML format).
+Determines how output from PowerShell is formatted. Valid values are "Text" (text strings) or "XML" (serialized CLIXML format).
 
 ### -PSConsoleFile <FilePath>
-Loads the specified Windows PowerShell console file. Enter the path and name of the console file. To create a console file, use the [Export-Console](https://technet.microsoft.com/en-us/library/4bab1c02-9e61-4aaf-9957-11d1934ef4ef) cmdlet in Windows PowerShell.
+Loads the specified PowerShell console file. Enter the path and name of the console file. To create a console file, use the [Export-Console](https://technet.microsoft.com/en-us/library/4bab1c02-9e61-4aaf-9957-11d1934ef4ef) cmdlet in PowerShell.
 
 ### -Sta
-Starts Windows PowerShell using a single-threaded apartment. In Windows PowerShell 3.0, single-threaded apartment (STA) is the default. In Windows PowerShell 2.0, multi-threaded apartment (MTA) is the default.
+Starts PowerShell using a single-threaded apartment. In PowerShell 3.0, single-threaded apartment (STA) is the default. In PowerShell 2.0, multi-threaded apartment (MTA) is the default.
 
-### -Version <Windows PowerShell Version>
-Starts the specified version of Windows PowerShell. The version that you specify must be installed on the system. If Windows PowerShell 3.0 is installed on the computer, valid values are "2.0" and "3.0". The default value is "3.0".
+### -Version <PowerShell Version>
+Starts the specified version of PowerShell. The version that you specify must be installed on the system. If PowerShell 3.0 is installed on the computer, valid values are "2.0" and "3.0". The default value is "3.0".
 
-If Windows PowerShell 3.0 is not installed, the only valid value is "2.0". Other values are ignored.
+If PowerShell 3.0 is not installed, the only valid value is "2.0". Other values are ignored.
 
-For more information, see "Installing Windows PowerShell" in the [Getting Started with Windows PowerShell [OLD MSDN]](https://technet.microsoft.com/en-us/library/69555d95-b481-43e1-86e7-b46d68b3e2dd).
+For more information, see "Installing PowerShell" in the [Getting Started with PowerShell [OLD MSDN]](https://technet.microsoft.com/en-us/library/69555d95-b481-43e1-86e7-b46d68b3e2dd).
 
 ### -WindowStyle <Window style>
 Sets the window style for the session. Valid values are Normal, Minimized, Maximized and Hidden.
 
 ### -Command
-Executes the specified commands (and any parameters) as though they were typed at the Windows PowerShell command prompt, and then exits, unless the NoExit parameter is specified.
+Executes the specified commands (and any parameters) as though they were typed at the PowerShell command prompt, and then exits, unless the NoExit parameter is specified.
 Essentially, any text after `-Command` is sent as a single command line to PowerShell (this is different from how `-File` handles parameters sent to a script).
 
 The value of Command can be "-", a string. or a script block. If the value of Command is "-", the command text is read from standard input.
 
-Script blocks must be enclosed in braces ({}). You can specify a script block only when running PowerShell.exe in Windows PowerShell. The results of the script are returned to the parent shell as deserialized XML objects, not live objects.
+Script blocks must be enclosed in braces ({}). You can specify a script block only when running PowerShell.exe in PowerShell. The results of the script are returned to the parent shell as deserialized XML objects, not live objects.
 
 If the value of Command is a string, **Command** must be the last parameter in the command, because any characters typed after the command are interpreted as the command arguments.
 
-To write a string that runs a Windows PowerShell command, use the format:
+To write a string that runs a PowerShell command, use the format:
 
 ```
 "& {<command>}"
@@ -106,10 +106,10 @@ To write a string that runs a Windows PowerShell command, use the format:
 where the quotation marks indicate a string and the invoke operator (&) causes the command to be executed.
 
 ### -Help, -?, /?
-Shows this message. If you are typing a PowerShell.exe command in Windows PowerShell, prepend the command parameters with a hyphen (-), not a forward slash (/). You can use either a hyphen or forward slash in Cmd.exe.
+Shows this message. If you are typing a PowerShell.exe command in PowerShell, prepend the command parameters with a hyphen (-), not a forward slash (/). You can use either a hyphen or forward slash in Cmd.exe.
 
 > [!NOTE]
-> Troubleshooting Note: In Windows PowerShell 2.0, starting some programs in the Windows PowerShell console fails with a LastExitCode of 0xc0000142.
+> Troubleshooting Note: In PowerShell 2.0, starting some programs in the Windows PowerShell console fails with a LastExitCode of 0xc0000142.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Removed 'Windows' from 'Windows PowerShell' for 6.0 documentation as it is now just PowerShell.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
