### PR TITLE
Escapes angle brackets in about_Requires

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -39,7 +39,7 @@ functions, cmdlets, or snap-ins.
 
 ### PARAMETERS
 
--Version <N>[.<n>]
+-Version \<N\>[.\<n\>]
 
 Specifies the minimum version of Windows PowerShell that the script requires.
 Enter a major version number and optional minor version number.
@@ -50,7 +50,7 @@ For example:
 #Requires -Version 3.0
 ```
 
--PSSnapin <PSSnapin-Name> [-Version <N>[.<n>]]
+-PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
 
 Specifies a Windows PowerShell snap-in that the script requires. Enter the
 snap-in name and an optional version number.
@@ -61,7 +61,7 @@ For example:
 #Requires -PSSnapin DiskSnapin -Version 1.2
 ```
 
--Modules <Module-Name> &#124; <Hashtable>
+-Modules \<Module-Name\> &#124; \<Hashtable\>
 
 Specifies Windows PowerShell modules that the script requires. Enter the
 module name and an optional version number. The Modules parameter is

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -40,7 +40,7 @@ functions, cmdlets, or snap-ins.
 
 ### PARAMETERS
 
--Version <N>[.<n>]
+-Version \<N\>[.\<n\>]
 
 Specifies the minimum version of Windows PowerShell that the script requires.
 Enter a major version number and optional minor version number.
@@ -51,7 +51,7 @@ For example:
 #Requires -Version 3.0
 ```
 
--PSSnapin <PSSnapin-Name> [-Version <N>[.<n>]]
+-PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
 
 Specifies a Windows PowerShell snap-in that the script requires. Enter the
 snap-in name and an optional version number.
@@ -62,7 +62,7 @@ For example:
 #Requires -PSSnapin DiskSnapin -Version 1.2
 ```
 
--Modules <Module-Name> &#124; <Hashtable>
+-Modules \<Module-Name\> &#124; \<Hashtable\>
 
 Specifies Windows PowerShell modules that the script requires. Enter the
 module name and an optional version number. The Modules parameter is

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -40,7 +40,7 @@ functions, cmdlets, or snap-ins.
 
 ### PARAMETERS
 
--Version <N>[.<n>]
+-Version \<N\>[.\<n\>]
 
 Specifies the minimum version of Windows PowerShell that the script requires.
 Enter a major version number and optional minor version number.
@@ -51,7 +51,7 @@ For example:
 #Requires -Version 3.0
 ```
 
--PSSnapin <PSSnapin-Name> [-Version <N>[.<n>]]
+-PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
 
 Specifies a Windows PowerShell snap-in that the script requires. Enter the
 snap-in name and an optional version number.
@@ -62,7 +62,7 @@ For example:
 #Requires -PSSnapin DiskSnapin -Version 1.2
 ```
 
--Modules <Module-Name> &#124; <Hashtable>
+-Modules \<Module-Name\> &#124; \<Hashtable\>
 
 Specifies Windows PowerShell modules that the script requires. Enter the
 module name and an optional version number. The Modules parameter is

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -40,7 +40,7 @@ functions, cmdlets, or snap-ins.
 
 ### PARAMETERS
 
--Version <N>[.<n>]
+-Version \<N\>[.\<n\>]
 
 Specifies the minimum version of Windows PowerShell that the script requires.
 Enter a major version number and optional minor version number.
@@ -51,7 +51,7 @@ For example:
 #Requires -Version 3.0
 ```
 
--PSSnapin <PSSnapin-Name> [-Version <N>[.<n>]]
+-PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
 
 Specifies a Windows PowerShell snap-in that the script requires. Enter the
 snap-in name and an optional version number.
@@ -62,7 +62,7 @@ For example:
 #Requires -PSSnapin DiskSnapin -Version 1.2
 ```
 
--Modules <Module-Name> &#124; <Hashtable>
+-Modules \<Module-Name\> &#124; \<Hashtable\>
 
 Specifies Windows PowerShell modules that the script requires. Enter the
 module name and an optional version number. The Modules parameter is

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -40,7 +40,7 @@ functions, cmdlets, or snap-ins.
 
 ### PARAMETERS
 
--Version <N>[.<n>]
+-Version \<N\>[.\<n\>]
 
 Specifies the minimum version of Windows PowerShell that the script requires.
 Enter a major version number and optional minor version number.
@@ -51,7 +51,7 @@ For example:
 #Requires -Version 3.0
 ```
 
--PSSnapin <PSSnapin-Name> [-Version <N>[.<n>]]
+-PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
 
 Specifies a Windows PowerShell snap-in that the script requires. Enter the
 snap-in name and an optional version number.
@@ -62,7 +62,7 @@ For example:
 #Requires -PSSnapin DiskSnapin -Version 1.2
 ```
 
--Modules <Module-Name> &#124; <Hashtable>
+-Modules \<Module-Name\> &#124; \<Hashtable\>
 
 Specifies Windows PowerShell modules that the script requires. Enter the
 module name and an optional version number. The Modules parameter is


### PR DESCRIPTION
This change makes content in this brackets displayable

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
