### PR TITLE
Fix $PSVersionTable.OS in What's New 6.0

### DIFF
--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-60.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-60.md
@@ -236,7 +236,7 @@ For more information about PowerShell jobs, see [about_Jobs](https://msdn.micros
   - `PSEdition`: This is set to `Core` on PowerShell Core and `Desktop` on Windows PowerShell
   - `GitCommitId`: This is the Git commit ID of the Git branch or tag where PowerShell was built.
     On released builds, it will likely be the same as `PSVersion`.
-  - `OS`: This is an OS version string returned by `[System.Environment]::OSVersion.VersionString`
+  - `OS`: This is an OS version string returned by `[System.Runtime.InteropServices.RuntimeInformation]::OSDescription`
   - `Platform`: This is returned by `[System.Environment]::OSVersion.Platform`
     It is set to `Win32NT` on Windows, `MacOSX` on macOS, and `Unix` on Linux.
 - Removed the `BuildVersion` property from `$PSVersionTable`.


### PR DESCRIPTION
`$PSVersionTable.OS` is:
x `[System.Environment]::OSVersion.VersionString`
o `[System.Runtime.InteropServices.RuntimeInformation]::OSDescription`

See [PSVersionInfo.cs](https://github.com/PowerShell/PowerShell/blob/6.0.0/src/System.Management.Automation/engine/PSVersionInfo.cs#L99) and the following test commands:

```powershell
PS> $PSVersionTable

Name                           Value
----                           -----
PSVersion                      6.0.0
PSEdition                      Core
GitCommitId                    v6.0.0
OS                             Microsoft Windows 10.0.16299
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0...}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0

PS> [System.Environment]::OSVersion.VersionString
Microsoft Windows NT 6.2.9200.0

PS> [System.Runtime.InteropServices.RuntimeInformation]::OSDescription
Microsoft Windows 10.0.16299
```

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 6.0 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
