### PR TITLE
Update Example 2 in Get-Alias.md (ineffective Exclude)

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -66,11 +66,12 @@ This command gets all aliases in the current session.
 The output shows the "\<alias\> -\> \<definition\>" format that was introduced in Windows PowerShell 3.0. 
 This format is used only for aliases that do not include hyphens, because aliases with hyphens are typically preferred names for cmdlets and functions, rather than nicknames.
 ### Example 2
-```
-PS C:\> Get-Alias -Name g*, s* -Exclude Get-*
+```powershell
+Get-Alias -Name gp*, sp* -Exclude *ps
 ```
 
-This command gets all aliases that begin with "g" or "s", except for aliases that begin with "get-".
+This command gets all aliases that begin with gp or sp, except for aliases that end with ps.
+
 ### Example 3
 ```
 PS C:\> Get-Alias -Definition Get-ChildItem

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -70,11 +70,11 @@ The output shows the "\<alias\> -\> \<definition\>" format that was introduced i
 This format is used only for aliases that do not include hyphens, because aliases with hyphens are typically preferred names for cmdlets and functions, rather than nicknames.
 
 ### Example 2
-```
-PS C:\> Get-Alias -Name g*, s* -Exclude Get-*
+```powershell
+Get-Alias -Name gp*, sp* -Exclude *ps
 ```
 
-This command gets all aliases that begin with "g" or "s", except for aliases that begin with "get-".
+This command gets all aliases that begin with gp or sp, except for aliases that end with ps.
 
 ### Example 3
 ```

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -70,11 +70,11 @@ The output shows the \<alias\> -\> \<definition\> format that was introduced in 
 This format is used only for aliases that do not include hyphens, because aliases with hyphens are typically preferred names for cmdlets and functions, rather than nicknames.
 
 ### Example 2: Get aliases by name
-```
-PS C:\> Get-Alias -Name g*, s* -Exclude Get-*
+```powershell
+Get-Alias -Name gp*, sp* -Exclude *ps
 ```
 
-This command gets all aliases that begin with g or s, except for aliases that begin with Get-.
+This command gets all aliases that begin with gp or sp, except for aliases that end with ps.
 
 ### Example 3: Get aliases for a cmdlet
 ```

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -59,11 +59,11 @@ The output shows the \<alias\> -\> \<definition\> format that was introduced in 
 This format is used only for aliases that do not include hyphens, because aliases with hyphens are typically preferred names for cmdlets and functions, rather than nicknames.
 
 ### Example 2: Get aliases by name
-```
-PS C:\> Get-Alias -Name g*, s* -Exclude Get-*
+```powershell
+Get-Alias -Name gp*, sp* -Exclude *ps
 ```
 
-This command gets all aliases that begin with g or s, except for aliases that begin with Get-.
+This command gets all aliases that begin with gp or sp, except for aliases that end with ps.
 
 ### Example 3: Get aliases for a cmdlet
 ```

--- a/reference/6/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -61,11 +61,11 @@ The output shows the \<alias\> -\> \<definition\> format that was introduced in 
 This format is used only for aliases that do not include hyphens, because aliases with hyphens are typically preferred names for cmdlets and functions, rather than nicknames.
 
 ### Example 2: Get aliases by name
-```
-PS C:\> Get-Alias -Name g*, s* -Exclude Get-*
+```powershell
+Get-Alias -Name gp*, sp* -Exclude *ps
 ```
 
-This command gets all aliases that begin with g or s, except for aliases that begin with Get-.
+This command gets all aliases that begin with gp or sp, except for aliases that end with ps.
 
 ### Example 3: Get aliases for a cmdlet
 ```


### PR DESCRIPTION
`-Exclude Get-*` is ineffective because there are no aliases that begin with `Get-`.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
