### PR TITLE
Fix example number in ConvertTo-Html.html

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Html.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Html.md
@@ -167,7 +167,7 @@ PS C:\> Get-Service | ConvertTo-HTML -Meta @{refresh=10;author="Author's Name";k
 
 This command creates the HTML for a webpage with the meta tags for refresh, author, and keywords. The charset for the page is set to UTF-9
 
-### Example 10: Set the HTML to XHTML Transitional DTD
+### Example 11: Set the HTML to XHTML Transitional DTD
 ```
 PS C:\> Get-Service | ConvertTo-HTML -Transitional
 ```


### PR DESCRIPTION
Example number '10' is duplicated.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 6 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
