### PR TITLE
Fix Example 2 in Set-PSReadlineKeyHandler.md

### DIFF
--- a/reference/5.0/PSReadline/Set-PSReadlineKeyHandler.md
+++ b/reference/5.0/PSReadline/Set-PSReadlineKeyHandler.md
@@ -41,11 +41,11 @@ PS C:\> Set-PSReadlineKeyHandler -Chord UpArrow -Function HistorySearchBackward
 This command binds the up arrow key to the function HistorySearchBackward, which uses the currently-entered command line as the start of the search string when it is searching through command history.
 
 ### Example 2: Bind a key to a script block
-```
-PS C:\> Set-PSReadlineKeyHandler -Chord Shift+Ctrl+B -ScriptBlock { 
-  [PSConsoleUtilities.PSConsoleReadLine]::RevertLine() 
-  [PSConsoleUtilities.PSConsoleReadLine]::Insert('build')
-      [PSConsoleUtilities.PSConsoleReadLine]::AcceptLine()
+```powershell
+Set-PSReadlineKeyHandler -Chord Ctrl+Shift+B -ScriptBlock { 
+	[Microsoft.PowerShell.PSConsoleReadLine]::RevertLine() 
+	[Microsoft.PowerShell.PSConsoleReadLine]::Insert('build')
+	[Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
 }
 ```
 

--- a/reference/5.1/PSReadline/Set-PSReadlineKeyHandler.md
+++ b/reference/5.1/PSReadline/Set-PSReadlineKeyHandler.md
@@ -41,11 +41,11 @@ PS C:\> Set-PSReadlineKeyHandler -Chord UpArrow -Function HistorySearchBackward
 This command binds the up arrow key to the function HistorySearchBackward, which uses the currently-entered command line as the start of the search string when it is searching through command history.
 
 ### Example 2: Bind a key to a script block
-```
-PS C:\> Set-PSReadlineKeyHandler -Chord Shift+Ctrl+B -ScriptBlock { 
-  [PSConsoleUtilities.PSConsoleReadLine]::RevertLine() 
-  [PSConsoleUtilities.PSConsoleReadLine]::Insert('build')
-      [PSConsoleUtilities.PSConsoleReadLine]::AcceptLine()
+```powershell
+Set-PSReadlineKeyHandler -Chord Ctrl+Shift+B -ScriptBlock { 
+	[Microsoft.PowerShell.PSConsoleReadLine]::RevertLine() 
+	[Microsoft.PowerShell.PSConsoleReadLine]::Insert('build')
+	[Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
 }
 ```
 

--- a/reference/6/PSReadLine/Set-PSReadlineKeyHandler.md
+++ b/reference/6/PSReadLine/Set-PSReadlineKeyHandler.md
@@ -41,11 +41,11 @@ PS C:\> Set-PSReadlineKeyHandler -Chord UpArrow -Function HistorySearchBackward
 This command binds the up arrow key to the function HistorySearchBackward, which uses the currently-entered command line as the start of the search string when it is searching through command history.
 
 ### Example 2: Bind a key to a script block
-```
-PS C:\> Set-PSReadlineKeyHandler -Chord Shift+Ctrl+B -ScriptBlock { 
-  [PSConsoleUtilities.PSConsoleReadLine]::RevertLine() 
-  [PSConsoleUtilities.PSConsoleReadLine]::Insert('build')
-      [PSConsoleUtilities.PSConsoleReadLine]::AcceptLine()
+```powershell
+Set-PSReadlineKeyHandler -Chord Ctrl+Shift+B -ScriptBlock { 
+	[Microsoft.PowerShell.PSConsoleReadLine]::RevertLine() 
+	[Microsoft.PowerShell.PSConsoleReadLine]::Insert('build')
+	[Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
 }
 ```
 


### PR DESCRIPTION
* `[PSConsoleUtilities.PSConsoleReadLine]` -> `[Microsoft.PowerShell.PSConsoleReadLine]`
* Shift+Ctrl+B -> Ctrl+Shift+B
* Added ```powershell
* Removed `PS C:\>`

Because running the example and pressing Ctrl+Shift+B causes the following error:
```
An exception occurred in custom key handler, see $error for more information:
 Unable to find type [PSConsoleUtilities.PSConsoleReadLine].
```

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in the above versions of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
