### PR TITLE
Fix parameter's position in ConvertTo-Xml.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -13,9 +13,9 @@ title:  ConvertTo-Xml
 Creates an XML-based representation of an object.
 ## SYNTAX
 
-```
-ConvertTo-Xml [-Depth <Int32>] [-InputObject] <PSObject> [-NoTypeInformation] [-As <String>]
- [<CommonParameters>]
+```powershell
+ConvertTo-Xml [-InputObject] <PSObject> [-Depth <Int32>] [-NoTypeInformation]
+ [-As <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -97,7 +97,7 @@ Parameter Sets: (All)
 Aliases: 
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: True

--- a/reference/4.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -15,9 +15,9 @@ Creates an XML-based representation of an object.
 
 ## SYNTAX
 
-```
-ConvertTo-Xml [-Depth <Int32>] [-InputObject] <PSObject> [-NoTypeInformation] [-As <String>]
- [<CommonParameters>]
+```powershell
+ConvertTo-Xml [-InputObject] <PSObject> [-Depth <Int32>] [-NoTypeInformation]
+ [-As <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -102,7 +102,7 @@ Parameter Sets: (All)
 Aliases: 
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: True

--- a/reference/5.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -15,9 +15,9 @@ Creates an XML-based representation of an object.
 
 ## SYNTAX
 
-```
-ConvertTo-Xml [-Depth <Int32>] [-InputObject] <PSObject> [-NoTypeInformation] [-As <String>]
- [<CommonParameters>]
+```powershell
+ConvertTo-Xml [-InputObject] <PSObject> [-Depth <Int32>] [-NoTypeInformation]
+ [-As <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -15,9 +15,9 @@ Creates an XML-based representation of an object.
 
 ## SYNTAX
 
-```
-ConvertTo-Xml [-Depth <Int32>] [-InputObject] <PSObject> [-NoTypeInformation] [-As <String>]
- [<CommonParameters>]
+```powershell
+ConvertTo-Xml [-InputObject] <PSObject> [-Depth <Int32>] [-NoTypeInformation]
+ [-As <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -15,9 +15,9 @@ Creates an XML-based representation of an object.
 
 ## SYNTAX
 
-```
-ConvertTo-Xml [-Depth <Int32>] [-InputObject] <PSObject> [-NoTypeInformation] [-As <String>]
- [-InformationAction <ActionPreference>] [-InformationVariable <String>] [<CommonParameters>]
+```powershell
+ConvertTo-Xml [-InputObject] <PSObject> [-Depth <Int32>] [-NoTypeInformation]
+ [-As <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -95,45 +95,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -InformationAction
--- String:  Returns a single string.
-
--- Stream:  Returns an array of strings.
-
--- Document:  Returns an XmlDocument object.
-
-The default is Document.```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
--- String:  Returns a single string.
-
--- Stream:  Returns an array of strings.
-
--- Document:  Returns an XmlDocument object.
-
-The default is Document.```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -InputObject
 Specifies the object to be converted.
 Enter a variable that contains the objects, or type a command or expression that gets the objects.
@@ -145,7 +106,7 @@ Parameter Sets: (All)
 Aliases: 
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False


### PR DESCRIPTION
* InputObject parameter's position is 0
* Removed InformationAction/InformationVariable in v6.0

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
