### PR TITLE
fixing issue 1769

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -27,7 +27,7 @@ You can select the indicators that the bar reflects and the text that appears ab
 ### Example 1
 ```
 PS C:\> for ($i = 1; $i -le 100; $i++ )
-{write-progress -activity "Search in Progress" -status "$i% Complete:" -percentcomplete $i;}
+{write-progress -activity "Search in Progress" -status "$i% Complete:" -PercentComplete $i;}
 ```
 
 This command displays the progress of a For loop that counts from 1 to 100.
@@ -35,9 +35,9 @@ The Write-Progress command includes a status bar heading ("activity"), a status 
 ### Example 2
 ```
 PS C:\> for($i = 1; $i -lt 101; $i++ )
-{write-progress -activity Updating -status 'Progress->' -percentcomplete $i -currentOperation OuterLoop; `
+{write-progress -activity Updating -status 'Progress->' -PercentComplete $i -currentOperation OuterLoop; `
 for($j = 1; $j -lt 101; $j++ )
-{write-progress -id  1 -activity Updating -status 'Progress' -percentcomplete $j -currentOperation InnerLoop} }
+{write-progress -id  1 -activity Updating -status 'Progress' -PercentComplete $j -currentOperation InnerLoop} }
 
 Updating
 Progress ->
@@ -58,7 +58,7 @@ Without the Id parameter, the progress bars would be superimposed on each other 
 PS C:\> $events = get-eventlog -logname system
 PS C:\> $events | foreach-object -begin {clear-host;$i=0;$out=""} `
 -process {if($_.message -like "*bios*") {$out=$out + $_.Message}; $i = $i+1;
-write-progress -activity "Searching Events" -status "Progress:" -percentcomplete ($i/$events.count*100)} `
+write-progress -activity "Searching Events" -status "Progress:" -PercentComplete ($i/$events.count*100)} `
 -end {$out}
 ```
 
@@ -86,7 +86,7 @@ This text describes the activity whose progress is being reported.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 1
@@ -102,7 +102,7 @@ If this parameter is omitted, Write-Progress displays progress information.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -118,7 +118,7 @@ This text describes the operation that is currently taking place.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -135,7 +135,7 @@ If the progress bars do not have different IDs, they are superimposed instead of
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 3
@@ -151,7 +151,7 @@ Use the value -1 if the current activity has no parent activity.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -167,7 +167,7 @@ Use the value -1 if the percentage complete is unknown or not applicable.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -183,7 +183,7 @@ Use the value -1 if the number of seconds remaining is unknown or not applicable
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -198,7 +198,7 @@ Identifies the source of the record.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -214,7 +214,7 @@ This text describes current state of the activity.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 2

--- a/reference/4.0/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -30,7 +30,7 @@ You can select the indicators that the bar reflects and the text that appears ab
 ### Example 1
 ```
 PS C:\> for ($i = 1; $i -le 100; $i++ )
-{write-progress -activity "Search in Progress" -status "$i% Complete:" -percentcomplete $i;}
+{write-progress -activity "Search in Progress" -status "$i% Complete:" -PercentComplete $i;}
 ```
 
 This command displays the progress of a For loop that counts from 1 to 100.
@@ -39,9 +39,9 @@ The Write-Progress command includes a status bar heading ("activity"), a status 
 ### Example 2
 ```
 PS C:\> for($i = 1; $i -lt 101; $i++ )
-{write-progress -activity Updating -status 'Progress->' -percentcomplete $i -currentOperation OuterLoop; `
+{write-progress -activity Updating -status 'Progress->' -PercentComplete $i -currentOperation OuterLoop; `
 for($j = 1; $j -lt 101; $j++ )
-{write-progress -id  1 -activity Updating -status 'Progress' -percentcomplete $j -currentOperation InnerLoop} }
+{write-progress -id  1 -activity Updating -status 'Progress' -PercentComplete $j -currentOperation InnerLoop} }
 
 Updating
 Progress ->
@@ -63,7 +63,7 @@ Without the Id parameter, the progress bars would be superimposed on each other 
 PS C:\> $events = get-eventlog -logname system
 PS C:\> $events | foreach-object -begin {clear-host;$i=0;$out=""} `
 -process {if($_.message -like "*bios*") {$out=$out + $_.Message}; $i = $i+1;
-write-progress -activity "Searching Events" -status "Progress:" -percentcomplete ($i/$events.count*100)} `
+write-progress -activity "Searching Events" -status "Progress:" -PercentComplete ($i/$events.count*100)} `
 -end {$out}
 ```
 
@@ -92,7 +92,7 @@ This text describes the activity whose progress is being reported.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 1
@@ -108,7 +108,7 @@ If this parameter is omitted, Write-Progress displays progress information.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -124,7 +124,7 @@ This text describes the operation that is currently taking place.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -141,7 +141,7 @@ If the progress bars do not have different IDs, they are superimposed instead of
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 3
@@ -157,7 +157,7 @@ Use the value -1 if the current activity has no parent activity.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -173,7 +173,7 @@ Use the value -1 if the percentage complete is unknown or not applicable.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -189,7 +189,7 @@ Use the value -1 if the number of seconds remaining is unknown or not applicable
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -204,7 +204,7 @@ Identifies the source of the record.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -220,7 +220,7 @@ This text describes current state of the activity.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 2

--- a/reference/5.0/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -41,14 +41,14 @@ The **Write-Progress** command includes a status bar heading ("activity"), a sta
 PS C:\> for($I = 1; $I -lt 101; $I++ )
 {Write-Progress -Activity Updating -Status 'Progress->' -PercentComplete $I -CurrentOperation OuterLoop; `
 PS C:\> for($j = 1; $j -lt 101; $j++ )
-{Write-Progress -Id 1 -Activity Updating -Status 'Progress' - PercentComplete $j -CurrentOperation InnerLoop} }
+{Write-Progress -Id 1 -Activity Updating -Status 'Progress' -PercentComplete $j -CurrentOperation InnerLoop} }
 Updating
 Progress ->
- [ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo] 
+ [ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo]
 OutsideLoop
 Updating
 Progress
- [oooooooooooooooooo                                                   ] 
+ [oooooooooooooooooo                                                   ]
 InnerLoop
 ```
 
@@ -91,7 +91,7 @@ This text describes the activity whose progress is being reported.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 0
@@ -107,7 +107,7 @@ If this parameter is omitted, **Write-Progress** displays progress information.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -123,7 +123,7 @@ This text describes the operation that is currently taking place.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -140,7 +140,7 @@ If the progress bars do not have different IDs, they are superimposed instead of
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 2
@@ -156,7 +156,7 @@ Use the value -1 if the current activity has no parent activity.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -172,7 +172,7 @@ Use the value -1 if the percentage complete is unknown or not applicable.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -188,7 +188,7 @@ Use the value -1 if the number of seconds remaining is unknown or not applicable
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -203,7 +203,7 @@ Specifies the source of the record.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -219,7 +219,7 @@ This text describes current state of the activity.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 1

--- a/reference/5.1/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -44,11 +44,11 @@ PS C:\> for($j = 1; $j -lt 101; $j++ )
 {Write-Progress -Id 1 -Activity Updating -Status 'Progress' -PercentComplete $j -CurrentOperation InnerLoop} }
 Updating
 Progress ->
- [ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo] 
+ [ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo]
 OutsideLoop
 Updating
 Progress
- [oooooooooooooooooo                                                   ] 
+ [oooooooooooooooooo                                                   ]
 InnerLoop
 ```
 
@@ -91,7 +91,7 @@ This text describes the activity whose progress is being reported.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 0
@@ -107,7 +107,7 @@ If this parameter is omitted, Write-Progress displays progress information.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -123,7 +123,7 @@ This text describes the operation that is currently taking place.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -140,7 +140,7 @@ If the progress bars do not have different IDs, they are superimposed instead of
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 2
@@ -156,7 +156,7 @@ Use the value -1 if the current activity has no parent activity.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -172,7 +172,7 @@ Use the value -1 if the percentage complete is unknown or not applicable.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -188,7 +188,7 @@ Use the value -1 if the number of seconds remaining is unknown or not applicable
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -203,7 +203,7 @@ Specifies the source of the record.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -219,7 +219,7 @@ This text describes current state of the activity.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 1

--- a/reference/6/Microsoft.PowerShell.Utility/Write-Progress.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Write-Progress.md
@@ -41,14 +41,14 @@ The **Write-Progress** command includes a status bar heading ("activity"), a sta
 PS C:\> for($I = 1; $I -lt 101; $I++ )
 {Write-Progress -Activity Updating -Status 'Progress->' -PercentComplete $I -CurrentOperation OuterLoop; `
 PS C:\> for($j = 1; $j -lt 101; $j++ )
-{Write-Progress -Id 1 -Activity Updating -Status 'Progress' - PercentComplete $j -CurrentOperation InnerLoop} }
+{Write-Progress -Id 1 -Activity Updating -Status 'Progress' -PercentComplete $j -CurrentOperation InnerLoop} }
 Updating
 Progress ->
- [ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo] 
+ [ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo]
 OutsideLoop
 Updating
 Progress
- [oooooooooooooooooo                                                   ] 
+ [oooooooooooooooooo                                                   ]
 InnerLoop
 ```
 
@@ -91,7 +91,7 @@ This text describes the activity whose progress is being reported.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 1
@@ -107,7 +107,7 @@ If this parameter is omitted, Write-Progress displays progress information.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -123,7 +123,7 @@ This text describes the operation that is currently taking place.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -140,7 +140,7 @@ If the progress bars do not have different IDs, they are superimposed instead of
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 3
@@ -183,7 +183,7 @@ Use the value -1 if the current activity has no parent activity.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -199,7 +199,7 @@ Use the value -1 if the percentage complete is unknown or not applicable.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -215,7 +215,7 @@ Use the value -1 if the number of seconds remaining is unknown or not applicable
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -230,7 +230,7 @@ Specifies the source of the record.
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -246,7 +246,7 @@ This text describes current state of the activity.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 2


### PR DESCRIPTION
Removing extra space in examples using -PercentComplete parameter. fixing issue #1769 

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

