### PR TITLE
Update Example 8 in Get-Process.md (find the owner of a process)

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-Process.md
@@ -114,9 +114,10 @@ This command gets the modules for the processes that have names that begin with 
 
 To run this command on Windows Vista (and later versions of Windows) with processes that you do not own, you must start Windows PowerShell with the "Run as administrator" option.
 ### Example 8
-```
-PS C:\> $p = get-wmiobject win32_process -filter "name='powershell.exe'"
-PS C:\> $p.getowner()
+```powershell
+PS C:\> $p = Get-WmiObject Win32_Process -Filter "name='powershell.exe'"
+PS C:\> $p.GetOwner()
+
 
 __GENUS          : 2
 __CLASS          : __PARAMETERS
@@ -134,15 +135,14 @@ User             : user01
 ```
 
 This command shows how to find the owner of a process.
-Because the System.Diagnostics.Process object that Get-Process returns does not have a property or method that returns the process owner, the command uses
+Because the System.Diagnostics.Process object that `Get-Process` returns does not have a property or method that returns the process owner, the command uses the `Get-WmiObject` cmdlet to get a Win32_Process object that represents the same process.
 
-the Get-WmiObject cmdlet to get a Win32_Process object that represents the same process.
-
-The first command uses Get-WmiObject to get the PowerShell process.
+The first command uses `Get-WmiObject` to get the PowerShell process.
 It saves it in the $p variable.
 
 The second command uses the GetOwner method to get the owner of the process in $p.
-The command reveals that the owner is Domain01\user01.
+The output reveals that the owner is Domain01\user01.
+
 ### Example 9
 ```
 PS C:\> get-process powershell

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-Process.md
@@ -145,13 +145,7 @@ PS C:\> Get-Process powershell -IncludeUserName
 Handles      WS(K)   CPU(s)     Id UserName            ProcessName
 -------      -----   ------     -- --------            -----------
     782     132080     2.08   2188 DOMAIN01\user01     powershell
-```
 
-This command shows how to find the owner of a process.
-The **IncludeUserName** parameter requires elevated user rights (Run as Administrator).
-The output reveals that the owner is Domain01\user01.
-
-```powershell
 PS C:\> $p = Get-WmiObject Win32_Process -Filter "name='powershell.exe'"
 PS C:\> $p.GetOwner()
 
@@ -171,12 +165,16 @@ ReturnValue      : 0
 User             : user01
 ```
 
-This is another way to find the owner of a process.
+The first command shows how to find the owner of a process.
+The **IncludeUserName** parameter requires elevated user rights (Run as Administrator).
+The output reveals that the owner is Domain01\user01.
 
-The first command uses `Get-WmiObject` to get the PowerShell process.
+The second and third command are another way to find the owner of a process.
+
+The second command uses `Get-WmiObject` to get the PowerShell process.
 It saves it in the $p variable.
 
-The second command uses the GetOwner method to get the owner of the process in $p.
+The third command uses the GetOwner method to get the owner of the process in $p.
 The output reveals that the owner is Domain01\user01.
 
 ### Example 9

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-Process.md
@@ -139,9 +139,22 @@ This command gets the modules for the processes that have names that begin with 
 To run this command on Windows Vista (and later versions of Windows) with processes that you do not own, you must start Windows PowerShell with the "Run as administrator" option.
 
 ### Example 8
+```powershell
+PS C:\> Get-Process powershell -IncludeUserName
+
+Handles      WS(K)   CPU(s)     Id UserName            ProcessName
+-------      -----   ------     -- --------            -----------
+    782     132080     2.08   2188 DOMAIN01\user01     powershell
 ```
-PS C:\> $p = get-wmiobject win32_process -filter "name='powershell.exe'"
-PS C:\> $p.getowner()
+
+This command shows how to find the owner of a process.
+The **IncludeUserName** parameter requires elevated user rights (Run as Administrator).
+The output reveals that the owner is Domain01\user01.
+
+```powershell
+PS C:\> $p = Get-WmiObject Win32_Process -Filter "name='powershell.exe'"
+PS C:\> $p.GetOwner()
+
 
 __GENUS          : 2
 __CLASS          : __PARAMETERS
@@ -158,16 +171,13 @@ ReturnValue      : 0
 User             : user01
 ```
 
-This command shows how to find the owner of a process.
-Because the System.Diagnostics.Process object that Get-Process returns does not have a property or method that returns the process owner, the command uses
+This is another way to find the owner of a process.
 
-the Get-WmiObject cmdlet to get a Win32_Process object that represents the same process.
-
-The first command uses Get-WmiObject to get the PowerShell process.
+The first command uses `Get-WmiObject` to get the PowerShell process.
 It saves it in the $p variable.
 
 The second command uses the GetOwner method to get the owner of the process in $p.
-The command reveals that the owner is Domain01\user01.
+The output reveals that the owner is Domain01\user01.
 
 ### Example 9
 ```

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-Process.md
@@ -147,46 +147,45 @@ This command gets the modules for the processes that have names that begin with 
 To run this command on Windows Vista and later versions of Windows with processes that you do not own, you must start Windows PowerShell with the Run as administrator option.
 
 ### Example 8: Find the owner of a process
+```powershell
+PS C:\> Get-Process powershell -IncludeUserName
+
+Handles      WS(K)   CPU(s)     Id UserName            ProcessName
+-------      -----   ------     -- --------            -----------
+    782     132080     2.08   2188 DOMAIN01\user01     powershell
 ```
-PS C:\> $P = Get-WmiObject win32_process -Filter "name='powershell.exe'"
-PS C:\> $P.getowner()
 
+This command shows how to find the owner of a process.
+The **IncludeUserName** parameter requires elevated user rights (Run as Administrator).
+The output reveals that the owner is Domain01\user01.
 
-
-
-
-
-
-
-
-
-
-
+```powershell
+PS C:\> $p = Get-WmiObject Win32_Process -Filter "name='powershell.exe'"
+PS C:\> $p.GetOwner()
 
 
 __GENUS          : 2
 __CLASS          : __PARAMETERS
-__SUPERCLASS     : 
+__SUPERCLASS     :
 __DYNASTY        : __PARAMETERS
-__RELPATH        : 
+__RELPATH        :
 __PROPERTY_COUNT : 3
 __DERIVATION     : {}
-__SERVER         : 
-__NAMESPACE      : 
-__PATH           : 
+__SERVER         :
+__NAMESPACE      :
+__PATH           :
 Domain           : DOMAIN01
 ReturnValue      : 0
 User             : user01
 ```
 
-This command shows how to find the owner of a process.
-Because the **System.Diagnostics.Process** object that **Get-Process** returns does not have a property or method that returns the process owner, the command uses the Get-WmiObject cmdlet to get a Win32_Process object that represents the same process.
+This is another way to find the owner of a process.
 
-The first command uses **Get-WmiObject** to get the PowerShell process.
-It saves it in the $P variable.
+The first command uses `Get-WmiObject` to get the PowerShell process.
+It saves it in the $p variable.
 
-The second command uses the **GetOwner** method to get the owner of the process in $P.
-The command reveals that the owner is Domain01\user01.
+The second command uses the GetOwner method to get the owner of the process in $p.
+The output reveals that the owner is Domain01\user01.
 
 ### Example 9: Use an automatic variable to identify the process hosting the current session
 ```

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-Process.md
@@ -153,13 +153,7 @@ PS C:\> Get-Process powershell -IncludeUserName
 Handles      WS(K)   CPU(s)     Id UserName            ProcessName
 -------      -----   ------     -- --------            -----------
     782     132080     2.08   2188 DOMAIN01\user01     powershell
-```
 
-This command shows how to find the owner of a process.
-The **IncludeUserName** parameter requires elevated user rights (Run as Administrator).
-The output reveals that the owner is Domain01\user01.
-
-```powershell
 PS C:\> $p = Get-WmiObject Win32_Process -Filter "name='powershell.exe'"
 PS C:\> $p.GetOwner()
 
@@ -179,12 +173,16 @@ ReturnValue      : 0
 User             : user01
 ```
 
-This is another way to find the owner of a process.
+The first command shows how to find the owner of a process.
+The **IncludeUserName** parameter requires elevated user rights (Run as Administrator).
+The output reveals that the owner is Domain01\user01.
 
-The first command uses `Get-WmiObject` to get the PowerShell process.
+The second and third command are another way to find the owner of a process.
+
+The second command uses `Get-WmiObject` to get the PowerShell process.
 It saves it in the $p variable.
 
-The second command uses the GetOwner method to get the owner of the process in $p.
+The third command uses the GetOwner method to get the owner of the process in $p.
 The output reveals that the owner is Domain01\user01.
 
 ### Example 9: Use an automatic variable to identify the process hosting the current session

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
@@ -147,21 +147,21 @@ This command gets the modules for the processes that have names that begin with 
 To run this command on Windows Vista and later versions of Windows with processes that you do not own, you must start Windows PowerShell with the Run as administrator option.
 
 ### Example 8: Find the owner of a process
+```powershell
+PS C:\> Get-Process powershell -IncludeUserName
+
+Handles      WS(K)   CPU(s)     Id UserName            ProcessName
+-------      -----   ------     -- --------            -----------
+    782     132080     2.08   2188 DOMAIN01\user01     powershell
 ```
-PS C:\> $P = Get-WmiObject win32_process -Filter "name='powershell.exe'"
-PS C:\> $P.getowner()
 
+This command shows how to find the owner of a process.
+The **IncludeUserName** parameter requires elevated user rights (Run as Administrator).
+The output reveals that the owner is Domain01\user01.
 
-
-
-
-
-
-
-
-
-
-
+```powershell
+PS C:\> $p = Get-WmiObject Win32_Process -Filter "name='powershell.exe'"
+PS C:\> $p.GetOwner()
 
 
 __GENUS          : 2
@@ -179,14 +179,13 @@ ReturnValue      : 0
 User             : user01
 ```
 
-This command shows how to find the owner of a process.
-Because the **System.Diagnostics.Process** object that **Get-Process** returns does not have a property or method that returns the process owner, the command uses the Get-WmiObject cmdlet to get a Win32_Process object that represents the same process.
+This is another way to find the owner of a process.
 
-The first command uses **Get-WmiObject** to get the PowerShell process.
-It saves it in the $P variable.
+The first command uses `Get-WmiObject` to get the PowerShell process.
+It saves it in the $p variable.
 
-The second command uses the **GetOwner** method to get the owner of the process in $P.
-The command reveals that the owner is Domain01\user01.
+The second command uses the GetOwner method to get the owner of the process in $p.
+The output reveals that the owner is Domain01\user01.
 
 ### Example 9: Use an automatic variable to identify the process hosting the current session
 ```

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
@@ -153,13 +153,7 @@ PS C:\> Get-Process powershell -IncludeUserName
 Handles      WS(K)   CPU(s)     Id UserName            ProcessName
 -------      -----   ------     -- --------            -----------
     782     132080     2.08   2188 DOMAIN01\user01     powershell
-```
 
-This command shows how to find the owner of a process.
-The **IncludeUserName** parameter requires elevated user rights (Run as Administrator).
-The output reveals that the owner is Domain01\user01.
-
-```powershell
 PS C:\> $p = Get-WmiObject Win32_Process -Filter "name='powershell.exe'"
 PS C:\> $p.GetOwner()
 
@@ -179,12 +173,16 @@ ReturnValue      : 0
 User             : user01
 ```
 
-This is another way to find the owner of a process.
+The first command shows how to find the owner of a process.
+The **IncludeUserName** parameter requires elevated user rights (Run as Administrator).
+The output reveals that the owner is Domain01\user01.
 
-The first command uses `Get-WmiObject` to get the PowerShell process.
+The second and third command are another way to find the owner of a process.
+
+The second command uses `Get-WmiObject` to get the PowerShell process.
 It saves it in the $p variable.
 
-The second command uses the GetOwner method to get the owner of the process in $p.
+The third command uses the GetOwner method to get the owner of the process in $p.
 The output reveals that the owner is Domain01\user01.
 
 ### Example 9: Use an automatic variable to identify the process hosting the current session

--- a/reference/6/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-Process.md
@@ -152,46 +152,17 @@ This command gets the modules for the processes that have names that begin with 
 To run this command on Windows Vista and later versions of Windows with processes that you do not own, you must start Windows PowerShell with the Run as administrator option.
 
 ### Example 8: Find the owner of a process
-```
-PS C:\> $P = Get-WmiObject win32_process -Filter "name='powershell.exe'"
-PS C:\> $P.getowner()
+```powershell
+PS C:\> Get-Process pwsh -IncludeUserName
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-__GENUS          : 2
-__CLASS          : __PARAMETERS
-__SUPERCLASS     :
-__DYNASTY        : __PARAMETERS
-__RELPATH        :
-__PROPERTY_COUNT : 3
-__DERIVATION     : {}
-__SERVER         :
-__NAMESPACE      :
-__PATH           :
-Domain           : DOMAIN01
-ReturnValue      : 0
-User             : user01
+Handles      WS(K)   CPU(s)     Id UserName            ProcessName
+-------      -----   ------     -- --------            -----------
+    782     132080     2.08   2188 DOMAIN01\user01     pwsh
 ```
 
 This command shows how to find the owner of a process.
-Because the **System.Diagnostics.Process** object that **Get-Process** returns does not have a property or method that returns the process owner, the command uses the Get-WmiObject cmdlet to get a Win32_Process object that represents the same process.
-
-The first command uses **Get-WmiObject** to get the PowerShell process.
-It saves it in the $P variable.
-
-The second command uses the **GetOwner** method to get the owner of the process in $P.
-The command reveals that the owner is Domain01\user01.
+On Windows, the **IncludeUserName** parameter requires elevated user rights (Run as Administrator).
+The output reveals that the owner is Domain01\user01.
 
 ### Example 9: Use an automatic variable to identify the process hosting the current session
 ```


### PR DESCRIPTION
There are two ways to find the owner of a process:

1. `Get-Process -IncludeUserName`
	This can be used in v4.0, 5.0, 5.1, and 6.0.
	This cannot be used in v3.0 because **IncludeUserName** parameter was [introduced in v4.0](https://docs.microsoft.com/en-us/powershell/scripting/whats-new/what-s-new-in-windows-powershell-50?view=powershell-5.1#new-features-in-windows-powershell-40).

2. `Get-WmiObject Win32_Process` and `GetOwner()`
	This can be used in v3.0, 4.0, 5.0, and 5.1.
	This cannot be used in v6.0 because `Get-WmiObject` is not supported in v6.0.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
