### PR TITLE
Removes unnecessary description about the RunAsAdministrator parameter

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -98,19 +98,6 @@ For example,
 #Requires -ShellId MyLocalShell
 ```
 
--RunAsAdministrator
-
-When this switch parameter is added to your requires statement, it specifies
-that the Windows PowerShell session in which you are running the script must
-be started with elevated user rights (Run as Administrator). This switch was
-introduced in PowerShell 4.
-
-For example,
-
-```powershell
-#Requires -RunAsAdministrator
-```
-
 ### EXAMPLES
 
 The following script has two \#Requires statements. If the requirements

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -102,8 +102,7 @@ For example,
 
 When this switch parameter is added to your requires statement, it specifies
 that the Windows PowerShell session in which you are running the script must
-be started with elevated user rights (Run as Administrator). This switch was
-introduced in PowerShell 4.
+be started with elevated user rights (Run as Administrator).
 
 For example,
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -102,8 +102,7 @@ For example,
 
 When this switch parameter is added to your requires statement, it specifies
 that the Windows PowerShell session in which you are running the script must
-be started with elevated user rights (Run as Administrator). This switch was
-introduced in PowerShell 4.
+be started with elevated user rights (Run as Administrator).
 
 For example,
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -102,8 +102,7 @@ For example,
 
 When this switch parameter is added to your requires statement, it specifies
 that the Windows PowerShell session in which you are running the script must
-be started with elevated user rights (Run as Administrator). This switch was
-introduced in PowerShell 4.
+be started with elevated user rights (Run as Administrator).
 
 For example,
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -102,8 +102,7 @@ For example,
 
 When this switch parameter is added to your requires statement, it specifies
 that the Windows PowerShell session in which you are running the script must
-be started with elevated user rights (Run as Administrator). This switch was
-introduced in PowerShell 4.
+be started with elevated user rights (Run as Administrator).
 
 For example,
 


### PR DESCRIPTION
There is no need to have documentation for functions which do not exists in the product.
There is no need to specify in which version this feature was added. Otherwise we need to add such remarks to many other features as well.

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
