### PR TITLE
updating metadata tags in docfx.json

### DIFF
--- a/dsc/docfx.json
+++ b/dsc/docfx.json
@@ -20,7 +20,7 @@
             "manager": "carmonm",
             "ms.devlang": "powershell",
             "ms.tgt_pltfr": "windows",
-            "ms.author": "eslesar"
+            "ms.author": "sewhee"
         },
         "resource": [
             {

--- a/gallery/docfx.json
+++ b/gallery/docfx.json
@@ -18,8 +18,8 @@
             "manager": "carmonm",
             "ms.devlang": "powershell",
             "ms.tgt_pltfr": "windows, macos, linux",
-            "author": "juanpablojofre",
-            "ms.author": "jpjofre"
+            "author": "JKeithB",
+            "ms.author": "keithb"
         },
         "resource": [
             {

--- a/jea/docfx.json
+++ b/jea/docfx.json
@@ -18,7 +18,7 @@
             "manager": "carmonm",
             "ms.devlang": "powershell",
             "ms.tgt_pltfr": "windows",
-            "ms.author": "jpjofre"
+            "ms.author": "sewhee"
         },
         "resource": [
             {

--- a/reference/docfx.json
+++ b/reference/docfx.json
@@ -238,8 +238,8 @@
       "ms.topic": "reference",
       "manager": "carmonm",
       "ms.tgt_pltfr": "windows, macos, linux",
-      "author": "juanpablojofre",
-      "ms.author": "jpjofre"
+      "author": "sdwheeler",
+      "ms.author": "sewhee"
     },
     "fileMetadata": {},
     "template": [],

--- a/reference/docs-conceptual/docfx.json
+++ b/reference/docs-conceptual/docfx.json
@@ -16,8 +16,8 @@
             "manager": "carmonm",
             "ms.devlang": "powershell",
             "ms.tgt_pltfr": "windows, macos, linux",
-            "author": "juanpablojofre",
-            "ms.author": "jpjofre"
+            "author": "sdwheeler",
+            "ms.author": "sewhee"
         },
         "resource": [
             {

--- a/wmf/docfx.json
+++ b/wmf/docfx.json
@@ -14,11 +14,11 @@
             "uhfHeaderId": "MSDocsHeader-Powershell",
             "ROBOTS": "INDEX, FOLLOW",
             "ms.prod": "powershell",
-            "ms.technology": "wmf",
+            "ms.technology": "",
             "manager": "carmonm",
             "ms.devlang": "powershell",
             "ms.tgt_pltfr": "windows",
-            "ms.author": "jpjofre"
+            "ms.author": "keithb"
         },
         "resource": [
             {


### PR DESCRIPTION
Updating author information in metadata and removing invalid "wmf" value. The invalid value is causing problems in the SkyEye reports.