### PR TITLE
Fix minor Markdown syntax error

### DIFF
--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-60.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-60.md
@@ -14,7 +14,7 @@ This means that Windows PowerShell exposes the API set offered by .NET Framework
 The APIs shared between .NET Core and .NET Framework are defined as part of [.NET Standard][].
 
 For more information on how this affects module/script compatibility between PowerShell Core and Windows PowerShell,
-see [Backwards compatibility with Windows PowerShell][#backwards-compatibility-with-windows-powershell]
+see [Backwards compatibility with Windows PowerShell](#backwards-compatibility-with-windows-powershell).
 
 ## Support for macOS and Linux
 


### PR DESCRIPTION
"Backwards compatibility with Windows PowerShell" anchor reference had incorrect Markdown syntax. Rendered incorrectly on both GitHub and Docs:

![image](https://user-images.githubusercontent.com/732366/34990060-1f4a301c-fade-11e7-9dfc-f1763c553d81.png)

**NOTE:** GitHub diff shows line 403 as changed, but I did not touch that one at all.

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 6.0 of PowerShell
- [x] This issue only shows up in version 6.0 of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
