### PR TITLE
Update docfx.json

### DIFF
--- a/reference/docfx.json
+++ b/reference/docfx.json
@@ -15,7 +15,8 @@
       },
       {
         "files": [
-          "**/*.md"
+          "**/*.md",
+          "images/"
         ],
         "src": "docs-conceptual",
         "version": "powershell-3.0",
@@ -50,7 +51,8 @@
       },
       {
         "files": [
-          "**/*.md"
+          "**/*.md",
+          "images/"
         ],
         "src": "docs-conceptual",
         "version": "powershell-4.0",
@@ -85,7 +87,8 @@
       },
       {
         "files": [
-          "**/*.md"
+          "**/*.md",
+          "images/"
         ],
         "src": "docs-conceptual",
         "version": "powershell-5.0",
@@ -120,7 +123,8 @@
       },
       {
         "files": [
-          "**/*.md"
+          "**/*.md",
+          "images/"
         ],
         "src": "docs-conceptual",
         "version": "powershell-5.1",
@@ -155,7 +159,8 @@
       },
       {
         "files": [
-          "**/*.md"
+          "**/*.md",
+          "images/"
         ],
         "src": "docs-conceptual",
         "version": "powershell-6",


### PR DESCRIPTION
Images broken in new v6 articles.

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
