### PR TITLE
Fix and add OUTPUTS in Get-Runspace.md

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Runspace.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Runspace.md
@@ -99,6 +99,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
+### System.Management.Automation.Runspaces.Runspace
+You can pipe the results of a `Get-Runspace` command to `Debug-Runspace`.
+
 ## NOTES
 
 ## RELATED LINKS

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Runspace.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Runspace.md
@@ -141,8 +141,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### System.Management.Automation.Runspaces.RunspaceBase
-You can pipe the results of a **Get-Runspace** command to **Debug-Runspace**.
+### System.Management.Automation.Runspaces.Runspace
+You can pipe the results of a `Get-Runspace` command to `Debug-Runspace`.
 
 ## NOTES
 

--- a/reference/6/Microsoft.PowerShell.Utility/Get-Runspace.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Runspace.md
@@ -96,6 +96,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
+### System.Management.Automation.Runspaces.Runspace
+You can pipe the results of a `Get-Runspace` command to `Debug-Runspace`.
+
 ## NOTES
 
 ## RELATED LINKS


### PR DESCRIPTION
`Get-Runspace` returns subclass objects derived from `System.Management.Automation.Runspaces.Runspace` public abstract class. 
```powershell
PS> (Get-Command Get-Runspace).OutputType | Format-List

Name              : System.Management.Automation.Runspaces.Runspace
Type              : System.Management.Automation.Runspaces.Runspace
TypeDefinitionAst :
```

`System.Management.Automation.Runspaces.RunspaceBase` is [an internal class derived from the Runspace class](https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs#L24).
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in the above versions of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
