### PR TITLE
Fix parameter's position in Tee-Object.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -15,17 +15,20 @@ Saves command output in a file or variable and also sends it down the pipeline.
 
 ### File (Default)
 ```
-Tee-Object [-InputObject <PSObject>] [-FilePath] <String> [-Append] [<CommonParameters>]
+Tee-Object [-FilePath] <String> [-InputObject <PSObject>] [-Append]
+ [<CommonParameters>]
 ```
 
 ### LiteralFile
 ```
-Tee-Object [-InputObject <PSObject>] -LiteralPath <String> [<CommonParameters>]
+Tee-Object -LiteralPath <String> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ### Variable
 ```
-Tee-Object [-InputObject <PSObject>] -Variable <String> [<CommonParameters>]
+Tee-Object -Variable <String> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -103,7 +106,7 @@ Parameter Sets: File
 Aliases: 
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: True

--- a/reference/4.0/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -17,17 +17,20 @@ Saves command output in a file or variable and also sends it down the pipeline.
 
 ### File (Default)
 ```
-Tee-Object [-InputObject <PSObject>] [-FilePath] <String> [-Append] [<CommonParameters>]
+Tee-Object [-FilePath] <String> [-InputObject <PSObject>] [-Append]
+ [<CommonParameters>]
 ```
 
 ### LiteralFile
 ```
-Tee-Object [-InputObject <PSObject>] -LiteralPath <String> [<CommonParameters>]
+Tee-Object -LiteralPath <String> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ### Variable
 ```
-Tee-Object [-InputObject <PSObject>] -Variable <String> [<CommonParameters>]
+Tee-Object -Variable <String> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -109,7 +112,7 @@ Parameter Sets: File
 Aliases: 
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: True

--- a/reference/5.0/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -17,17 +17,20 @@ Saves command output in a file or variable and also sends it down the pipeline.
 
 ### File (Default)
 ```
-Tee-Object [-InputObject <PSObject>] [-FilePath] <String> [-Append] [<CommonParameters>]
+Tee-Object [-FilePath] <String> [-InputObject <PSObject>] [-Append]
+ [<CommonParameters>]
 ```
 
 ### LiteralFile
 ```
-Tee-Object [-InputObject <PSObject>] -LiteralPath <String> [<CommonParameters>]
+Tee-Object -LiteralPath <String> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ### Variable
 ```
-Tee-Object [-InputObject <PSObject>] -Variable <String> [<CommonParameters>]
+Tee-Object -Variable <String> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/5.1/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -17,17 +17,20 @@ Saves command output in a file or variable and also sends it down the pipeline.
 
 ### File (Default)
 ```
-Tee-Object [-InputObject <PSObject>] [-FilePath] <String> [-Append] [<CommonParameters>]
+Tee-Object [-FilePath] <String> [-InputObject <PSObject>] [-Append]
+ [<CommonParameters>]
 ```
 
 ### LiteralFile
 ```
-Tee-Object [-InputObject <PSObject>] -LiteralPath <String> [<CommonParameters>]
+Tee-Object -LiteralPath <String> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ### Variable
 ```
-Tee-Object [-InputObject <PSObject>] -Variable <String> [<CommonParameters>]
+Tee-Object -Variable <String> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/reference/6/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -17,20 +17,20 @@ Saves command output in a file or variable and also sends it down the pipeline.
 
 ### File (Default)
 ```
-Tee-Object [-InputObject <PSObject>] [-FilePath] <String> [-Append] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [<CommonParameters>]
+Tee-Object [-FilePath] <String> [-InputObject <PSObject>] [-Append]
+ [<CommonParameters>]
 ```
 
 ### LiteralFile
 ```
-Tee-Object [-InputObject <PSObject>] -LiteralPath <String> [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [<CommonParameters>]
+Tee-Object -LiteralPath <String> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ### Variable
 ```
-Tee-Object [-InputObject <PSObject>] -Variable <String> [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [<CommonParameters>]
+Tee-Object -Variable <String> [-InputObject <PSObject>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -109,34 +109,7 @@ Parameter Sets: File
 Aliases: 
 
 Required: True
-Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationAction
-This parameter is introduced in Windows PowerShell 3.0.```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
-This parameter is introduced in Windows PowerShell 3.0.```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
-
-Required: False
-Position: Named
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False


### PR DESCRIPTION
* FilePath: 0
* Removed InformationAction/InformationVariable in v6.0

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
