### PR TITLE
Update WSMan-Remoting-in-PowerShell-Core.md

### DIFF
--- a/reference/docs-conceptual/core-powershell/WSMan-Remoting-in-PowerShell-Core.md
+++ b/reference/docs-conceptual/core-powershell/WSMan-Remoting-in-PowerShell-Core.md
@@ -35,13 +35,14 @@ Install-PowerShellRemoting.ps1
 #### Executed by another instance of PowerShell on behalf of the instance that it will register
 
 ``` powershell
-<path to powershell>\Install-PowerShellRemoting.ps1 -PowerShellHome "<absolute path to the instance's $PSHOME>" -PowerShellVersion "<the powershell version tag>"
+<path to powershell>\Install-PowerShellRemoting.ps1 -PowerShellHome "<absolute path to the instance's $PSHOME>"
 ```
 
 For Example:
 
 ``` powershell
-C:\Program Files\PowerShell\6.0.0.9\Install-PowerShellRemoting.ps1 -PowerShellHome "C:\Program Files\PowerShell\6.0.0.9\" -PowerShellVersion "6.0.0-alpha.9"
+Set-Location -Path 'C:\Program Files\PowerShell\6.0.0\'
+.\Install-PowerShellRemoting.ps1 -PowerShellHome "C:\Program Files\PowerShell\6.0.0\"
 ```
 
 **NOTE:** The remoting registration script will restart WinRM, so all existing PSRP sessions will terminate immediately after the script is run. If run during a remote session, this will terminate the connection.
@@ -51,8 +52,8 @@ C:\Program Files\PowerShell\6.0.0.9\Install-PowerShellRemoting.ps1 -PowerShellHo
 Create a PowerShell session to the new PowerShell endpoint by specifying `-ConfigurationName "some endpoint name"`. To connect to the PowerShell instance from the example above, use either:
 
 ``` powershell
-New-PSSession ... -ConfigurationName "powershell.6.0.0-alpha.9"
-Enter-PSSession ... -ConfigurationName "powershell.6.0.0-alpha.9"
+New-PSSession ... -ConfigurationName "powershell.6.0.0"
+Enter-PSSession ... -ConfigurationName "powershell.6.0.0"
 ```
 
 Note that `New-PSSession` and `Enter-PSSession` invocations that do not specify `-ConfigurationName` will target the default PowerShell endpoint, `microsoft.powershell`.


### PR DESCRIPTION
The current example doesn't work for me when specifying the full file path.  It just outputs the file location rather than running the script.  I had to move to the location of the file and run it from there.

The parameter PowerShellVersion also doesn't appear to exist anymore so I have removed that.  

I've also changes file paths to match the 6.0.0 GA release rather than the previous alpha 9.