### PR TITLE
Fix YAML metadata on "Understanding Concepts"

### DIFF
--- a/reference/docs-conceptual/getting-started/understanding-concepts-reference.md
+++ b/reference/docs-conceptual/getting-started/understanding-concepts-reference.md
@@ -1,4 +1,4 @@
-.md---
+---
 ms.date:  2017-06-05
 keywords:  powershell,cmdlet
 title:  understanding concepts reference


### PR DESCRIPTION
I'm not quite sure what this means, but it certainly looks terrible on docs.microsoft.com when it's malformed.

(To be perfectly honest, I only managed to even figure out it's called "YAML metadata" by peeking at the DOM of github's HTML.)
