### PR TITLE
fixing issue 1651

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -192,7 +192,7 @@ When Select-String finds more than one match in a line of text, it still emits o
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -208,7 +208,7 @@ By default, matches are not case-sensitive.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -239,7 +239,7 @@ When the context includes a match, the MatchInfo object for each match includes 
 ```yaml
 Type: Int32[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -259,7 +259,7 @@ Valid values are "UTF7", "UTF8", "UTF32", "ASCII", "Unicode", "BigEndianUnicode"
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -277,7 +277,7 @@ Wildcards are permitted.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -295,7 +295,7 @@ Wildcards are permitted.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -317,7 +317,7 @@ The differences are as follows:
 ```yaml
 Type: PSObject
 Parameter Sets: Object
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -333,7 +333,7 @@ By default, Select-String returns a MatchInfo object for each match it finds.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -348,7 +348,7 @@ Finds text that does not match the specified pattern.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -368,7 +368,7 @@ If you specify only a directory, the command fails.
 ```yaml
 Type: String[]
 Parameter Sets: File
-Aliases: 
+Aliases:
 
 Required: True
 Position: 2
@@ -387,7 +387,7 @@ To learn about regular expressions, see about_Regular_Expressions.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 1
@@ -403,7 +403,7 @@ The value is "true" if the pattern is found; otherwise, the value is "false".
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -420,7 +420,7 @@ It does not interpret the value of the Pattern parameter as a regular expression
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -461,7 +461,7 @@ By default, the output is a set of MatchInfo objects, one for each match found.
 If you use the Quiet parameter, the output is a Boolean value indicating whether the pattern was found.
 ## NOTES
 * Select-String is like the Grep command in UNIX and the FindStr command in Windows.
-* The "sst" alias for the Select-String cmdlet was introduced in Windows PowerShell 3.0.
+* The **sst** alias for the Select-String cmdlet was introduced in Windows PowerShell 3.0.
 * To use Select-String, type the text that you want to find as the value of the Pattern parameter.
 
   To specify the text to be searched, do the following:

--- a/reference/4.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -204,7 +204,7 @@ When Select-String finds more than one match in a line of text, it still emits o
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -220,7 +220,7 @@ By default, matches are not case-sensitive.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -251,7 +251,7 @@ When the context includes a match, the MatchInfo object for each match includes 
 ```yaml
 Type: Int32[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -271,7 +271,7 @@ Valid values are "UTF7", "UTF8", "UTF32", "ASCII", "Unicode", "BigEndianUnicode"
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -289,7 +289,7 @@ Wildcards are permitted.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -307,7 +307,7 @@ Wildcards are permitted.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -329,7 +329,7 @@ The differences are as follows:
 ```yaml
 Type: PSObject
 Parameter Sets: Object
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -345,7 +345,7 @@ By default, Select-String returns a MatchInfo object for each match it finds.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -360,7 +360,7 @@ Finds text that does not match the specified pattern.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -380,7 +380,7 @@ If you specify only a directory, the command fails.
 ```yaml
 Type: String[]
 Parameter Sets: File
-Aliases: 
+Aliases:
 
 Required: True
 Position: 2
@@ -399,7 +399,7 @@ To learn about regular expressions, see about_Regular_Expressions.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 1
@@ -415,7 +415,7 @@ The value is "true" if the pattern is found; otherwise, the value is "false".
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -432,7 +432,7 @@ It does not interpret the value of the Pattern parameter as a regular expression
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -476,7 +476,7 @@ If you use the Quiet parameter, the output is a Boolean value indicating whether
 
 ## NOTES
 * Select-String is like the Grep command in UNIX and the FindStr command in Windows.
-* The "sst" alias for the Select-String cmdlet was introduced in Windows PowerShell 3.0.
+* The **sst** alias for the Select-String cmdlet was introduced in Windows PowerShell 3.0.
 * To use Select-String, type the text that you want to find as the value of the Pattern parameter.
 
   To specify the text to be searched, do the following:

--- a/reference/5.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -200,7 +200,7 @@ When **Select-String** finds more than one match in a line of text, it still emi
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -216,7 +216,7 @@ By default, matches are not case-sensitive.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -247,7 +247,7 @@ When the context includes a match, the **MatchInfo** object for each match inclu
 ```yaml
 Type: Int32[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -277,7 +277,7 @@ OEM is the current original equipment manufacturer code page identifier for the 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: unicode, utf7, utf8, utf32, ascii, bigendianunicode, default, oem
 
 Required: False
@@ -296,7 +296,7 @@ Wildcards are permitted.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -314,7 +314,7 @@ Wildcards are permitted.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -336,7 +336,7 @@ The differences are as follows:
 ```yaml
 Type: PSObject
 Parameter Sets: Object
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -352,7 +352,7 @@ By default, **Select-String** returns a **MatchInfo** object for each match it f
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -386,7 +386,7 @@ Indicates that the cmdlet finds text that does not match the specified pattern.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -406,7 +406,7 @@ If you specify only a directory, the command fails.
 ```yaml
 Type: String[]
 Parameter Sets: File
-Aliases: 
+Aliases:
 
 Required: True
 Position: 1
@@ -425,7 +425,7 @@ To learn about regular expressions, see about_Regular_Expressions.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 0
@@ -441,7 +441,7 @@ The value is True if the pattern is found; otherwise, the value is False.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -458,7 +458,7 @@ It does not interpret the value of the *Pattern* parameter as a regular expressi
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -483,7 +483,7 @@ If you use the *Quiet* parameter, the output is a Boolean value indicating wheth
 
 ## NOTES
 * **Select-String** is like the Grep command in UNIX and the FindStr command in Windows.
-* The **sst** alias for the **Select-String** cmdlet was introduced in Windows PowerShell 3.0.
+* The **sls** alias for the **Select-String** cmdlet was introduced in Windows PowerShell 3.0.
 * To use **Select-String**, type the text that you want to find as the value of the *Pattern* parameter.
 
   To specify the text to be searched, do the following:

--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-String.md
@@ -200,7 +200,7 @@ When **Select-String** finds more than one match in a line of text, it still emi
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -216,7 +216,7 @@ By default, matches are not case-sensitive.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -247,7 +247,7 @@ When the context includes a match, the **MatchInfo** object for each match inclu
 ```yaml
 Type: Int32[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -277,7 +277,7 @@ OEM is the current original equipment manufacturer code page identifier for the 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: unicode, utf7, utf8, utf32, ascii, bigendianunicode, default, oem
 
 Required: False
@@ -296,7 +296,7 @@ Wildcards are permitted.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -314,7 +314,7 @@ Wildcards are permitted.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -336,7 +336,7 @@ The differences are as follows:
 ```yaml
 Type: PSObject
 Parameter Sets: Object
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -352,7 +352,7 @@ By default, **Select-String** returns a **MatchInfo** object for each match it f
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -386,7 +386,7 @@ Indicates that the cmdlet finds text that does not match the specified pattern.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -406,7 +406,7 @@ If you specify only a directory, the command fails.
 ```yaml
 Type: String[]
 Parameter Sets: File
-Aliases: 
+Aliases:
 
 Required: True
 Position: 1
@@ -425,7 +425,7 @@ To learn about regular expressions, see about_Regular_Expressions.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 0
@@ -441,7 +441,7 @@ The value is True if the pattern is found; otherwise, the value is False.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -458,7 +458,7 @@ It does not interpret the value of the *Pattern* parameter as a regular expressi
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -483,7 +483,7 @@ If you use the *Quiet* parameter, the output is a Boolean value indicating wheth
 
 ## NOTES
 * **Select-String** is like the Grep command in UNIX and the FindStr command in Windows.
-* The **sst** alias for the **Select-String** cmdlet was introduced in Windows PowerShell 3.0.
+* The **sls** alias for the **Select-String** cmdlet was introduced in Windows PowerShell 3.0.
 * To use **Select-String**, type the text that you want to find as the value of the *Pattern* parameter.
 
   To specify the text to be searched, do the following:

--- a/reference/6/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Select-String.md
@@ -203,7 +203,7 @@ When **Select-String** finds more than one match in a line of text, it still emi
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -219,7 +219,7 @@ By default, matches are not case-sensitive.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -250,7 +250,7 @@ When the context includes a match, the **MatchInfo** object for each match inclu
 ```yaml
 Type: Int32[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -280,7 +280,7 @@ OEM is the current original equipment manufacturer code page identifier for the 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 Accepted values: unicode, utf7, utf8, utf32, ascii, bigendianunicode, default, oem
 
 Required: False
@@ -299,7 +299,7 @@ Wildcards are permitted.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -317,7 +317,7 @@ Wildcards are permitted.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -366,7 +366,7 @@ The differences are as follows:
 ```yaml
 Type: PSObject
 Parameter Sets: Object
-Aliases: 
+Aliases:
 
 Required: True
 Position: Named
@@ -382,7 +382,7 @@ By default, **Select-String** returns a **MatchInfo** object for each match it f
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -397,7 +397,7 @@ Indicates that the cmdlet finds text that does not match the specified pattern.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -417,7 +417,7 @@ If you specify only a directory, the command fails.
 ```yaml
 Type: String[]
 Parameter Sets: File
-Aliases: 
+Aliases:
 
 Required: True
 Position: 2
@@ -436,7 +436,7 @@ To learn about regular expressions, see about_Regular_Expressions.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: True
 Position: 1
@@ -452,7 +452,7 @@ The value is True if the pattern is found; otherwise, the value is False.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -469,7 +469,7 @@ It does not interpret the value of the *Pattern* parameter as a regular expressi
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -513,7 +513,7 @@ If you use the *Quiet* parameter, the output is a Boolean value indicating wheth
 
 ## NOTES
 * **Select-String** is like the Grep command in UNIX and the FindStr command in Windows.
-* The **sst** alias for the **Select-String** cmdlet was introduced in Windows PowerShell 3.0.
+* The **sls** alias for the **Select-String** cmdlet was introduced in Windows PowerShell 3.0.
 * To use **Select-String**, type the text that you want to find as the value of the *Pattern* parameter.
 
   To specify the text to be searched, do the following:


### PR DESCRIPTION
See Issue #1651
Fixed erroneous sst alias. Recursive examples of Get-Item/Get-ChildItem have already been added. 

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
