### PR TITLE
final pass on About_ topic reformat

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -244,11 +244,11 @@ The environment variables that store preferences include:
   The default value of $Env:PSModulePath is:
 
   ```
-  $home\Documents\WindowsPowerShell\Modules; $pshome\Modules
+  $HOME\Documents\WindowsPowerShell\Modules; $PSHOME\Modules
   ```
 
-Windows PowerShell sets the value of "\$pshome\\Modules" in the registry. It
-sets the value of "\$home\\Documents\\WindowsPowerShell\\Modules" each time you
+Windows PowerShell sets the value of "\$PSHOME\\Modules" in the registry. It
+sets the value of "\$HOME\\Documents\\WindowsPowerShell\\Modules" each time you
 start Windows PowerShell.
 
 In addition, setup programs that install modules in other directories, such as
@@ -294,7 +294,7 @@ $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
 ```
 
 For more information about the methods of the System.Environment class, see
-[Environment Methods](http://go.microsoft.com/fwlink/?LinkId=242783) in
+[Environment Methods](https://go.microsoft.com/fwlink/?LinkId=242783) in
 MSDN.
 
 You can add also add a command that changes the value to your profile or use

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_For.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_For.md
@@ -25,7 +25,7 @@ all the values in an array, consider using a Foreach statement.
 The following shows the For statement syntax.
 
 ```powershell
-for (>init>; <condition>; <repeat>)
+for (<init>; <condition>; <repeat>)
 {<statement list>}
 ```
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -27,8 +27,7 @@ the following methods:
 
 All the methods and properties of the `PSCmdlet` class are available to
 advanced functions. For more information about these methods and properties,
-see `System.Management.Automation.PSCmdlet` in the MSDN (Microsoft Developer
-Network) library at http://go.microsoft.com/fwlink/?LinkId=142139.
+see [`System.Management.Automation.PSCmdlet`](http://go.microsoft.com/fwlink/?LinkId=142139) in the MSDN library.
 
 ### Input Processing Methods
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -516,7 +516,7 @@ Syntax:
 do {<statement list>} while (<condition>)
 ```
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Special_Characters](about_Special_Characters.md)
 - [about_Wildcards](about_Wildcards.md)

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -486,18 +486,13 @@ NOTE: Remote sessions, including sessions that are started by using the
 commands are packaged in snap-ins.
 
 The following modules (or snap-ins) are installed with PowerShell.
-* Microsoft.PowerShell.Archive
 * Microsoft.PowerShell.Core
 * Microsoft.PowerShell.Diagnostics
 * Microsoft.PowerShell.Host
 * Microsoft.PowerShell.Management
-* Microsoft.PowerShell.ODataUtils
 * Microsoft.PowerShell.Security
 * Microsoft.PowerShell.Utility
 * Microsoft.WSMan.Management
-* OneGet
-* PowerShellGet
-* PSDesiredStateConfiguration
 * PSScheduledJob
 * PSWorkflow
 * PSWorkflowUtility

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Parameters.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Parameters.md
@@ -10,11 +10,11 @@ title:  about_Parameters
 
 ## SHORT DESCRIPTION
 
-Describes how to work with command parameters in Windows PowerShell®.
+Describes how to work with command parameters in PowerShell.
 
 ## LONG DESCRIPTION
 
-Most Windows PowerShell commands, such as cmdlets, functions, and scripts,
+Most PowerShell commands, such as cmdlets, functions, and scripts,
 rely on parameters to allow users to select options or provide input. The
 parameters follow the command name and have the following form:
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  2017-12-01
+ms.date:  2017-12-06
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -167,9 +167,9 @@ Switch has the following parameters:
 |             |condition. Wildcard and Exact are ignored. Also, if the    |
 |             |match clause is not a string, this parameter is ignored.   |
 
+In this example, there is no matching case so there is no output.
 
 ```powershell
-Example:
    PS> switch ("fourteen")
        {
            1 {"It is one."; Break}
@@ -179,7 +179,12 @@ Example:
            3 {"Three again."; Break}
            "fo*" {"That's too many."}
        }
+```
 
+For the word "fourteen" to match a case you must use the **-Wildcard** or
+**-Regex** parameter.
+
+```powershell
    PS> switch -Regex ("fourteen")
        {
            1 {"It is one."; Break}
@@ -189,6 +194,11 @@ Example:
            3 {"Three again."; Break}
            "fo*" {"That's too many."}
        }
+ ```
+ 
+ Result:
+ 
+ ```Output
 That's too many.
 ```
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_WS-Management_Cmdlets.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_WS-Management_Cmdlets.md
@@ -1,0 +1,196 @@
+---
+ms.date:  2018-01-04
+schema:  2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+title:  about_WS Management_Cmdlets
+---
+
+# About WS-Management Cmdlets
+
+## SHORT DESCRIPTION
+
+Provides an overview of Web Services for Management (WS-Management) as
+background for using the WS-Management cmdlets in Windows PowerShell.
+
+## LONG DESCRIPTION
+
+This topic provides an overview of Web Services for Management (WS-Management)
+as background for using the WS-Management cmdlets in Windows PowerShell. This
+topic also provides links to more information about WS-Management. The
+Microsoft implementation of WS-Management is also known as Windows Remote
+Management (WinRM).
+
+### About WS-Management
+
+Windows Remote Management is the Microsoft implementation of the WS-Management
+protocol, a standard SOAP-based, firewall-friendly protocol that allows
+hardware and operating systems from different vendors to interoperate. The
+WS-Management protocol specification provides a common way for systems to
+access and exchange management information across an information technology
+(IT) infrastructure. WS-Management and Intelligent Platform Management
+Interface (IPMI), along with the Event Collector, are components of the
+Windows Hardware Management features.
+
+The WS-Management protocol is based on the following standard Web service
+specifications: HTTPS, SOAP over HTTP (WS-I profile), SOAP 1.2, WS-Addressing,
+WS-Transfer, WS-Enumeration, and WS-Eventing.
+
+### WS-Management and WMI
+
+WS-Management can be used to retrieve data exposed by Windows Management
+Instrumentation (WMI). You can obtain WMI data with scripts or applications
+that use the WS-Management Scripting API or through the WinRM command-line
+tool. WS-Management supports most of the familiar WMI classes and operations,
+including embedded objects. WS-Management can leverage WMI to collect data
+about resources or to manage resources on a Windows-based computers. That
+means that you can obtain data about objects such as disks, network adapters,
+services, or processes in your enterprise through the existing set of WMI
+classes. You can also access the hardware data that is available from the
+standard WMI IPMI provider.
+
+### WS-Management Windows PowerShell Provider (WSMan)
+
+The WSMan provider provides a hierarchical view into the available
+WS-Management configuration settings. The provider allows you to explore and
+set the various WS-Management configuration options.
+
+### WS-Management Configuration
+
+If WS-Management is not installed and configured, Windows PowerShell remoting
+is not available, the WS-Management cmdlets do not run, WS-Management scripts
+do not run, and the WSMan provider cannot perform data operations. The
+WS-Management command-line tool, WinRM, and event forwarding also depend on
+the WS-Management configuration.
+
+### WS-Management Cmdlets
+
+WS-Management functionality is implemented in Windows PowerShell through a
+module that contains a set of cmdlets and the WSMan provider. You can use
+these cmdlets to complete the end-to-end tasks necessary to manage
+WS-Management settings on local and remote computers.
+
+The following WS-Management cmdlets are available.
+
+### Connection Cmdlets
+
+- Connect-WSMan: Connects the local computer to the WS-Management (WinRM)
+  service on a remote computer.
+
+- Disconnect-WSMan: Disconnects the local computer from the WS-Management
+  (WinRM) service on a remote computer.
+
+### Management-Data Cmdlets
+
+- Get-WSManInstance: Displays management information for a resource instance
+  that is specified by a resource URI.
+
+- Invoke-WSManAction: Invokes an action on the target object that is specified
+  by the resource URI and by the selectors.
+
+- New-WSManInstance: Creates a new management resource instance.
+
+- Remove-WSManInstance: Deletes a management resource instance.
+
+- Set-WSManInstance: Modifies the management information that is related to a
+  resource.
+
+### Setup and Configuration Cmdlets
+
+- Set-WSManQuickConfig: Configures the local computer for remote management.
+  You can use the Set-WSManQuickConfig cmdlet to configure WS-Management to
+  allow remote connections to the WS-Management (WinRM) service. The
+  Set-WSManQuickConfig cmdlet performs the following operations:
+  - It determines whether the WS-Management (WinRM) service is running. If the
+    WinRM service is not running, the Set-WSManQuickConfig cmdlet starts the
+    service.
+  - It sets the WS-Management (WinRM) service startup type to automatic.
+  - It creates a listener that accepts requests from any IP address. The
+    default transport protocol is HTTP.
+  - It enables a firewall exception for WS-Management traffic.
+
+  Note: To run this cmdlet in Windows Vista, Windows Server 2008, and later
+  versions of Windows, you must start Windows PowerShell with the "Run as
+  administrator" option.
+
+- Test-WSMan: Verifies that WS-Management is installed and configured. The
+  Test-WSMan cmdlet tests whether the WS-Management (WinRM) service is running
+  and configured on a local or remote computer.
+
+- Disable-WSManCredSSP: Disables CredSSP authentication on a client computer.
+
+- Enable-WSManCredSSP: Enables CredSSP authentication on a client computer.
+
+- Get-WSManCredSSP: Gets the CredSSP-related configuration for a client
+  computer.
+
+### WS-Management-Specific Cmdlets
+
+- New-WSManSessionOption: Creates a WSManSessionOption object to use as input
+  to one or more parameters of a WS-Management cmdlet.
+
+### Additional WS-Management Information
+
+For more information about WS-Management, see the following topics in the
+MSDN (Microsoft Developer Network) library.
+
+"Windows Remote Management"
+http://go.microsoft.com/fwlink/?LinkId=142321
+
+"About Windows Remote Management"
+http://go.microsoft.com/fwlink/?LinkId=142322
+
+"Installation and Configuration for Windows Remote Management"
+http://go.microsoft.com/fwlink/?LinkId=142323
+
+"Windows Remote Management Architecture"
+http://go.microsoft.com/fwlink/?LinkId=142324
+
+"WS-Management Protocol"
+http://go.microsoft.com/fwlink/?LinkId=142325
+
+"Windows Remote Management and WMI"
+http://go.microsoft.com/fwlink/?LinkId=142326
+
+"Resource URIs"
+http://go.microsoft.com/fwlink/?LinkId=142327
+
+"Remote Hardware Management"
+http://go.microsoft.com/fwlink/?LinkId=142328
+
+"Events"
+http://go.microsoft.com/fwlink/?LinkId=142329
+
+## SEE ALSO
+
+[Connect-WSMan](../../Microsoft.WSMan.Management/Connect-WSMan.md)
+
+[Disable-WSManCredSSP](../../Microsoft.WSMan.Management/Disable-WSManCredSSP.md)
+
+[Disconnect-WSMan](../../Microsoft.WSMan.Management/Disconnect-WSMan.md)
+
+[Enable-WSManCredSSP](../../Microsoft.WSMan.Management/Enable-WSManCredSSP.md)
+
+[Get-WSManCredSSP](../../Microsoft.WSMan.Management/Get-WSManCredSSP.md)
+
+[Get-WSManInstance](../../Microsoft.WSMan.Management/Get-WSManInstance.md)
+
+[Invoke-WSManAction](../../Microsoft.WSMan.Management/Invoke-WSManAction.md)
+
+[New-WSManInstance](../../Microsoft.WSMan.Management/New-WSManInstance.md)
+
+[Remove-WSManInstance](../../Microsoft.WSMan.Management/Remove-WSManInstance.md)
+
+[Set-WSManInstance](../../Microsoft.WSMan.Management/Set-WSManInstance.md)
+
+[Set-WSManQuickConfig](../../Microsoft.WSMan.Management/Set-WSManQuickConfig.md)
+
+[Set-WSManSessionOption](../../Microsoft.WSMan.Management/Set-WSManSessionOption.md)
+
+[Test-WSMan](../../Microsoft.WSMan.Management/Test-WSMan.md)
+
+# KEYWORDS
+
+about_WSMAN
+
+about_WinRM

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -60,7 +60,7 @@ following command gets services in which the ServiceType property value
 includes "Interactive".
 
 ```powershell
-Get-Service | Where-Object {$_.ServiceType -like "Interactive"}
+Get-Service | Where-Object {$_.ServiceType -like "*Interactive*"}
 ```
 
 In the following example, wildcard characters are used to find property
@@ -71,7 +71,7 @@ value of the CreationTime property of the restore point to a log file.
 ```powershell
 $p = Get-ComputerRestorePoint
 foreach ($point in $p) {
-  if ($point.description -like "PowerShell") {
+  if ($point.description -like "*PowerShell*") {
     add-content -path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
   }
 }

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -244,11 +244,11 @@ The environment variables that store preferences include:
   The default value of $Env:PSModulePath is:
 
   ```
-  $home\Documents\WindowsPowerShell\Modules; $pshome\Modules
+  $HOME\Documents\WindowsPowerShell\Modules; $PSHOME\Modules
   ```
 
-Windows PowerShell sets the value of "\$pshome\\Modules" in the registry. It
-sets the value of "\$home\\Documents\\WindowsPowerShell\\Modules" each time you
+Windows PowerShell sets the value of "\$PSHOME\\Modules" in the registry. It
+sets the value of "\$HOME\\Documents\\WindowsPowerShell\\Modules" each time you
 start Windows PowerShell.
 
 In addition, setup programs that install modules in other directories, such as
@@ -294,7 +294,7 @@ $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
 ```
 
 For more information about the methods of the System.Environment class, see
-[Environment Methods](http://go.microsoft.com/fwlink/?LinkId=242783) in
+[Environment Methods](https://go.microsoft.com/fwlink/?LinkId=242783) in
 MSDN.
 
 You can add also add a command that changes the value to your profile or use

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_For.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_For.md
@@ -25,7 +25,7 @@ all the values in an array, consider using a Foreach statement.
 The following shows the For statement syntax.
 
 ```powershell
-for (>init>; <condition>; <repeat>)
+for (<init>; <condition>; <repeat>)
 {<statement list>}
 ```
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -27,8 +27,7 @@ the following methods:
 
 All the methods and properties of the `PSCmdlet` class are available to
 advanced functions. For more information about these methods and properties,
-see `System.Management.Automation.PSCmdlet` in the MSDN (Microsoft Developer
-Network) library at http://go.microsoft.com/fwlink/?LinkId=142139.
+see [`System.Management.Automation.PSCmdlet`](http://go.microsoft.com/fwlink/?LinkId=142139) in the MSDN library.
 
 ### Input Processing Methods
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -495,7 +495,6 @@ The following modules (or snap-ins) are installed with PowerShell.
 * Microsoft.PowerShell.Security
 * Microsoft.PowerShell.Utility
 * Microsoft.WSMan.Management
-* OneGet
 * PowerShellGet
 * PSDesiredStateConfiguration
 * PSScheduledJob

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Parameters.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Parameters.md
@@ -14,7 +14,7 @@ Describes how to work with command parameters in PowerShell.
 
 ## LONG DESCRIPTION
 
-Most Windows PowerShell commands, such as cmdlets, functions, and scripts,
+Most PowerShell commands, such as cmdlets, functions, and scripts,
 rely on parameters to allow users to select options or provide input. The
 parameters follow the command name and have the following form:
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  2017-12-01
+ms.date:  2017-12-06
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -167,9 +167,9 @@ Switch has the following parameters:
 |             |condition. Wildcard and Exact are ignored. Also, if the    |
 |             |match clause is not a string, this parameter is ignored.   |
 
+In this example, there is no matching case so there is no output.
 
 ```powershell
-Example:
    PS> switch ("fourteen")
        {
            1 {"It is one."; Break}
@@ -179,7 +179,12 @@ Example:
            3 {"Three again."; Break}
            "fo*" {"That's too many."}
        }
+```
 
+For the word "fourteen" to match a case you must use the **-Wildcard** or
+**-Regex** parameter.
+
+```powershell
    PS> switch -Regex ("fourteen")
        {
            1 {"It is one."; Break}
@@ -189,6 +194,11 @@ Example:
            3 {"Three again."; Break}
            "fo*" {"That's too many."}
        }
+ ```
+ 
+ Result:
+ 
+ ```Output
 That's too many.
 ```
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_WS-Management_Cmdlets.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_WS-Management_Cmdlets.md
@@ -1,0 +1,196 @@
+---
+ms.date:  2018-01-04
+schema:  2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+title:  about_WS Management_Cmdlets
+---
+
+# About WS-Management Cmdlets
+
+## SHORT DESCRIPTION
+
+Provides an overview of Web Services for Management (WS-Management) as
+background for using the WS-Management cmdlets in Windows PowerShell.
+
+## LONG DESCRIPTION
+
+This topic provides an overview of Web Services for Management (WS-Management)
+as background for using the WS-Management cmdlets in Windows PowerShell. This
+topic also provides links to more information about WS-Management. The
+Microsoft implementation of WS-Management is also known as Windows Remote
+Management (WinRM).
+
+### About WS-Management
+
+Windows Remote Management is the Microsoft implementation of the WS-Management
+protocol, a standard SOAP-based, firewall-friendly protocol that allows
+hardware and operating systems from different vendors to interoperate. The
+WS-Management protocol specification provides a common way for systems to
+access and exchange management information across an information technology
+(IT) infrastructure. WS-Management and Intelligent Platform Management
+Interface (IPMI), along with the Event Collector, are components of the
+Windows Hardware Management features.
+
+The WS-Management protocol is based on the following standard Web service
+specifications: HTTPS, SOAP over HTTP (WS-I profile), SOAP 1.2, WS-Addressing,
+WS-Transfer, WS-Enumeration, and WS-Eventing.
+
+### WS-Management and WMI
+
+WS-Management can be used to retrieve data exposed by Windows Management
+Instrumentation (WMI). You can obtain WMI data with scripts or applications
+that use the WS-Management Scripting API or through the WinRM command-line
+tool. WS-Management supports most of the familiar WMI classes and operations,
+including embedded objects. WS-Management can leverage WMI to collect data
+about resources or to manage resources on a Windows-based computers. That
+means that you can obtain data about objects such as disks, network adapters,
+services, or processes in your enterprise through the existing set of WMI
+classes. You can also access the hardware data that is available from the
+standard WMI IPMI provider.
+
+### WS-Management Windows PowerShell Provider (WSMan)
+
+The WSMan provider provides a hierarchical view into the available
+WS-Management configuration settings. The provider allows you to explore and
+set the various WS-Management configuration options.
+
+### WS-Management Configuration
+
+If WS-Management is not installed and configured, Windows PowerShell remoting
+is not available, the WS-Management cmdlets do not run, WS-Management scripts
+do not run, and the WSMan provider cannot perform data operations. The
+WS-Management command-line tool, WinRM, and event forwarding also depend on
+the WS-Management configuration.
+
+### WS-Management Cmdlets
+
+WS-Management functionality is implemented in Windows PowerShell through a
+module that contains a set of cmdlets and the WSMan provider. You can use
+these cmdlets to complete the end-to-end tasks necessary to manage
+WS-Management settings on local and remote computers.
+
+The following WS-Management cmdlets are available.
+
+### Connection Cmdlets
+
+- Connect-WSMan: Connects the local computer to the WS-Management (WinRM)
+  service on a remote computer.
+
+- Disconnect-WSMan: Disconnects the local computer from the WS-Management
+  (WinRM) service on a remote computer.
+
+### Management-Data Cmdlets
+
+- Get-WSManInstance: Displays management information for a resource instance
+  that is specified by a resource URI.
+
+- Invoke-WSManAction: Invokes an action on the target object that is specified
+  by the resource URI and by the selectors.
+
+- New-WSManInstance: Creates a new management resource instance.
+
+- Remove-WSManInstance: Deletes a management resource instance.
+
+- Set-WSManInstance: Modifies the management information that is related to a
+  resource.
+
+### Setup and Configuration Cmdlets
+
+- Set-WSManQuickConfig: Configures the local computer for remote management.
+  You can use the Set-WSManQuickConfig cmdlet to configure WS-Management to
+  allow remote connections to the WS-Management (WinRM) service. The
+  Set-WSManQuickConfig cmdlet performs the following operations:
+  - It determines whether the WS-Management (WinRM) service is running. If the
+    WinRM service is not running, the Set-WSManQuickConfig cmdlet starts the
+    service.
+  - It sets the WS-Management (WinRM) service startup type to automatic.
+  - It creates a listener that accepts requests from any IP address. The
+    default transport protocol is HTTP.
+  - It enables a firewall exception for WS-Management traffic.
+
+  Note: To run this cmdlet in Windows Vista, Windows Server 2008, and later
+  versions of Windows, you must start Windows PowerShell with the "Run as
+  administrator" option.
+
+- Test-WSMan: Verifies that WS-Management is installed and configured. The
+  Test-WSMan cmdlet tests whether the WS-Management (WinRM) service is running
+  and configured on a local or remote computer.
+
+- Disable-WSManCredSSP: Disables CredSSP authentication on a client computer.
+
+- Enable-WSManCredSSP: Enables CredSSP authentication on a client computer.
+
+- Get-WSManCredSSP: Gets the CredSSP-related configuration for a client
+  computer.
+
+### WS-Management-Specific Cmdlets
+
+- New-WSManSessionOption: Creates a WSManSessionOption object to use as input
+  to one or more parameters of a WS-Management cmdlet.
+
+### Additional WS-Management Information
+
+For more information about WS-Management, see the following topics in the
+MSDN (Microsoft Developer Network) library.
+
+"Windows Remote Management"
+http://go.microsoft.com/fwlink/?LinkId=142321
+
+"About Windows Remote Management"
+http://go.microsoft.com/fwlink/?LinkId=142322
+
+"Installation and Configuration for Windows Remote Management"
+http://go.microsoft.com/fwlink/?LinkId=142323
+
+"Windows Remote Management Architecture"
+http://go.microsoft.com/fwlink/?LinkId=142324
+
+"WS-Management Protocol"
+http://go.microsoft.com/fwlink/?LinkId=142325
+
+"Windows Remote Management and WMI"
+http://go.microsoft.com/fwlink/?LinkId=142326
+
+"Resource URIs"
+http://go.microsoft.com/fwlink/?LinkId=142327
+
+"Remote Hardware Management"
+http://go.microsoft.com/fwlink/?LinkId=142328
+
+"Events"
+http://go.microsoft.com/fwlink/?LinkId=142329
+
+## SEE ALSO
+
+[Connect-WSMan](../../Microsoft.WSMan.Management/Connect-WSMan.md)
+
+[Disable-WSManCredSSP](../../Microsoft.WSMan.Management/Disable-WSManCredSSP.md)
+
+[Disconnect-WSMan](../../Microsoft.WSMan.Management/Disconnect-WSMan.md)
+
+[Enable-WSManCredSSP](../../Microsoft.WSMan.Management/Enable-WSManCredSSP.md)
+
+[Get-WSManCredSSP](../../Microsoft.WSMan.Management/Get-WSManCredSSP.md)
+
+[Get-WSManInstance](../../Microsoft.WSMan.Management/Get-WSManInstance.md)
+
+[Invoke-WSManAction](../../Microsoft.WSMan.Management/Invoke-WSManAction.md)
+
+[New-WSManInstance](../../Microsoft.WSMan.Management/New-WSManInstance.md)
+
+[Remove-WSManInstance](../../Microsoft.WSMan.Management/Remove-WSManInstance.md)
+
+[Set-WSManInstance](../../Microsoft.WSMan.Management/Set-WSManInstance.md)
+
+[Set-WSManQuickConfig](../../Microsoft.WSMan.Management/Set-WSManQuickConfig.md)
+
+[Set-WSManSessionOption](../../Microsoft.WSMan.Management/Set-WSManSessionOption.md)
+
+[Test-WSMan](../../Microsoft.WSMan.Management/Test-WSMan.md)
+
+# KEYWORDS
+
+about_WSMAN
+
+about_WinRM

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -60,7 +60,7 @@ following command gets services in which the ServiceType property value
 includes "Interactive".
 
 ```powershell
-Get-Service | Where-Object {$_.ServiceType -like "Interactive"}
+Get-Service | Where-Object {$_.ServiceType -like "*Interactive*"}
 ```
 
 In the following example, wildcard characters are used to find property
@@ -71,7 +71,7 @@ value of the CreationTime property of the restore point to a log file.
 ```powershell
 $p = Get-ComputerRestorePoint
 foreach ($point in $p) {
-  if ($point.description -like "PowerShell") {
+  if ($point.description -like "*PowerShell*") {
     add-content -path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
   }
 }

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Windows_RT.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Windows_RT.md
@@ -69,4 +69,3 @@ For more information about ConstrainedLanguage language mode, see
 [about_Remote](about_Remote.md)
 
 [about_Windows_PowerShell_ISE](about_Windows_PowerShell_ISE.md)
-

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_desiredstateconfiguration.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_desiredstateconfiguration.md
@@ -1,0 +1,172 @@
+---
+ms.date:  2018-01-04
+schema:  2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+title:  about_DesiredStateConfiguration
+---
+
+# about_DesiredStateConfiguration
+
+## SHORT DESCRIPTION
+
+Provides a brief introduction to the PowerShell Desired State
+Configuration (DSC) feature.
+
+## LONG DESCRIPTION
+
+DSC is a management platform in PowerShell that enables deploying and managing
+configuration data for software services, and managing the environment in
+which these services run.
+
+DSC provides a set of PowerShell language extensions, new cmdlets, and
+resources that you can use to declaratively specify how you want the state of
+your software environment to be configured. It also provides a means to
+maintain and manage existing configurations.
+
+DSC is introduced in PowerShell 4.0.
+
+For detailed information about DSC, see
+[PowerShell Desired State Configuration Overview](http://go.microsoft.com/fwlink/?LinkId=311940)
+in the TechNet Library.
+
+## DEVELOPING DSC RESOURCES WITH CLASSES
+
+Starting in PowerShell 5.0, you can develop DSC resources by using classes.
+For more information, see [about_Classes](about_Classes.md), and
+[Writing a custom DSC resource with PowerShell classes](http://technet.microsoft.com/library/dn948461.aspx)
+on Microsoft TechNet.
+
+## USING DSC
+
+To use DSC to configure your environment, first define a PowerShell
+script block using the Configuration keyword, followed by an identifier, which
+is in turn followed by the pair of curly braces delimiting the block. Inside
+the configuration block you can define node blocks that specify the desired
+configuration state for each node (computer) in the environment. A node block
+starts with the Node keyword, followed by the name of the target computer,
+which can be a variable. After the computer name, come the curly braces that
+delimit the node block. Inside the node block, you can define resource blocks
+to configure specific resources. A resource block starts with the type name of
+the resource, followed by the identifier you want to specify for that block,
+followed by the curly braces that delimit the block, as shown in the following
+example. Configuration MyWebConfig { # Parameters are optional param
+($MachineName, $WebsiteFilePath)
+
+```powershell
+# A Configuration block can have one or more Node blocks
+Node $MachineName
+{
+    # Next, specify one or more resource blocks
+    # WindowsFeature is one of the resources you can use in a Node block
+    # This example ensures the Web Server (IIS) role is installed
+    WindowsFeature IIS
+    {
+        # To ensure that the role is not installed, set Ensure to "Absent"
+        Ensure = "Present"
+        Name = "Web-Server" # Use the Name property from Get-WindowsFeature
+    }
+
+    # You can use the File resource to create files and folders
+    # "WebDirectory" is the name you want to use to refer to this instance
+    File WebDirectory
+    {
+        Ensure = "Present"  # You can also set Ensure to "Absent“
+        Type = "Directory“ # Default is “File”
+        Recurse = $true
+        SourcePath = $WebsiteFilePath
+        DestinationPath = "C:\inetpub\wwwroot"
+
+        # Ensure that the IIS block is successfully run first before
+        # configuring this resource
+        Requires = "[WindowsFeature]IIS"  # Use Requires for dependencies
+    }
+}
+}
+```
+
+To create a configuration, invoke the Configuration block the same way you
+would invoke a PowerShell function, passing in any expected parameters you may
+have defined (two in the example above). For example, in this case:
+
+```powershell
+MyWebConfig -MachineName "TestMachine" –WebsiteFilePath `
+  "\\filesrv\WebFiles" -OutputPath "C:\Windows\system32\temp"
+# OutputPath is optional
+```
+
+This generates a MOF file per node at the path you specify. These MOF files
+specify the desired configuration for each node. Next, use the following
+cmdlet to parse the configuration MOF files, send each node its corresponding
+configuration, and enact those configurations. Note that you do not need to
+create a separate MOF file for class-based DSC resources.
+
+```powershell
+Start-DscConfiguration –Verbose -Wait -Path "C:\Windows\system32\temp"
+```
+
+## USING DSC TO MAINTAIN CONFIGURATION STATE
+
+With DSC, configuration is idempotent. This means that if you use DSC to enact
+the same configuration more than once, the resulting configuration state will
+always be the same. Because of this, if you suspect that any nodes in your
+environment may have drifted from the desired state of configuration, you can
+enact the same DSC configuration again to bring them back to the desired
+state. You do not need to modify the configuration script to address only
+those resources whose state has drifted from the desired state.
+
+The following example shows how you can verify whether the actual state of
+configuration on a given node has drifted from the last DSC configuration
+enacted on the node. In this example we are checking the configuration of the
+local computer.
+
+```powershell
+$session = New-CimSession -ComputerName "localhost"
+Test-DscConfiguration -CimSession $session
+```
+
+## BUILT-IN DSC RESOURCES
+
+You can use the following built-in resources in your configuration scripts:
+
+|Name                  |Properties                                         |
+|----------------------|---------------------------------------------------|
+|File                  |{DestinationPath, Attributes, Checksum, Content...}|
+|Archive               |{Destination, Path, Checksum, Credential...}       |
+|Environment           |{Name, DependsOn, Ensure, Path...}                 |
+|Group                 |{GroupName, Credential, DependsOn, Description...} |
+|Log                   |{Message, DependsOn, PsDscRunAsCredential}         |
+|Package               |{Name, Path, ProductId, Arguments...}              |
+|Registry              |{Key, ValueName, DependsOn, Ensure...}             |
+|Script                |{GetScript, SetScript, TestScript, Credential...}  |
+|Service               |{Name, BuiltInAccount, Credential, Dependencies...}|
+|User                  |{UserName, DependsOn, Description, Disabled...}    |
+|WaitForAll            |{NodeName, ResourceName, DependsOn, PsDscRunAsC...}|
+|WaitForAny            |{NodeName, ResourceName, DependsOn, PsDscRunAsC...}|
+|WaitForSome           |{NodeCount, NodeName, ResourceName, DependsOn...}  |
+|WindowsFeature        |{Name, Credential, DependsOn, Ensure...}           |
+|WindowsOptionalFeature|{Name, DependsOn, Ensure, LogLevel...}             |
+|WindowsProcess        |{Arguments, Path, Credential, DependsOn...}        |
+
+To get a list of available DSC resources on your system, run the
+Get-DscResource cmdlet.
+
+The example in this topic demonstrates how to use the File and WindowsFeature
+resources. To see all properties that you can use with a resource, insert the
+cursor in the resource keyword (for example, File) within your configuration
+script in PowerShell ISE, hold down CTRL, and then press SPACEBAR.
+
+## FIND MORE RESOURCES
+
+You can download, install, and learn about many other available DSC resources
+that have been created by the PowerShell and DSC user community, and by
+Microsoft. Visit the [PowerShell Gallery](https://www.powershellgallery.com/)
+to browse and learn about available DSC resources.
+
+## SEE ALSO
+
+[PowerShell Desired State Configuration Overview](/powershell/dsc/overview)
+
+[Built-In PowerShell Desired State Configuration Resources](/powershell/dsc/builtinresource)
+
+[Build Custom PowerShell Desired State Configuration Resources](/powershell/dsc/authoringResource)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_dsclogresource.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_dsclogresource.md
@@ -1,0 +1,18 @@
+---
+ms.date:  2017-06-09
+schema:  2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+title:  about_DSCLogResource
+---
+
+# about_DSCLogResource
+
+## SHORT DESCRIPTION
+
+Provides a brief introduction to the PowerShell Desired State Configuration
+(DSC) Log Resource. LONG DESCRIPTION
+
+## LONG DESCRIPTION
+
+## HOW TO USE THE DSC LOG RESOURCE

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -244,11 +244,11 @@ The environment variables that store preferences include:
   The default value of $Env:PSModulePath is:
 
   ```
-  $home\Documents\WindowsPowerShell\Modules; $pshome\Modules
+  $HOME\Documents\WindowsPowerShell\Modules; $PSHOME\Modules
   ```
 
-Windows PowerShell sets the value of "\$pshome\\Modules" in the registry. It
-sets the value of "\$home\\Documents\\WindowsPowerShell\\Modules" each time you
+Windows PowerShell sets the value of "\$PSHOME\\Modules" in the registry. It
+sets the value of "\$HOME\\Documents\\WindowsPowerShell\\Modules" each time you
 start Windows PowerShell.
 
 In addition, setup programs that install modules in other directories, such as
@@ -294,7 +294,7 @@ $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
 ```
 
 For more information about the methods of the System.Environment class, see
-[Environment Methods](http://go.microsoft.com/fwlink/?LinkId=242783) in
+[Environment Methods](https://go.microsoft.com/fwlink/?LinkId=242783) in
 MSDN.
 
 You can add also add a command that changes the value to your profile or use

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -27,8 +27,7 @@ the following methods:
 
 All the methods and properties of the `PSCmdlet` class are available to
 advanced functions. For more information about these methods and properties,
-see `System.Management.Automation.PSCmdlet` in the MSDN (Microsoft Developer
-Network) library at http://go.microsoft.com/fwlink/?LinkId=142139.
+see [`System.Management.Automation.PSCmdlet`](http://go.microsoft.com/fwlink/?LinkId=142139) in the MSDN library.
 
 ### Input Processing Methods
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -495,9 +495,10 @@ The following modules (or snap-ins) are installed with PowerShell.
 * Microsoft.PowerShell.Security
 * Microsoft.PowerShell.Utility
 * Microsoft.WSMan.Management
-* OneGet
+* PackageManagement
 * PowerShellGet
 * PSDesiredStateConfiguration
+* PSReadline
 * PSScheduledJob
 * PSWorkflow
 * PSWorkflowUtility

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Providers.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Providers.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  2017-06-09
+ms.date:  2018-01-03
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -7,61 +7,58 @@ title:  about_Providers
 ---
 
 # About Providers
-## about_Providers
 
-
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Describes how Windows PowerShell providers provide access to data and
-components that would not otherwise be easily accessible at the command
-line. The data is presented in a consistent format that resembles a file
-system drive.
+components that would not otherwise be easily accessible at the command line.
+The data is presented in a consistent format that resembles a file system
+drive.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
-Windows PowerShell providers are Microsoft .NET Framework-based programs
-that make the data in a specialized data store available in Windows
-PowerShell so that you can view and manage it.
+Windows PowerShell providers are Microsoft .NET Framework-based programs that
+make the data in a specialized data store available in Windows PowerShell so
+that you can view and manage it.
 
-The data that a provider exposes appears in a drive, and you access the
-data in a path like you would on a hard disk drive. You can use any of the
-built-in cmdlets that the provider supports to manage the data in the
-provider drive. And, you can use custom cmdlets that are designed
-especially for the data.
+The data that a provider exposes appears in a drive, and you access the data
+in a path like you would on a hard disk drive. You can use any of the built-in
+cmdlets that the provider supports to manage the data in the provider drive.
+And, you can use custom cmdlets that are designed especially for the data.
 
-The providers can also add dynamic parameters to the built-in cmdlets.
-These are parameters that are available only when you use the cmdlet with
-the provider data.
+The providers can also add dynamic parameters to the built-in cmdlets. These
+are parameters that are available only when you use the cmdlet with the
+provider data.
 
-# BUILT-IN PROVIDERS
+## BUILT-IN PROVIDERS
 
-Windows PowerShell includes a set of built-in providers that you can use
-to access the different types of data stores.
+Windows PowerShell includes a set of built-in providers that you can use to
+access the different types of data stores.
 
-| Provider    | Drive        | Data store                                 |
-| ----------- | ------------ | ------------------------------------------ |
-| Alias       | Alias:       | Windows PowerShell aliases                 |
-| Certificate | Cert:        | x509 certificates for digital signatures   |
-| Environment | Env:         | Windows environment variables              |
-| FileSystem  | (*)          | File system drives, directories, and files |
-| Function    | Function:    | Windows PowerShell functions               |
-| Registry    | HKLM:, HKCU: | Windows registry                           |
-| Variable    | Variable:    | Windows PowerShell variables               |
-| WSMan       | WSMan:       | WS-Management configuration information    |
+|Provider    |Drive        |Data store                                 |
+|------------|-------------|-------------------------------------------|
+|Alias       |Alias:       |Windows PowerShell aliases                 |
+|Certificate |Cert:        |x509 certificates for digital signatures   |
+|Environment |Env:         |Windows environment variables              |
+|FileSystem  |(*)          |File system drives, directories, and files |
+|Function    |Function:    |Windows PowerShell functions               |
+|Registry    |HKLM:, HKCU: |Windows registry                           |
+|Variable    |Variable:    |Windows PowerShell variables               |
+|WSMan       |WSMan:       |WS-Management configuration information    |
 
 (*) The FileSystem drives vary on each system.
 
-You can also create your own Windows PowerShell providers, and you can
-install providers that others develop. To list the providers that are
-available in your session, type:
+You can also create your own Windows PowerShell providers, and you can install
+providers that others develop. To list the providers that are available in
+your session, type:
 
 get-psprovider
 
-# INSTALLING AND REMOVING PROVIDERS
+## INSTALLING AND REMOVING PROVIDERS
 
 Windows PowerShell providers are delivered to you in Windows PowerShell
-snap-ins, which are .NET Framework-based programs that are compiled
-into .dll files. The snap-ins can include providers and cmdlets.
+snap-ins, which are .NET Framework-based programs that are compiled into .dll
+files. The snap-ins can include providers and cmdlets.
 
 Before you use the provider features, you have to install the snap-in and
 then add it to your Windows PowerShell session. For more information, see
@@ -76,96 +73,99 @@ cmdlet. This cmdlet does not uninstall the provider, but it makes
 the provider unavailable in the session.
 
 You can also use the Remove-PSDrive cmdlet to remove any drive from the
-current session. This data on the drive is not affected, but the drive is
-no longer available in that session.
+current session. This data on the drive is not affected, but the drive is no
+longer available in that session.
 
-# VIEWING PROVIDERS
+## VIEWING PROVIDERS
 
 To view the Windows PowerShell providers on your computer, type:
 
+```powershell
 get-psprovider
+```
 
-The output lists the built-in providers and the providers that you added
-to the session.
+The output lists the built-in providers and the providers that you added to
+the session.
 
-# THE PROVIDER CMDLETS
+## THE PROVIDER CMDLETS
 
-The following cmdlets are designed to work with the data exposed by
-any provider. You can use the same cmdlets in the same way to manage
-the different types of data that providers expose. After you
-learn to manage the data of one provider, you can use the same
-procedures with the data from any provider.
+The following cmdlets are designed to work with the data exposed by any
+provider. You can use the same cmdlets in the same way to manage the different
+types of data that providers expose. After you learn to manage the data of one
+provider, you can use the same procedures with the data from any provider.
 
-For example, the New-Item cmdlet creates a new item. In the C: drive that
-is supported by the FileSystem provider, you can use New-Item to create a
-new file or folder. In the drives that are supported by the Registry
-provider, you can use New-Item to create a new registry key. In the Alias:
-drive, you can use New-Item to create a new alias.
+For example, the New-Item cmdlet creates a new item. In the C: drive that is
+supported by the FileSystem provider, you can use New-Item to create a new
+file or folder. In the drives that are supported by the Registry provider, you
+can use New-Item to create a new registry key. In the Alias: drive, you can
+use New-Item to create a new alias.
 
 For detailed information about any of the following cmdlets, type:
 
+```
 get-help <cmdlet-name> -detailed
+```
 
-# CHILDITEM CMDLETS
+### CHILDITEM CMDLETS
 
-Get-ChildItem
+- Get-ChildItem
 
-# CONTENT CMDLETS
+### CONTENT CMDLETS
 
-Add-Content
-Clear-Content
-Get-Content
-Set-Content
+- Add-Content
+- Clear-Content
+- Get-Content
+- Set-Content
 
-# ITEM CMDLETS
+### ITEM CMDLETS
 
-Clear-Item
-Copy-Item
-Get-Item
-Invoke-Item
-Move-Item
-New-Item
-Remove-Item
-Rename-Item
-Set-Item
+- Clear-Item
+- Copy-Item
+- Get-Item
+- Invoke-Item
+- Move-Item
+- New-Item
+- Remove-Item
+- Rename-Item
+- Set-Item
 
-# ITEMPROPERTY CMDLETS
+### ITEMPROPERTY CMDLETS
 
-Clear-ItemProperty
-Copy-ItemProperty
-Get-ItemProperty
-Move-ItemProperty
-New-ItemProperty
-Remove-ItemProperty
-Rename-ItemProperty
-Set-ItemProperty
+- Clear-ItemProperty
+- Copy-ItemProperty
+- Get-ItemProperty
+- Move-ItemProperty
+- New-ItemProperty
+- Remove-ItemProperty
+- Rename-ItemProperty
+- Set-ItemProperty
 
-# LOCATION CMDLETS
+### LOCATION CMDLETS
 
-Get-Location
-Pop-Location
-Push-Location
-Set-Location
+- Get-Location
+- Pop-Location
+- Push-Location
+- Set-Location
 
-# PATH CMDLETS
+### PATH CMDLETS
 
-Join-Path
-Convert-Path
-Split-Path
-Resolve-Path
-Test-Path
+- Join-Path
+- Convert-Path
+- Split-Path
+- Resolve-Path
+- Test-Path
 
-# PSDRIVE CMDLETS
+### PSDRIVE CMDLETS
 
-Get-PSDrive
-New-PSDrive
-Remove-PSDrive
+- Get-PSDrive
+- New-PSDrive
+- Remove-PSDrive
 
-# PSPROVIDER CMDLETS
+### PSPROVIDER CMDLETS
 
-Get-PSProvider
+- Get-PSProvider
 
-# VIEWING PROVIDER DATA
+## VIEWING PROVIDER DATA
 
 The primary benefit of a provider is that it exposes its data in a familiar
 and consistent way. The model for data presentation is a file system
@@ -190,85 +190,108 @@ To view the contents of a provider drive, use the Get-Item or Get-ChildItem
 cmdlets. Type the drive name followed by a colon (:). For example, to
 view the contents of the Alias: drive, type:
 
+```powershell
 get-item alias:
+```
 
 You can view and manage the data in any drive from another drive by
 including the drive name in the path. For example, to view the
 HKLM\Software registry key in the HKLM: drive from another drive, type:
 
+```powershell
 get-childitem hklm:\software
+```
 
 To open the drive, use the Set-Location cmdlet. Remember the colon
 when you specify the drive path. For example, to change your location
 to the root directory of the Cert: drive, type:
 
+```powershell
 set-location cert:
+```
 
 Then, to view the contents of the Cert: drive, type:
 
+```powershell
 get-childitem
+```
 
-# MOVING THROUGH HIERARCHICAL DATA
+## MOVING THROUGH HIERARCHICAL DATA
 
 You can move through a provider drive just as you would a hard disk drive.
 If the data is arranged in a hierarchy of items within items, use a
 backslash () to indicate a child item. Use the following format:
 
+```
 drive:\location\child-location\...
+```
 
 For example, to change your location to the HKLM\Software registry key,
 type a Set-Location command, such as:
 
+```powershell
 set-location hklm:\software
+```
 
 You can also use relative references to locations. A dot (.) represents the
 current location. For example, if you are in the HKLM:\Software\Microsoft
 registry key, and you want to list the registry subkeys in the
 HKLM:\Software\Microsoft\PowerShell key, type the following command:
 
+```powershell
 get-childitem .\PowerShell
+```
 
-# FINDING DYNAMIC PARAMETERS
+## FINDING DYNAMIC PARAMETERS
 
-Dynamic parameters are cmdlet parameters that are added to a cmdlet
-by a provider. These parameters are available only when the cmdlet is
-used with the provider that added them.
+Dynamic parameters are cmdlet parameters that are added to a cmdlet by a
+provider. These parameters are available only when the cmdlet is used with the
+provider that added them.
 
-For example, the Cert: drive adds the CodeSigningCert parameter
-to the Get-Item and Get-ChildItem cmdlets. You can use this parameter
-only when you use Get-Item or Get-ChildItem in the Cert: drive.
+For example, the Cert: drive adds the CodeSigningCert parameter to the
+Get-Item and Get-ChildItem cmdlets. You can use this parameter only when you
+use Get-Item or Get-ChildItem in the Cert: drive.
 
-For a list of the dynamic parameters that a provider supports, see the
-Help file for the provider. Type:
+For a list of the dynamic parameters that a provider supports, see the Help
+file for the provider. Type:
 
+```
 get-help <provider-name>
+```
 
 For example:
 
+```powershell
 get-help certificate
+```
 
-# LEARNING ABOUT PROVIDERS
+## LEARNING ABOUT PROVIDERS
 
-Although all provider data appears in drives, and you use the same methods
-to move through them, the similarity stops there. The data stores that
-the provider exposes can be as varied as Active Directory locations and
-Microsoft Exchange Server mailboxes.
+Although all provider data appears in drives, and you use the same methods to
+move through them, the similarity stops there. The data stores that the
+provider exposes can be as varied as Active Directory locations and Microsoft
+Exchange Server mailboxes.
 
 For information about individual Windows PowerShell providers, type:
 
+```
 get-help <ProviderName>
+```
 
 For example:
 
+```powershell
 get-help registry
+```
 
 For a list of Help topics about the providers, type:
 
+```powershell
 get-help * -category provider
+```
 
-# SEE ALSO
+## SEE ALSO
 
-about_Locations
+[about_Locations](about_Locations.md)
 
 [about_Path_Syntax](about_Path_Syntax.md)
-

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Switch.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Switch.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  2017-12-01
+ms.date:  2017-12-06
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -167,9 +167,9 @@ Switch has the following parameters:
 |             |condition. Wildcard and Exact are ignored. Also, if the    |
 |             |match clause is not a string, this parameter is ignored.   |
 
+In this example, there is no matching case so there is no output.
 
 ```powershell
-Example:
    PS> switch ("fourteen")
        {
            1 {"It is one."; Break}
@@ -179,7 +179,12 @@ Example:
            3 {"Three again."; Break}
            "fo*" {"That's too many."}
        }
+```
 
+For the word "fourteen" to match a case you must use the **-Wildcard** or
+**-Regex** parameter.
+
+```powershell
    PS> switch -Regex ("fourteen")
        {
            1 {"It is one."; Break}
@@ -189,6 +194,11 @@ Example:
            3 {"Three again."; Break}
            "fo*" {"That's too many."}
        }
+ ```
+ 
+ Result:
+ 
+ ```Output
 That's too many.
 ```
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_WS-Management_Cmdlets.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_WS-Management_Cmdlets.md
@@ -1,0 +1,196 @@
+---
+ms.date:  2018-01-04
+schema:  2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+title:  about_WS Management_Cmdlets
+---
+
+# About WS-Management Cmdlets
+
+## SHORT DESCRIPTION
+
+Provides an overview of Web Services for Management (WS-Management) as
+background for using the WS-Management cmdlets in Windows PowerShell.
+
+## LONG DESCRIPTION
+
+This topic provides an overview of Web Services for Management (WS-Management)
+as background for using the WS-Management cmdlets in Windows PowerShell. This
+topic also provides links to more information about WS-Management. The
+Microsoft implementation of WS-Management is also known as Windows Remote
+Management (WinRM).
+
+### About WS-Management
+
+Windows Remote Management is the Microsoft implementation of the WS-Management
+protocol, a standard SOAP-based, firewall-friendly protocol that allows
+hardware and operating systems from different vendors to interoperate. The
+WS-Management protocol specification provides a common way for systems to
+access and exchange management information across an information technology
+(IT) infrastructure. WS-Management and Intelligent Platform Management
+Interface (IPMI), along with the Event Collector, are components of the
+Windows Hardware Management features.
+
+The WS-Management protocol is based on the following standard Web service
+specifications: HTTPS, SOAP over HTTP (WS-I profile), SOAP 1.2, WS-Addressing,
+WS-Transfer, WS-Enumeration, and WS-Eventing.
+
+### WS-Management and WMI
+
+WS-Management can be used to retrieve data exposed by Windows Management
+Instrumentation (WMI). You can obtain WMI data with scripts or applications
+that use the WS-Management Scripting API or through the WinRM command-line
+tool. WS-Management supports most of the familiar WMI classes and operations,
+including embedded objects. WS-Management can leverage WMI to collect data
+about resources or to manage resources on a Windows-based computers. That
+means that you can obtain data about objects such as disks, network adapters,
+services, or processes in your enterprise through the existing set of WMI
+classes. You can also access the hardware data that is available from the
+standard WMI IPMI provider.
+
+### WS-Management Windows PowerShell Provider (WSMan)
+
+The WSMan provider provides a hierarchical view into the available
+WS-Management configuration settings. The provider allows you to explore and
+set the various WS-Management configuration options.
+
+### WS-Management Configuration
+
+If WS-Management is not installed and configured, Windows PowerShell remoting
+is not available, the WS-Management cmdlets do not run, WS-Management scripts
+do not run, and the WSMan provider cannot perform data operations. The
+WS-Management command-line tool, WinRM, and event forwarding also depend on
+the WS-Management configuration.
+
+### WS-Management Cmdlets
+
+WS-Management functionality is implemented in Windows PowerShell through a
+module that contains a set of cmdlets and the WSMan provider. You can use
+these cmdlets to complete the end-to-end tasks necessary to manage
+WS-Management settings on local and remote computers.
+
+The following WS-Management cmdlets are available.
+
+### Connection Cmdlets
+
+- Connect-WSMan: Connects the local computer to the WS-Management (WinRM)
+  service on a remote computer.
+
+- Disconnect-WSMan: Disconnects the local computer from the WS-Management
+  (WinRM) service on a remote computer.
+
+### Management-Data Cmdlets
+
+- Get-WSManInstance: Displays management information for a resource instance
+  that is specified by a resource URI.
+
+- Invoke-WSManAction: Invokes an action on the target object that is specified
+  by the resource URI and by the selectors.
+
+- New-WSManInstance: Creates a new management resource instance.
+
+- Remove-WSManInstance: Deletes a management resource instance.
+
+- Set-WSManInstance: Modifies the management information that is related to a
+  resource.
+
+### Setup and Configuration Cmdlets
+
+- Set-WSManQuickConfig: Configures the local computer for remote management.
+  You can use the Set-WSManQuickConfig cmdlet to configure WS-Management to
+  allow remote connections to the WS-Management (WinRM) service. The
+  Set-WSManQuickConfig cmdlet performs the following operations:
+  - It determines whether the WS-Management (WinRM) service is running. If the
+    WinRM service is not running, the Set-WSManQuickConfig cmdlet starts the
+    service.
+  - It sets the WS-Management (WinRM) service startup type to automatic.
+  - It creates a listener that accepts requests from any IP address. The
+    default transport protocol is HTTP.
+  - It enables a firewall exception for WS-Management traffic.
+
+  Note: To run this cmdlet in Windows Vista, Windows Server 2008, and later
+  versions of Windows, you must start Windows PowerShell with the "Run as
+  administrator" option.
+
+- Test-WSMan: Verifies that WS-Management is installed and configured. The
+  Test-WSMan cmdlet tests whether the WS-Management (WinRM) service is running
+  and configured on a local or remote computer.
+
+- Disable-WSManCredSSP: Disables CredSSP authentication on a client computer.
+
+- Enable-WSManCredSSP: Enables CredSSP authentication on a client computer.
+
+- Get-WSManCredSSP: Gets the CredSSP-related configuration for a client
+  computer.
+
+### WS-Management-Specific Cmdlets
+
+- New-WSManSessionOption: Creates a WSManSessionOption object to use as input
+  to one or more parameters of a WS-Management cmdlet.
+
+### Additional WS-Management Information
+
+For more information about WS-Management, see the following topics in the
+MSDN (Microsoft Developer Network) library.
+
+"Windows Remote Management"
+http://go.microsoft.com/fwlink/?LinkId=142321
+
+"About Windows Remote Management"
+http://go.microsoft.com/fwlink/?LinkId=142322
+
+"Installation and Configuration for Windows Remote Management"
+http://go.microsoft.com/fwlink/?LinkId=142323
+
+"Windows Remote Management Architecture"
+http://go.microsoft.com/fwlink/?LinkId=142324
+
+"WS-Management Protocol"
+http://go.microsoft.com/fwlink/?LinkId=142325
+
+"Windows Remote Management and WMI"
+http://go.microsoft.com/fwlink/?LinkId=142326
+
+"Resource URIs"
+http://go.microsoft.com/fwlink/?LinkId=142327
+
+"Remote Hardware Management"
+http://go.microsoft.com/fwlink/?LinkId=142328
+
+"Events"
+http://go.microsoft.com/fwlink/?LinkId=142329
+
+## SEE ALSO
+
+[Connect-WSMan](../../Microsoft.WSMan.Management/Connect-WSMan.md)
+
+[Disable-WSManCredSSP](../../Microsoft.WSMan.Management/Disable-WSManCredSSP.md)
+
+[Disconnect-WSMan](../../Microsoft.WSMan.Management/Disconnect-WSMan.md)
+
+[Enable-WSManCredSSP](../../Microsoft.WSMan.Management/Enable-WSManCredSSP.md)
+
+[Get-WSManCredSSP](../../Microsoft.WSMan.Management/Get-WSManCredSSP.md)
+
+[Get-WSManInstance](../../Microsoft.WSMan.Management/Get-WSManInstance.md)
+
+[Invoke-WSManAction](../../Microsoft.WSMan.Management/Invoke-WSManAction.md)
+
+[New-WSManInstance](../../Microsoft.WSMan.Management/New-WSManInstance.md)
+
+[Remove-WSManInstance](../../Microsoft.WSMan.Management/Remove-WSManInstance.md)
+
+[Set-WSManInstance](../../Microsoft.WSMan.Management/Set-WSManInstance.md)
+
+[Set-WSManQuickConfig](../../Microsoft.WSMan.Management/Set-WSManQuickConfig.md)
+
+[Set-WSManSessionOption](../../Microsoft.WSMan.Management/Set-WSManSessionOption.md)
+
+[Test-WSMan](../../Microsoft.WSMan.Management/Test-WSMan.md)
+
+# KEYWORDS
+
+about_WSMAN
+
+about_WinRM

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -60,7 +60,7 @@ following command gets services in which the ServiceType property value
 includes "Interactive".
 
 ```powershell
-Get-Service | Where-Object {$_.ServiceType -like "Interactive"}
+Get-Service | Where-Object {$_.ServiceType -like "*Interactive*"}
 ```
 
 In the following example, wildcard characters are used to find property
@@ -71,7 +71,7 @@ value of the CreationTime property of the restore point to a log file.
 ```powershell
 $p = Get-ComputerRestorePoint
 foreach ($point in $p) {
-  if ($point.description -like "PowerShell") {
+  if ($point.description -like "*PowerShell*") {
     add-content -path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
   }
 }

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_packagemanagement.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_packagemanagement.md
@@ -104,7 +104,7 @@ For more information about the PackageManagement open development project,
 including how to create a PackageManagement package provider, see the
 PackageManagement project on GitHub at https://oneget.org.
 
-# SEE ALSO
+## SEE ALSO
 
 [Get-PackageProvider](../../PackageManagement/Get-PackageProvider.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Environment_Variables.md
@@ -244,11 +244,11 @@ The environment variables that store preferences include:
   The default value of $Env:PSModulePath is:
 
   ```
-  $home\Documents\WindowsPowerShell\Modules; $pshome\Modules
+  $HOME\Documents\WindowsPowerShell\Modules; $PSHOME\Modules
   ```
 
-Windows PowerShell sets the value of "\$pshome\\Modules" in the registry. It
-sets the value of "\$home\\Documents\\WindowsPowerShell\\Modules" each time you
+Windows PowerShell sets the value of "\$PSHOME\\Modules" in the registry. It
+sets the value of "\$HOME\\Documents\\WindowsPowerShell\\Modules" each time you
 start Windows PowerShell.
 
 In addition, setup programs that install modules in other directories, such as
@@ -294,7 +294,7 @@ $path = [System.Environment]::GetEnvironmentVariable("PSModulePath",
 ```
 
 For more information about the methods of the System.Environment class, see
-[Environment Methods](http://go.microsoft.com/fwlink/?LinkId=242783) in
+[Environment Methods](https://go.microsoft.com/fwlink/?LinkId=242783) in
 MSDN.
 
 You can add also add a command that changes the value to your profile or use

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Methods.md
@@ -27,8 +27,7 @@ the following methods:
 
 All the methods and properties of the `PSCmdlet` class are available to
 advanced functions. For more information about these methods and properties,
-see `System.Management.Automation.PSCmdlet` in the MSDN (Microsoft Developer
-Network) library at http://go.microsoft.com/fwlink/?LinkId=142139.
+see [`System.Management.Automation.PSCmdlet`](http://go.microsoft.com/fwlink/?LinkId=142139) in the MSDN library.
 
 ### Input Processing Methods
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  2017-11-29
+ms.date:  2018-01-04
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -486,6 +486,7 @@ NOTE: Remote sessions, including sessions that are started by using the
 commands are packaged in snap-ins.
 
 The following modules (or snap-ins) are installed with PowerShell.
+* CimCmdlets
 * Microsoft.PowerShell.Archive
 * Microsoft.PowerShell.Core
 * Microsoft.PowerShell.Diagnostics
@@ -495,9 +496,10 @@ The following modules (or snap-ins) are installed with PowerShell.
 * Microsoft.PowerShell.Security
 * Microsoft.PowerShell.Utility
 * Microsoft.WSMan.Management
-* OneGet
+* PackageManagement
 * PowerShellGet
 * PSDesiredStateConfiguration
+* PSDiagnostics
 * PSScheduledJob
 * PSWorkflow
 * PSWorkflowUtility

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_WS-Management_Cmdlets.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_WS-Management_Cmdlets.md
@@ -1,0 +1,196 @@
+---
+ms.date:  2018-01-04
+schema:  2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+title:  about_WS Management_Cmdlets
+---
+
+# About WS-Management Cmdlets
+
+## SHORT DESCRIPTION
+
+Provides an overview of Web Services for Management (WS-Management) as
+background for using the WS-Management cmdlets in Windows PowerShell.
+
+## LONG DESCRIPTION
+
+This topic provides an overview of Web Services for Management (WS-Management)
+as background for using the WS-Management cmdlets in Windows PowerShell. This
+topic also provides links to more information about WS-Management. The
+Microsoft implementation of WS-Management is also known as Windows Remote
+Management (WinRM).
+
+### About WS-Management
+
+Windows Remote Management is the Microsoft implementation of the WS-Management
+protocol, a standard SOAP-based, firewall-friendly protocol that allows
+hardware and operating systems from different vendors to interoperate. The
+WS-Management protocol specification provides a common way for systems to
+access and exchange management information across an information technology
+(IT) infrastructure. WS-Management and Intelligent Platform Management
+Interface (IPMI), along with the Event Collector, are components of the
+Windows Hardware Management features.
+
+The WS-Management protocol is based on the following standard Web service
+specifications: HTTPS, SOAP over HTTP (WS-I profile), SOAP 1.2, WS-Addressing,
+WS-Transfer, WS-Enumeration, and WS-Eventing.
+
+### WS-Management and WMI
+
+WS-Management can be used to retrieve data exposed by Windows Management
+Instrumentation (WMI). You can obtain WMI data with scripts or applications
+that use the WS-Management Scripting API or through the WinRM command-line
+tool. WS-Management supports most of the familiar WMI classes and operations,
+including embedded objects. WS-Management can leverage WMI to collect data
+about resources or to manage resources on a Windows-based computers. That
+means that you can obtain data about objects such as disks, network adapters,
+services, or processes in your enterprise through the existing set of WMI
+classes. You can also access the hardware data that is available from the
+standard WMI IPMI provider.
+
+### WS-Management Windows PowerShell Provider (WSMan)
+
+The WSMan provider provides a hierarchical view into the available
+WS-Management configuration settings. The provider allows you to explore and
+set the various WS-Management configuration options.
+
+### WS-Management Configuration
+
+If WS-Management is not installed and configured, Windows PowerShell remoting
+is not available, the WS-Management cmdlets do not run, WS-Management scripts
+do not run, and the WSMan provider cannot perform data operations. The
+WS-Management command-line tool, WinRM, and event forwarding also depend on
+the WS-Management configuration.
+
+### WS-Management Cmdlets
+
+WS-Management functionality is implemented in Windows PowerShell through a
+module that contains a set of cmdlets and the WSMan provider. You can use
+these cmdlets to complete the end-to-end tasks necessary to manage
+WS-Management settings on local and remote computers.
+
+The following WS-Management cmdlets are available.
+
+### Connection Cmdlets
+
+- Connect-WSMan: Connects the local computer to the WS-Management (WinRM)
+  service on a remote computer.
+
+- Disconnect-WSMan: Disconnects the local computer from the WS-Management
+  (WinRM) service on a remote computer.
+
+### Management-Data Cmdlets
+
+- Get-WSManInstance: Displays management information for a resource instance
+  that is specified by a resource URI.
+
+- Invoke-WSManAction: Invokes an action on the target object that is specified
+  by the resource URI and by the selectors.
+
+- New-WSManInstance: Creates a new management resource instance.
+
+- Remove-WSManInstance: Deletes a management resource instance.
+
+- Set-WSManInstance: Modifies the management information that is related to a
+  resource.
+
+### Setup and Configuration Cmdlets
+
+- Set-WSManQuickConfig: Configures the local computer for remote management.
+  You can use the Set-WSManQuickConfig cmdlet to configure WS-Management to
+  allow remote connections to the WS-Management (WinRM) service. The
+  Set-WSManQuickConfig cmdlet performs the following operations:
+  - It determines whether the WS-Management (WinRM) service is running. If the
+    WinRM service is not running, the Set-WSManQuickConfig cmdlet starts the
+    service.
+  - It sets the WS-Management (WinRM) service startup type to automatic.
+  - It creates a listener that accepts requests from any IP address. The
+    default transport protocol is HTTP.
+  - It enables a firewall exception for WS-Management traffic.
+
+  Note: To run this cmdlet in Windows Vista, Windows Server 2008, and later
+  versions of Windows, you must start Windows PowerShell with the "Run as
+  administrator" option.
+
+- Test-WSMan: Verifies that WS-Management is installed and configured. The
+  Test-WSMan cmdlet tests whether the WS-Management (WinRM) service is running
+  and configured on a local or remote computer.
+
+- Disable-WSManCredSSP: Disables CredSSP authentication on a client computer.
+
+- Enable-WSManCredSSP: Enables CredSSP authentication on a client computer.
+
+- Get-WSManCredSSP: Gets the CredSSP-related configuration for a client
+  computer.
+
+### WS-Management-Specific Cmdlets
+
+- New-WSManSessionOption: Creates a WSManSessionOption object to use as input
+  to one or more parameters of a WS-Management cmdlet.
+
+### Additional WS-Management Information
+
+For more information about WS-Management, see the following topics in the
+MSDN (Microsoft Developer Network) library.
+
+"Windows Remote Management"
+http://go.microsoft.com/fwlink/?LinkId=142321
+
+"About Windows Remote Management"
+http://go.microsoft.com/fwlink/?LinkId=142322
+
+"Installation and Configuration for Windows Remote Management"
+http://go.microsoft.com/fwlink/?LinkId=142323
+
+"Windows Remote Management Architecture"
+http://go.microsoft.com/fwlink/?LinkId=142324
+
+"WS-Management Protocol"
+http://go.microsoft.com/fwlink/?LinkId=142325
+
+"Windows Remote Management and WMI"
+http://go.microsoft.com/fwlink/?LinkId=142326
+
+"Resource URIs"
+http://go.microsoft.com/fwlink/?LinkId=142327
+
+"Remote Hardware Management"
+http://go.microsoft.com/fwlink/?LinkId=142328
+
+"Events"
+http://go.microsoft.com/fwlink/?LinkId=142329
+
+## SEE ALSO
+
+[Connect-WSMan](../../Microsoft.WSMan.Management/Connect-WSMan.md)
+
+[Disable-WSManCredSSP](../../Microsoft.WSMan.Management/Disable-WSManCredSSP.md)
+
+[Disconnect-WSMan](../../Microsoft.WSMan.Management/Disconnect-WSMan.md)
+
+[Enable-WSManCredSSP](../../Microsoft.WSMan.Management/Enable-WSManCredSSP.md)
+
+[Get-WSManCredSSP](../../Microsoft.WSMan.Management/Get-WSManCredSSP.md)
+
+[Get-WSManInstance](../../Microsoft.WSMan.Management/Get-WSManInstance.md)
+
+[Invoke-WSManAction](../../Microsoft.WSMan.Management/Invoke-WSManAction.md)
+
+[New-WSManInstance](../../Microsoft.WSMan.Management/New-WSManInstance.md)
+
+[Remove-WSManInstance](../../Microsoft.WSMan.Management/Remove-WSManInstance.md)
+
+[Set-WSManInstance](../../Microsoft.WSMan.Management/Set-WSManInstance.md)
+
+[Set-WSManQuickConfig](../../Microsoft.WSMan.Management/Set-WSManQuickConfig.md)
+
+[Set-WSManSessionOption](../../Microsoft.WSMan.Management/Set-WSManSessionOption.md)
+
+[Test-WSMan](../../Microsoft.WSMan.Management/Test-WSMan.md)
+
+# KEYWORDS
+
+about_WSMAN
+
+about_WinRM

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Wildcards.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Wildcards.md
@@ -60,7 +60,7 @@ following command gets services in which the ServiceType property value
 includes "Interactive".
 
 ```powershell
-Get-Service | Where-Object {$_.ServiceType -like "Interactive"}
+Get-Service | Where-Object {$_.ServiceType -like "*Interactive*"}
 ```
 
 In the following example, wildcard characters are used to find property
@@ -71,7 +71,7 @@ value of the CreationTime property of the restore point to a log file.
 ```powershell
 $p = Get-ComputerRestorePoint
 foreach ($point in $p) {
-  if ($point.description -like "PowerShell") {
+  if ($point.description -like "*PowerShell*") {
     add-content -path C:\TechDocs\RestoreLog.txt "$($point.CreationTime)"
   }
 }

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -446,11 +446,8 @@ Get-Command <cmdlet-name> | Format-List -Property verb,noun,pssnapin,module
 For example, to find the source of the `Get-Date` cmdlet, type:
 
 ```powershell
-Get-Command Get-Date | Format-List -Property verb,noun,pssnapin,module
+Get-Command Get-Date | Format-List -Property verb,noun,module
 ```
-
-For more information about PowerShell snap-ins, see
-[about_PSSnapins](about_PSSnapins.md).
 
 ## Module-related Warnings and Errors
 
@@ -508,8 +505,6 @@ The following modules (or snap-ins) are installed with PowerShell.
 about_DesiredStateConfiguration
 
 [about_Group_Policy_Settings](about_Group_Policy_Settings.md)
-
-[about_PSSnapins](about_PSSnapins.md)
 
 [Get-Command](../Get-Command.md)
 


### PR DESCRIPTION
This is the final PR in the series to clean up the formatting of About_ topics. This cleans up the formatting in preparation for Pandoc processing. I have removed topics from v6 that are no supported and I have added topics to older versions where they were missing.

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
