### PR TITLE
Actually call the configuration in the example

### DIFF
--- a/dsc/configurations.md
+++ b/dsc/configurations.md
@@ -26,7 +26,8 @@ Configuration MyDscConfiguration {
 			Name = "Bitlocker"
 		}
 	}
-} 
+}
+MyDscConfiguration
 
 ```
 
@@ -60,6 +61,7 @@ Configuration MyDscConfiguration {
 		}
 	}
 }
+MyDscConfiguration
 
 ```
 


### PR DESCRIPTION
On line 74, it says...

"The last line of the example containing only the name of the configuration, calls the configuration."

This change actually makes that call.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
