### PR TITLE
Remove hash algorithms unsupported in v6.0

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/About_Using.md
@@ -49,7 +49,7 @@ and to `[MemoryStream]` in *System.IO*.
     using namespace System.IO
 
     [string]$string = "Hello World"
-    [string]$algorithm = "SHA256" ## Valid values are "SHA1", "SHA256", "SHA384", "SHA512", "MACTripleDES", "MD5", "RIPEMD160"
+    [string]$algorithm = "SHA256" ## Valid values are "SHA1", "SHA256", "SHA384", "SHA512", "MD5"
 
     [byte[]]$stringbytes = [UnicodeEncoding]::Unicode.GetBytes($string)
 

--- a/reference/6/Microsoft.PowerShell.Utility/Get-FileHash.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-FileHash.md
@@ -127,9 +127,7 @@ The acceptable values for this parameter are:
 - SHA256
 - SHA384
 - SHA512
-- MACTripleDES
 - MD5
-- RIPEMD160
 
 If no value is specified, or if the parameter is omitted, the default value is SHA256.
 
@@ -139,7 +137,7 @@ For security reasons, MD5 and SHA1, which are no longer considered secure, shoul
 Type: String
 Parameter Sets: (All)
 Aliases: 
-Accepted values: SHA1, SHA256, SHA384, SHA512, MACTripleDES, MD5, RIPEMD160
+Accepted values: SHA1, SHA256, SHA384, SHA512, MD5
 
 Required: False
 Position: Named


### PR DESCRIPTION
MACTripleDES and RIPEMD160 are no longer supported in v6.0. See [GetHash.cs](https://github.com/PowerShell/PowerShell/blob/v6.0.0-rc/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs#L199-L203) and [#3024 in PowerShell](https://github.com/PowerShell/PowerShell/pull/3024).

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 6.0 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
