### PR TITLE
Fixed formatting on expanded example

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_pipelines.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_pipelines.md
@@ -67,59 +67,46 @@ This pipeline is comprised of four commands in the specified order. The command
 is written horizontally, but we will show the process vertically in the following
 graphic.
 
-`Get-ChildItem` `-Path` *.txt
+```powershell
+Get-ChildItem -Path '*.txt'
 
- **|**
+|
+|   ( FileInfo objects )
+|   (    .txt          )
+|
+V
 
-|   (FileInfo objects )
-|   (    .txt         )
+Where-Object { $_.Length -gt 10000 }
 
- **|**
-
- **V**
-
-`Where-Object` {$_.length `-gt` 10000}
-
- **|**
-
-|   (FileInfo objects )
-|   (    .txt         )
-|   ( Length > 10000  )
-
- **|**
-
- **V**
-
-
-`Sort-Object` `-Property` Length
-
- **|**
-
-|   (FileInfo objects  )
+|
+|   ( FileInfo objects )
 |   (    .txt          )
 |   ( Length > 10000   )
+|
+V
+
+Sort-Object -Property 'Length'
+
+|
+|   ( FileInfo objects )
+|   (     .txt         )
+|   ( Length > 10000   )
 |   ( Sorted by length )
+|
+V
 
- **|**
+Format-Table -Property @('Name', 'Length')
 
- **V**
+|
+|   ( FileInfo objects     )
+|   (    .txt              )
+|   ( Length > 10000       )
+|   ( Sorted by length     )
+|   ( Formatted in a table )
+|
+V
 
 
-`Format-Table` `-Property` name, length
-
- **|**
-
-|   (FileInfo objects     )
-|   (    .txt             )
-|   ( Length > 10000      )
-|   ( Sorted by length    )
-|   (Formatted in a table )
-
- **|**
-
- **V**
-
-```
 Name                       Length
 ----                       ------
 tmp1.txt                    82920


### PR DESCRIPTION
The formatting on the MS page looks really convoluted with the expanded example so I changed the example into one large codeblock for consistent formatting

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
