### PR TITLE
fix typo

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Variables.md
@@ -43,7 +43,7 @@ remote variable must be defined in the same PSSession.
 ```powershell
 $s = New-PSSession -ComputerName S1
 Invoke-Command -ComputerName S1 -ScriptBlock {$ps = "Windows PowerShell"}
-Invoke-Command -Sessions $s -ScriptBlock {Get-WinEvent -LogName $ps}
+Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $ps}
 ```
 
 ## USING LOCAL VARIABLES
@@ -76,7 +76,7 @@ You can also use the Using scope modifier in PSSessions.
 ```powershell
 $s = New-PSSession -ComputerName S1
 $ps = "Windows PowerShell"
-Invoke-Command -Sessions $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
+Invoke-Command -Session $s -ScriptBlock {Get-WinEvent -LogName $Using:ps}
 ```
 
 ## USING LOCAL VARIABLES IN WINDOWS POWERSHELL 2.0


### PR DESCRIPTION
fix typo of invoke-command session parameter

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

