### PR TITLE
Document -Path aliases added to several cmdlets

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/6/Microsoft.PowerShell.Core/Save-Help.md
@@ -189,7 +189,7 @@ Do not specify a file name or file name extension.
 ```yaml
 Type: String[]
 Parameter Sets: Path
-Aliases: 
+Aliases: Path
 
 Required: True
 Position: 0

--- a/reference/6/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/6/Microsoft.PowerShell.Core/Update-Help.md
@@ -374,7 +374,7 @@ For more information, see about_Group_Policy_Settings (http://go.microsoft.com/f
 ```yaml
 Type: String[]
 Parameter Sets: Path
-Aliases: 
+Aliases: Path
 
 Required: False
 Position: 1

--- a/reference/6/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/New-Service.md
@@ -67,7 +67,7 @@ This parameter is required.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: Path
 
 Required: True
 Position: 2

--- a/reference/6/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/6/Microsoft.PowerShell.Management/Start-Process.md
@@ -167,7 +167,7 @@ If you specify only a file name, use the *WorkingDirectory* parameter to specify
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: PSPath
+Aliases: PSPath, Path
 
 Required: True
 Position: 1

--- a/reference/6/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -81,7 +81,7 @@ If you use this parameter to start the trace, use the *RemoveFileListener* param
 ```yaml
 Type: String
 Parameter Sets: optionsSet
-Aliases: PSPath
+Aliases: PSPath, Path
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -106,7 +106,7 @@ Specifies a file that this cmdlet saves the object to Wildcard characters are pe
 ```yaml
 Type: String
 Parameter Sets: File
-Aliases: 
+Aliases: Path
 
 Required: True
 Position: 0

--- a/reference/6/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -139,7 +139,7 @@ This parameter also selects the file trace listener.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: PSPath
+Aliases: PSPath, Path
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.WSMan.Management/Invoke-WSManAction.md
+++ b/reference/6/Microsoft.WSMan.Management/Invoke-WSManAction.md
@@ -279,7 +279,7 @@ The file, Input.xml, contains the following content:
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases: Path
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.WSMan.Management/New-WSManInstance.md
+++ b/reference/6/Microsoft.WSMan.Management/New-WSManInstance.md
@@ -201,7 +201,7 @@ You specify the management resource by using the *ResourceURI* parameter and the
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases: Path
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.WSMan.Management/Set-WSManInstance.md
+++ b/reference/6/Microsoft.WSMan.Management/Set-WSManInstance.md
@@ -282,7 +282,7 @@ You specify the management resource by using the *ResourceURI* parameter and the
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: 
+Aliases: Path
 
 Required: False
 Position: Named


### PR DESCRIPTION
add Path alias to DestinationPath for Save-Help
add Path alias to SourcePath for Update-Help
add Path alias to BinaryPathName for New-Service
add Path alias to FilePath for Start-Process, Set-TraceSource, Tee-Object, Trace-Command, Invoke-WSManAction, New-WSManInstance, and Set-WSManInstance


Version(s) of document impacted
------------------------------
- [X] Impacts 6 document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version 6.1 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
