### PR TITLE
Fix parameter's position in Join-Path.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Management/Join-Path.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Join-Path.md
@@ -14,9 +14,9 @@ Combines a path and a child path into a single path.
 The provider supplies the path delimiters.
 ## SYNTAX
 
-```
-Join-Path [-Path] <String[]> [-ChildPath] <String> [-Resolve] [-Credential <PSCredential>] [-UseTransaction]
- [<CommonParameters>]
+```powershell
+Join-Path [-Path] <String[]> [-ChildPath] <String>
+ [-Resolve] [-Credential <PSCredential>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -76,7 +76,7 @@ Parameter Sets: (All)
 Aliases: 
 
 Required: True
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: True
@@ -117,7 +117,7 @@ Parameter Sets: (All)
 Aliases: PSPath
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: True

--- a/reference/4.0/Microsoft.PowerShell.Management/Join-Path.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Join-Path.md
@@ -16,9 +16,9 @@ The provider supplies the path delimiters.
 
 ## SYNTAX
 
-```
-Join-Path [-Path] <String[]> [-ChildPath] <String> [-Resolve] [-Credential <PSCredential>] [-UseTransaction]
- [<CommonParameters>]
+```powershell
+Join-Path [-Path] <String[]> [-ChildPath] <String>
+ [-Resolve] [-Credential <PSCredential>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -84,7 +84,7 @@ Parameter Sets: (All)
 Aliases: 
 
 Required: True
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: True
@@ -125,7 +125,7 @@ Parameter Sets: (All)
 Aliases: PSPath
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: True

--- a/reference/5.0/Microsoft.PowerShell.Management/Join-Path.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Join-Path.md
@@ -15,9 +15,9 @@ Combines a path and a child path into a single path.
 
 ## SYNTAX
 
-```
-Join-Path [-Path] <String[]> [-ChildPath] <String> [-Resolve] [-Credential <PSCredential>] [-UseTransaction]
- [<CommonParameters>]
+```powershell
+Join-Path [-Path] <String[]> [-ChildPath] <String>
+ [-Resolve] [-Credential <PSCredential>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Management/Join-Path.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Join-Path.md
@@ -15,9 +15,9 @@ Combines a path and a child path into a single path.
 
 ## SYNTAX
 
-```
-Join-Path [-Path] <String[]> [-ChildPath] <String> [-Resolve] [-Credential <PSCredential>] [-UseTransaction]
- [<CommonParameters>]
+```powershell
+Join-Path [-Path] <String[]> [-ChildPath] <String>
+ [-Resolve] [-Credential <PSCredential>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/Microsoft.PowerShell.Management/Join-Path.md
+++ b/reference/6/Microsoft.PowerShell.Management/Join-Path.md
@@ -15,10 +15,10 @@ Combines a path and a child path into a single path.
 
 ## SYNTAX
 
-```
-Join-Path [-Path] <String[]> [-ChildPath] <String> [-AdditionalChildPath <String[]>] [-Resolve]
- [-Credential <PSCredential>] [-InformationAction <ActionPreference>] [-InformationVariable <String>]
- [-UseTransaction] [<CommonParameters>]
+```powershell
+Join-Path [-Path] <String[]> [-ChildPath] <String>
+ [[-AdditionalChildPath] <String[]>]
+ [-Resolve] [-Credential <PSCredential>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -82,7 +82,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 2
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -99,7 +99,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -127,33 +127,6 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -InformationAction
-```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Path
 Specifies the main path (or paths) to which the child-path is appended.
 Wildcards are permitted.
@@ -167,7 +140,7 @@ Parameter Sets: (All)
 Aliases: PSPath
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False


### PR DESCRIPTION
* Path parameter's position is 0
* ChildPath parameter's position is 1
* AdditionalChildPath parameter's position is 2 in v6.0
* Removed InformationAction/InformationVariable in v6.0

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
