### PR TITLE
Fixed formatting of output per issue #808

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  2017-06-09
+ms.date:  2017-12-04
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -9,8 +9,10 @@ title:  Export-Csv
 ---
 
 # Export-Csv
+
 ## SYNOPSIS
 Converts objects into a series of comma-separated (CSV) strings and saves the strings in a CSV file.
+
 ## SYNTAX
 
 ### Delimiter (Default)
@@ -48,37 +50,35 @@ This command selects a few properties of the WmiPrvse process and exports them t
 ### Example 2: Export processes to a comma-delimited file
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv"
-<#
-In processes.csv:
-
-#TYPE System.Diagnostics.Process
-__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,... 
-Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS... 
-Process,powershell,257,151920640,38322176,37052416,7836,C:\WINDOWS\...
-
-#>
+Get-Content -Path "processes.csv"
 ```
 
-This command exports objects representing the processes on the computer to the Processes.csv file in the current directory.
+```Output
+#TYPE System.Diagnostics.Process
+__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,...
+Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS...
+Process,powershell,257,151920640,38322176,37052416,7836,C:\WINDOWS\...
+```
+
+This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
 Because it does not specify a delimiter, a comma (`,`) is used to separate the fields in the file.
 
 ### Example 3: Export processes to a semicolon-delimited file
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv" -Delimiter ";"
-<#
+Get-Content -Path "processes.csv"
+```
 
-In processes.csv:
-
+```Output
 #TYPE System.Diagnostics.Process
-__NounName;Name;Handles;VM;WS;PM;NPM;Path;Company;CPU;FileVersion;... 
-Process;powershell;626;201666560;76058624;61943808;11960;C:\WINDOWS... 
+__NounName;Name;Handles;VM;WS;PM;NPM;Path;Company;CPU;FileVersion;...
+Process;powershell;626;201666560;76058624;61943808;11960;C:\WINDOWS...
 Process;powershell;257;151920640;38322176;37052416;7836;C:\WINDOWS\...
 
-#>
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-Delimiter` parameter to specify the semicolon (`;`).
+It uses the **-Delimiter** parameter to specify the semicolon (`;`).
 As a result, the fields in the file are separated by semicolons.
 
 ### Example 4: Export using the list separator of the current culture
@@ -87,23 +87,22 @@ Get-Process | Export-Csv -Path "processes.csv" -UseCulture
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-UseCulture` parameter to direct `Export-CSV` to use the delimiter specified by the ListSeparator property of the current culture.
+It uses the `-UseCulture` parameter to direct `Export-CSV` to use the delimiter specified by the **ListSeparator** property of the current culture.
 
 ### Example 5: Export processes without type information
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv" -NoTypeInformation
-<#
-In processes.csv:
+Get-Content -Path "processes.csv"
+```
 
-__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,... 
-Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS... 
+```Output
+__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,...
+Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS...
 Process,powershell,257,151920640,38322176,37052416,7836,C:\WINDOWS\...
-
-#>
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-NoTypeInformation` parameter to suppress the type information in the file.
+It uses the **-NoTypeInformation** parameter to suppress the type information in the file.
 
 ### Example 6: Export and append script properties
 ```powershell
@@ -116,7 +115,7 @@ The second command uses the `Select-Object` cmdlet to select the relevant proper
 
 The third command uses a pipeline operator (`|`) to send the script file information in the `$ScriptFiles` variable to the `Export-CSV` cmdlet. The command uses the `-Path` parameter to specify the output file and the `-Append` parameter to add the new script data to the end of the output file, instead of replacing the existing file contents.
 
-These commands add information about new Windows PowerShell scripts to a script inventory file.
+These commands add information about new PowerShell scripts to a script inventory file.
 
 The first command uses the `Get-ChildItem` cmdlet to do a recursive search in the `D:` drive for files with the `.ps1` file name extension.
 It uses a pipeline operator to sends the results to the `Where-Object` cmdlet, which gets only files that were created after January 1, 2011, and then saves them in the `$ScriptFiles` variable.
@@ -124,27 +123,31 @@ It uses a pipeline operator to sends the results to the `Where-Object` cmdlet, w
 ### Example 7: Select properties to export
 ```powershell
 Get-Date | Select-Object -Property DateTime, Day, DayOfWeek, DayOfYear | Export-Csv -Path Date.csv -NoTypeInformation
-<#
-In Date.csv:
+Get-Content -Path "Date.csv"
+```
 
-"DateTime","Day","DayOfWeek","DayOfYear""Tuesday, October 05, 2010 2:45:13 PM","5","Tuesday","278"
+```Output
+"DateTime","Day","DayOfWeek","DayOfYear"
+"Tuesday, October 05, 2010 2:45:13 PM","5","Tuesday","278"
+```
 
-#>
-
+```powershell
 Get-Date | Format-Table -Property DateTime, Day, DayOfWeek, DayOfYear | Export-Csv -Path Date.csv -NoTypeInformation
-<#
-In Date.csv:
+Get-Content -Path "Date.csv"
+```
 
+```Output
 "ClassId2e4f51ef21dd47e99d3c952918aff9cd","pageHeaderEntry","pageFooterEntry","autosizeInfo","shapeInfo","groupingEntry"
-"033ecb2bc07a4d43b5ef94ed5a35d280",,,,"Microsoft.PowerShell.Commands.Internal.Format.TableHeaderInfo","9e210fe47d09416682b841769c78b8a3"
-,,,,,"27c87ef9bbda4f709f6b4002fa4af63c",,,,,"4ec4f0187cb04f4cb6973460dfe252df",,,,,"cf522b78d86c486691226b40aa69e95c",,,,,
-
-#>
+"033ecb2bc07a4d43b5ef94ed5a35d280",,,,"Microsoft.PowerShell.Commands.Internal.Format.TableHeaderInfo",
+"9e210fe47d09416682b841769c78b8a3",,,,,
+"27c87ef9bbda4f709f6b4002fa4af63c",,,,,
+"4ec4f0187cb04f4cb6973460dfe252df",,,,,
+"cf522b78d86c486691226b40aa69e95c",,,,,
 ```
 
 The first command shows how to select properties of an object and export them to a CSV file. This command uses the `Get-Date` cmdlet to get the current date and time. It uses the `Select-Object` cmdlet to select the desired properties, and the `Export-CSV` cmdlet to export the object and its properties to the `Date.csv` file. The output shows the expected content in the `Date.csv` file.
 
-The second command shows that when you use the `Format-Table` cmdlet to format your data before exporting it, the output is not useful. 
+The second command shows that when you use the `Format-Table` cmdlet to format your data before exporting it, the output is not useful.
 
 This example demonstrates one of most common problems that users encounter when using the `Export-CSV` cmdlet.
 It explains how to recognize and avoid this error.
@@ -166,7 +169,7 @@ This parameter was introduced in Windows PowerShell 3.0.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -199,11 +202,11 @@ To specify a semicolon (`;`), enclose it in quotation marks.
 ```yaml
 Type: Char
 Parameter Sets: Delimiter
-Aliases: 
+Aliases:
 
 Required: False
-Position: 2
-Default value: , (comma)
+Position: 1
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -226,22 +229,23 @@ The default value is ASCII.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
+Accepted values: Unicode, UTF7, UTF8, ASCII, UTF32, BigEndianUnicode, Default, OEM
 
 Required: False
 Position: Named
-Default value: ASCII
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Force
-Overwrites the file specified in path without prompting.
+Forces the command to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -304,7 +308,8 @@ Accept wildcard characters: False
 
 ### -NoTypeInformation
 Indicates that this cmdlet omits the type information from the CSV file.
-By default, the first line of the CSV file contains `#TYPE` followed by the fully-qualified name of the type of the object.
+This is the default behavior beginning with PowerShell 6.0.
+This parameter is included for backwards compatibility.
 
 ```yaml
 Type: SwitchParameter
@@ -313,7 +318,7 @@ Aliases: NTI
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -325,30 +330,30 @@ This parameter is required.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
-Position: 1
-Default value: Current location
+Position: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -UseCulture
-Use the list separator for the current culture as the item delimiter.
-The default is a comma (,).
+Indicates that this cmdlet uses the list separator for the current culture as the item delimiter.
+The default is a comma (`,`).
 
 This parameter is very useful in scripts that are being distributed to users worldwide.
-To find the list separator for a culture, use the following command: (Get-Culture).TextInfo.ListSeparator.
+To find the list separator for a culture, use the following command: `(Get-Culture).TextInfo.ListSeparator`.
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: UseCulture
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
-Default value: Comma
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -383,7 +388,8 @@ You can pipe any object with an Extended Type System (ETS) adapter to `Export-CS
 The CSV list is sent to the file designated in the Path parameter.
 
 ## NOTES
-* The `Export-CSV` cmdlet converts the objects that you submit into a series of CSV variable-length strings and saves them in the specified text file. You can use `Export-CSV` to save objects in a CSV file and then use the Import-Csv cmdlet to create objects from the text in the CSV file.
+* The `Export-CSV` cmdlet converts the objects that you submit into a series of CSV variable-length strings and saves them in the specified text file.
+  You can use `Export-CSV` to save objects in a CSV file and then use the Import-Csv cmdlet to create objects from the text in the CSV file.
 
   In the CSV file, each object is represented by a comma-separated list of the property values of the object.
 The property values are converted to strings (by using the `ToString()` method of the object), so they are generally represented by the name of the property value.
@@ -391,8 +397,8 @@ The property values are converted to strings (by using the `ToString()` method o
 
   The format of an exported file is as follows:
 
-  - The first line of the CSV file contains the string `#TYPE` followed by the fully qualified name of the object, such as `#TYPE System.Diagnostics.Process`.
-To suppress this line, use the `-NoTypeInformation` parameter.
+  - The first line of the CSV file contains the string #TYPE followed by the fully qualified name of the object, such as `#TYPE System.Diagnostics.Process`.
+This line will not be included by default. You must specify `-IncludeTypeInformation` to include type information.
 
   - The next line of the CSV file represents the column headers.
 It contains a comma-separated list of the names of all the properties of the first object.
@@ -414,4 +420,6 @@ It contains a comma-separated list of the names of all the properties of the fir
 [Import-Csv](Import-Csv.md)
 
 [Select-Object](Select-Object.md)
+
+[Where-Object](../Microsoft.PowerShell.Core/Where-Object.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  2017-06-09
+ms.date:  2017-12-04
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -50,37 +50,35 @@ This command selects a few properties of the WmiPrvse process and exports them t
 ### Example 2: Export processes to a comma-delimited file
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv"
-<#
-In processes.csv:
-
-#TYPE System.Diagnostics.Process
-__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,... 
-Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS... 
-Process,powershell,257,151920640,38322176,37052416,7836,C:\WINDOWS\...
-
-#>
+Get-Content -Path "processes.csv"
 ```
 
-This command exports objects representing the processes on the computer to the Processes.csv file in the current directory.
+```Output
+#TYPE System.Diagnostics.Process
+__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,...
+Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS...
+Process,powershell,257,151920640,38322176,37052416,7836,C:\WINDOWS\...
+```
+
+This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
 Because it does not specify a delimiter, a comma (`,`) is used to separate the fields in the file.
 
 ### Example 3: Export processes to a semicolon-delimited file
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv" -Delimiter ";"
-<#
+Get-Content -Path "processes.csv"
+```
 
-In processes.csv:
-
+```Output
 #TYPE System.Diagnostics.Process
-__NounName;Name;Handles;VM;WS;PM;NPM;Path;Company;CPU;FileVersion;... 
-Process;powershell;626;201666560;76058624;61943808;11960;C:\WINDOWS... 
+__NounName;Name;Handles;VM;WS;PM;NPM;Path;Company;CPU;FileVersion;...
+Process;powershell;626;201666560;76058624;61943808;11960;C:\WINDOWS...
 Process;powershell;257;151920640;38322176;37052416;7836;C:\WINDOWS\...
 
-#>
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-Delimiter` parameter to specify the semicolon (`;`).
+It uses the **-Delimiter** parameter to specify the semicolon (`;`).
 As a result, the fields in the file are separated by semicolons.
 
 ### Example 4: Export using the list separator of the current culture
@@ -89,23 +87,22 @@ Get-Process | Export-Csv -Path "processes.csv" -UseCulture
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-UseCulture` parameter to direct `Export-CSV` to use the delimiter specified by the ListSeparator property of the current culture.
+It uses the `-UseCulture` parameter to direct `Export-CSV` to use the delimiter specified by the **ListSeparator** property of the current culture.
 
 ### Example 5: Export processes without type information
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv" -NoTypeInformation
-<#
-In processes.csv:
+Get-Content -Path "processes.csv"
+```
 
-__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,... 
-Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS... 
+```Output
+__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,...
+Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS...
 Process,powershell,257,151920640,38322176,37052416,7836,C:\WINDOWS\...
-
-#>
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-NoTypeInformation` parameter to suppress the type information in the file.
+It uses the **-NoTypeInformation** parameter to suppress the type information in the file.
 
 ### Example 6: Export and append script properties
 ```powershell
@@ -118,7 +115,7 @@ The second command uses the `Select-Object` cmdlet to select the relevant proper
 
 The third command uses a pipeline operator (`|`) to send the script file information in the `$ScriptFiles` variable to the `Export-CSV` cmdlet. The command uses the `-Path` parameter to specify the output file and the `-Append` parameter to add the new script data to the end of the output file, instead of replacing the existing file contents.
 
-These commands add information about new Windows PowerShell scripts to a script inventory file.
+These commands add information about new PowerShell scripts to a script inventory file.
 
 The first command uses the `Get-ChildItem` cmdlet to do a recursive search in the `D:` drive for files with the `.ps1` file name extension.
 It uses a pipeline operator to sends the results to the `Where-Object` cmdlet, which gets only files that were created after January 1, 2011, and then saves them in the `$ScriptFiles` variable.
@@ -126,27 +123,31 @@ It uses a pipeline operator to sends the results to the `Where-Object` cmdlet, w
 ### Example 7: Select properties to export
 ```powershell
 Get-Date | Select-Object -Property DateTime, Day, DayOfWeek, DayOfYear | Export-Csv -Path Date.csv -NoTypeInformation
-<#
-In Date.csv:
+Get-Content -Path "Date.csv"
+```
 
-"DateTime","Day","DayOfWeek","DayOfYear""Tuesday, October 05, 2010 2:45:13 PM","5","Tuesday","278"
+```Output
+"DateTime","Day","DayOfWeek","DayOfYear"
+"Tuesday, October 05, 2010 2:45:13 PM","5","Tuesday","278"
+```
 
-#>
-
+```powershell
 Get-Date | Format-Table -Property DateTime, Day, DayOfWeek, DayOfYear | Export-Csv -Path Date.csv -NoTypeInformation
-<#
-In Date.csv:
+Get-Content -Path "Date.csv"
+```
 
+```Output
 "ClassId2e4f51ef21dd47e99d3c952918aff9cd","pageHeaderEntry","pageFooterEntry","autosizeInfo","shapeInfo","groupingEntry"
-"033ecb2bc07a4d43b5ef94ed5a35d280",,,,"Microsoft.PowerShell.Commands.Internal.Format.TableHeaderInfo","9e210fe47d09416682b841769c78b8a3"
-,,,,,"27c87ef9bbda4f709f6b4002fa4af63c",,,,,"4ec4f0187cb04f4cb6973460dfe252df",,,,,"cf522b78d86c486691226b40aa69e95c",,,,,
-
-#>
+"033ecb2bc07a4d43b5ef94ed5a35d280",,,,"Microsoft.PowerShell.Commands.Internal.Format.TableHeaderInfo",
+"9e210fe47d09416682b841769c78b8a3",,,,,
+"27c87ef9bbda4f709f6b4002fa4af63c",,,,,
+"4ec4f0187cb04f4cb6973460dfe252df",,,,,
+"cf522b78d86c486691226b40aa69e95c",,,,,
 ```
 
 The first command shows how to select properties of an object and export them to a CSV file. This command uses the `Get-Date` cmdlet to get the current date and time. It uses the `Select-Object` cmdlet to select the desired properties, and the `Export-CSV` cmdlet to export the object and its properties to the `Date.csv` file. The output shows the expected content in the `Date.csv` file.
 
-The second command shows that when you use the `Format-Table` cmdlet to format your data before exporting it, the output is not useful. 
+The second command shows that when you use the `Format-Table` cmdlet to format your data before exporting it, the output is not useful.
 
 This example demonstrates one of most common problems that users encounter when using the `Export-CSV` cmdlet.
 It explains how to recognize and avoid this error.
@@ -168,7 +169,7 @@ This parameter was introduced in Windows PowerShell 3.0.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -201,39 +202,50 @@ To specify a semicolon (`;`), enclose it in quotation marks.
 ```yaml
 Type: Char
 Parameter Sets: Delimiter
-Aliases: 
+Aliases:
 
 Required: False
-Position: 2
-Default value: , (comma)
+Position: 1
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Encoding
 Specifies the encoding for the exported CSV file.
-Valid values are Unicode, UTF7, UTF8, ASCII, UTF32, BigEndianUnicode, Default, and OEM.
-The default is ASCII.
+The acceptable values for this parameter are:
+
+- Unicode
+- UTF7
+- UTF8
+- ASCII
+- UTF32
+- BigEndianUnicode
+- Default
+- OEM
+
+The default value is ASCII.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
+Accepted values: Unicode, UTF7, UTF8, ASCII, UTF32, BigEndianUnicode, Default, OEM
 
 Required: False
 Position: Named
-Default value: ASCII
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Force
-Overwrites the file specified in path without prompting.
+Forces the command to run without asking for user confirmation.
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -296,7 +308,8 @@ Accept wildcard characters: False
 
 ### -NoTypeInformation
 Indicates that this cmdlet omits the type information from the CSV file.
-By default, the first line of the CSV file contains `#TYPE` followed by the fully-qualified name of the type of the object.
+This is the default behavior beginning with PowerShell 6.0.
+This parameter is included for backwards compatibility.
 
 ```yaml
 Type: SwitchParameter
@@ -305,7 +318,7 @@ Aliases: NTI
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -317,11 +330,11 @@ This parameter is required.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
-Position: 1
-Default value: Current location
+Position: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -336,11 +349,11 @@ To find the list separator for a culture, use the following command: `(Get-Cultu
 ```yaml
 Type: SwitchParameter
 Parameter Sets: UseCulture
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
-Default value: Comma
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -375,7 +388,8 @@ You can pipe any object with an Extended Type System (ETS) adapter to `Export-CS
 The CSV list is sent to the file designated in the Path parameter.
 
 ## NOTES
-* The `Export-CSV` cmdlet converts the objects that you submit into a series of CSV variable-length strings and saves them in the specified text file. You can use `Export-CSV` to save objects in a CSV file and then use the Import-Csv cmdlet to create objects from the text in the CSV file.
+* The `Export-CSV` cmdlet converts the objects that you submit into a series of CSV variable-length strings and saves them in the specified text file.
+  You can use `Export-CSV` to save objects in a CSV file and then use the Import-Csv cmdlet to create objects from the text in the CSV file.
 
   In the CSV file, each object is represented by a comma-separated list of the property values of the object.
 The property values are converted to strings (by using the `ToString()` method of the object), so they are generally represented by the name of the property value.
@@ -383,8 +397,8 @@ The property values are converted to strings (by using the `ToString()` method o
 
   The format of an exported file is as follows:
 
-  - The first line of the CSV file contains the string `#TYPE` followed by the fully qualified name of the object, such as `#TYPE System.Diagnostics.Process`.
-To suppress this line, use the `-NoTypeInformation` parameter.
+  - The first line of the CSV file contains the string #TYPE followed by the fully qualified name of the object, such as `#TYPE System.Diagnostics.Process`.
+This line will not be included by default. You must specify `-IncludeTypeInformation` to include type information.
 
   - The next line of the CSV file represents the column headers.
 It contains a comma-separated list of the names of all the properties of the first object.
@@ -406,4 +420,6 @@ It contains a comma-separated list of the names of all the properties of the fir
 [Import-Csv](Import-Csv.md)
 
 [Select-Object](Select-Object.md)
+
+[Where-Object](../Microsoft.PowerShell.Core/Where-Object.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  2017-06-09
+ms.date:  2017-12-04
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -50,37 +50,35 @@ This command selects a few properties of the WmiPrvse process and exports them t
 ### Example 2: Export processes to a comma-delimited file
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv"
-<#
-In processes.csv:
-
-#TYPE System.Diagnostics.Process
-__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,... 
-Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS... 
-Process,powershell,257,151920640,38322176,37052416,7836,C:\WINDOWS\...
-
-#>
+Get-Content -Path "processes.csv"
 ```
 
-This command exports objects representing the processes on the computer to the Processes.csv file in the current directory.
+```Output
+#TYPE System.Diagnostics.Process
+__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,...
+Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS...
+Process,powershell,257,151920640,38322176,37052416,7836,C:\WINDOWS\...
+```
+
+This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
 Because it does not specify a delimiter, a comma (`,`) is used to separate the fields in the file.
 
 ### Example 3: Export processes to a semicolon-delimited file
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv" -Delimiter ";"
-<#
+Get-Content -Path "processes.csv"
+```
 
-In processes.csv:
-
+```Output
 #TYPE System.Diagnostics.Process
-__NounName;Name;Handles;VM;WS;PM;NPM;Path;Company;CPU;FileVersion;... 
-Process;powershell;626;201666560;76058624;61943808;11960;C:\WINDOWS... 
+__NounName;Name;Handles;VM;WS;PM;NPM;Path;Company;CPU;FileVersion;...
+Process;powershell;626;201666560;76058624;61943808;11960;C:\WINDOWS...
 Process;powershell;257;151920640;38322176;37052416;7836;C:\WINDOWS\...
 
-#>
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-Delimiter` parameter to specify the semicolon (`;`).
+It uses the **-Delimiter** parameter to specify the semicolon (`;`).
 As a result, the fields in the file are separated by semicolons.
 
 ### Example 4: Export using the list separator of the current culture
@@ -89,23 +87,22 @@ Get-Process | Export-Csv -Path "processes.csv" -UseCulture
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-UseCulture` parameter to direct `Export-CSV` to use the delimiter specified by the ListSeparator property of the current culture.
+It uses the `-UseCulture` parameter to direct `Export-CSV` to use the delimiter specified by the **ListSeparator** property of the current culture.
 
 ### Example 5: Export processes without type information
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv" -NoTypeInformation
-<#
-In processes.csv:
+Get-Content -Path "processes.csv"
+```
 
-__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,... 
-Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS... 
+```Output
+__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,...
+Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS...
 Process,powershell,257,151920640,38322176,37052416,7836,C:\WINDOWS\...
-
-#>
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-NoTypeInformation` parameter to suppress the type information in the file.
+It uses the **-NoTypeInformation** parameter to suppress the type information in the file.
 
 ### Example 6: Export and append script properties
 ```powershell
@@ -118,7 +115,7 @@ The second command uses the `Select-Object` cmdlet to select the relevant proper
 
 The third command uses a pipeline operator (`|`) to send the script file information in the `$ScriptFiles` variable to the `Export-CSV` cmdlet. The command uses the `-Path` parameter to specify the output file and the `-Append` parameter to add the new script data to the end of the output file, instead of replacing the existing file contents.
 
-These commands add information about new Windows PowerShell scripts to a script inventory file.
+These commands add information about new PowerShell scripts to a script inventory file.
 
 The first command uses the `Get-ChildItem` cmdlet to do a recursive search in the `D:` drive for files with the `.ps1` file name extension.
 It uses a pipeline operator to sends the results to the `Where-Object` cmdlet, which gets only files that were created after January 1, 2011, and then saves them in the `$ScriptFiles` variable.
@@ -126,27 +123,31 @@ It uses a pipeline operator to sends the results to the `Where-Object` cmdlet, w
 ### Example 7: Select properties to export
 ```powershell
 Get-Date | Select-Object -Property DateTime, Day, DayOfWeek, DayOfYear | Export-Csv -Path Date.csv -NoTypeInformation
-<#
-In Date.csv:
+Get-Content -Path "Date.csv"
+```
 
-"DateTime","Day","DayOfWeek","DayOfYear""Tuesday, October 05, 2010 2:45:13 PM","5","Tuesday","278"
+```Output
+"DateTime","Day","DayOfWeek","DayOfYear"
+"Tuesday, October 05, 2010 2:45:13 PM","5","Tuesday","278"
+```
 
-#>
-
+```powershell
 Get-Date | Format-Table -Property DateTime, Day, DayOfWeek, DayOfYear | Export-Csv -Path Date.csv -NoTypeInformation
-<#
-In Date.csv:
+Get-Content -Path "Date.csv"
+```
 
+```Output
 "ClassId2e4f51ef21dd47e99d3c952918aff9cd","pageHeaderEntry","pageFooterEntry","autosizeInfo","shapeInfo","groupingEntry"
-"033ecb2bc07a4d43b5ef94ed5a35d280",,,,"Microsoft.PowerShell.Commands.Internal.Format.TableHeaderInfo","9e210fe47d09416682b841769c78b8a3"
-,,,,,"27c87ef9bbda4f709f6b4002fa4af63c",,,,,"4ec4f0187cb04f4cb6973460dfe252df",,,,,"cf522b78d86c486691226b40aa69e95c",,,,,
-
-#>
+"033ecb2bc07a4d43b5ef94ed5a35d280",,,,"Microsoft.PowerShell.Commands.Internal.Format.TableHeaderInfo",
+"9e210fe47d09416682b841769c78b8a3",,,,,
+"27c87ef9bbda4f709f6b4002fa4af63c",,,,,
+"4ec4f0187cb04f4cb6973460dfe252df",,,,,
+"cf522b78d86c486691226b40aa69e95c",,,,,
 ```
 
 The first command shows how to select properties of an object and export them to a CSV file. This command uses the `Get-Date` cmdlet to get the current date and time. It uses the `Select-Object` cmdlet to select the desired properties, and the `Export-CSV` cmdlet to export the object and its properties to the `Date.csv` file. The output shows the expected content in the `Date.csv` file.
 
-The second command shows that when you use the `Format-Table` cmdlet to format your data before exporting it, the output is not useful. 
+The second command shows that when you use the `Format-Table` cmdlet to format your data before exporting it, the output is not useful.
 
 This example demonstrates one of most common problems that users encounter when using the `Export-CSV` cmdlet.
 It explains how to recognize and avoid this error.
@@ -168,7 +169,7 @@ This parameter was introduced in Windows PowerShell 3.0.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -201,7 +202,7 @@ To specify a semicolon (`;`), enclose it in quotation marks.
 ```yaml
 Type: Char
 Parameter Sets: Delimiter
-Aliases: 
+Aliases:
 
 Required: False
 Position: 1
@@ -228,7 +229,7 @@ The default value is ASCII.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: Unicode, UTF7, UTF8, ASCII, UTF32, BigEndianUnicode, Default, OEM
 
 Required: False
@@ -244,7 +245,7 @@ Forces the command to run without asking for user confirmation.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -307,7 +308,8 @@ Accept wildcard characters: False
 
 ### -NoTypeInformation
 Indicates that this cmdlet omits the type information from the CSV file.
-By default, the first line of the CSV file contains `#TYPE` followed by the fully-qualified name of the type of the object.
+This is the default behavior beginning with PowerShell 6.0.
+This parameter is included for backwards compatibility.
 
 ```yaml
 Type: SwitchParameter
@@ -323,11 +325,12 @@ Accept wildcard characters: False
 
 ### -Path
 Specifies the path to the CSV output file.
+This parameter is required.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 0
@@ -346,7 +349,7 @@ To find the list separator for a culture, use the following command: `(Get-Cultu
 ```yaml
 Type: SwitchParameter
 Parameter Sets: UseCulture
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -385,7 +388,8 @@ You can pipe any object with an Extended Type System (ETS) adapter to `Export-CS
 The CSV list is sent to the file designated in the Path parameter.
 
 ## NOTES
-* The `Export-CSV` cmdlet converts the objects that you submit into a series of CSV variable-length strings and saves them in the specified text file. You can use `Export-CSV` to save objects in a CSV file and then use the Import-Csv cmdlet to create objects from the text in the CSV file.
+* The `Export-CSV` cmdlet converts the objects that you submit into a series of CSV variable-length strings and saves them in the specified text file.
+  You can use `Export-CSV` to save objects in a CSV file and then use the Import-Csv cmdlet to create objects from the text in the CSV file.
 
   In the CSV file, each object is represented by a comma-separated list of the property values of the object.
 The property values are converted to strings (by using the `ToString()` method of the object), so they are generally represented by the name of the property value.
@@ -393,8 +397,8 @@ The property values are converted to strings (by using the `ToString()` method o
 
   The format of an exported file is as follows:
 
-  - The first line of the CSV file contains the string `#TYPE` followed by the fully qualified name of the object, such as `#TYPE System.Diagnostics.Process`.
-To suppress this line, use the `-NoTypeInformation` parameter.
+  - The first line of the CSV file contains the string #TYPE followed by the fully qualified name of the object, such as `#TYPE System.Diagnostics.Process`.
+This line will not be included by default. You must specify `-IncludeTypeInformation` to include type information.
 
   - The next line of the CSV file represents the column headers.
 It contains a comma-separated list of the names of all the properties of the first object.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  2017-06-09
+ms.date:  2017-12-04
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -50,37 +50,35 @@ This command selects a few properties of the WmiPrvse process and exports them t
 ### Example 2: Export processes to a comma-delimited file
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv"
-<#
-In processes.csv:
-
-#TYPE System.Diagnostics.Process
-__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,... 
-Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS... 
-Process,powershell,257,151920640,38322176,37052416,7836,C:\WINDOWS\...
-
-#>
+Get-Content -Path "processes.csv"
 ```
 
-This command exports objects representing the processes on the computer to the Processes.csv file in the current directory.
+```Output
+#TYPE System.Diagnostics.Process
+__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,...
+Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS...
+Process,powershell,257,151920640,38322176,37052416,7836,C:\WINDOWS\...
+```
+
+This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
 Because it does not specify a delimiter, a comma (`,`) is used to separate the fields in the file.
 
 ### Example 3: Export processes to a semicolon-delimited file
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv" -Delimiter ";"
-<#
+Get-Content -Path "processes.csv"
+```
 
-In processes.csv:
-
+```Output
 #TYPE System.Diagnostics.Process
-__NounName;Name;Handles;VM;WS;PM;NPM;Path;Company;CPU;FileVersion;... 
-Process;powershell;626;201666560;76058624;61943808;11960;C:\WINDOWS... 
+__NounName;Name;Handles;VM;WS;PM;NPM;Path;Company;CPU;FileVersion;...
+Process;powershell;626;201666560;76058624;61943808;11960;C:\WINDOWS...
 Process;powershell;257;151920640;38322176;37052416;7836;C:\WINDOWS\...
 
-#>
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-Delimiter` parameter to specify the semicolon (`;`).
+It uses the **-Delimiter** parameter to specify the semicolon (`;`).
 As a result, the fields in the file are separated by semicolons.
 
 ### Example 4: Export using the list separator of the current culture
@@ -89,23 +87,22 @@ Get-Process | Export-Csv -Path "processes.csv" -UseCulture
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-UseCulture` parameter to direct `Export-CSV` to use the delimiter specified by the ListSeparator property of the current culture.
+It uses the `-UseCulture` parameter to direct `Export-CSV` to use the delimiter specified by the **ListSeparator** property of the current culture.
 
 ### Example 5: Export processes without type information
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv" -NoTypeInformation
-<#
-In processes.csv:
+Get-Content -Path "processes.csv"
+```
 
-__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,... 
-Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS... 
+```Output
+__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,...
+Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS...
 Process,powershell,257,151920640,38322176,37052416,7836,C:\WINDOWS\...
-
-#>
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-NoTypeInformation` parameter to suppress the type information in the file.
+It uses the **-NoTypeInformation** parameter to suppress the type information in the file.
 
 ### Example 6: Export and append script properties
 ```powershell
@@ -118,7 +115,7 @@ The second command uses the `Select-Object` cmdlet to select the relevant proper
 
 The third command uses a pipeline operator (`|`) to send the script file information in the `$ScriptFiles` variable to the `Export-CSV` cmdlet. The command uses the `-Path` parameter to specify the output file and the `-Append` parameter to add the new script data to the end of the output file, instead of replacing the existing file contents.
 
-These commands add information about new Windows PowerShell scripts to a script inventory file.
+These commands add information about new PowerShell scripts to a script inventory file.
 
 The first command uses the `Get-ChildItem` cmdlet to do a recursive search in the `D:` drive for files with the `.ps1` file name extension.
 It uses a pipeline operator to sends the results to the `Where-Object` cmdlet, which gets only files that were created after January 1, 2011, and then saves them in the `$ScriptFiles` variable.
@@ -126,27 +123,31 @@ It uses a pipeline operator to sends the results to the `Where-Object` cmdlet, w
 ### Example 7: Select properties to export
 ```powershell
 Get-Date | Select-Object -Property DateTime, Day, DayOfWeek, DayOfYear | Export-Csv -Path Date.csv -NoTypeInformation
-<#
-In Date.csv:
+Get-Content -Path "Date.csv"
+```
 
-"DateTime","Day","DayOfWeek","DayOfYear""Tuesday, October 05, 2010 2:45:13 PM","5","Tuesday","278"
+```Output
+"DateTime","Day","DayOfWeek","DayOfYear"
+"Tuesday, October 05, 2010 2:45:13 PM","5","Tuesday","278"
+```
 
-#>
-
+```powershell
 Get-Date | Format-Table -Property DateTime, Day, DayOfWeek, DayOfYear | Export-Csv -Path Date.csv -NoTypeInformation
-<#
-In Date.csv:
+Get-Content -Path "Date.csv"
+```
 
+```Output
 "ClassId2e4f51ef21dd47e99d3c952918aff9cd","pageHeaderEntry","pageFooterEntry","autosizeInfo","shapeInfo","groupingEntry"
-"033ecb2bc07a4d43b5ef94ed5a35d280",,,,"Microsoft.PowerShell.Commands.Internal.Format.TableHeaderInfo","9e210fe47d09416682b841769c78b8a3"
-,,,,,"27c87ef9bbda4f709f6b4002fa4af63c",,,,,"4ec4f0187cb04f4cb6973460dfe252df",,,,,"cf522b78d86c486691226b40aa69e95c",,,,,
-
-#>
+"033ecb2bc07a4d43b5ef94ed5a35d280",,,,"Microsoft.PowerShell.Commands.Internal.Format.TableHeaderInfo",
+"9e210fe47d09416682b841769c78b8a3",,,,,
+"27c87ef9bbda4f709f6b4002fa4af63c",,,,,
+"4ec4f0187cb04f4cb6973460dfe252df",,,,,
+"cf522b78d86c486691226b40aa69e95c",,,,,
 ```
 
 The first command shows how to select properties of an object and export them to a CSV file. This command uses the `Get-Date` cmdlet to get the current date and time. It uses the `Select-Object` cmdlet to select the desired properties, and the `Export-CSV` cmdlet to export the object and its properties to the `Date.csv` file. The output shows the expected content in the `Date.csv` file.
 
-The second command shows that when you use the `Format-Table` cmdlet to format your data before exporting it, the output is not useful. 
+The second command shows that when you use the `Format-Table` cmdlet to format your data before exporting it, the output is not useful.
 
 This example demonstrates one of most common problems that users encounter when using the `Export-CSV` cmdlet.
 It explains how to recognize and avoid this error.
@@ -168,7 +169,7 @@ This parameter was introduced in Windows PowerShell 3.0.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -201,7 +202,7 @@ To specify a semicolon (`;`), enclose it in quotation marks.
 ```yaml
 Type: Char
 Parameter Sets: Delimiter
-Aliases: 
+Aliases:
 
 Required: False
 Position: 1
@@ -228,7 +229,7 @@ The default value is ASCII.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: Unicode, UTF7, UTF8, ASCII, UTF32, BigEndianUnicode, Default, OEM
 
 Required: False
@@ -244,7 +245,7 @@ Forces the command to run without asking for user confirmation.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -307,7 +308,8 @@ Accept wildcard characters: False
 
 ### -NoTypeInformation
 Indicates that this cmdlet omits the type information from the CSV file.
-By default, the first line of the CSV file contains `#TYPE` followed by the fully-qualified name of the type of the object.
+This is the default behavior beginning with PowerShell 6.0.
+This parameter is included for backwards compatibility.
 
 ```yaml
 Type: SwitchParameter
@@ -328,7 +330,7 @@ This parameter is required.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: 0
@@ -347,7 +349,7 @@ To find the list separator for a culture, use the following command: `(Get-Cultu
 ```yaml
 Type: SwitchParameter
 Parameter Sets: UseCulture
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -386,7 +388,8 @@ You can pipe any object with an Extended Type System (ETS) adapter to `Export-CS
 The CSV list is sent to the file designated in the Path parameter.
 
 ## NOTES
-* The `Export-CSV` cmdlet converts the objects that you submit into a series of CSV variable-length strings and saves them in the specified text file. You can use `Export-CSV` to save objects in a CSV file and then use the Import-Csv cmdlet to create objects from the text in the CSV file.
+* The `Export-CSV` cmdlet converts the objects that you submit into a series of CSV variable-length strings and saves them in the specified text file.
+  You can use `Export-CSV` to save objects in a CSV file and then use the Import-Csv cmdlet to create objects from the text in the CSV file.
 
   In the CSV file, each object is represented by a comma-separated list of the property values of the object.
 The property values are converted to strings (by using the `ToString()` method of the object), so they are generally represented by the name of the property value.
@@ -394,8 +397,8 @@ The property values are converted to strings (by using the `ToString()` method o
 
   The format of an exported file is as follows:
 
-  - The first line of the CSV file contains the string `#TYPE` followed by the fully qualified name of the object, such as `#TYPE System.Diagnostics.Process`.
-To suppress this line, use the `-NoTypeInformation` parameter.
+  - The first line of the CSV file contains the string #TYPE followed by the fully qualified name of the object, such as `#TYPE System.Diagnostics.Process`.
+This line will not be included by default. You must specify `-IncludeTypeInformation` to include type information.
 
   - The next line of the CSV file represents the column headers.
 It contains a comma-separated list of the names of all the properties of the first object.
@@ -417,4 +420,6 @@ It contains a comma-separated list of the names of all the properties of the fir
 [Import-Csv](Import-Csv.md)
 
 [Select-Object](Select-Object.md)
+
+[Where-Object](../Microsoft.PowerShell.Core/Where-Object.md)
 

--- a/reference/6/Microsoft.PowerShell.Utility/Export-Csv.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-Csv.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  2017-06-09
+ms.date:  2017-12-04
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -51,14 +51,13 @@ This command selects a few properties of the WmiPrvse process and exports them t
 ### Example 2: Export processes to a comma-delimited file
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv"
-<#
-In processes.csv:
+Get-Content -Path "processes.csv"
+```
 
-__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,... 
-Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS... 
+```Output
+__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,...
+Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS...
 Process,powershell,257,151920640,38322176,37052416,7836,C:\WINDOWS\...
-
-#>
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
@@ -67,18 +66,18 @@ Because it does not specify a delimiter, a comma (`,`) is used to separate the f
 ### Example 3: Export processes to a semicolon-delimited file
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv" -Delimiter ";"
-<#
-In processes.csv:
+Get-Content -Path "processes.csv"
+```
 
-__NounName;Name;Handles;VM;WS;PM;NPM;Path;Company;CPU;FileVersion;... 
-Process;powershell;626;201666560;76058624;61943808;11960;C:\WINDOWS... 
+```Output
+__NounName;Name;Handles;VM;WS;PM;NPM;Path;Company;CPU;FileVersion;...
+Process;powershell;626;201666560;76058624;61943808;11960;C:\WINDOWS...
 Process;powershell;257;151920640;38322176;37052416;7836;C:\WINDOWS\...
 
-#>
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-Delimiter` parameter to specify the semicolon `;`.
+It uses the **-Delimiter** parameter to specify the semicolon (`;`).
 As a result, the fields in the file are separated by semicolons.
 
 ### Example 4: Export using the list separator of the current culture
@@ -87,24 +86,23 @@ Get-Process | Export-Csv -Path "processes.csv" -UseCulture
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-UseCulture` parameter to direct `Export-CSV` to use the delimiter specified by the `ListSeparator` property of the current culture.
+It uses the `-UseCulture` parameter to direct `Export-CSV` to use the delimiter specified by the **ListSeparator** property of the current culture.
 
 ### Example 5: Export processes with type information
 ```powershell
 Get-Process | Export-Csv -Path "processes.csv" -IncludeTypeInformation
-<#
-In processes.csv:
+Get-Content -Path "processes.csv"
+```
 
+```Output
 #TYPE System.Diagnostics.Process
-__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,... 
-Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS... 
+__NounName,Name,Handles,VM,WS,PM,NPM,Path,Company,CPU,FileVersion,...
+Process,powershell,626,201666560,76058624,61943808,11960,C:\WINDOWS...
 Process,powershell,257,151920640,38322176,37052416,7836,C:\WINDOWS\...
-
-#>
 ```
 
 This command exports objects representing the processes on the computer to the `processes.csv` file in the current directory.
-It uses the `-IncludeTypeInformation` parameter to include the type information in the file.
+It uses the **-NoTypeInformation** parameter to suppress the type information in the file.
 
 ### Example 6: Export and append script properties
 ```powershell
@@ -124,28 +122,32 @@ It uses a pipeline operator to sends the results to the `Where-Object` cmdlet, w
 
 ### Example 7: Select properties to export
 ```powershell
-Get-Date | Select-Object -Property DateTime, Day, DayOfWeek, DayOfYear | Export-Csv -Path Date.csv
-<#
-In Date.csv:
+Get-Date | Select-Object -Property DateTime, Day, DayOfWeek, DayOfYear | Export-Csv -Path Date.csv -NoTypeInformation
+Get-Content -Path "Date.csv"
+```
 
-"DateTime","Day","DayOfWeek","DayOfYear""Tuesday, October 05, 2010 2:45:13 PM","5","Tuesday","278"
+```Output
+"DateTime","Day","DayOfWeek","DayOfYear"
+"Tuesday, October 05, 2010 2:45:13 PM","5","Tuesday","278"
+```
 
-#>
+```powershell
+Get-Date | Format-Table -Property DateTime, Day, DayOfWeek, DayOfYear | Export-Csv -Path Date.csv -NoTypeInformation
+Get-Content -Path "Date.csv"
+```
 
-Get-Date | Format-Table -Property DateTime, Day, DayOfWeek, DayOfYear | Export-Csv -Path Date.csv
-<#
-In Date.csv:
-
+```Output
 "ClassId2e4f51ef21dd47e99d3c952918aff9cd","pageHeaderEntry","pageFooterEntry","autosizeInfo","shapeInfo","groupingEntry"
-"033ecb2bc07a4d43b5ef94ed5a35d280",,,,"Microsoft.PowerShell.Commands.Internal.Format.TableHeaderInfo","9e210fe47d09416682b841769c78b8a3"
-,,,,,"27c87ef9bbda4f709f6b4002fa4af63c",,,,,"4ec4f0187cb04f4cb6973460dfe252df",,,,,"cf522b78d86c486691226b40aa69e95c",,,,,
-
-#>
+"033ecb2bc07a4d43b5ef94ed5a35d280",,,,"Microsoft.PowerShell.Commands.Internal.Format.TableHeaderInfo",
+"9e210fe47d09416682b841769c78b8a3",,,,,
+"27c87ef9bbda4f709f6b4002fa4af63c",,,,,
+"4ec4f0187cb04f4cb6973460dfe252df",,,,,
+"cf522b78d86c486691226b40aa69e95c",,,,,
 ```
 
 The first command shows how to select properties of an object and export them to a CSV file. This command uses the `Get-Date` cmdlet to get the current date and time. It uses the `Select-Object` cmdlet to select the desired properties, and the `Export-CSV` cmdlet to export the object and its properties to the `Date.csv` file. The output shows the expected content in the `Date.csv` file.
 
-The second command shows that when you use the `Format-Table` cmdlet to format your data before exporting it, the output is not useful. 
+The second command shows that when you use the `Format-Table` cmdlet to format your data before exporting it, the output is not useful.
 
 This example demonstrates one of most common problems that users encounter when using the `Export-CSV` cmdlet.
 It explains how to recognize and avoid this error.
@@ -167,11 +169,26 @@ This parameter was introduced in Windows PowerShell 3.0.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -185,10 +202,10 @@ To specify a semicolon (`;`), enclose it in quotation marks.
 ```yaml
 Type: Char
 Parameter Sets: Delimiter
-Aliases: 
+Aliases:
 
 Required: False
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -212,7 +229,7 @@ The default value is ASCII.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: Unicode, UTF7, UTF8, ASCII, UTF32, BigEndianUnicode, Default, OEM
 
 Required: False
@@ -228,7 +245,7 @@ Forces the command to run without asking for user confirmation.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -264,12 +281,31 @@ You can also pipe objects to `Export-CSV`.
 ```yaml
 Type: PSObject
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -LiteralPath
+Specifies the path to the CSV output file.
+Unlike `-Path`, the value of the `-LiteralPath` parameter is used exactly as it is typed.
+No characters are interpreted as wildcards.
+If the path includes escape characters, enclose it in single quotation marks.
+Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: PSPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -291,7 +327,8 @@ Accept wildcard characters: False
 
 ### -NoTypeInformation
 Indicates that this cmdlet omits the type information from the CSV file.
-This behavior is default beginning with PowerShell 6.0. This parameter is included for backwards compatibility.
+This is the default behavior beginning with PowerShell 6.0.
+This parameter is included for backwards compatibility.
 
 ```yaml
 Type: SwitchParameter
@@ -312,10 +349,10 @@ This parameter is required.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -331,45 +368,11 @@ To find the list separator for a culture, use the following command: `(Get-Cultu
 ```yaml
 Type: SwitchParameter
 Parameter Sets: UseCulture
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -LiteralPath
-Specifies the path to the CSV output file.
-Unlike `-Path`, the value of the `-LiteralPath` parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: PSPath
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -404,7 +407,8 @@ You can pipe any object with an Extended Type System (ETS) adapter to `Export-CS
 The CSV list is sent to the file designated in the Path parameter.
 
 ## NOTES
-* The `Export-CSV` cmdlet converts the objects that you submit into a series of CSV variable-length strings and saves them in the specified text file. You can use `Export-CSV -IncludeTypeInformation` to save objects in a CSV file and then use the `Import-Csv` cmdlet to create objects from the text in the CSV file.
+* The `Export-CSV` cmdlet converts the objects that you submit into a series of CSV variable-length strings and saves them in the specified text file.
+  You can use `Export-CSV -IncludeTypeInformation` to save objects in a CSV file and then use the `Import-Csv` cmdlet to create objects from the text in the CSV file.
 
   In the CSV file, each object is represented by a comma-separated list of the property values of the object.
 The property values are converted to strings (by using the `ToString()` method of the object), so they are generally represented by the name of the property value.


### PR DESCRIPTION
The examples were confusing because of the way the output was formatted. Fixed formatting to be clearer about the contents of the CSV files.

See issue #808 for more info.

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
