### PR TITLE
Fix Get-Alias -Name parameter

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -14,13 +14,15 @@ Gets the aliases for the current session.
 ## SYNTAX
 
 ### Default (Default)
-```
-Get-Alias [[-Name] <String[]>] [-Exclude <String[]>] [-Scope <String>] [<CommonParameters>]
+```powershell
+Get-Alias [[-Name] <String[]>] [-Exclude <String[]>] [-Scope <String>]
+ [<CommonParameters>]
 ```
 
 ### Definition
-```
-Get-Alias [-Exclude <String[]>] [-Scope <String>] [-Definition <String[]>] [<CommonParameters>]
+```powershell
+Get-Alias [-Exclude <String[]>] [-Scope <String>] [-Definition <String[]>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -139,19 +141,19 @@ Accept wildcard characters: True
 ```
 
 ### -Name
-Specifies the aliases to retrieve.
+Specifies the aliases that this cmdlet gets.
 Wildcards are permitted.
-By default, Get-Alias retrieves all aliases defined for the current session.
-The parameter name ("Name") is optional.
-You can also pipe alias names to Get-Alias.
+By default, `Get-Alias` retrieves all aliases defined for the current session.
+The parameter name **Name** is optional.
+You can also pipe alias names to `Get-Alias`.
 
 ```yaml
 Type: String[]
 Parameter Sets: Default
-Aliases: 
+Aliases:
 
 Required: False
-Position: 1
+Position: 0
 Default value: All aliases
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: True

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -16,13 +16,15 @@ Gets the aliases for the current session.
 ## SYNTAX
 
 ### Default (Default)
-```
-Get-Alias [[-Name] <String[]>] [-Exclude <String[]>] [-Scope <String>] [<CommonParameters>]
+```powershell
+Get-Alias [[-Name] <String[]>] [-Exclude <String[]>] [-Scope <String>]
+ [<CommonParameters>]
 ```
 
 ### Definition
-```
-Get-Alias [-Exclude <String[]>] [-Scope <String>] [-Definition <String[]>] [<CommonParameters>]
+```powershell
+Get-Alias [-Exclude <String[]>] [-Scope <String>] [-Definition <String[]>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -146,19 +148,19 @@ Accept wildcard characters: True
 ```
 
 ### -Name
-Specifies the aliases to retrieve.
+Specifies the aliases that this cmdlet gets.
 Wildcards are permitted.
-By default, Get-Alias retrieves all aliases defined for the current session.
-The parameter name ("Name") is optional.
-You can also pipe alias names to Get-Alias.
+By default, `Get-Alias` retrieves all aliases defined for the current session.
+The parameter name **Name** is optional.
+You can also pipe alias names to `Get-Alias`.
 
 ```yaml
 Type: String[]
 Parameter Sets: Default
-Aliases: 
+Aliases:
 
 Required: False
-Position: 1
+Position: 0
 Default value: All aliases
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: True

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -16,13 +16,15 @@ Gets the aliases for the current session.
 ## SYNTAX
 
 ### Default (Default)
-```
-Get-Alias [[-Name] <String[]>] [-Exclude <String[]>] [-Scope <String>] [<CommonParameters>]
+```powershell
+Get-Alias [[-Name] <String[]>] [-Exclude <String[]>] [-Scope <String>]
+ [<CommonParameters>]
 ```
 
 ### Definition
-```
-Get-Alias [-Exclude <String[]>] [-Scope <String>] [-Definition <String[]>] [<CommonParameters>]
+```powershell
+Get-Alias [-Exclude <String[]>] [-Scope <String>] [-Definition <String[]>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -148,20 +150,20 @@ Accept wildcard characters: False
 ### -Name
 Specifies the aliases that this cmdlet gets.
 Wildcards are permitted.
-By default, **Get-Alias** retrieves all aliases defined for the current session.
-The parameter name *Name* is optional.
-You can also pipe alias names to **Get-Alias**.
+By default, `Get-Alias` retrieves all aliases defined for the current session.
+The parameter name **Name** is optional.
+You can also pipe alias names to `Get-Alias`.
 
 ```yaml
 Type: String[]
 Parameter Sets: Default
-Aliases: 
+Aliases:
 
 Required: False
 Position: 0
-Default value: None
+Default value: All aliases
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Scope

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -16,13 +16,15 @@ Gets the aliases for the current session.
 ## SYNTAX
 
 ### Default (Default)
-```
-Get-Alias [[-Name] <String[]>] [-Exclude <String[]>] [-Scope <String>] [<CommonParameters>]
+```powershell
+Get-Alias [[-Name] <String[]>] [-Exclude <String[]>] [-Scope <String>]
+ [<CommonParameters>]
 ```
 
 ### Definition
-```
-Get-Alias [-Exclude <String[]>] [-Scope <String>] [-Definition <String[]>] [<CommonParameters>]
+```powershell
+Get-Alias [-Exclude <String[]>] [-Scope <String>] [-Definition <String[]>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -137,20 +139,20 @@ Accept wildcard characters: False
 ### -Name
 Specifies the aliases that this cmdlet gets.
 Wildcards are permitted.
-By default, **Get-Alias** retrieves all aliases defined for the current session.
-The parameter name *Name* is optional.
-You can also pipe alias names to **Get-Alias**.
+By default, `Get-Alias` retrieves all aliases defined for the current session.
+The parameter name **Name** is optional.
+You can also pipe alias names to `Get-Alias`.
 
 ```yaml
 Type: String[]
 Parameter Sets: Default
-Aliases: 
+Aliases:
 
 Required: False
 Position: 0
-Default value: None
+Default value: All aliases
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Scope

--- a/reference/6/Microsoft.PowerShell.Utility/Get-Alias.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Alias.md
@@ -16,15 +16,15 @@ Gets the aliases for the current session.
 ## SYNTAX
 
 ### Default (Default)
-```
-Get-Alias [[-Name] <String[]>] [-Exclude <String[]>] [-Scope <String>] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [<CommonParameters>]
+```powershell
+Get-Alias [[-Name] <String[]>] [-Exclude <String[]>] [-Scope <String>]
+ [<CommonParameters>]
 ```
 
 ### Definition
-```
+```powershell
 Get-Alias [-Exclude <String[]>] [-Scope <String>] [-Definition <String[]>]
- [-InformationAction <ActionPreference>] [-InformationVariable <String>] [<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -136,50 +136,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -InformationAction
-This parameter is called Definition, because it searches for the item name in the Definition property of the alias object.```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
-This parameter is called Definition, because it searches for the item name in the Definition property of the alias object.```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Name
 Specifies the aliases that this cmdlet gets.
 Wildcards are permitted.
-By default, **Get-Alias** retrieves all aliases defined for the current session.
-The parameter name *Name* is optional.
-You can also pipe alias names to **Get-Alias**.
+By default, `Get-Alias` retrieves all aliases defined for the current session.
+The parameter name **Name** is optional.
+You can also pipe alias names to `Get-Alias`.
 
 ```yaml
 Type: String[]
 Parameter Sets: Default
-Aliases: 
+Aliases:
 
 Required: False
-Position: 1
-Default value: None
+Position: 0
+Default value: All aliases
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Scope


### PR DESCRIPTION
* Position: 0
* Default value: All aliases
* Accept wildcard characters: True
* Fixed minor differences in formatting and wording

And also removed InformationAction/InformationVariable in v6.0.

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
