### PR TITLE
Test-Connection Default Count value is 4 not None

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Test-Connection.md
@@ -238,7 +238,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 4
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/5.1/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Test-Connection.md
@@ -200,7 +200,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 4
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/6/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/6/Microsoft.PowerShell.Management/Test-Connection.md
@@ -201,7 +201,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 4
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
Currently the text description clearly describes the default functionality: four pings are sent.
The documentation for the Count's Default value stated that None was default which was false.

This change in documentation happened at PowerShell 5.0 docs, prior to that it clearly states `Default value: 4`

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (5.0, 5.1, 6.0) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work

