### PR TITLE
Split parameter set in Sort-Object.md v6.0

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Sort-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Sort-Object.md
@@ -15,10 +15,18 @@ Sorts objects by property values.
 
 ## SYNTAX
 
+### Default
 ```
-Sort-Object [-Descending] [-Unique] [-InputObject <PSObject>] [[-Property] <Object[]>] [-Culture <String>]
- [-CaseSensitive] [-InformationAction <ActionPreference>] [-InformationVariable <String>] [<CommonParameters>]
- [-Top <Int32>] [-Bottom <Int32>]
+Sort-Object [[-Property] <Object[]>] [-Descending] [-Unique] [-Top <Int32>]
+ [-InputObject <PSObject>] [-Culture <String>] [-CaseSensitive]
+ [<CommonParameters>]
+```
+
+### Bottom
+```
+Sort-Object [[-Property] <Object[]>] -Bottom <Int32> [-Descending] [-Unique]
+ [-InputObject <PSObject>] [-Culture <String>] [-CaseSensitive]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -182,7 +190,7 @@ Specifies the number of objects to get from the end of the sorted object array.
 
 ```yaml
 Type: Int32
-Parameter Sets: (All)
+Parameter Sets: Bottom
 Aliases:
 
 Required: False
@@ -242,33 +250,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -InformationAction
-```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: infa
-Accepted values: SilentlyContinue, Stop, Continue, Inquire, Ignore, Suspend
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InformationVariable
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: iv
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -InputObject
 Specifies the objects to sort.
 
@@ -315,7 +296,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -326,7 +307,7 @@ Specifies the number of objects to get from the start of the sorted object array
 
 ```yaml
 Type: Int32
-Parameter Sets: (All)
+Parameter Sets: Default
 Aliases:
 
 Required: False


### PR DESCRIPTION
Since v6.0, Sort-Object cmdlet has two parameter sets, "Default" and "Bottom".

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 6.0 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
