### PR TITLE
Fix parameter's position in Get-Random.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Random.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Random.md
@@ -14,13 +14,15 @@ Gets a random number, or selects objects randomly from a collection.
 ## SYNTAX
 
 ### RandomNumberParameterSet (Default)
-```
-Get-Random [-SetSeed <Int32>] [[-Maximum] <Object>] [-Minimum <Object>] [<CommonParameters>]
+```powershell
+Get-Random [[-Maximum] <Object>] [-SetSeed <Int32>] [-Minimum <Object>]
+ [<CommonParameters>]
 ```
 
 ### RandomListItemParameterSet
-```
-Get-Random [-SetSeed <Int32>] [-InputObject] <Object[]> [-Count <Int32>] [<CommonParameters>]
+```powershell
+Get-Random [-InputObject] <Object[]> [-SetSeed <Int32>] [-Count <Int32>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -172,7 +174,8 @@ PS C:\> Get-Random 10001
 ```
 
 This command gets a random integer less than 10001.
-Because the Maximum parameter has position 1, you can omit the parameter name when the value is the first or only unnamed parameter in the command.
+Because the **Maximum** parameter has position 0, you can omit the parameter name when the value is the first or only unnamed parameter in the command.
+
 ### Example 14
 ```
 PS C:\> Get-Random -Minimum ([Int64]::MinValue)3738173363251507200
@@ -219,7 +222,7 @@ Parameter Sets: RandomListItemParameterSet
 Aliases: 
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
@@ -247,7 +250,7 @@ Parameter Sets: RandomNumberParameterSet
 Aliases: 
 
 Required: False
-Position: 1
+Position: 0
 Default value: Int32.MaxValue, Double.MaxValue, Int64.MaxValue
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Random.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Random.md
@@ -16,13 +16,15 @@ Gets a random number, or selects objects randomly from a collection.
 ## SYNTAX
 
 ### RandomNumberParameterSet (Default)
-```
-Get-Random [-SetSeed <Int32>] [[-Maximum] <Object>] [-Minimum <Object>] [<CommonParameters>]
+```powershell
+Get-Random [[-Maximum] <Object>] [-SetSeed <Int32>] [-Minimum <Object>]
+ [<CommonParameters>]
 ```
 
 ### RandomListItemParameterSet
-```
-Get-Random [-SetSeed <Int32>] [-InputObject] <Object[]> [-Count <Int32>] [<CommonParameters>]
+```powershell
+Get-Random [-InputObject] <Object[]> [-SetSeed <Int32>] [-Count <Int32>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -187,7 +189,7 @@ PS C:\> Get-Random 10001
 ```
 
 This command gets a random integer less than 10001.
-Because the Maximum parameter has position 1, you can omit the parameter name when the value is the first or only unnamed parameter in the command.
+Because the **Maximum** parameter has position 0, you can omit the parameter name when the value is the first or only unnamed parameter in the command.
 
 ### Example 14
 ```
@@ -236,7 +238,7 @@ Parameter Sets: RandomListItemParameterSet
 Aliases: 
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
@@ -264,7 +266,7 @@ Parameter Sets: RandomNumberParameterSet
 Aliases: 
 
 Required: False
-Position: 1
+Position: 0
 Default value: Int32.MaxValue, Double.MaxValue, Int64.MaxValue
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Random.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Random.md
@@ -16,13 +16,15 @@ Gets a random number, or selects objects randomly from a collection.
 ## SYNTAX
 
 ### RandomNumberParameterSet (Default)
-```
-Get-Random [-SetSeed <Int32>] [[-Maximum] <Object>] [-Minimum <Object>] [<CommonParameters>]
+```powershell
+Get-Random [[-Maximum] <Object>] [-SetSeed <Int32>] [-Minimum <Object>]
+ [<CommonParameters>]
 ```
 
 ### RandomListItemParameterSet
-```
-Get-Random [-SetSeed <Int32>] [-InputObject] <Object[]> [-Count <Int32>] [<CommonParameters>]
+```powershell
+Get-Random [-InputObject] <Object[]> [-SetSeed <Int32>] [-Count <Int32>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -186,7 +188,7 @@ PS C:\> Get-Random 10001
 ```
 
 This command gets a random integer less than 10001.
-Because the *Maximum* parameter has position 1, you can omit the parameter name when the value is the first or only unnamed parameter in the command.
+Because the **Maximum** parameter has position 0, you can omit the parameter name when the value is the first or only unnamed parameter in the command.
 
 ### Example 14: Get random 64-bit numbers
 ```

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Random.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Random.md
@@ -16,13 +16,15 @@ Gets a random number, or selects objects randomly from a collection.
 ## SYNTAX
 
 ### RandomNumberParameterSet (Default)
-```
-Get-Random [-SetSeed <Int32>] [[-Maximum] <Object>] [-Minimum <Object>] [<CommonParameters>]
+```powershell
+Get-Random [[-Maximum] <Object>] [-SetSeed <Int32>] [-Minimum <Object>]
+ [<CommonParameters>]
 ```
 
 ### RandomListItemParameterSet
-```
-Get-Random [-SetSeed <Int32>] [-InputObject] <Object[]> [-Count <Int32>] [<CommonParameters>]
+```powershell
+Get-Random [-InputObject] <Object[]> [-SetSeed <Int32>] [-Count <Int32>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -186,7 +188,7 @@ PS C:\> Get-Random 10001
 ```
 
 This command gets a random integer less than 10001.
-Because the *Maximum* parameter has position 1, you can omit the parameter name when the value is the first or only unnamed parameter in the command.
+Because the **Maximum** parameter has position 0, you can omit the parameter name when the value is the first or only unnamed parameter in the command.
 
 ### Example 14: Get random 64-bit numbers
 ```

--- a/reference/6/Microsoft.PowerShell.Utility/Get-Random.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Random.md
@@ -16,15 +16,15 @@ Gets a random number, or selects objects randomly from a collection.
 ## SYNTAX
 
 ### RandomNumberParameterSet (Default)
-```
-Get-Random [-SetSeed <Int32>] [[-Maximum] <Object>] [-Minimum <Object>] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [<CommonParameters>]
+```powershell
+Get-Random [[-Maximum] <Object>] [-SetSeed <Int32>] [-Minimum <Object>]
+ [<CommonParameters>]
 ```
 
 ### RandomListItemParameterSet
-```
-Get-Random [-SetSeed <Int32>] [-InputObject] <Object[]> [-Count <Int32>]
- [-InformationAction <ActionPreference>] [-InformationVariable <String>] [<CommonParameters>]
+```powershell
+Get-Random [-InputObject] <Object[]> [-SetSeed <Int32>] [-Count <Int32>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -188,7 +188,7 @@ PS C:\> Get-Random 10001
 ```
 
 This command gets a random integer less than 10001.
-Because the *Maximum* parameter has position 1, you can omit the parameter name when the value is the first or only unnamed parameter in the command.
+Because the **Maximum** parameter has position 0, you can omit the parameter name when the value is the first or only unnamed parameter in the command.
 
 ### Example 14: Get random 64-bit numbers
 ```
@@ -224,33 +224,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -InformationAction
-```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -InputObject
 Specifies a collection of objects.
 **Get-Random** gets randomly selected objects in random order from the collection.
@@ -263,7 +236,7 @@ Parameter Sets: RandomListItemParameterSet
 Aliases: 
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
@@ -291,7 +264,7 @@ Parameter Sets: RandomNumberParameterSet
 Aliases: 
 
 Required: False
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False


### PR DESCRIPTION
* [**Maximum** parameter's position is 0](https://github.com/PowerShell/PowerShell/blob/v6.0.0-rc/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs#L204-L205)
* [**InputObject** parameter's position is 0](https://github.com/PowerShell/PowerShell/blob/v6.0.0-rc/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRandomCommand.cs#L272-L275)
* Removed InformationAction/InformationVariable in v6.0

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
