### PR TITLE
Fix formatting: DESCRIPTION section in ConvertTo-Xml.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -19,13 +19,14 @@ ConvertTo-Xml [-InputObject] <PSObject> [-Depth <Int32>] [-NoTypeInformation]
 ```
 
 ## DESCRIPTION
-The ConvertTo-Xml cmdlet creates an XML-based representation of one or more Microsoft .NET Framework objects.
-To use this cmdlet, pipe one or more objects to the cmdlet, or use the InputObject parameter to specify the object.
+The `ConvertTo-Xml` cmdlet creates an XML-based representation of one or more Microsoft .NET Framework objects.
+To use this cmdlet, pipe one or more objects to the cmdlet, or use the **InputObject** parameter to specify the object.
 
-When you pipe multiple objects to ConvertTo-XML or use the InputObject parameter to submit multiple objects, ConvertTo-XML returns a single XML document that includes representations of all of the objects.
+When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit multiple objects, `ConvertTo-Xml` returns a single XML document that includes representations of all of the objects.
 
-This cmdlet is similar to Export-Clixml except that Export-Clixml stores the resulting XML in a file.
-ConvertTo-XML returns the XML, so you can continue to process it in Windows PowerShell.
+This cmdlet is similar to `Export-Clixml` except that `Export-Clixml` stores the resulting XML in a file.
+`ConvertTo-Xml` returns the XML, so you can continue to process it in PowerShell.
+
 ## EXAMPLES
 
 ### Example 1

--- a/reference/4.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -21,13 +21,13 @@ ConvertTo-Xml [-InputObject] <PSObject> [-Depth <Int32>] [-NoTypeInformation]
 ```
 
 ## DESCRIPTION
-The ConvertTo-Xml cmdlet creates an XML-based representation of one or more Microsoft .NET Framework objects.
-To use this cmdlet, pipe one or more objects to the cmdlet, or use the InputObject parameter to specify the object.
+The `ConvertTo-Xml` cmdlet creates an XML-based representation of one or more Microsoft .NET Framework objects.
+To use this cmdlet, pipe one or more objects to the cmdlet, or use the **InputObject** parameter to specify the object.
 
-When you pipe multiple objects to ConvertTo-XML or use the InputObject parameter to submit multiple objects, ConvertTo-XML returns a single XML document that includes representations of all of the objects.
+When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit multiple objects, `ConvertTo-Xml` returns a single XML document that includes representations of all of the objects.
 
-This cmdlet is similar to Export-Clixml except that Export-Clixml stores the resulting XML in a file.
-ConvertTo-XML returns the XML, so you can continue to process it in Windows PowerShell.
+This cmdlet is similar to `Export-Clixml` except that `Export-Clixml` stores the resulting XML in a file.
+`ConvertTo-Xml` returns the XML, so you can continue to process it in PowerShell.
 
 ## EXAMPLES
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -21,13 +21,13 @@ ConvertTo-Xml [-InputObject] <PSObject> [-Depth <Int32>] [-NoTypeInformation]
 ```
 
 ## DESCRIPTION
-The **ConvertTo-Xml** cmdlet creates an XML-based representation of one or more Microsoft .NET Framework objects.
-To use this cmdlet, pipe one or more objects to the cmdlet, or use the *InputObject* parameter to specify the object.
+The `ConvertTo-Xml` cmdlet creates an XML-based representation of one or more Microsoft .NET Framework objects.
+To use this cmdlet, pipe one or more objects to the cmdlet, or use the **InputObject** parameter to specify the object.
 
-When you pipe multiple objects to **ConvertTo-XML** or use the *InputObject* parameter to submit multiple objects, **ConvertTo-XML** returns a single XML document that includes representations of all of the objects.
+When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit multiple objects, `ConvertTo-Xml` returns a single XML document that includes representations of all of the objects.
 
-This cmdlet is similar to Export-Clixml except that **Export-Clixml** stores the resulting XML in a file**.
-ConvertTo-XML** returns the XML, so you can continue to process it in Windows PowerShell.
+This cmdlet is similar to `Export-Clixml` except that `Export-Clixml` stores the resulting XML in a file.
+`ConvertTo-Xml` returns the XML, so you can continue to process it in PowerShell.
 
 ## EXAMPLES
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -21,13 +21,13 @@ ConvertTo-Xml [-InputObject] <PSObject> [-Depth <Int32>] [-NoTypeInformation]
 ```
 
 ## DESCRIPTION
-The **ConvertTo-Xml** cmdlet creates an XML-based representation of one or more Microsoft .NET Framework objects.
-To use this cmdlet, pipe one or more objects to the cmdlet, or use the *InputObject* parameter to specify the object.
+The `ConvertTo-Xml` cmdlet creates an XML-based representation of one or more Microsoft .NET Framework objects.
+To use this cmdlet, pipe one or more objects to the cmdlet, or use the **InputObject** parameter to specify the object.
 
-When you pipe multiple objects to **ConvertTo-XML** or use the *InputObject* parameter to submit multiple objects, **ConvertTo-XML** returns a single XML document that includes representations of all of the objects.
+When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit multiple objects, `ConvertTo-Xml` returns a single XML document that includes representations of all of the objects.
 
-This cmdlet is similar to Export-Clixml except that **Export-Clixml** stores the resulting XML in a file**.
-ConvertTo-XML** returns the XML, so you can continue to process it in Windows PowerShell.
+This cmdlet is similar to `Export-Clixml` except that `Export-Clixml` stores the resulting XML in a file.
+`ConvertTo-Xml` returns the XML, so you can continue to process it in PowerShell.
 
 ## EXAMPLES
 

--- a/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertTo-Xml.md
@@ -21,13 +21,13 @@ ConvertTo-Xml [-InputObject] <PSObject> [-Depth <Int32>] [-NoTypeInformation]
 ```
 
 ## DESCRIPTION
-The **ConvertTo-Xml** cmdlet creates an XML-based representation of one or more Microsoft .NET Framework objects.
-To use this cmdlet, pipe one or more objects to the cmdlet, or use the *InputObject* parameter to specify the object.
+The `ConvertTo-Xml` cmdlet creates an XML-based representation of one or more Microsoft .NET Framework objects.
+To use this cmdlet, pipe one or more objects to the cmdlet, or use the **InputObject** parameter to specify the object.
 
-When you pipe multiple objects to **ConvertTo-XML** or use the *InputObject* parameter to submit multiple objects, **ConvertTo-XML** returns a single XML document that includes representations of all of the objects.
+When you pipe multiple objects to `ConvertTo-Xml` or use the **InputObject** parameter to submit multiple objects, `ConvertTo-Xml` returns a single XML document that includes representations of all of the objects.
 
-This cmdlet is similar to Export-Clixml except that **Export-Clixml** stores the resulting XML in a file**.
-ConvertTo-XML** returns the XML, so you can continue to process it in Windows PowerShell.
+This cmdlet is similar to `Export-Clixml` except that `Export-Clixml` stores the resulting XML in a file.
+`ConvertTo-Xml` returns the XML, so you can continue to process it in PowerShell.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Fixed the odd bold ("**") marks as follows:
> ... in a file**.
> ConvertTo-XML** returns the XML, ...

And also fixed the formatting for the DESCRIPTION section.

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
