### PR TITLE
Fix Example 1 in Remove-PSReadlineKeyHandler.md

### DIFF
--- a/reference/5.0/PSReadline/Remove-PSReadlineKeyHandler.md
+++ b/reference/5.0/PSReadline/Remove-PSReadlineKeyHandler.md
@@ -26,12 +26,12 @@ Create a key binding by running the Set-PSReadlineKeyHandler cmdlet.
 ## EXAMPLES
 
 ### Example 1: Remove a binding
-```
-PS C:\> Remove-PSReadlineKeyHandler -Chord "Shift+Ctrl+B"
+```powershell
+Remove-PSReadlineKeyHandler -Chord Ctrl+Shift+B
 ```
 
 This command removes the binding from the key combination, or chord, Ctrl+Shift+B.
-The Ctrl+Shift+B chord is created in the Set-PSReadlineKeyHandler topic.
+The Ctrl+Shift+B chord is created in the `Set-PSReadlineKeyHandler` topic.
 
 ## PARAMETERS
 

--- a/reference/5.1/PSReadline/Remove-PSReadlineKeyHandler.md
+++ b/reference/5.1/PSReadline/Remove-PSReadlineKeyHandler.md
@@ -26,12 +26,12 @@ Create a key binding by running the Set-PSReadlineKeyHandler cmdlet.
 ## EXAMPLES
 
 ### Example 1: Remove a binding
-```
-PS C:\> Remove-PSReadlineKeyHandler -Chord "Shift+Ctrl+B"
+```powershell
+Remove-PSReadlineKeyHandler -Chord Ctrl+Shift+B
 ```
 
 This command removes the binding from the key combination, or chord, Ctrl+Shift+B.
-The Ctrl+Shift+B chord is created in the Set-PSReadlineKeyHandler topic.
+The Ctrl+Shift+B chord is created in the `Set-PSReadlineKeyHandler` topic.
 
 ## PARAMETERS
 

--- a/reference/6/PSReadLine/Remove-PSReadlineKeyHandler.md
+++ b/reference/6/PSReadLine/Remove-PSReadlineKeyHandler.md
@@ -26,12 +26,12 @@ Create a key binding by running the Set-PSReadlineKeyHandler cmdlet.
 ## EXAMPLES
 
 ### Example 1: Remove a binding
-```
-PS C:\> Remove-PSReadlineKeyHandler -Chord "Shift+Ctrl+B"
+```powershell
+Remove-PSReadlineKeyHandler -Chord Ctrl+Shift+B
 ```
 
 This command removes the binding from the key combination, or chord, Ctrl+Shift+B.
-The Ctrl+Shift+B chord is created in the Set-PSReadlineKeyHandler topic.
+The Ctrl+Shift+B chord is created in the `Set-PSReadlineKeyHandler` topic.
 
 ## PARAMETERS
 


### PR DESCRIPTION
* Shift+Ctrl+B -> Ctrl+Shift+B
* Added ```powershell
* Removed `PS C:\>`

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in the above versions of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
