### PR TITLE
Bad link

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -103,7 +103,7 @@ from other sources. Before you sign any script, examine each command
 to verify that it is safe to run.
 
 For best practices about code signing, see "Code-Signing
-Best Practices" at http://go.microsoft.com/fwlink/?LinkId=119096.
+Best Practices" at http://download.microsoft.com/download/a/f/7/af7777e5-7dcd-4800-8a0a-b18336565f5b/best_practices.doc.
 
 For more information about how to sign a script file, see
 Set-AuthenticodeSignature.


### PR DESCRIPTION
The link "http://go.microsoft.com/fwlink/?LinkId=119096" is supposed to point to a page or a document about **"Code-Signing Best Practices"**.
However, it points to a video about "Understanding Extension INFs and Component INFs".
I watched the whole video and there is nothing inside about "Code-Signing Best Practices".

The best match I have found is the following one: http://download.microsoft.com/download/a/f/7/af7777e5-7dcd-4800-8a0a-b18336565f5b/best_practices.doc
It would be a very good idea to make a web page from this document. Pieces of advice it contains are still accurate.