### PR TITLE
Fix the example of `Format-Table -DisplayError`

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Format-Table.md
@@ -132,14 +132,17 @@ Accept wildcard characters: False
 ```
 
 ### -DisplayError
-Displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a Format-Table command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the DisplayError parameter with an expression.
+Indicates that the cmdlet displays errors at the command line.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Table` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
+```powershell
+PS C:\> Get-Date | Format-Table DayOfWeek, { $_ / $null } -DisplayError
+
 DayOfWeek  $_ / $null
 --------- ------------
 Wednesday #ERR
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/4.0/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Format-Table.md
@@ -141,14 +141,17 @@ Accept wildcard characters: False
 ```
 
 ### -DisplayError
-Displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a Format-Table command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the DisplayError parameter with an expression.
+Indicates that the cmdlet displays errors at the command line.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Table` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
+```powershell
+PS C:\> Get-Date | Format-Table DayOfWeek, { $_ / $null } -DisplayError
+
 DayOfWeek  $_ / $null
 --------- ------------
 Wednesday #ERR
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-Table.md
@@ -142,13 +142,16 @@ Accept wildcard characters: False
 
 ### -DisplayError
 Indicates that the cmdlet displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a **Format-Table** command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the DisplayError parameter with an expression.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Table` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
+```powershell
+PS C:\> Get-Date | Format-Table DayOfWeek, { $_ / $null } -DisplayError
+
 DayOfWeek  $_ / $null
 --------- ------------
 Wednesday #ERR
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Table.md
@@ -142,13 +142,16 @@ Accept wildcard characters: False
 
 ### -DisplayError
 Indicates that the cmdlet displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a **Format-Table** command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the DisplayError parameter with an expression.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Table` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
+```powershell
+PS C:\> Get-Date | Format-Table DayOfWeek, { $_ / $null } -DisplayError
+
 DayOfWeek  $_ / $null
 --------- ------------
 Wednesday #ERR
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/6/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Format-Table.md
@@ -142,13 +142,16 @@ Accept wildcard characters: False
 
 ### -DisplayError
 Indicates that the cmdlet displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a **Format-Table** command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the DisplayError parameter with an expression.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Table` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
+```powershell
+PS C:\> Get-Date | Format-Table DayOfWeek, { $_ / $null } -DisplayError
+
 DayOfWeek  $_ / $null
 --------- ------------
 Wednesday #ERR
+```
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
The example is a `-DisplayError` parameter example. But it uses `-ShowError` parameter.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
