### PR TITLE
Rename PowerShellProperties.json to powershell.config.json

### DIFF
--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-60.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-60.md
@@ -248,7 +248,7 @@ For more information about PowerShell jobs, see [about_Jobs](https://msdn.micros
   `$IsWindows`, `$IsMacOs`, and `$IsLinux`.
 - Add `GitCommitId` to PowerShell Core banner.
   Now you don't have to run `$PSVersionTable` as soon as you start PowerShell to get the version! (#3916) (Thanks to @iSazonov!)
-- Add a JSON config file called `PowerShellProperties.json` in `$PSHome` to store some settings required before startup time (e.g. `ExecutionPolicy`).
+- Add a JSON config file called `powershell.config.json` in `$PSHome` to store some settings required before startup time (e.g. `ExecutionPolicy`).
 - Don't block pipeline when running Windows EXE's
 - Enabled enumeration of COM collections. (#4553)
 


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->

`PowerShellProperties.json` was renamed to `powershell.config.json`.

See these commit and pull request : 

* [Rename 'PowerShellProperties.json' to 'powershell.config.json'](https://github.com/PowerShell/PowerShell/commit/3b5badca047acb5e979e21bce80a1e988535b872)
* [Change 'PowerShellProperties.json' to 'powershell.config.json' in about_logging](https://github.com/PowerShell/PowerShell-Docs/pull/2050)

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
