### PR TITLE
Update Alias-Provider.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/Providers/Alias-Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Providers/Alias-Provider.md
@@ -30,7 +30,7 @@ online version:  http://go.microsoft.com/fwlink/?LinkId=834943
 
  The Windows PowerShell **Alias** provider lets you get, add, change, clear, and delete aliases in Windows PowerShell.  
 
- An alias is an alternate name for a cmdlet, function, or executable file. Windows PowerShell includes a set of built-in aliases. And, you can add your own aliases to the current session and to your Windows PowerShell profile.  
+ An alias is an alternate name for a cmdlet, function, executable file, or PowerShell script. Windows PowerShell includes a set of built-in aliases. You can add your own aliases to the current session and to your Windows PowerShell profile.  
 
  The **Alias** provider is a flat namespace that contains only the alias objects. The aliases have no child items.  
 
@@ -54,7 +54,7 @@ Set-Location Alias:
 
  When you use these cmdlets, you do not need to specify the `Alias:` drive in the name.  
 
- The **Alias** provider supports all the cmdlets that have the *Item* noun except for the [Invoke-Item](../../Microsoft.PowerShell.Management/Invoke-Item.md) cmdlet. And, it supports the [Get-Content](../../Microsoft.PowerShell.Management/Get-Content.md) and [Set-Content](../../Microsoft.PowerShell.Management/Set-Content.md) cmdlets. The **Alias** provider does not support the cmdlets that have the *ItemProperty* noun. And, the **Alias** provider does not support the `-Filter` parameter in any cmdlet.  
+ The **Alias** provider supports all the cmdlets that have the *Item* noun except for the [Invoke-Item](../../Microsoft.PowerShell.Management/Invoke-Item.md) cmdlet and supports the [Get-Content](../../Microsoft.PowerShell.Management/Get-Content.md) and [Set-Content](../../Microsoft.PowerShell.Management/Set-Content.md) cmdlets. The **Alias** provider does not support the cmdlets that have the *ItemProperty* noun and does not support the `-Filter` parameter in any cmdlet.  
 
  All changes to the aliases affect the current session only. To save the changes, add the changes to the Windows PowerShell profile. Or, use the [Export-Alias](../../Microsoft.PowerShell.Utility/Export-Alias.md) and [Import-Alias](../../Microsoft.PowerShell.Utility/Import-Alias.md) cmdlets.  
 
@@ -110,8 +110,7 @@ Get-Item -Path Alias:ls
 Get-Item -Path Alias:* | Where-Object {$_.Definition -eq "Get-ChildItem"}
 ```
 
- When the aliased item is an executable file, the `Definition` contains the fully qualified path of the file.  
-
+ 
 
 #### Example 4
 


### PR DESCRIPTION
1. Removed statement that an alias is to an executable, the definition cotnains the path. It may - but does not need to be. For example:
Try Set-Alias np Notepad then look at the definition.
2. Clarified that an alias can also be to a powershell script (ps1 file).
3. Tidied up the language removing multiple 'And,' clauses to improve readability.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
