### PR TITLE
Update the example of `Where-Object -IsNot`

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Where-Object.md
@@ -428,7 +428,7 @@ Accept wildcard characters: False
 Specifies the Is operator, which gets objects when the property value is an instance of the specified .NET Framework type.
 Enclose the type name in square brackets.
 
-For example, `Get-Process | where StartTime -is \[DateTime\]`
+For example, `Get-Process | where StartTime -Is [DateTime]`
 
 This parameter is introduced in Windows PowerShell 3.0.
 
@@ -447,7 +447,7 @@ Accept wildcard characters: False
 ### -IsNot
 Specifies the Is-Not operator, which gets objects when the property value is not an instance of the specified .NET Framework type.
 
-For example, `Get-Process | where StartTime -IsNot \[System.String\]`
+For example, `Get-Process | where StartTime -IsNot [DateTime]`
 
 This parameter is introduced in Windows PowerShell 3.0.
 

--- a/reference/4.0/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Where-Object.md
@@ -713,7 +713,7 @@ Accept wildcard characters: False
 Specifies the Is operator, which gets objects when the property value is an instance of the specified .NET Framework type.
 Enclose the type name in square brackets.
 
-For example, `Get-Process | where StartTime -Is \[DateTime\]`
+For example, `Get-Process | where StartTime -Is [DateTime]`
 
 This parameter is introduced in Windows PowerShell 3.0.
 
@@ -732,7 +732,7 @@ Accept wildcard characters: False
 ### -IsNot
 Specifies the Is-Not operator, which gets objects when the property value is not an instance of the specified .NET Framework type.
 
-For example, `Get-Process | where StartTime -IsNot \[System.String\]`
+For example, `Get-Process | where StartTime -IsNot [DateTime]`
 
 This parameter is introduced in Windows PowerShell 3.0.
 

--- a/reference/5.0/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Where-Object.md
@@ -729,7 +729,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value is an instance of the specified .NET Framework type.
 Enclose the type name in square brackets.
 
-For example, `Get-Process | where StartTime -Is \[DateTime\]`
+For example, `Get-Process | where StartTime -Is [DateTime]`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -748,7 +748,7 @@ Accept wildcard characters: False
 ### -IsNot
 Indicates that this cmdlet gets objects if the property value is not an instance of the specified .NET Framework type.
 
-For example, `Get-Process | where StartTime -IsNot \[System.String\]`
+For example, `Get-Process | where StartTime -IsNot [DateTime]`
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Where-Object.md
@@ -729,7 +729,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value is an instance of the specified .NET Framework type.
 Enclose the type name in square brackets.
 
-For example, `Get-Process | where StartTime -Is \[DateTime\]`
+For example, `Get-Process | where StartTime -Is [DateTime]`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -748,7 +748,7 @@ Accept wildcard characters: False
 ### -IsNot
 Indicates that this cmdlet gets objects if the property value is not an instance of the specified .NET Framework type.
 
-For example, `Get-Process | where StartTime -IsNot \[System.String\]`
+For example, `Get-Process | where StartTime -IsNot [DateTime]`
 
 This parameter was introduced in Windows PowerShell 3.0.
 

--- a/reference/6/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/6/Microsoft.PowerShell.Core/Where-Object.md
@@ -729,7 +729,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet gets objects if the property value is an instance of the specified .NET Framework type.
 Enclose the type name in square brackets.
 
-For example, `Get-Process | where StartTime -Is \[DateTime\]`
+For example, `Get-Process | where StartTime -Is [DateTime]`
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -748,7 +748,7 @@ Accept wildcard characters: False
 ### -IsNot
 Indicates that this cmdlet gets objects if the property value is not an instance of the specified .NET Framework type.
 
-For example, `Get-Process | where StartTime -IsNot \[System.String\]`
+For example, `Get-Process | where StartTime -IsNot [DateTime]`
 
 This parameter was introduced in Windows PowerShell 3.0.
 


### PR DESCRIPTION
`-IsNot [System.String]` does not filter anything:

```powershell
PS> (Get-Process | where StartTime -IsNot [System.String] | Measure-Object).Count
123
PS> (Get-Process | Measure-Object).Count
123
```

As with the example of `-Is`, `[DateTime]` should be used instead of `[System.String]`:

```powershell
PS> (Get-Process | where StartTime -IsNot [DateTime] | Measure-Object).Count
92
PS> (Get-Process | where StartTime -Is [DateTime] | Measure-Object).Count
31
PS> (Get-Process | Measure-Object).Count
123
```
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
