### PR TITLE
Clarify the docs regarding libcurl for installation on openSUSE

### DIFF
--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS-and-Linux.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS-and-Linux.md
@@ -387,10 +387,21 @@ sudo yum remove powershell
 
 ## OpenSUSE 42.2
 
-> **Note:** When installing PowerShell Core, OpenSUSE may report that nothing provides `libcurl`.
-`libcurl` should already be installed on supported versions of OpenSUSE.
-Run `zypper search libcurl` to confirm.
-The error will present 2 'solutions'. Choose 'Solution 2' to continue installing PowerShell Core.
+> **Note:** When installing PowerShell Core, `zypper` may report the following error:
+>
+> ```text
+> Problem: nothing provides libcurl needed by powershell-6.0.1-1.rhel.7.x86_64
+>  Solution 1: do not install powershell-6.0.1-1.rhel.7.x86_64
+>  Solution 2: break powershell-6.0.1-1.rhel.7.x86_64 by ignoring some of its dependencies
+> ```
+>
+> In this case, verify that a compatible `libcurl` library is present by checking that the following command shows the `libcurl4` package as installed:
+>
+> ```sh
+> zypper search --file-list --match-exact '/usr/lib64/libcurl.so.4'
+> ```
+>
+> Then choose the `break powershell-6.0.1-1.rhel.7.x86_64 by ignoring some of its dependencies` solution when installing the `powershell` package.
 
 ### Installation via Package Repository (preferred) - OpenSUSE 42.2
 


### PR DESCRIPTION
- Explicitly mention the conflict error and the solution.

- Make the command that looks for libcurl more precise, since the goal is to find the specific package that places the lib in the place where the RHEL PS package looks for it.

Ref: https://github.com/PowerShell/PowerShell/issues/6184

Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 6 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
