### PR TITLE
Fix the example of `Format-Wide -DisplayError`

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -78,14 +78,16 @@ Accept wildcard characters: False
 ```
 
 ### -DisplayError
-Displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a Format-Wide command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the DisplayError parameter with an expression.
+Indicates that this cmdlet displays errors at the command line.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
+```powershell
+PS C:\> Get-Date | Format-Wide { $_ / $null } -DisplayError
+
+
+#ERR
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/4.0/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -83,14 +83,16 @@ Accept wildcard characters: False
 ```
 
 ### -DisplayError
-Displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a Format-Wide command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the DisplayError parameter with an expression.
+Indicates that this cmdlet displays errors at the command line.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
+```powershell
+PS C:\> Get-Date | Format-Wide { $_ / $null } -DisplayError
+
+
+#ERR
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -83,14 +83,16 @@ Accept wildcard characters: False
 ```
 
 ### -DisplayError
-Indicates that the cmdlet displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a **Format-Wide** command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the *DisplayError* parameter with an expression.
+Indicates that this cmdlet displays errors at the command line.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
+```powershell
+PS C:\> Get-Date | Format-Wide { $_ / $null } -DisplayError
+
+
+#ERR
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -84,13 +84,15 @@ Accept wildcard characters: False
 
 ### -DisplayError
 Indicates that this cmdlet displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a **Format-Wide** command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the *DisplayError* parameter with an expression.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
+```powershell
+PS C:\> Get-Date | Format-Wide { $_ / $null } -DisplayError
+
+
+#ERR
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/6/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -85,13 +85,15 @@ Accept wildcard characters: False
 
 ### -DisplayError
 Indicates that this cmdlet displays errors at the command line.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a **Format-Wide** command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the *DisplayError* parameter with an expression.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **DisplayError** parameter with an expression.
 
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
+```powershell
+PS C:\> Get-Date | Format-Wide { $_ / $null } -DisplayError
+
+
+#ERR
+```
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
The example is a `-DisplayError` parameter example. But it uses `-ShowError` parameter.

Additionally, it throws exception because its `-Property` parameter accepts an Object, not an array:
```powershell
PS> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
Format-Wide : Cannot convert System.Object[] to one of the following types {System.String,
System.Management.Automation.ScriptBlock}.
At line:1 char:12
+ Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Format-Wide], NotSupportedException
    + FullyQualifiedErrorId : DictionaryKeyUnknownType,Microsoft.PowerShell.Commands.FormatWideCommand
```

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
