### PR TITLE
Fix link for about_Remote_Requirements

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/New-PSSession.md
@@ -541,7 +541,7 @@ You can pipe a computer name (string), ConnectionURI (URI), or session (PSSessio
 ### System.Management.Automation.Runspaces.PSSession
 
 ## NOTES
-* This cmdlet uses the Windows PowerShell remoting infrastructure. To use this cmdlet, the local computer and any remote computers must be configured for Windows PowerShell remoting. For more information, see about_Remote_Requirements (http://go.microsoft.com/fwlink/?LinkID=135187).
+* This cmdlet uses the Windows PowerShell remoting infrastructure. To use this cmdlet, the local computer and any remote computers must be configured for Windows PowerShell remoting. For more information, see [about_Remote_Requirements](About/about_Remote_Requirements.md).
 * To create a PSSession on the local computer, start Windows PowerShell with the "Run as administrator" option.
 * When you are finished with the PSSession, use the Remove-PSSession cmdlet to delete the PSSession and release its resources.
 

--- a/reference/3.0/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -110,7 +110,7 @@ These settings are designed for enterprises in which DCOM-based restarts fail be
 Runs the command as a background job.
 
 Note: To use this parameter, the local and remote computers must be configured for remoting and, on Windows Vista and later versions of Windows, you must open Windows PowerShell with the "Run as administrator" option.
-For more information, see about_Remote_Requirements (http://go.microsoft.com/fwlink/?LinkID=135187).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 When you use the **AsJob** parameter, the command immediately returns an object that represents the background job.
 You can continue to work in the session while the job completes.

--- a/reference/3.0/Microsoft.PowerShell.Management/Stop-Computer.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Stop-Computer.md
@@ -87,7 +87,7 @@ It also uses the ThrottleLimit parameter to limit the command to 10 concurrent c
 Runs the command as a background job.
 
 Note: To use this parameter, the local and remote computers must be configured for remoting and, on Windows Vista and later versions of Windows, you must open Windows PowerShell with the "Run as administrator" option.
-For more information, see about_Remote_Requirements".
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 When you use the AsJob parameter, the command immediately returns an object that represents the background job.
 You can continue to work in the session while the job completes.

--- a/reference/4.0/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/New-PSSession.md
@@ -557,7 +557,7 @@ You can pipe a computer name (string), ConnectionURI (URI), or session (PSSessio
 ### System.Management.Automation.Runspaces.PSSession
 
 ## NOTES
-* This cmdlet uses the Windows PowerShell remoting infrastructure. To use this cmdlet, the local computer and any remote computers must be configured for Windows PowerShell remoting. For more information, see about_Remote_Requirements (http://go.microsoft.com/fwlink/?LinkID=135187).
+* This cmdlet uses the Windows PowerShell remoting infrastructure. To use this cmdlet, the local computer and any remote computers must be configured for Windows PowerShell remoting. For more information, see [about_Remote_Requirements](About/about_Remote_Requirements.md).
 * To create a PSSession on the local computer, start Windows PowerShell with the "Run as administrator" option.
 * When you are finished with the PSSession, use the Remove-PSSession cmdlet to delete the PSSession and release its resources.
 

--- a/reference/4.0/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -120,7 +120,7 @@ These settings are designed for enterprises in which DCOM-based restarts fail be
 Runs the command as a background job.
 
 Note: To use this parameter, the local and remote computers must be configured for remoting and, on Windows Vista and later versions of Windows, you must open Windows PowerShell with the "Run as administrator" option.
-For more information, see about_Remote_Requirements (http://go.microsoft.com/fwlink/?LinkID=135187).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 When you use the **AsJob** parameter, the command immediately returns an object that represents the background job.
 You can continue to work in the session while the job completes.

--- a/reference/4.0/Microsoft.PowerShell.Management/Stop-Computer.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Stop-Computer.md
@@ -95,7 +95,7 @@ It also uses the ThrottleLimit parameter to limit the command to 10 concurrent c
 Runs the command as a background job.
 
 Note: To use this parameter, the local and remote computers must be configured for remoting and, on Windows Vista and later versions of Windows, you must open Windows PowerShell with the "Run as administrator" option.
-For more information, see about_Remote_Requirements".
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 When you use the AsJob parameter, the command immediately returns an object that represents the background job.
 You can continue to work in the session while the job completes.

--- a/reference/5.0/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/New-PSSession.md
@@ -567,7 +567,7 @@ You can pipe a string, URI, or session object to this cmdlet.
 ### System.Management.Automation.Runspaces.PSSession
 
 ## NOTES
-* This cmdlet uses the Windows PowerShell remoting infrastructure. To use this cmdlet, the local computer and any remote computers must be configured for Windows PowerShell remoting. For more information, see about_Remote_Requirements (http://go.microsoft.com/fwlink/?LinkID=135187).
+* This cmdlet uses the Windows PowerShell remoting infrastructure. To use this cmdlet, the local computer and any remote computers must be configured for Windows PowerShell remoting. For more information, see [about_Remote_Requirements](About/about_Remote_Requirements.md).
 * To create a **PSSession** on the local computer, start Windows PowerShell with the Run as administrator option.
 * When you are finished with the **PSSession**, use the Remove-PSSession cmdlet to delete the **PSSession** and release its resources.
 

--- a/reference/5.0/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -119,7 +119,7 @@ These settings are designed for enterprises in which DCOM-based restarts fail be
 Indicates that this cmdlet runs as a background job.
 
 To use this parameter, the local and remote computers must be configured for remoting and, on Windows Vista and later versions of the Windows operating system, you must open Windows PowerShell by using the Run as administrator option.
-For more information, see about_Remote_Requirements (http://go.microsoft.com/fwlink/?LinkID=135187).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 When you specify the *AsJob* parameter, the command immediately returns an object that represents the background job.
 You can continue to work in the session while the job finishes.

--- a/reference/5.0/PSDesiredStateConfiguration/Disable-DscDebug.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Disable-DscDebug.md
@@ -52,7 +52,7 @@ To manage the job, use the Job cmdlets.
 To get the job results, use the Receive-Job cmdlet.
 
 To use this parameter, the local and remote computers must be configured for remoting, and on Windows Vista and later versions of the Windows operating system, you must open Windows PowerShell with the Run as administrator option.
-For more information, see about_Remote_Requirementshttp://go.microsoft.com/fwlink/?LinkId=623526 (http://go.microsoft.com/fwlink/?LinkId=623526).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](../Microsoft.PowerShell.Core/About/about_Jobs.md) and [about_Remote_Jobs](../Microsoft.PowerShell.Core/About/about_Remote_Jobs.md).
 

--- a/reference/5.0/PSDesiredStateConfiguration/Enable-DscDebug.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Enable-DscDebug.md
@@ -53,7 +53,7 @@ To manage the job, use the Job cmdlets.
 To get the job results, use the Receive-Job cmdlet.
 
 To use this parameter, the local and remote computers must be configured for remoting, and on Windows Vista and later versions of the Windows operating system, you must open Windows PowerShell with the Run as administrator option.
-For more information, see about_Remote_Requirementshttp://go.microsoft.com/fwlink/?LinkId=623526 (http://go.microsoft.com/fwlink/?LinkId=623526).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](../Microsoft.PowerShell.Core/About/about_Jobs.md) and [about_Remote_Jobs](../Microsoft.PowerShell.Core/About/about_Remote_Jobs.md).
 

--- a/reference/5.0/PSDesiredStateConfiguration/Get-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Get-DscConfiguration.md
@@ -61,7 +61,7 @@ To manage the job, use the Job cmdlets.
 To get the job results, use the Receive-Job cmdlet.
 
 To use this parameter, the local and remote computers must be configured for remoting, and on Windows Vista and later versions of the Windows operating system, you must open Windows PowerShell with the Run as administrator option.
-For more information, see about_Remote_Requirementshttp://go.microsoft.com/fwlink/?LinkId=623526 (http://go.microsoft.com/fwlink/?LinkId=623526).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](../Microsoft.PowerShell.Core/About/about_Jobs.md) and [about_Remote_Jobs](../Microsoft.PowerShell.Core/About/about_Remote_Jobs.md).
 

--- a/reference/5.0/PSDesiredStateConfiguration/Get-DscConfigurationStatus.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Get-DscConfigurationStatus.md
@@ -76,7 +76,7 @@ To manage the job, use the Job cmdlets.
 To get the job results, use the Receive-Job cmdlet.
 
 To use this parameter, the local and remote computers must be configured for remoting, and on Windows Vista and later versions of the Windows operating system, you must open Windows PowerShell with the Run as administrator option.
-For more information, see about_Remote_Requirementshttp://go.microsoft.com/fwlink/?LinkId=623526 (http://go.microsoft.com/fwlink/?LinkId=623526).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](../Microsoft.PowerShell.Core/About/about_Jobs.md) and [about_Remote_Jobs](../Microsoft.PowerShell.Core/About/about_Remote_Jobs.md).
 

--- a/reference/5.0/PSDesiredStateConfiguration/Get-DscLocalConfigurationManager.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Get-DscLocalConfigurationManager.md
@@ -62,7 +62,7 @@ To manage the job, use the Job cmdlets.
 To get the job results, use the Receive-Job cmdlet.
 
 To use this parameter, the local and remote computers must be configured for remoting, and on Windows Vista and later versions of the Windows operating system, you must open Windows PowerShell with the Run as administrator option.
-For more information, see about_Remote_Requirementshttp://go.microsoft.com/fwlink/?LinkId=623526 (http://go.microsoft.com/fwlink/?LinkId=623526).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](../Microsoft.PowerShell.Core/About/about_Jobs.md) and [about_Remote_Jobs](../Microsoft.PowerShell.Core/About/about_Remote_Jobs.md).
 

--- a/reference/5.0/PSDesiredStateConfiguration/Remove-DscConfigurationDocument.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Remove-DscConfigurationDocument.md
@@ -54,7 +54,7 @@ To manage the job, use the Job cmdlets.
 To get the job results, use the Receive-Job cmdlet.
 
 To use this parameter, the local and remote computers must be configured for remoting, and on Windows Vista and later versions of the Windows operating system, you must open Windows PowerShell with the Run as administrator option.
-For more information, see about_Remote_Requirementshttp://go.microsoft.com/fwlink/?LinkId=623526 (http://go.microsoft.com/fwlink/?LinkId=623526).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](../Microsoft.PowerShell.Core/About/about_Jobs.md) and [about_Remote_Jobs](../Microsoft.PowerShell.Core/About/about_Remote_Jobs.md).
 

--- a/reference/5.0/PSDesiredStateConfiguration/Restore-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Restore-DscConfiguration.md
@@ -65,7 +65,7 @@ To manage the job, use the Job cmdlets.
 To get the job results, use the Receive-Job cmdlet.
 
 To use this parameter, the local and remote computers must be configured for remoting, and on Windows Vista and later versions of the Windows operating system, you must open Windows PowerShell with the Run as administrator option.
-For more information, see about_Remote_Requirementshttp://go.microsoft.com/fwlink/?LinkId=623526 (http://go.microsoft.com/fwlink/?LinkId=623526).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](../Microsoft.PowerShell.Core/About/about_Jobs.md) and [about_Remote_Jobs](../Microsoft.PowerShell.Core/About/about_Remote_Jobs.md).
 

--- a/reference/5.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
@@ -56,7 +56,7 @@ To manage the job, use the Job cmdlets.
 To get the job results, use the Receive-Job cmdlet.
 
 To use this parameter, the local and remote computers must be configured for remoting, and on Windows Vista and later versions of the Windows operating system, you must open Windows PowerShell with the Run as administrator option.
-For more information, see about_Remote_Requirementshttp://go.microsoft.com/fwlink/?LinkId=623526 (http://go.microsoft.com/fwlink/?LinkId=623526).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](../Microsoft.PowerShell.Core/About/about_Jobs.md) and [about_Remote_Jobs](../Microsoft.PowerShell.Core/About/about_Remote_Jobs.md).
 

--- a/reference/5.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -118,7 +118,7 @@ To manage the job, use the Job cmdlets.
 To get the job results, use the Receive-Job cmdlet.
 
 To use this parameter, the local and remote computers must be configured for remoting, and on Windows Vista and later versions of the Windows operating system, you must open Windows PowerShell with the Run as administrator option.
-For more information, see about_Remote_Requirementshttp://go.microsoft.com/fwlink/?LinkId=623526 (http://go.microsoft.com/fwlink/?LinkId=623526).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](../Microsoft.PowerShell.Core/About/about_Jobs.md) and [about_Remote_Jobs](../Microsoft.PowerShell.Core/About/about_Remote_Jobs.md).
 

--- a/reference/5.1/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-PSSession.md
@@ -665,7 +665,7 @@ You can pipe a string, URI, or session object to this cmdlet.
 ### System.Management.Automation.Runspaces.PSSession
 
 ## NOTES
-* This cmdlet uses the Windows PowerShell remoting infrastructure. To use this cmdlet, the local computer and any remote computers must be configured for Windows PowerShell remoting. For more information, see about_Remote_Requirements (http://go.microsoft.com/fwlink/?LinkID=135187).
+* This cmdlet uses the Windows PowerShell remoting infrastructure. To use this cmdlet, the local computer and any remote computers must be configured for Windows PowerShell remoting. For more information, see [about_Remote_Requirements](About/about_Remote_Requirements.md).
 * To create a **PSSession** on the local computer, start Windows PowerShell with the Run as administrator option.
 * When you are finished with the **PSSession**, use the Remove-PSSession cmdlet to delete the **PSSession** and release its resources.
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -119,7 +119,7 @@ These settings are designed for enterprises in which DCOM-based restarts fail be
 Indicates that this cmdlet runs as a background job.
 
 To use this parameter, the local and remote computers must be configured for remoting and, on Windows Vista and later versions of the Windows operating system, you must open Windows PowerShell by using the Run as administrator option.
-For more information, see about_Remote_Requirements (http://go.microsoft.com/fwlink/?LinkID=135187).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 When you specify the *AsJob* parameter, the command immediately returns an object that represents the background job.
 You can continue to work in the session while the job finishes.

--- a/reference/5.1/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -118,7 +118,7 @@ To manage the job, use the Job cmdlets.
 To get the job results, use the Receive-Job cmdlet.
 
 To use this parameter, the local and remote computers must be configured for remoting, and on Windows Vista and later versions of the Windows operating system, you must open Windows PowerShell with the Run as administrator option.
-For more information, see about_Remote_Requirementshttp://go.microsoft.com/fwlink/?LinkId=623526 (http://go.microsoft.com/fwlink/?LinkId=623526).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 For more information about Windows PowerShell background jobs, see [about_Jobs](../Microsoft.PowerShell.Core/About/about_Jobs.md) and [about_Remote_Jobs](../Microsoft.PowerShell.Core/About/about_Remote_Jobs.md).
 

--- a/reference/6/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/New-PSSession.md
@@ -803,7 +803,7 @@ You can pipe a string, URI, or session object to this cmdlet.
 ### System.Management.Automation.Runspaces.PSSession
 
 ## NOTES
-* This cmdlet uses the Windows PowerShell remoting infrastructure. To use this cmdlet, the local computer and any remote computers must be configured for Windows PowerShell remoting. For more information, see about_Remote_Requirements (http://go.microsoft.com/fwlink/?LinkID=135187).
+* This cmdlet uses the Windows PowerShell remoting infrastructure. To use this cmdlet, the local computer and any remote computers must be configured for Windows PowerShell remoting. For more information, see [about_Remote_Requirements](About/about_Remote_Requirements.md).
 * To create a **PSSession** on the local computer, start Windows PowerShell with the Run as administrator option.
 * When you are finished with the **PSSession**, use the Remove-PSSession cmdlet to delete the **PSSession** and release its resources.
 * The **HostName** and **SSHConnection** parameter sets were included starting with PowerShell 6.0. They were added to provide PowerShell remoting based on Secure Shell (SSH). Both SSH and PowerShell are supported on multiple platforms (Windows, Linux, macOS) and PowerShell remoting will work over these platforms where PowerShell and SSH are installed and configured. This is separate from the previous Windows only remoting that is based on WinRM and much of the WinRM specific features and limitations do not apply. For example WinRM based quotas, session options, custom endpoint configuration, and disconnect/reconnect features are currently not supported.

--- a/reference/6/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/6/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -119,7 +119,7 @@ These settings are designed for enterprises in which DCOM-based restarts fail be
 Indicates that this cmdlet runs as a background job.
 
 To use this parameter, the local and remote computers must be configured for remoting and, on Windows Vista and later versions of the Windows operating system, you must open Windows PowerShell by using the Run as administrator option.
-For more information, see about_Remote_Requirements (http://go.microsoft.com/fwlink/?LinkID=135187).
+For more information, see [about_Remote_Requirements](../Microsoft.PowerShell.Core/About/about_Remote_Requirements.md).
 
 When you specify the *AsJob* parameter, the command immediately returns an object that represents the background job.
 You can continue to work in the session while the job finishes.


### PR DESCRIPTION
Fixed url and odd formatting such as ```about_Remote_Requirements"```, ```about_Remote_Requirementshttp:...```, etc.

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
