### PR TITLE
update file encoding of New-ModuleManifest

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/6/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -47,7 +47,7 @@ Unless specified in the parameter description, if you omit a parameter from the 
 In Windows PowerShell 2.0, **New-ModuleManifest** prompts you for the values of frequently used parameters that are not specified in the command, in addition to required parameter values.
 Starting in Windows PowerShell 3.0, it prompts only when required parameter values are not specified.
 
-Module manifest (.psd1) file encoding depends on environment: if it is PowerShell Core running on Linux then encoding is UTF-8 (no BOM); otherwise encoding is UTF-16 (with BOM).
+Module manifest (.psd1) file encoding is UTF-8 (no BOM) on all platforms.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Change in PSCore6.1 for file encoding of New-ModuleManifest to be UTF-8 NoBOM: https://github.com/PowerShell/PowerShell/pull/5923

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version (6.1) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
