### PR TITLE
Add resource per version in docfx.json

### DIFF
--- a/reference/docfx.json
+++ b/reference/docfx.json
@@ -206,6 +206,66 @@
           "**/obj/**",
           "**/includes/**"
         ]
+      },
+      {
+        "files": [
+          "**/images/**",
+          "**/*.png",
+          "**/*.jpg"
+        ],
+        "exclude": [
+          "**/obj/**",
+          "**/includes/**"
+        ],
+        "version": "powershell-3.0"
+      },
+      {
+        "files": [
+          "**/images/**",
+          "**/*.png",
+          "**/*.jpg"
+        ],
+        "exclude": [
+          "**/obj/**",
+          "**/includes/**"
+        ],
+        "version": "powershell-4.0"
+      },
+      {
+        "files": [
+          "**/images/**",
+          "**/*.png",
+          "**/*.jpg"
+        ],
+        "exclude": [
+          "**/obj/**",
+          "**/includes/**"
+        ],
+        "version": "powershell-5.0"
+      },
+      {
+        "files": [
+          "**/images/**",
+          "**/*.png",
+          "**/*.jpg"
+        ],
+        "exclude": [
+          "**/obj/**",
+          "**/includes/**"
+        ],
+        "version": "powershell-5.1"
+      },
+      {
+        "files": [
+          "**/images/**",
+          "**/*.png",
+          "**/*.jpg"
+        ],
+        "exclude": [
+          "**/obj/**",
+          "**/includes/**"
+        ],
+        "version": "powershell-6"
       }
     ],
     "versions": {


### PR DESCRIPTION
Images broken in new v6 articles.

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
