### PR TITLE
Fix the example of `Format-List -DisplayError`

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Format-List.md
@@ -71,14 +71,17 @@ Format-List automatically sends the results to the default output cmdlet for dis
 ## PARAMETERS
 
 ### -DisplayError
-Displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a Format-List command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the DisplayError parameter with an expression.
+Indicates that this cmdlet displays errors at the command line.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-List` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
+```powershell
+PS C:\> Get-Date | Format-List DayOfWeek, { $_ / $null } -DisplayError
+
+
+DayOfWeek    : Monday
+ $_ / $null  : #ERR
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/4.0/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Format-List.md
@@ -78,14 +78,17 @@ Format-List automatically sends the results to the default output cmdlet for dis
 ## PARAMETERS
 
 ### -DisplayError
-Displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a Format-List command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the DisplayError parameter with an expression.
+Indicates that this cmdlet displays errors at the command line.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-List` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
+```powershell
+PS C:\> Get-Date | Format-List DayOfWeek, { $_ / $null } -DisplayError
+
+
+DayOfWeek    : Monday
+ $_ / $null  : #ERR
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-List.md
@@ -79,13 +79,16 @@ Because the name of the *Property* parameter is optional, you can omit it and ty
 
 ### -DisplayError
 Indicates that this cmdlet displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a **Format-List** command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the *DisplayError* parameter with an expression.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-List` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
+```powershell
+PS C:\> Get-Date | Format-List DayOfWeek, { $_ / $null } -DisplayError
+
+
+DayOfWeek    : Monday
+ $_ / $null  : #ERR
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-List.md
@@ -79,13 +79,16 @@ Because the name of the *Property* parameter is optional, you can omit it and ty
 
 ### -DisplayError
 Indicates that this cmdlet displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a Format-List command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the *DisplayError* parameter with an expression.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-List` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
+```powershell
+PS C:\> Get-Date | Format-List DayOfWeek, { $_ / $null } -DisplayError
+
+
+DayOfWeek    : Monday
+ $_ / $null  : #ERR
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/6/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Format-List.md
@@ -80,13 +80,16 @@ Because the name of the *Property* parameter is optional, you can omit it and ty
 
 ### -DisplayError
 Indicates that this cmdlet displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a Format-List command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the *DisplayError* parameter with an expression.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-List` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
+```powershell
+PS C:\> Get-Date | Format-List DayOfWeek, { $_ / $null } -DisplayError
+
+
+DayOfWeek    : Monday
+ $_ / $null  : #ERR
+```
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
The example is a `-DisplayError` parameter example. But it uses `-ShowError` parameter.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
