### PR TITLE
Fix link for logical operators in about_Operator_Precedence.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -77,7 +77,7 @@ order:
 |OPERATOR                  |REFERENCE|
 |--------------------------|---------|
 |`-band -bor -bxor`        |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
-|`-and -or -xor`           |[about_comparison_operators](about_comparison_operators.md)|
+|`-and -or -xor`           |[about_Logical_Operators](about_logical_operators.md)|
 |`.` (dot-source)          |[about_Scopes](about_Scopes.md)|
 |`&` (call)                |[about_Operators](about_Operators.md)|
 |&#124; (pipeline operator)|[about_Operators](about_Operators.md)|

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -77,7 +77,7 @@ order:
 |OPERATOR                  |REFERENCE|
 |--------------------------|---------|
 |`-band -bor -bxor`        |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
-|`-and -or -xor`           |[about_comparison_operators](about_comparison_operators.md)|
+|`-and -or -xor`           |[about_Logical_Operators](about_logical_operators.md)|
 |`.` (dot-source)          |[about_Scopes](about_Scopes.md)|
 |`&` (call)                |[about_Operators](about_Operators.md)|
 |&#124; (pipeline operator)|[about_Operators](about_Operators.md)|

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -77,7 +77,7 @@ order:
 |OPERATOR                  |REFERENCE|
 |--------------------------|---------|
 |`-band -bor -bxor`        |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
-|`-and -or -xor`           |[about_comparison_operators](about_comparison_operators.md)|
+|`-and -or -xor`           |[about_Logical_Operators](about_logical_operators.md)|
 |`.` (dot-source)          |[about_Scopes](about_Scopes.md)|
 |`&` (call)                |[about_Operators](about_Operators.md)|
 |&#124; (pipeline operator)|[about_Operators](about_Operators.md)|

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -77,7 +77,7 @@ order:
 |OPERATOR                  |REFERENCE|
 |--------------------------|---------|
 |`-band -bor -bxor`        |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
-|`-and -or -xor`           |[about_comparison_operators](about_comparison_operators.md)|
+|`-and -or -xor`           |[about_Logical_Operators](about_logical_operators.md)|
 |`.` (dot-source)          |[about_Scopes](about_Scopes.md)|
 |`&` (call)                |[about_Operators](about_Operators.md)|
 |&#124; (pipeline operator)|[about_Operators](about_Operators.md)|

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -77,7 +77,7 @@ order:
 |OPERATOR                  |REFERENCE|
 |--------------------------|---------|
 |`-band -bor -bxor`        |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
-|`-and -or -xor`           |[about_comparison_operators](about_comparison_operators.md)|
+|`-and -or -xor`           |[about_Logical_Operators](about_logical_operators.md)|
 |`.` (dot-source)          |[about_Scopes](about_Scopes.md)|
 |`&` (call)                |[about_Operators](about_Operators.md)|
 |&#124; (pipeline operator)|[about_Operators](about_Operators.md)|


### PR DESCRIPTION
Logical operators are described in about_logical_operators.md, not in about_comparison_operators.md

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
