### PR TITLE
Remove `Get-Process -ComputerName` example in Debug-Process.md v6.0

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Debug-Process.md
+++ b/reference/6/Microsoft.PowerShell.Management/Debug-Process.md
@@ -90,17 +90,7 @@ Then, it uses a pipeline operator (|) to send the process ID to the **Debug-Proc
 
 For more information about the $PID automatic variable, see about_Automatic_Variables.
 
-### Example 7: Attach a debugger to the specified process on multiple computers
-```
-PS C:\> Get-Process -ComputerName "Server01", "Server02" -Name "MyApp" | Debug-Process
-```
-
-This command attaches a debugger to the MyApp processes on the Server01 and Server02 computers.
-
-The command uses the **Get-Process** cmdlet to get the MyApp processes on the Server01 and Server02 computers.
-It uses a pipeline operator to send the processes to the Debug-Process cmdlet, which attaches the debuggers.
-
-### Example 8: Attach a debugger to a process that uses the InputObject parameter
+### Example 7: Attach a debugger to a process that uses the InputObject parameter
 ```
 PS C:\> $P = Get-Process "Windows PowerShell"
 PS C:\> Debug-Process -InputObject $P


### PR DESCRIPTION
`Get-Process -ComputerName` parameter is not supported since v6.0. See PowerShell/PowerShell#4960

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version 6.0 of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
