### PR TITLE
Removed 'Windows' from 'Windows PowerShell' for 6.0

### DIFF
--- a/reference/docs-conceptual/core-powershell/console/Using-Tab-Expansion.md
+++ b/reference/docs-conceptual/core-powershell/console/Using-Tab-Expansion.md
@@ -6,14 +6,14 @@ ms.assetid:  c8730471-bf6a-43b8-ab1d-f9ef5a74f04e
 ---
 
 # Using Tab Expansion
-Command-line shells often provide a way to complete the names of long files or commands automatically, speeding up command entry and providing hints. Windows PowerShell allows you to fill in file names and cmdlet names by pressing the **Tab** key.
+Command-line shells often provide a way to complete the names of long files or commands automatically, speeding up command entry and providing . Windows PowerShell allows you to fill in file names and cmdlet names by pressing the **Tab** key.
 
 > [!NOTE]
-> Tab expansion is controlled by the internal function TabExpansion or TabExpansion2. Since this function can be modified or overridden, this discussion is a guide to the behavior of the default Windows PowerShell configuration.
+> Tab expansion is controlled by the internal function TabExpansion or TabExpansion2. Since this function can be modified or overridden, this discussion is a guide to the behavior of the default PowerShell configuration.
 
-To fill in a filename or path from the available choices automatically, type part of the name and press the **Tab** key. Windows PowerShell will automatically expand the name to the first match that it finds. Pressing the **Tab** key repeatedly will cycle through all of the available choices.
+To fill in a filename or path from the available choices automatically, type part of the name and press the **Tab** key. PowerShell will automatically expand the name to the first match that it finds. Pressing the **Tab** key repeatedly will cycle through all of the available choices.
 
-The tab expansion of cmdlet names is slightly different. To use tab expansion on a cmdlet name, type the entire first part of the name (the verb) and the hyphen that follows it. You can fill in more of the name for a partial match. For example, if you type **get-co** and then press the **Tab** key, Windows PowerShell will automatically expand this to the **Get-Command** cmdlet (notice that it also changes the case of letters to their standard form). If you press **Tab** key again, Windows PowerShell replaces this with the only other matching cmdlet name, **Get-Content**.
+The tab expansion of cmdlet names is slightly different. To use tab expansion on a cmdlet name, type the entire first part of the name (the verb) and the hyphen that follows it. You can fill in more of the name for a partial match. For example, if you type **get-co** and then press the **Tab** key, PowerShell will automatically expand this to the **Get-Command** cmdlet (notice that it also changes the case of letters to their standard form). If you press **Tab** key again, PowerShell replaces this with the only other matching cmdlet name, **Get-Content**.
 
 You can use tab expansion repeatedly on the same line. For example, you can use tab expansion on the name of the **Get-Content** cmdlet by entering:
 
@@ -40,5 +40,5 @@ PS> Get-Content C:\windows\actsetup.log
 ```
 
 > [!NOTE]
-> One limitation of the tab expansion process is that tabs are always interpreted as attempts to complete a word. If you copy and paste command examples into a Windows PowerShell console, make sure that the sample does not contain tabs; if it does, the results will be unpredictable and will almost certainly not be what you intended.
+> One limitation of the tab expansion process is that tabs are always interpreted as attempts to complete a word. If you copy and paste command examples into a PowerShell console, make sure that the sample does not contain tabs; if it does, the results will be unpredictable and will almost certainly not be what you intended.
 


### PR DESCRIPTION
Removed 'Windows' from 'Windows PowerShell' for 6.0

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
