### PR TITLE
Fixed a typo

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Register-WmiEvent.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Register-WmiEvent.md
@@ -58,7 +58,7 @@ This class raises an event whenever a process starts.
 
 ### Example 2: Subscribe to creation events for a process
 ```
-PS C:\> Register-WmiEvent -Auery "select * from __instancecreationevent within 5 where targetinstance isa 'win32_process'" -SourceIdentifier "WMIProcess" -MessageData "Test 01" -TimeOut 500
+PS C:\> Register-WmiEvent -Query "select * from __instancecreationevent within 5 where targetinstance isa 'win32_process'" -SourceIdentifier "WMIProcess" -MessageData "Test 01" -TimeOut 500
 ```
 
 This command uses a query to subscribe to Win32_process instance creation events.


### PR DESCRIPTION
Fixed a typo in argument of "Example 2: Subscribe to creation events for a process", changed argument from Auery to Query.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document (as 6 redirects to 5.1 document)
- [x] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (5.1 and 6 (as 6 redirects to 5.1 document) ) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
