### PR TITLE
Fix parameter's position in Measure-Command.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -16,7 +16,8 @@ Measures the time it takes to run script blocks and cmdlets.
 ## Syntax
 
 ```powershell
-Measure-Command [-InputObject <PSObject>] [-Expression] <ScriptBlock> [<CommonParameters>]
+Measure-Command [-Expression] <ScriptBlock> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ## Description
@@ -89,7 +90,7 @@ Parameter Sets: (All)
 Aliases: 
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/reference/4.0/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -16,7 +16,8 @@ Measures the time it takes to run script blocks and cmdlets.
 ## Syntax
 
 ```powershell
-Measure-Command [-InputObject <PSObject>] [-Expression] <ScriptBlock> [<CommonParameters>]
+Measure-Command [-Expression] <ScriptBlock> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ## Description
@@ -88,7 +89,7 @@ Parameter Sets: (All)
 Aliases: 
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/reference/5.0/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -16,7 +16,8 @@ Measures the time it takes to run script blocks and cmdlets.
 ## Syntax
 
 ```powershell
-Measure-Command [-InputObject <PSObject>] [-Expression] <ScriptBlock> [<CommonParameters>]
+Measure-Command [-Expression] <ScriptBlock> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ## Description

--- a/reference/5.1/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -16,7 +16,8 @@ Measures the time it takes to run script blocks and cmdlets.
 ## Syntax
 
 ```powershell
-Measure-Command [-InputObject <PSObject>] [-Expression] <ScriptBlock> [<CommonParameters>]
+Measure-Command [-Expression] <ScriptBlock> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ## Description

--- a/reference/6/Microsoft.PowerShell.Utility/Measure-Command.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Measure-Command.md
@@ -16,8 +16,8 @@ Measures the time it takes to run script blocks and cmdlets.
 ## Syntax
 
 ```powershell
-Measure-Command [-InputObject <PSObject>] [-Expression] <ScriptBlock> [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [<CommonParameters>]
+Measure-Command [-Expression] <ScriptBlock> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ## Description
@@ -78,7 +78,7 @@ These commands show the value of using a provider-specific filter in Windows Pow
 
 ## Parameters
 
-### `-Expression`
+### -Expression
 Specifies the expression that is being timed.
 Enclose the expression in braces ({}).
 The parameter name ("**Expression**") is optional.
@@ -89,34 +89,7 @@ Parameter Sets: (All)
 Aliases: 
 
 Required: True
-Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### `-InformationAction`
-```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
-
-Required: False
-Position: Named
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False


### PR DESCRIPTION
* [Expression parameter's position is 0](https://github.com/PowerShell/PowerShell/blob/v6.0.0-rc/src/Microsoft.PowerShell.Commands.Utility/commands/utility/TimeExpressionCommand.cs#L35-L36)
* Removed InformationAction/InformationVariable in v6.0

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
