### PR TITLE
Minor typo fix in Format-List.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-List.md
@@ -209,7 +209,7 @@ Required: False
 Position: 0
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -ShowError


### PR DESCRIPTION
Changed the value of "Accept wildcard characters" from "False" to "True" for the "-Property" parameter. Example 4 clearly shows that this parameter accepts wildcards.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
