### PR TITLE
Change 'PowerShellProperties.json' to 'powershell.config.json' in about_logging

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Logging.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Logging.md
@@ -148,7 +148,7 @@ sudo log stream --predicate 'process == "pwsh"' --info
 
 On Windows, logging is configured by creating ETW trace listeners or by using 
 the Event Viewer to enable Analytic logging. On Linux and MacOS, logging is 
-configured using the file `PowerShellProperties.json`. The rest of this section 
+configured using the file `powershell.config.json`. The rest of this section 
 will discuss configuring PowerShell logging on non-Windows system.
 
 By default, PowerShell enables informational logging to the operational 
@@ -157,7 +157,7 @@ marked as operational and has a log (trace) level greater then informational
 will be logged.  Occasionally, diagnoses may require additional log output, 
 such as verbose log output or enabling analytic log output.
 
-The file `PowerShellProperties.json` is a JSON formatted file residing in the 
+The file `powershell.config.json` is a JSON formatted file residing in the 
 PowerShell $PSHOME directory. Each installation of PowerShell uses it's own 
 copy of this file. For normal operation, this file is left unchanged but it 
 can be useful for diagnosis or for distinguishing between multiple PowerShell 


### PR DESCRIPTION
Summary
-----------
The powershell core 6 configuration file name was changed. This PR update `about_logging.md` to refer to `powershell.config.json` as the name of the configuration file.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
