### PR TITLE
Continuation of #2057

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -29,7 +29,6 @@ functions, cmdlets, or snap-ins.
 #Requires -PSSnapin <PSSnapin-Name> [-Version <N>[.<n>]]
 #Requires -Modules { <Module-Name> | <Hashtable> }
 #Requires -ShellId <ShellId>
-#Requires -RunAsAdministrator
 ```
 
 ### RULES FOR USE


### PR DESCRIPTION
The reasons to remove are the same as in #2057. I just forgot about the SYNTAX section.

Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [x] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 4.0 of PowerShell
- [x] This issue only shows up in version 3.0 of the document
