### PR TITLE
Remove SkipCertificateCheck flag

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -115,7 +115,7 @@ $Body = @{
     earliest_time = "-2d@d"
     latest_time = "-1d@d"
 }
-Invoke-RestMethod -Method 'Post' -Uri $url -Credential $Cred -Body $body -SkipCertificateCheck -OutFile output.csv
+Invoke-RestMethod -Method 'Post' -Uri $url -Credential $Cred -Body $body -OutFile output.csv
 ```
 
 In the above example, a user runs `Invoke-RestMethod` to perform a POST request on an intranet website in the user's organization.


### PR DESCRIPTION
Example #2 in its current form is unsafe, because it includes the SkipCertificateCheck flag for no documented reason. If a user based their solution off of the example and did not notice the needed to remove the flag, they could create a security vulnerability.

Removing the flag does not appear to impact the example in any way other than to resolve this problem.

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version 6 of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work

