### PR TITLE
update TOC and change title of setup mac/linux article

### DIFF
--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS-and-Linux.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS-and-Linux.md
@@ -1,4 +1,4 @@
-# Package installation instructions
+# Installing PowerShell Core on macOS and Linux
 
 Supports [Ubuntu 14.04][u14], [Ubuntu 16.04][u16], [Ubuntu 17.04][u17], [Debian 8][deb8], [Debian 9][deb9],
 [CentOS 7][cos], [Red Hat Enterprise Linux (RHEL) 7][rhel7], [OpenSUSE 42.2][opensuse], [Fedora 25][fed25],

--- a/reference/docs-conceptual/toc.yml
+++ b/reference/docs-conceptual/toc.yml
@@ -74,8 +74,8 @@
       href: core-powershell/ise-guide.md
     - name: Visual Studio Code
       items:
-      - name: Using Visual Studio Cod
-        href: core-powershell/vscode/using-vscode.m
+      - name: Using Visual Studio Code
+        href: core-powershell/vscode/using-vscode.md
     - name: Running Remote Commands
       href: core-powershell/running-remote-commands.md
       items:

--- a/reference/docs-conceptual/toc.yml
+++ b/reference/docs-conceptual/toc.yml
@@ -1,4 +1,4 @@
-- name: Conceptual 
+- name: Conceptual
   href: PowerShell-Scripting.md
   items:
   - name: Core PowerShell
@@ -72,8 +72,17 @@
         href: core-powershell/ise/windows-powershell-ise-object-model-reference.md
     - name: ISE Guide
       href: core-powershell/ise-guide.md
+    - name: Visual Studio Code
+      items:
+      - name: Using Visual Studio Cod
+        href: core-powershell/vscode/using-vscode.m
     - name: Running Remote Commands
       href: core-powershell/running-remote-commands.md
+      items:
+      - name: PowerShell Remoting Over SSH
+        href: core-powershell/SSH-Remoting-in-PowerShell-Core.md
+      - name: WS-Management (WSMan) Remoting in PowerShell Core
+        href: core-powershell/WSMan-Remoting-in-PowerShell-Core.md
     - name: Web Access
       href: core-powershell/web-access.md
       items:
@@ -105,13 +114,13 @@
         href: getting-started/cookbooks/changing-computer-state.md
       - name: Collecting Information About Computers
         href: getting-started/cookbooks/collecting-information-about-computers.md
-      - name: Creating .NET and COM Objects  New Object 
+      - name: Creating .NET and COM Objects  New Object
         href: getting-started/cookbooks/creating-.net-and-com-objects--new-object-.md
       - name: Creating a Custom Input Box
         href: getting-started/cookbooks/creating-a-custom-input-box.md
       - name: Creating a Graphical Date Picker
         href: getting-started/cookbooks/creating-a-graphical-date-picker.md
-      - name: Getting WMI Objects  Get WmiObject 
+      - name: Getting WMI Objects  Get WmiObject
         href: getting-started/cookbooks/getting-wmi-objects--get-wmiobject-.md
       - name: Managing Current Location
         href: getting-started/cookbooks/managing-current-location.md
@@ -131,13 +140,13 @@
         href: getting-started/cookbooks/performing-networking-tasks.md
       - name: Redirecting Data with Out   Cmdlets
         href: getting-started/cookbooks/redirecting-data-with-out---cmdlets.md
-      - name: Removing Objects from the Pipeline  Where Object 
+      - name: Removing Objects from the Pipeline  Where Object
         href: getting-started/cookbooks/removing-objects-from-the-pipeline--where-object-.md
-      - name: Repeating a Task for Multiple Objects  ForEach Object 
+      - name: Repeating a Task for Multiple Objects  ForEach Object
         href: getting-started/cookbooks/repeating-a-task-for-multiple-objects--foreach-object-.md
       - name: Selecting Items from a List Box
         href: getting-started/cookbooks/selecting-items-from-a-list-box.md
-      - name: Selecting Parts of Objects  Select Object 
+      - name: Selecting Parts of Objects  Select Object
         href: getting-started/cookbooks/selecting-parts-of-objects--select-object-.md
       - name: Sorting Objects
         href: getting-started/cookbooks/sorting-objects.md
@@ -145,7 +154,7 @@
         href: getting-started/cookbooks/using-format-commands-to-change-output-view.md
       - name: Using Static Classes and Methods
         href: getting-started/cookbooks/using-static-classes-and-methods.md
-      - name: Viewing Object Structure  Get Member 
+      - name: Viewing Object Structure  Get Member
         href: getting-started/cookbooks/viewing-object-structure--get-member-.md
       - name: Working with Files and Folders
         href: getting-started/cookbooks/working-with-files-and-folders.md
@@ -192,7 +201,7 @@
         href: getting-started/fundamental/using-windows-powershell-for-administration.md
       - name: Windows PowerShell Basics
         href: getting-started/fundamental/windows-powershell-basics.md
-      - name: Windows PowerShell Integrated Scripting Environment  ISE 
+      - name: Windows PowerShell Integrated Scripting Environment  ISE
         href: getting-started/fundamental/windows-powershell-integrated-scripting-environment--ise-.md
     - name: Fundamental Concepts
       href: getting-started/fundamental-concepts.md
@@ -207,6 +216,10 @@
   - name: Setup
     href: ''
     items:
+    - name: Installing PowerShell Core on Windows
+      href: setup/Installing-PowerShell-Core-on-Windows.md
+    - name: Installing PowerShell Core on macOS and Linux
+      href: setup/Installing-PowerShell-Core-on-macOS-and-Linux.md
     - name: Accessibility in Windows PowerShell ISE
       href: setup/accessibility-in-windows-powershell-ise.md
     - name: Installing the Windows PowerShell 2.0 Engine
@@ -234,12 +247,14 @@
   - name: What's New
     href: ''
     items:
-    - name: What's New in the PowerShell 50 ISE
-      href: whats-new/what-s-new-in-the-powershell-50-ise.md
-    - name: What's New in Windows PowerShell 50
-      href: whats-new/what-s-new-in-windows-powershell-50.md
-    - name: What's New With PowerShell
+    - name: What's new with PowerShell
       href: whats-new/what-s-new-with-powershell.md
+    - name: What's new in Windows PowerShell 5.0
+      href: whats-new/what-s-new-in-windows-powershell-50.md
+    - name: What's new in the PowerShell 5.0 ISE
+      href: whats-new/what-s-new-in-the-powershell-50-ise.md
+    - name: What's new in PowerShell Core 6.0
+      href: whats-new/what-s-new-in-powershell-core-60.md
   - name: PowerShell Core Support Lifecycle
     href: PowerShell-Core-Support.md
   - name: Glossary


### PR DESCRIPTION
Adding new PSCore v6 articles to TOC and fixing one title

Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
