### PR TITLE
Removing extra space in the Example 5A script

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-String.md
@@ -220,23 +220,23 @@ Notice the difference in alignment for the age column between both examples.
 ### Example 5A: Get to know the generated object
 
  ```
- $template = @'
- {[string]Name*:Phoebe Cat}, {[string]phone:425-123-6789}, {[int]age:6}
- {[string]Name*:Lucky Shot}, {[string]phone:(206) 987-4321}, {[int]age:12}
- '@
+$template = @'
+{[string]Name*:Phoebe Cat}, {[string]phone:425-123-6789}, {[int]age:6}
+{[string]Name*:Lucky Shot}, {[string]phone:(206) 987-4321}, {[int]age:12}
+'@
 
- $testText = @'
- Phoebe Cat, 425-123-6789, 6
- Lucky Shot, (206) 987-4321, 12
- Elephant Wise, 425-888-7766, 87
- Wild Shrimp, (111)  222-3333, 1
- '@
+$testText = @'
+Phoebe Cat, 425-123-6789, 6
+Lucky Shot, (206) 987-4321, 12
+Elephant Wise, 425-888-7766, 87
+Wild Shrimp, (111)  222-3333, 1
+'@
 
- $testText  |
-     ConvertFrom-String -TemplateContent $template -OutVariable PersonalData |
-     Out-Null
+$testText  |
+    ConvertFrom-String -TemplateContent $template -OutVariable PersonalData |
+    Out-Null
 
- $PersonalData | Get-Member
+$PersonalData | Get-Member
 
 
 


### PR DESCRIPTION
It was highlighting as string in the documentation, I was trying to remove all the extra space.
![image](https://user-images.githubusercontent.com/1416699/33303999-4798cd90-d42c-11e7-9571-c5b8a537993e.png)

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
