### PR TITLE
Fix ordering of example and description text

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Security/Protect-CmsMessage.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/Protect-CmsMessage.md
@@ -16,18 +16,18 @@ Encrypts content by using the Cryptographic Message Syntax format.
 ## SYNTAX
 
 ### ByContent (Default)
-```
+```PowerShell
 Protect-CmsMessage [-To] <CmsMessageRecipient[]> [-Content] <PSObject> [[-OutFile] <String>]
  [<CommonParameters>]
 ```
 
 ### ByPath
-```
+```PowerShell
 Protect-CmsMessage [-To] <CmsMessageRecipient[]> [-Path] <String> [[-OutFile] <String>] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
-```
+```PowerShell
 Protect-CmsMessage [-To] <CmsMessageRecipient[]> [-LiteralPath] <String> [[-OutFile] <String>]
  [<CommonParameters>]
 ```
@@ -49,7 +49,11 @@ For an example of a certificate that would work for document encryption, see Exa
 ## EXAMPLES
 
 ### Example 1: Create a certificate for encrypting content
-```
+
+Before you can run the **Protect-CmsMessage** cmdlet, you must create an encryption certificate.
+Using the following text, change the name in the Subject line to your name, email, or other identifier, and save the certificate in a file (such as DocumentEncryption.inf, as shown in this example).
+
+```PowerShell
 PS C:\> # Create .INF file for certreq
 
 PS C:\> {[Version]
@@ -79,24 +83,24 @@ ValidityPeriodUnits = "1000"
 PS C:\> Certreq -new DocumentEncryption.inf DocumentEncryption.cer
 ```
 
-Before you can run the **Protect-CmsMessage** cmdlet, you must create an encryption certificate.
-Using the following text, change the name in the Subject line to your name, email, or other identifier, and save the certificate in a file (such as DocumentEncryption.inf, as shown in this example).
-
 ### Example 2: Encrypt a message sent by email
-```
+
+In the following example, you encrypt a message, Hello World, by saving the message in a variable, and then piping it to the **Protect-CmsMessage** cmdlet.
+
+The *To* parameter uses the value of the Subject line in the certificate.
+
+```PowerShell
 PS C:\> $Protected = "Hello World" | Protect-CmsMessage -To "*youralias@emailaddress.com*"
 ```
 
-In the following example, you encrypt a message, Hello World, by saving the message in a variable, and then piping it to the **Protect-CmsMessage** cmdlet.
-The *To* parameter uses the value of the Subject line in the certificate.
-
 ### Example 3: View document encryption certificates
-```
+
+```PowerShell
 PS C:\> 58 [Cert:\currentuser\my]
 >> Get-ChildItem -DocumentEncryptionCert
 ```
 
-To view document encryption certificates in the certificate provider, you can add the *DocumentEncryptionCert* dynamic parameter of Get-ChildItemhttp://technet.microsoft.com/library/hh847761.aspx, available only when the certificate provider is loaded.
+To view document encryption certificates in the certificate provider, you can add the *DocumentEncryptionCert* dynamic parameter of [Get-ChildItem](../Microsoft.PowerShell.Management/Get-ChildItem.md), available only when the certificate provider is loaded.
 
 ## PARAMETERS
 


### PR DESCRIPTION
The description text for the examples referred to 'following..' while the example it referenced preceded it. I move the description above each example code. Also fixed code highlighting and the link to Get-ChildItem.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
