### PR TITLE
Update unapproved verbs examples in Get-Verb.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/Functions/Get-Verb.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Functions/Get-Verb.md
@@ -84,39 +84,15 @@ Unprotect Security
 This command gets all approved verbs in the Security group.
 
 ### Example 4
+```powershell
+Get-Command -Module Microsoft.PowerShell.Utility | where Verb -NotIn (Get-Verb).Verb
+# CommandType     Name            Version    Source
+# -----------     ----            -------    ------
+# Cmdlet          Sort-Object     3.1.0.0    Microsoft.PowerShell.Utility
+# Cmdlet          Tee-Object      3.1.0.0    Microsoft.PowerShell.Utility
 ```
-get-command -module MyModule | where { (get-verb $_.Verb) -eq $null }
-```
-
-Description
-
------------
 
 This command finds all commands in a module that have unapproved verbs.
-
-### Example 5
-```
-$approvedVerbs = get-verb | foreach {$_.verb}
-
-C:\PS> $myVerbs = get-command -module MyModule | foreach {$_.verb}
-
-# Does MyModule export functions with unapproved verbs?
-C:\PS> ($myVerbs | foreach {$approvedVerbs -contains $_}) -contains $false
-True
-
-# Which unapproved verbs are used in MyModule?
-C:\PS>  ($myverbs | where {$approvedVerbs -notcontains $_})
-ForEach
-Sort
-Tee
-Where
-```
-
-Description
-
------------
-
-These commands detect unapproved verbs in a module and tell which unapproved verbs were detected in the module.
 
 ## PARAMETERS
 

--- a/reference/4.0/Microsoft.PowerShell.Core/Functions/Get-Verb.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Functions/Get-Verb.md
@@ -84,39 +84,15 @@ Unprotect Security
 This command gets all approved verbs in the Security group.
 
 ### Example 4
+```powershell
+Get-Command -Module Microsoft.PowerShell.Utility | where Verb -NotIn (Get-Verb).Verb
+# CommandType     Name            Version    Source
+# -----------     ----            -------    ------
+# Cmdlet          Sort-Object     3.1.0.0    Microsoft.PowerShell.Utility
+# Cmdlet          Tee-Object      3.1.0.0    Microsoft.PowerShell.Utility
 ```
-get-command -module MyModule | where { (get-verb $_.Verb) -eq $null }
-```
-
-Description
-
------------
 
 This command finds all commands in a module that have unapproved verbs.
-
-### Example 5
-```
-$approvedVerbs = get-verb | foreach {$_.verb}
-
-C:\PS> $myVerbs = get-command -module MyModule | foreach {$_.verb}
-
-# Does MyModule export functions with unapproved verbs?
-C:\PS> ($myVerbs | foreach {$approvedVerbs -contains $_}) -contains $false
-True
-
-# Which unapproved verbs are used in MyModule?
-C:\PS>  ($myverbs | where {$approvedVerbs -notcontains $_})
-ForEach
-Sort
-Tee
-Where
-```
-
-Description
-
------------
-
-These commands detect unapproved verbs in a module and tell which unapproved verbs were detected in the module.
 
 ## PARAMETERS
 

--- a/reference/5.0/Microsoft.PowerShell.Core/Functions/Get-Verb.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Functions/Get-Verb.md
@@ -84,39 +84,15 @@ Unprotect Security
 This command gets all approved verbs in the Security group.
 
 ### Example 4
+```powershell
+Get-Command -Module Microsoft.PowerShell.Utility | where Verb -NotIn (Get-Verb).Verb
+# CommandType     Name            Version    Source
+# -----------     ----            -------    ------
+# Cmdlet          Sort-Object     3.1.0.0    Microsoft.PowerShell.Utility
+# Cmdlet          Tee-Object      3.1.0.0    Microsoft.PowerShell.Utility
 ```
-get-command -module MyModule | where { (get-verb $_.Verb) -eq $null }
-```
-
-Description
-
------------
 
 This command finds all commands in a module that have unapproved verbs.
-
-### Example 5
-```
-$approvedVerbs = get-verb | foreach {$_.verb}
-
-C:\PS> $myVerbs = get-command -module MyModule | foreach {$_.verb}
-
-# Does MyModule export functions with unapproved verbs?
-C:\PS> ($myVerbs | foreach {$approvedVerbs -contains $_}) -contains $false
-True
-
-# Which unapproved verbs are used in MyModule?
-C:\PS>  ($myverbs | where {$approvedVerbs -notcontains $_})
-ForEach
-Sort
-Tee
-Where
-```
-
-Description
-
------------
-
-These commands detect unapproved verbs in a module and tell which unapproved verbs were detected in the module.
 
 ## PARAMETERS
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Functions/Get-Verb.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Functions/Get-Verb.md
@@ -84,39 +84,15 @@ Unprotect Security
 This command gets all approved verbs in the Security group.
 
 ### Example 4
+```powershell
+Get-Command -Module Microsoft.PowerShell.Utility | where Verb -NotIn (Get-Verb).Verb
+# CommandType     Name            Version    Source
+# -----------     ----            -------    ------
+# Cmdlet          Sort-Object     3.1.0.0    Microsoft.PowerShell.Utility
+# Cmdlet          Tee-Object      3.1.0.0    Microsoft.PowerShell.Utility
 ```
-get-command -module MyModule | where { (get-verb $_.Verb) -eq $null }
-```
-
-Description
-
------------
 
 This command finds all commands in a module that have unapproved verbs.
-
-### Example 5
-```
-$approvedVerbs = get-verb | foreach {$_.verb}
-
-C:\PS> $myVerbs = get-command -module MyModule | foreach {$_.verb}
-
-# Does MyModule export functions with unapproved verbs?
-C:\PS> ($myVerbs | foreach {$approvedVerbs -contains $_}) -contains $false
-True
-
-# Which unapproved verbs are used in MyModule?
-C:\PS>  ($myverbs | where {$approvedVerbs -notcontains $_})
-ForEach
-Sort
-Tee
-Where
-```
-
-Description
-
------------
-
-These commands detect unapproved verbs in a module and tell which unapproved verbs were detected in the module.
 
 ## PARAMETERS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Get-Verb.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Verb.md
@@ -80,40 +80,16 @@ Unprotect up          Security Removes safeguards from a resource that wer...
 
 This command gets all approved verbs in the Security group.
 
-### -------------------------- EXAMPLE 4 --------------------------
+### Example 4
+```powershell
+Get-Command -Module Microsoft.PowerShell.Utility | where Verb -NotIn (Get-Verb).Verb
+# CommandType     Name            Version    Source
+# -----------     ----            -------    ------
+# Cmdlet          Sort-Object     3.1.0.0    Microsoft.PowerShell.Utility
+# Cmdlet          Tee-Object      3.1.0.0    Microsoft.PowerShell.Utility
 ```
-get-command -module MyModule | where { (get-verb $_.Verb) -eq $null }
-```
-
-Description
-
------------
 
 This command finds all commands in a module that have unapproved verbs.
-
-### -------------------------- EXAMPLE 5 --------------------------
-```
-$approvedVerbs = get-verb | foreach {$_.verb}
-
-C:\PS> $myVerbs = get-command -module MyModule | foreach {$_.verb}
-
-# Does MyModule export functions with unapproved verbs?
-C:\PS> ($myVerbs | foreach {$approvedVerbs -contains $_}) -contains $false
-True
-
-# Which unapproved verbs are used in MyModule?
-C:\PS>  ($myverbs | where {$approvedVerbs -notcontains $_})
-ForEach
-Sort
-Tee
-Where
-```
-
-Description
-
------------
-
-These commands detect unapproved verbs in a module and tell which unapproved verbs were detected in the module.
 
 ## PARAMETERS
 


### PR DESCRIPTION
* Example 4
  Replaced "MyModule" with "Microsoft.PowerShell.Utility", which has unapproved verb cmdlets.

* Example 5
  Removed. Because it is similar to Example 4 and somewhat verbose.

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
