### PR TITLE
$PSVersionTable.Platform returns Unix on macOS

### DIFF
--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-60.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-60.md
@@ -239,7 +239,7 @@ For more information about PowerShell jobs, see [about_Jobs](https://msdn.micros
     On released builds, it will likely be the same as `PSVersion`.
   - `OS`: This is an OS version string returned by `[System.Runtime.InteropServices.RuntimeInformation]::OSDescription`
   - `Platform`: This is returned by `[System.Environment]::OSVersion.Platform`
-    It is set to `Win32NT` on Windows, `MacOSX` on macOS, and `Unix` on Linux.
+    It is set to `Win32NT` on Windows, `Unix` on macOS, and `Unix` on Linux.
 - Removed the `BuildVersion` property from `$PSVersionTable`.
   This property was strongly tied to the Windows build version.
   Instead, we recommend that you use `GitCommitId` to retrieve the exact build version of PowerShell Core. (#3877) (Thanks to @iSazonov!)


### PR DESCRIPTION
Fix https://github.com/PowerShell/PowerShell/issues/6513

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6.1 document
- [X] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version 6.0 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work