### PR TITLE
Fix release links/names (6.0.0)

### DIFF
--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS-and-Linux.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS-and-Linux.md
@@ -4,13 +4,9 @@ Supports [Ubuntu 14.04][u14], [Ubuntu 16.04][u16], [Ubuntu 17.04][u17], [Debian 
 [CentOS 7][cos], [Red Hat Enterprise Linux (RHEL) 7][rhel7], [OpenSUSE 42.2][opensuse], [Fedora 25][fed25],
 [Fedora 26][fed26], [Arch Linux][arch], and [macOS 10.12][mac].
 
-For Linux distributions that are not officially supported,
-you can try using the [PowerShell AppImage][lai].
-You can also try deploying PowerShell binaries directly using the Linux [`tar.gz` archive][tar],
-but you would need to set up the necessary dependencies based on the OS in separate steps.
+For Linux distributions that are not officially supported, you can try using the [PowerShell AppImage][lai]. You can also try deploying PowerShell binaries directly using the Linux [`tar.gz` archive][tar], but you would need to set up the necessary dependencies based on the OS in separate steps.
 
-All packages are available on our GitHub [releases][] page.
-Once the package is installed, run `pwsh` from a terminal.
+All packages are available on our GitHub [releases][] page. Once the package is installed, run `pwsh` from a terminal.
 
 [u14]: #ubuntu-1404
 [u16]: #ubuntu-1604
@@ -31,8 +27,7 @@ Once the package is installed, run `pwsh` from a terminal.
 
 ### Installation via Package Repository - Ubuntu 14.04
 
-PowerShell Core, for Linux, is published to package repositories for easy installation (and updates).
-This is the preferred method.
+PowerShell Core, for Linux, is published to package repositories for easy installation (and updates). This is the preferred method.
 
 ```sh
 # Import the public repository GPG keys
@@ -51,19 +46,20 @@ sudo apt-get install -y powershell
 pwsh
 ```
 
-After registering the Microsoft repository once as superuser,
-from then on, you just need to use `sudo apt-get upgrade powershell` to update it.
+After registering the Microsoft repository once as superuser, from then on, you just need to use `sudo apt-get upgrade powershell` to update it.
 
 ### Installation via Direct Download - Ubuntu 14.04
 
-Download the Debian package
-`powershell_6.0.0-rc-1.ubuntu.14.04_amd64.deb`
-from the [releases][] page onto the Ubuntu machine.
+Download the Debian package `powershell_6.0.0-1.ubuntu.14.04_amd64.deb` from the [releases][] page onto the Ubuntu machine.
+
+```sh
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell_6.0.0-1.ubuntu.14.04_amd64.deb
+```
 
 Then execute the following in the terminal:
 
 ```sh
-sudo dpkg -i powershell_6.0.0-rc-1.ubuntu.14.04_amd64.deb
+sudo dpkg -i powershell_6.0.0-1.ubuntu.14.04_amd64.deb
 sudo apt-get install -f
 ```
 
@@ -106,14 +102,16 @@ from then on, you just need to use `sudo apt-get upgrade powershell` to update i
 
 ### Installation via Direct Download - Ubuntu 16.04
 
-Download the Debian package
-`powershell_6.0.0-rc-1.ubuntu.16.04_amd64.deb`
-from the [releases][] page onto the Ubuntu machine.
+Download the Debian package `powershell_6.0.0-1.ubuntu.16.04_amd64.deb` from the [releases][] page onto the Ubuntu machine:
+
+```sh
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell_6.0.0-1.ubuntu.16.04_amd64.deb
+```
 
 Then execute the following in the terminal:
 
 ```sh
-sudo dpkg -i powershell_6.0.0-rc-1.ubuntu.16.04_amd64.deb
+sudo dpkg -i powershell_6.0.0-1.ubuntu.16.04_amd64.deb
 sudo apt-get install -f
 ```
 
@@ -156,14 +154,16 @@ from then on, you just need to use `sudo apt-get upgrade powershell` to update i
 
 ### Installation via Direct Download - Ubuntu 17.04
 
-Download the Debian package
-`powershell_6.0.0-rc-1.ubuntu.17.04_amd64.deb`
-from the [releases][] page onto the Ubuntu machine.
+Download the Debian package `powershell_6.0.0-1.ubuntu.17.04_amd64.deb` from the [releases][] page onto the Ubuntu machine:
+
+```sh
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell_6.0.0-1.ubuntu.17.04_amd64.deb
+```
 
 Then execute the following in the terminal:
 
 ```sh
-sudo dpkg -i powershell_6.0.0-rc-1.ubuntu.17.04_amd64.deb
+sudo dpkg -i powershell_6.0.0-1.ubuntu.17.04_amd64.deb
 sudo apt-get install -f
 ```
 
@@ -210,14 +210,16 @@ from then on, you just need to use `sudo apt-get upgrade powershell` to update i
 
 ### Installation via Direct Download - Debian 8
 
-Download the Debian package
-`powershell_6.0.0-rc-1.debian.8_amd64.deb`
-from the [releases][] page onto the Debian machine.
+Download the Debian package `powershell_6.0.0-1.debian.8_amd64.deb` from the [releases][] page onto the Debian machine:
+
+```sh
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell_6.0.0-1.debian.8_amd64.deb
+```
 
 Then execute the following in the terminal:
 
 ```sh
-sudo dpkg -i powershell_6.0.0-rc-1.debian.8_amd64.deb
+sudo dpkg -i powershell_6.0.0-1.debian.8_amd64.deb
 sudo apt-get install -f
 ```
 
@@ -264,14 +266,16 @@ from then on, you just need to use `sudo apt-get upgrade powershell` to update i
 
 ### Installation via Direct Download - Debian 9
 
-Download the Debian package
-`powershell_6.0.0-rc-1.debian.9_amd64.deb`
-from the [releases][] page onto the Debian machine.
+Download the Debian package `powershell_6.0.0-1.debian.9_amd64.deb` from the [releases][] page onto the Debian machine:
+
+```sh
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell_6.0.0-1.debian.9_amd64.deb
+```
 
 Then execute the following in the terminal:
 
 ```sh
-sudo dpkg -i powershell_6.0.0-rc-1.debian.9_amd64.deb
+sudo dpkg -i powershell_6.0.0-1.debian.9_amd64.deb
 sudo apt-get install -f
 ```
 
@@ -309,20 +313,22 @@ you just need to use `sudo yum update powershell` to update PowerShell.
 
 ### Installation via Direct Download - CentOS 7
 
-Using [CentOS 7][], download the RPM package
-`powershell-6.0.0_rc-1.rhel.7.x86_64.rpm`
-from the [releases][] page onto the CentOS machine.
+Using [CentOS 7][], download the RPM package `powershell-6.0.0-1.rhel.7.x86_64.rpm` from the [releases][] page onto the CentOS machine:
+
+```sh
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell-6.0.0-1.rhel.7.x86_64.rpm
+```
 
 Then execute the following in the terminal:
 
 ```sh
-sudo yum install powershell-6.0.0_rc-1.rhel.7.x86_64.rpm
+sudo yum install powershell-6.0.0-1.rhel.7.x86_64.rpm
 ```
 
 You can also install the RPM without the intermediate step of downloading it:
 
 ```sh
-sudo yum install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-rc/powershell-6.0.0_rc-1.rhel.7.x86_64.rpm
+sudo yum install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell-6.0.0-1.rhel.7.x86_64.rpm
 ```
 
 ### Uninstallation - CentOS 7
@@ -355,20 +361,22 @@ you just need to use `sudo yum update powershell` to update PowerShell.
 
 ### Installation via Direct Download - Red Hat Enterprise Linux (RHEL) 7
 
-Download the RPM package
-`powershell-6.0.0_rc-1.rhel.7.x86_64.rpm`
-from the [releases][] page onto the Red Hat Enterprise Linux machine.
+Download the RPM package `powershell-6.0.0-1.rhel.7.x86_64.rpm` from the [releases][] page onto the Red Hat Enterprise Linux machine:
+
+```sh
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell_6.0.0-1.debian.9_amd64.deb
+```
 
 Then execute the following in the terminal:
 
 ```sh
-sudo yum install powershell-6.0.0_rc-1.rhel.7.x86_64.rpm
+sudo yum install powershell-6.0.0-1.rhel.7.x86_64.rpm
 ```
 
 You can also install the RPM without the intermediate step of downloading it:
 
 ```sh
-sudo yum install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-rc/powershell-6.0.0_rc-1.rhel.7.x86_64.rpm
+sudo yum install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell-6.0.0-1.rhel.7.x86_64.rpm
 ```
 
 ### Uninstallation - Red Hat Enterprise Linux (RHEL) 7
@@ -407,19 +415,22 @@ pwsh
 
 ### Installation via Direct Download - OpenSUSE 42.2
 
-Download the RPM package `powershell-6.0.0_rc-1.rhel.7.x86_64.rpm`
-from the [releases][] page onto the OpenSUSE machine.
+Download the RPM package `powershell-6.0.0-1.rhel.7.x86_64.rpm` from the [releases][] page onto the OpenSUSE machine:
+
+```sh
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell-6.0.0-1.rhel.7.x86_64.rpm
+```
 
 ```sh
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-sudo zypper install powershell-6.0.0_rc-1.rhel.7.x86_64.rpm
+sudo zypper install powershell-6.0.0-1.rhel.7.x86_64.rpm
 ```
 
 You can also install the RPM without the intermediate step of downloading it:
 
 ```sh
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-sudo zypper install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-rc/powershell-6.0.0_rc-1.rhel.7.x86_64.rpm
+sudo zypper install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell-6.0.0-1.rhel.7.x86_64.rpm
 ```
 
 ### Uninstallation - OpenSUSE 42.2
@@ -453,20 +464,22 @@ pwsh
 
 ### Installation via Direct Download - Fedora 25
 
-Download the RPM package
-`powershell-6.0.0_rc-1.rhel.7.x86_64.rpm`
-from the [releases][] page onto the Fedora machine.
+Download the RPM package `powershell-6.0.0-1.rhel.7.x86_64.rpm` from the [releases][] page onto the Fedora machine:
+
+```sh
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell-6.0.0-1.rhel.7.x86_64.rpm
+```
 
 Then execute the following in the terminal:
 
 ```sh
-sudo dnf install powershell-6.0.0_rc-1.rhel.7.x86_64.rpm
+sudo dnf install powershell-6.0.0-1.rhel.7.x86_64.rpm
 ```
 
 You can also install the RPM without the intermediate step of downloading it:
 
 ```sh
-sudo dnf install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-rc/powershell-6.0.0_rc-1.rhel.7.x86_64.rpm
+sudo dnf install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell-6.0.0-1.rhel.7.x86_64.rpm
 ```
 
 ### Uninstallation - Fedora 25
@@ -503,16 +516,18 @@ pwsh
 
 ### Installation via Direct Download - Fedora 26
 
-Download the RPM package
-`powershell-6.0.0_rc-1.rhel.7.x86_64.rpm`
-from the [releases][] page onto the Fedora machine.
+Download the RPM package `powershell-6.0.0-1.rhel.7.x86_64.rpm` from the [releases][] page onto the Fedora machine:
+
+```sh
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell-6.0.0-1.rhel.7.x86_64.rpm
+```
 
 Then execute the following in the terminal:
 
 ```sh
 sudo dnf update
 sudo dnf install compat-openssl10
-sudo dnf install powershell-6.0.0_rc-1.rhel.7.x86_64.rpm
+sudo dnf install powershell-6.0.0-1.rhel.7.x86_64.rpm
 ```
 
 You can also install the RPM without the intermediate step of downloading it:
@@ -520,7 +535,7 @@ You can also install the RPM without the intermediate step of downloading it:
 ```sh
 sudo dnf update
 sudo dnf install compat-openssl10
-sudo dnf install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-rc/powershell-6.0.0_rc-1.rhel.7.x86_64.rpm
+sudo dnf install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell-6.0.0-1.rhel.7.x86_64.rpm
 ```
 
 ### Uninstallation - Fedora 26
@@ -548,22 +563,16 @@ For more information on installing packages from the AUR, see the [Arch Linux wi
 
 ## Linux AppImage
 
-Using a recent Linux distribution,
-download the AppImage `powershell-6.0.0-rc-x86_64.AppImage`
-from the [releases][] page onto the Linux machine.
+Using a recent Linux distribution, download the AppImage `powershell-6.0.0-x86_64.AppImage` from the [releases][] page onto the Linux machine.
 
 Then execute the following in the terminal:
 
 ```bash
-chmod a+x powershell-6.0.0-rc-x86_64.AppImage
-./powershell-6.0.0-rc-x86_64.AppImage
+chmod a+x powershell-6.0.0-x86_64.AppImage
+./powershell-6.0.0-x86_64.AppImage
 ```
 
-The [AppImage][] lets you run PowerShell without installing it.
-It is a portable application that bundles PowerShell and its dependencies
-(including .NET Core's system dependencies) into one cohesive package.
-This package works independently of the user's Linux distribution,
-and is a single binary.
+The [AppImage][] lets you run PowerShell without installing it. It is a portable application that bundles PowerShell and its dependencies (including .NET Core's system dependencies) into one cohesive package. This package works independently of the user's Linux distribution, and is a single binary.
 
 [appimage]: http://appimage.org/
 
@@ -571,12 +580,9 @@ and is a single binary.
 
 ### Installation via Homebrew (preferred) - macOS 10.12
 
-[Homebrew][brew] is the missing package manager for macOS.
-If the `brew` command is not found,
-you need to install Homebrew following [their instructions][brew].
+[Homebrew][brew] is the missing package manager for macOS. If the `brew` command is not found, you need to install Homebrew following [their instructions][brew].
 
-Once you've installed Homebrew, installing PowerShell is easy.
-First, install [Homebrew-Cask][cask], so you can install more packages:
+Once you've installed Homebrew, installing PowerShell is easy. First, install [Homebrew-Cask][cask], so you can install more packages:
 
 ```sh
 brew tap caskroom/cask
@@ -588,8 +594,7 @@ Now, you can install PowerShell:
 brew cask install powershell
 ```
 
-When new versions of PowerShell are released,
-simply update Homebrew's formulae and upgrade PowerShell:
+When new versions of PowerShell are released, simply update Homebrew's formulae and upgrade PowerShell:
 
 ```sh
 brew update
@@ -603,15 +608,12 @@ brew cask reinstall powershell
 
 ### Installation via Direct Download - macOS 10.12
 
-Using macOS 10.12, download the PKG package
-`powershell-6.0.0-rc-osx.10.12-x64.pkg`
-from the [releases][] page onto the macOS machine.
+Using macOS 10.12, download the PKG package `powershell-6.0.0-osx.10.12-x64.pkg` from the [releases][] page onto the macOS machine.
 
-Either double-click the file and follow the prompts,
-or install it from the terminal:
+Either double-click the file and follow the prompts, or install it from the terminal:
 
 ```sh
-sudo installer -pkg powershell-6.0.0-rc-osx.10.12-x64.pkg -target /
+sudo installer -pkg powershell-6.0.0-osx.10.12-x64.pkg -target /
 ```
 
 ### Uninstallation - macOS 10.12
@@ -622,17 +624,13 @@ If you installed PowerShell with Homebrew, uninstallation is easy:
 brew cask uninstall powershell
 ```
 
-If you installed PowerShell via direct download,
-PowerShell must be removed manually:
+If you installed PowerShell via direct download, PowerShell must be removed manually:
 
 ```sh
 sudo rm -rf /usr/local/bin/pwsh /usr/local/microsoft/powershell
 ```
 
-To uninstall the additional PowerShell paths (such as the user profile path)
-please see the [paths][paths] section below in this document
-and remove the desired the paths with `sudo rm`.
-(Note: this is not necessary if you installed with Homebrew.)
+To uninstall the additional PowerShell paths (such as the user profile path) please see the [paths][paths] section below in this document and remove the desired the paths with `sudo rm`. (Note: this is not necessary if you installed with Homebrew.)
 
 [paths]:#paths
 
@@ -641,13 +639,14 @@ and remove the desired the paths with `sudo rm`.
 ### Installation
 
 ```sh
-# Install prerequisites
-apt-get install libunwind8 libicu55
+# Download & Install prerequisites
+sudo apt-get install libunwind8 libicu55
 wget http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u6_amd64.deb
-dpkg -i libssl1.0.0_1.0.1t-1+deb8u6_amd64.deb
+sudo dpkg -i libssl1.0.0_1.0.1t-1+deb8u6_amd64.deb
 
-# Install PowerShell
-dpkg -i powershell_6.0.0-rc-1.ubuntu.16.04_amd64.deb
+# Download & Install PowerShell
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell_6.0.0-1.ubuntu.16.04_amd64.deb
+sudo dpkg -i powershell_6.0.0-1.ubuntu.16.04_amd64.deb
 
 # Start PowerShell
 pwsh
@@ -657,19 +656,19 @@ pwsh
 
 ```sh
 # Grab the latest App Image
-wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-rc/powershell-6.0.0-rc-x86_64.AppImage
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell-6.0.0-x86_64.AppImage
 
 # Make executable
-chmod a+x powershell-6.0.0-rc-x86_64.AppImage
+chmod a+x powershell-6.0.0-x86_64.AppImage
 
 # Start PowerShell
-./powershell-6.0.0-rc-x86_64.AppImage
+./powershell-6.0.0-x86_64.AppImage
 ```
 
 ### Uninstallation - Kali
 
 ```sh
-dpkg -r powershell_6.0.0-rc-1.ubuntu.16.04_amd64.deb
+sudo dpkg -r powershell-6.0.0-x86_64.AppImage
 ```
 
 ## Raspbian
@@ -683,13 +682,13 @@ Currently, PowerShell is only supported on Raspbian Stretch.
 sudo apt-get install libunwind8
 
 # Grab the latest tar.gz
-wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-rc/powershell-6.0.0-rc-linux-arm32.tar.gz
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell-6.0.0-linux-arm32.tar.gz
 
 # Make folder to put powershell
 mkdir ~/powershell
 
 # Unpack the tar.gz file
-tar -xvf ./powershell-6.0.0-rc-linux-arm32.tar.gz -C ~/powershell
+tar -xvf ./powershell-6.0.0-linux-arm32.tar.gz -C ~/powershell
 
 # Start PowerShell
 ~/powershell/pwsh
@@ -708,8 +707,7 @@ PowerShell binary `tar.gz` archives are provided for macOS and Linux platforms t
 ### Dependencies
 
 For Linux, PowerShell builds portable binaries for all Linux distributions.
-But .NET Core runtime requires different dependencies on different distributions,
-and hence PowerShell does the same.
+But .NET Core runtime requires different dependencies on different distributions, and hence PowerShell does the same.
 
 The following chart shows the .NET Core 2.0 dependencies on different Linux distributions that are officially supported.
 
@@ -723,10 +721,7 @@ The following chart shows the .NET Core 2.0 dependencies on different Linux dist
 | CentOS 7 <br> Oracle Linux 7 <br> RHEL 7 <br> OpenSUSE 42.2 <br> Fedora 25 | libunwind, libcurl, openssl-libs, libicu |
 | Fedora 26          | libunwind, libcurl, openssl-libs, libicu, compat-openssl10 |
 
-In order to deploy PowerShell binaries on Linux distributions that are not officially supported,
-you would need to install the necessary dependencies for the target OS in separate steps.
-For example, our [Amazon Linux dockerfile][amazon-dockerfile] installs dependencies first,
-and then extracts the Linux `tar.gz` archive.
+In order to deploy PowerShell binaries on Linux distributions that are not officially supported, you would need to install the necessary dependencies for the target OS in separate steps. For example, our [Amazon Linux dockerfile][amazon-dockerfile] installs dependencies first, and then extracts the Linux `tar.gz` archive.
 
 [amazon-dockerfile]: https://github.com/PowerShell/PowerShell/blob/master/docker/community/amazonlinux/Dockerfile
 
@@ -736,38 +731,38 @@ and then extracts the Linux `tar.gz` archive.
 
 ```sh
 # Download the powershell '.tar.gz' archive
-curl -L -o /tmp/powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-rc/powershell-6.0.0-rc-linux-x64.tar.gz
+curl -L -o /tmp/powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell-6.0.0-linux-x64.tar.gz
 
 # Create the target folder where powershell will be placed
-sudo mkdir -p /opt/microsoft/powershell/6.0.0-rc
+sudo mkdir -p /opt/microsoft/powershell/6.0.0
 
 # Expand powershell to the target folder
-sudo tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/6.0.0-rc
+sudo tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/6.0.0
 
 # Set execute permissions
-sudo chmod +x /usr/local/microsoft/powershell/6.0.0-rc/pwsh
+sudo chmod +x /usr/local/microsoft/powershell/6.0.0/pwsh
 
 # Create the symbolic link that points to pwsh
-sudo ln -s /opt/microsoft/powershell/6.0.0-rc/pwsh /usr/bin/pwsh
+sudo ln -s /opt/microsoft/powershell/6.0.0/pwsh /usr/bin/pwsh
 ```
 
 #### macOS
 
 ```sh
 # Download the powershell '.tar.gz' archive
-curl -L -o /tmp/powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-rc/powershell-6.0.0-rc-osx-x64.tar.gz
+curl -L -o /tmp/powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell-6.0.0-osx-x64.tar.gz
 
 # Create the target folder where powershell will be placed
-sudo mkdir -p /usr/local/microsoft/powershell/6.0.0-rc
+sudo mkdir -p /usr/local/microsoft/powershell/6.0.0
 
 # Expand powershell to the target folder
-sudo tar zxf /tmp/powershell.tar.gz -C /usr/local/microsoft/powershell/6.0.0-rc
+sudo tar zxf /tmp/powershell.tar.gz -C /usr/local/microsoft/powershell/6.0.0
 
 # Set execute permissions
-sudo chmod +x /usr/local/microsoft/powershell/6.0.0-rc/pwsh
+sudo chmod +x /usr/local/microsoft/powershell/6.0.0/pwsh
 
 # Create the symbolic link that points to pwsh
-sudo ln -s /usr/local/microsoft/powershell/6.0.0-rc/pwsh /usr/local/bin/pwsh
+sudo ln -s /usr/local/microsoft/powershell/6.0.0/pwsh /usr/local/bin/pwsh
 ```
 
 ### Uninstallation - Binary Archives
@@ -786,7 +781,7 @@ sudo rm -rf /usr/local/bin/pwsh /usr/local/microsoft/powershell
 
 ## Paths
 
-* `$PSHOME` is `/opt/microsoft/powershell/6.0.0-rc/`
+* `$PSHOME` is `/opt/microsoft/powershell/6.0.0/`
 * User profiles will be read from `~/.config/powershell/profile.ps1`
 * Default profiles will be read from `$PSHOME/profile.ps1`
 * User modules will be read from `~/.local/share/powershell/Modules`
@@ -794,15 +789,11 @@ sudo rm -rf /usr/local/bin/pwsh /usr/local/microsoft/powershell
 * Default modules will be read from `$PSHOME/Modules`
 * PSReadline history will be recorded to `~/.local/share/powershell/PSReadLine/ConsoleHost_history.txt`
 
-The profiles respect PowerShell's per-host configuration,
-so the default host-specific profiles exists at `Microsoft.PowerShell_profile.ps1` in the same locations.
+The profiles respect PowerShell's per-host configuration, so the default host-specific profiles exists at `Microsoft.PowerShell_profile.ps1` in the same locations.
 
 On Linux and macOS, the [XDG Base Directory Specification][xdg-bds] is respected.
 
-Note that because macOS is a derivation of BSD,
-instead of `/opt`, the prefix used is `/usr/local`.
-Thus, `$PSHOME` is `/usr/local/microsoft/powershell/6.0.0-rc/`,
-and the symlink is placed at `/usr/local/bin/pwsh`.
+Note that because macOS is a derivation of BSD, instead of `/opt`, the prefix used is `/usr/local`. Thus, `$PSHOME` is `/usr/local/microsoft/powershell/6.0.0/`, and the symlink is placed at `/usr/local/bin/pwsh`.
 
 [releases]: https://github.com/PowerShell/PowerShell/releases/latest
 [xdg-bds]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html


### PR DESCRIPTION
Corrected links and names to match the 6.0.0 release.

Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
