### PR TITLE
Fix the example of `Format-Wide -ShowError`

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -208,18 +208,18 @@ Accept wildcard characters: True
 ```
 
 ### -ShowError
-Sends errors through the pipeline.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a Format-Wide command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the ShowError parameter with an expression.
+Indicates that the cmdlet sends errors through the pipeline.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **ShowError** parameter with an expression.
 
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
+```powershell
+PS C:\> Get-Date | Format-Wide { $_ / $null } -ShowError
+
 
 Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
+    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) [], RuntimeException
     + FullyQualifiedErrorId : mshExpressionError
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/4.0/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -213,18 +213,18 @@ Accept wildcard characters: True
 ```
 
 ### -ShowError
-Sends errors through the pipeline.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a Format-Wide command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the ShowError parameter with an expression.
+Indicates that the cmdlet sends errors through the pipeline.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **ShowError** parameter with an expression.
 
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
+```powershell
+PS C:\> Get-Date | Format-Wide { $_ / $null } -ShowError
+
 
 Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
+    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) [], RuntimeException
     + FullyQualifiedErrorId : mshExpressionError
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -217,17 +217,17 @@ Accept wildcard characters: False
 
 ### -ShowError
 Indicates that the cmdlet sends errors through the pipeline.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a **Format-Wide** command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the *ShowError* parameter with an expression.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **ShowError** parameter with an expression.
 
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
+```powershell
+PS C:\> Get-Date | Format-Wide { $_ / $null } -ShowError
+
 
 Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
+    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) [], RuntimeException
     + FullyQualifiedErrorId : mshExpressionError
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -217,17 +217,17 @@ Accept wildcard characters: False
 
 ### -ShowError
 Indicates that the cmdlet sends errors through the pipeline.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a **Format-Wide** command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the *ShowError* parameter with an expression.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **ShowError** parameter with an expression.
 
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
+```powershell
+PS C:\> Get-Date | Format-Wide { $_ / $null } -ShowError
+
 
 Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
+    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) [], RuntimeException
     + FullyQualifiedErrorId : mshExpressionError
+```
 
 ```yaml
 Type: SwitchParameter

--- a/reference/6/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -245,17 +245,17 @@ Accept wildcard characters: False
 
 ### -ShowError
 Indicates that the cmdlet sends errors through the pipeline.
-This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a **Format-Wide** command, and the expressions do not appear to be working.
-The following shows an example of the results of adding the *ShowError* parameter with an expression.
+This parameter is rarely used, but can be used as a debugging aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not appear to be working.
+The following shows an example of the results of adding the **ShowError** parameter with an expression.
 
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
+```powershell
+PS C:\> Get-Date | Format-Wide { $_ / $null } -ShowError
+
 
 Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
+    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) [], RuntimeException
     + FullyQualifiedErrorId : mshExpressionError
+```
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
The example throws exception because its `-Property` parameter accepts an Object, not an array:

```powershell
PS> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
Format-Wide : Cannot convert System.Object[] to one of the following types {System.String, System.Management.Automation.ScriptBlock}.
At line:1 char:12
+ Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Format-Wide], NotSupportedException
    + FullyQualifiedErrorId : DictionaryKeyUnknownType,Microsoft.PowerShell.Commands.FormatWideCommand
```

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
