### PR TITLE
Removed unused variable in Example 1

### DIFF
--- a/dsc/scriptResource.md
+++ b/dsc/scriptResource.md
@@ -47,8 +47,6 @@ Script [string] #ResourceName
 
 ## Example 1
 ```powershell
-$version = Get-Content 'version.txt'
-
 Configuration ScriptTest
 {
     Import-DscResource –ModuleName 'PSDesiredStateConfiguration'


### PR DESCRIPTION
The variable was declared but not used.  It also appears in the same place in Example 2 but is used later on.