### PR TITLE
Fix New-ModuleManifest encoding in What's New 6.0

### DIFF
--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-60.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-60.md
@@ -172,7 +172,7 @@ and you can use your existing SSH-based authenticate mechanisms (like passwords 
 For more information on configuring and using SSH-based remoting,
 see [PowerShell Remoting over SSH][ssh-remoting].
 
-## Default encoding is UTF-8 without a BOM
+## Default encoding is UTF-8 without a BOM except for New-ModuleManifest
 
 In the past, Windows PowerShell cmdlets like `Get-Content`, `Set-Content` used different encodings, such as ASCII and UTF-16.
 The variance in encoding defaults created problems when mixing cmdlets without specifying an encoding.
@@ -191,7 +191,6 @@ The following cmdlets are affected by this change:
 - Format-Hex
 - Get-Content
 - Import-Csv
-- New-ModuleManifest
 - Out-File
 - Select-String
 - Send-MailMessage
@@ -202,6 +201,8 @@ These cmdlets have also been updated so that the `-Encoding` parameter universal
 The default value of `$OutputEncoding` has also been changed to UTF-8.
 
 As a best practice, you should explicitly set encodings in scripts using the `-Encoding` parameter to produce deterministic behavior across platforms.
+
+`New-ModuleManifest` cmdlet does not have **Encoding** parameter. The encoding of the module manifest (.psd1) file created with `New-ModuleManifest` cmdlet depends on environment: if it is PowerShell Core running on Linux then encoding is UTF-8 (no BOM); otherwise encoding is UTF-16 (with BOM). (#3940)
 
 ## Support backgrounding of pipelines with ampersand (`&`) (#3360)
 


### PR DESCRIPTION
@sdwheeler  I am not sure whether it is a documentation bug or a software bug. If it is a software bug, please close this PR.

According to the [New-ModuleManifest.md](https://github.com/PowerShell/PowerShell-Docs/blob/staging/reference/6/Microsoft.PowerShell.Core/New-ModuleManifest.md):
* `New-ModuleManifest` does not have **Encoding** parameter
* The encoding of the module manifest (.psd1) file created with `New-ModuleManifest` cmdlet depends on environment: if it is PowerShell Core running on Linux then encoding is UTF-8 (no BOM); otherwise encoding is UTF-16 (with BOM)

See [NewModuleManifestCommand.cs](https://github.com/PowerShell/PowerShell/blob/6.0.0/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs#L944-L948) and the following test commands:

Windows:
```powershell
PS> $PSVersionTable

Name                           Value
----                           -----
PSVersion                      6.0.0
PSEdition                      Core
GitCommitId                    v6.0.0
OS                             Microsoft Windows 10.0.16299
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0...}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0

PS> New-ModuleManifest -Path .\test.psd1
PS> '{0:X2}' -f (Get-Content -AsByteStream -Path .\test.psd1 -ReadCount 8 -TotalCount 8)
FF FE 23 00 0D 00 0A 00
```

Linux:
```powershell
PS /> $PSVersionTable

Name                           Value
----                           -----
PSVersion                      6.0.0
PSEdition                      Core
GitCommitId                    v6.0.0
OS                             Linux 4.4.108-boot2docker #1 SMP Wed Dec 27 23:32:59 UTC 2017
Platform                       Unix
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0...}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0


PS /> New-ModuleManifest -Path .\test.psd1
PS /> '{0:X2}' -f (Get-Content -AsByteStream -Path .\test.psd1 -ReadCount 8 -TotalCount 8)
23 0A 23 20 4D 6F 64 75
```

`FF FE` indicates BOM UTF-16 little-endian (Windows).
`23 0A 23 ...` indicates NoBOM (Linux).
See [The Unicode Consortium FAQ](http://unicode.org/faq/utf_bom.html#bom4).

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 6.0 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
