### PR TITLE
Update outputs of Get-Verb v6.0

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Get-Verb.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Verb.md
@@ -144,15 +144,9 @@ Accept wildcard characters: True
 
 ## OUTPUTS
 
-### Selected.Microsoft.PowerShell.Commands.MemberDefinition
+### System.Management.Automation.VerbInfo
 
 ## NOTES
-Get-Verb returns a modified version of a Microsoft.PowerShell.Commands.MemberDefinition object.
-The object does not have the standard properties of a MemberDefinition object.
-Instead it has Verb and Group properties.
-The Verb property contains a string with the verb name.
-The Group property contains a string with the verb group.
-
 Windows PowerShell verbs are assigned to a group based on their most common use.
 The groups are designed to make the verbs easy to find and compare, not to restrict their use.
 You can use any approved verb for any type of command.


### PR DESCRIPTION
Since v6.0, `Get-Verb` returns  not MemberDefinition but VerbInfo that has Verb and Group properties. See [GetVerbCommand.cs](https://github.com/PowerShell/PowerShell/blob/v6.0.0-rc/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetVerbCommand.cs#L14-L15) and [VerbInfo](https://github.com/PowerShell/PowerShell/blob/v6.0.0-rc/src/System.Management.Automation/utils/Verbs.cs#L1133-L1166).

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 6.0 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
