### PR TITLE
Adds foreach & where method added in PowerShell v4

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Arrays.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Arrays.md
@@ -437,6 +437,9 @@ for each element of the array.
 The following example shows how use the foreach method. In this case the
 intent is to generate the square value of the elements in the array.
 
+Please note this method was added in PowerShell v4 and is not available in versions below this. 
+For prior versions please use the Pipelining method to the ForEach-Object Cmdlet
+
 ```powershell
 $a = @(0 .. 3)
 $a.ForEach({ $_ * $_})
@@ -477,6 +480,9 @@ the element to show after the `Where`
 > The syntax requires the usage of curly brackets; parenthesis are optional
 
 The following example shows how to select all odd numbers from the array.
+
+Please note this method was added in PowerShell v4 and is not available in versions below this. 
+For prior versions please use the Pipelining method to the Where-Object Cmdlet
 
 ```powershell
 @(0..9).Where{ $_ % 2 }


### PR DESCRIPTION
Adding details about foreach & where methods being added in PowerShell v4 and that they aren't available downlevel (for historical purposes) and also points to using the Pipeline methods with the resulting Foreach-Object & Where-Object cmdlets

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
