### PR TITLE
Update Example 5 in Group-Object.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Group-Object.md
@@ -67,24 +67,26 @@ The command uses the Property parameter to specify that the events should be gro
 
 In the output, the Count column represents the number of entries in each group, the Name column represents the EventID values that define a group, and the Group column represents the objects in each group.
 ### Example 5
+```powershell
+PS C:\> Get-Process | Group-Object -Property PriorityClass
+
+Count Name         Group
+----- ----         -----
+   55 Normal       {System.Diagnostics.Process (AdtAgent), System.Diagnosti...
+    1              {System.Diagnostics.Process (Idle)}
+    3 High         {System.Diagnostics.Process (Newproc), System.Diagnostic...
+    2 BelowNormal  {System.Diagnostics.Process (winperf),
 ```
-PS C:\> get-process | group-object -property priorityclass
 
-Count Name                Group
------ ----                -----
-55 Normal              {System.Diagnostics.Process (AdtAgent), System.Diagnostics.Process (alg), System.Dia...
-1                     {System.Diagnostics.Process (Idle)}
-3 High                {System.Diagnostics.Process (Newproc), System.Diagnostics.Process (winlogon), System.D...
-2 BelowNormal         {System.Diagnostics.Process (winperf),
-
-PS C:\> get-process | group-object -property company -noelement
+```powershell
+PS C:\> Get-Process | Group-Object -Property PriorityClass -NoElement
 
 Count Name
 ----- ----
-55 Normal
-1
-3 High
-2 BelowNormal
+   55 Normal
+    1
+    3 High
+    2 BelowNormal
 ```
 
 This example demonstrates the effect of the NoElement parameter.

--- a/reference/4.0/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Group-Object.md
@@ -74,24 +74,26 @@ The command uses the Property parameter to specify that the events should be gro
 In the output, the Count column represents the number of entries in each group, the Name column represents the EventID values that define a group, and the Group column represents the objects in each group.
 
 ### Example 5
+```powershell
+PS C:\> Get-Process | Group-Object -Property PriorityClass
+
+Count Name         Group
+----- ----         -----
+   55 Normal       {System.Diagnostics.Process (AdtAgent), System.Diagnosti...
+    1              {System.Diagnostics.Process (Idle)}
+    3 High         {System.Diagnostics.Process (Newproc), System.Diagnostic...
+    2 BelowNormal  {System.Diagnostics.Process (winperf),
 ```
-PS C:\> get-process | group-object -property priorityclass
 
-Count Name                Group
------ ----                -----
-55 Normal              {System.Diagnostics.Process (AdtAgent), System.Diagnostics.Process (alg), System.Dia...
-1                     {System.Diagnostics.Process (Idle)}
-3 High                {System.Diagnostics.Process (Newproc), System.Diagnostics.Process (winlogon), System.D...
-2 BelowNormal         {System.Diagnostics.Process (winperf),
-
-PS C:\> get-process | group-object -property company -noelement
+```powershell
+PS C:\> Get-Process | Group-Object -Property PriorityClass -NoElement
 
 Count Name
 ----- ----
-55 Normal
-1
-3 High
-2 BelowNormal
+   55 Normal
+    1
+    3 High
+    2 BelowNormal
 ```
 
 This example demonstrates the effect of the NoElement parameter.

--- a/reference/5.0/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Group-Object.md
@@ -73,20 +73,26 @@ The command uses the *Property* parameter to specify that the events should be g
 In the output, the Count column represents the number of entries in each group, the Name column represents the EventID values that define a group, and the Group column represents the objects in each group.
 
 ### Example 5: Group processes by priority class
-```
+```powershell
 PS C:\> Get-Process | Group-Object -Property PriorityClass
-Count Name                Group
------ ----                -----
-55 Normal              {System.Diagnostics.Process (AdtAgent), System.Diagnostics.Process (alg), System.Dia... 
-1                     {System.Diagnostics.Process (Idle)} 
-3 High                {System.Diagnostics.Process (Newproc), System.Diagnostics.Process (winlogon), System.D... 
-2 BelowNormal         {System.Diagnostics.Process (winperf), PS C:\> Get-Process | Group-Object -Property company -NoElement
+
+Count Name         Group
+----- ----         -----
+   55 Normal       {System.Diagnostics.Process (AdtAgent), System.Diagnosti...
+    1              {System.Diagnostics.Process (Idle)}
+    3 High         {System.Diagnostics.Process (Newproc), System.Diagnostic...
+    2 BelowNormal  {System.Diagnostics.Process (winperf),
+```
+
+```powershell
+PS C:\> Get-Process | Group-Object -Property PriorityClass -NoElement
+
 Count Name
 ----- ----
-55 Normal
-1
-3 High
-2 BelowNormal
+   55 Normal
+    1
+    3 High
+    2 BelowNormal
 ```
 
 This example demonstrates the effect of the *NoElement* parameter.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Group-Object.md
@@ -73,20 +73,26 @@ The command uses the *Property* parameter to specify that the events should be g
 In the output, the Count column represents the number of entries in each group, the Name column represents the EventID values that define a group, and the Group column represents the objects in each group.
 
 ### Example 5: Group processes by priority class
-```
+```powershell
 PS C:\> Get-Process | Group-Object -Property PriorityClass
-Count Name                Group
------ ----                -----
-55 Normal              {System.Diagnostics.Process (AdtAgent), System.Diagnostics.Process (alg), System.Dia... 
-1                     {System.Diagnostics.Process (Idle)} 
-3 High                {System.Diagnostics.Process (Newproc), System.Diagnostics.Process (winlogon), System.D... 
-2 BelowNormal         {System.Diagnostics.Process (winperf), PS C:\> Get-Process | Group-Object -Property company -NoElement
+
+Count Name         Group
+----- ----         -----
+   55 Normal       {System.Diagnostics.Process (AdtAgent), System.Diagnosti...
+    1              {System.Diagnostics.Process (Idle)}
+    3 High         {System.Diagnostics.Process (Newproc), System.Diagnostic...
+    2 BelowNormal  {System.Diagnostics.Process (winperf),
+```
+
+```powershell
+PS C:\> Get-Process | Group-Object -Property PriorityClass -NoElement
+
 Count Name
 ----- ----
-55 Normal
-1
-3 High
-2 BelowNormal
+   55 Normal
+    1
+    3 High
+    2 BelowNormal
 ```
 
 This example demonstrates the effect of the *NoElement* parameter.

--- a/reference/6/Microsoft.PowerShell.Utility/Group-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Group-Object.md
@@ -74,20 +74,26 @@ The command uses the *Property* parameter to specify that the events should be g
 In the output, the Count column represents the number of entries in each group, the Name column represents the EventID values that define a group, and the Group column represents the objects in each group.
 
 ### Example 5: Group processes by priority class
-```
+```powershell
 PS C:\> Get-Process | Group-Object -Property PriorityClass
-Count Name                Group
------ ----                -----
-55 Normal              {System.Diagnostics.Process (AdtAgent), System.Diagnostics.Process (alg), System.Dia... 
-1                     {System.Diagnostics.Process (Idle)} 
-3 High                {System.Diagnostics.Process (Newproc), System.Diagnostics.Process (winlogon), System.D... 
-2 BelowNormal         {System.Diagnostics.Process (winperf), PS C:\> Get-Process | Group-Object -Property company -NoElement
+
+Count Name         Group
+----- ----         -----
+   55 Normal       {System.Diagnostics.Process (AdtAgent), System.Diagnosti...
+    1              {System.Diagnostics.Process (Idle)}
+    3 High         {System.Diagnostics.Process (Newproc), System.Diagnostic...
+    2 BelowNormal  {System.Diagnostics.Process (winperf),
+```
+
+```powershell
+PS C:\> Get-Process | Group-Object -Property PriorityClass -NoElement
+
 Count Name
 ----- ----
-55 Normal
-1
-3 High
-2 BelowNormal
+   55 Normal
+    1
+    3 High
+    2 BelowNormal
 ```
 
 This example demonstrates the effect of the *NoElement* parameter.


### PR DESCRIPTION
The second command should use `-Property PriorityClass` instead of `-Property company`.

Because the first command uses `-Property PriorityClass` and the description says:
> The second command is identical to the first, except that it uses the *NoElement* parameter

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
