### PR TITLE
Fix example numbers in about_Transactions.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Transactions.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Transactions.md
@@ -579,7 +579,7 @@ $t.tostring()
 
 Windows PowerShell
 
-# EXAMPLE 7: MANAGING MULTI-SUBSCRIBER TRANSACTIONS
+# EXAMPLE 8: MANAGING MULTI-SUBSCRIBER TRANSACTIONS
 
 
 When you start a transaction while another transaction is in
@@ -663,7 +663,7 @@ RollbackPreference   SubscriberCount   Status
 ------------------   ---------------   ------
 Error                0                 Committed
 
-# EXAMPLE 8: MANAGING INDEPENDENT TRANSACTIONS
+# EXAMPLE 9: MANAGING INDEPENDENT TRANSACTIONS
 
 
 When you start a transaction while another transaction is in

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Transactions.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Transactions.md
@@ -579,7 +579,7 @@ $t.tostring()
 
 Windows PowerShell
 
-# EXAMPLE 7: MANAGING MULTI-SUBSCRIBER TRANSACTIONS
+# EXAMPLE 8: MANAGING MULTI-SUBSCRIBER TRANSACTIONS
 
 
 When you start a transaction while another transaction is in
@@ -663,7 +663,7 @@ RollbackPreference   SubscriberCount   Status
 ------------------   ---------------   ------
 Error                0                 Committed
 
-# EXAMPLE 8: MANAGING INDEPENDENT TRANSACTIONS
+# EXAMPLE 9: MANAGING INDEPENDENT TRANSACTIONS
 
 
 When you start a transaction while another transaction is in

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Transactions.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Transactions.md
@@ -579,7 +579,7 @@ $t.tostring()
 
 Windows PowerShell
 
-# EXAMPLE 7: MANAGING MULTI-SUBSCRIBER TRANSACTIONS
+# EXAMPLE 8: MANAGING MULTI-SUBSCRIBER TRANSACTIONS
 
 
 When you start a transaction while another transaction is in
@@ -663,7 +663,7 @@ RollbackPreference   SubscriberCount   Status
 ------------------   ---------------   ------
 Error                0                 Committed
 
-# EXAMPLE 8: MANAGING INDEPENDENT TRANSACTIONS
+# EXAMPLE 9: MANAGING INDEPENDENT TRANSACTIONS
 
 
 When you start a transaction while another transaction is in

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Transactions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Transactions.md
@@ -579,7 +579,7 @@ $t.tostring()
 
 Windows PowerShell
 
-# EXAMPLE 7: MANAGING MULTI-SUBSCRIBER TRANSACTIONS
+# EXAMPLE 8: MANAGING MULTI-SUBSCRIBER TRANSACTIONS
 
 
 When you start a transaction while another transaction is in
@@ -663,7 +663,7 @@ RollbackPreference   SubscriberCount   Status
 ------------------   ---------------   ------
 Error                0                 Committed
 
-# EXAMPLE 8: MANAGING INDEPENDENT TRANSACTIONS
+# EXAMPLE 9: MANAGING INDEPENDENT TRANSACTIONS
 
 
 When you start a transaction while another transaction is in

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Transactions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Transactions.md
@@ -579,7 +579,7 @@ $t.tostring()
 
 Windows PowerShell
 
-# EXAMPLE 7: MANAGING MULTI-SUBSCRIBER TRANSACTIONS
+# EXAMPLE 8: MANAGING MULTI-SUBSCRIBER TRANSACTIONS
 
 
 When you start a transaction while another transaction is in
@@ -663,7 +663,7 @@ RollbackPreference   SubscriberCount   Status
 ------------------   ---------------   ------
 Error                0                 Committed
 
-# EXAMPLE 8: MANAGING INDEPENDENT TRANSACTIONS
+# EXAMPLE 9: MANAGING INDEPENDENT TRANSACTIONS
 
 
 When you start a transaction while another transaction is in


### PR DESCRIPTION
Example number '7' is duplicated.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
