### PR TITLE
Update docs with the info about session configurations created by Enable-PSRemoting cmdlet.

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -195,7 +195,9 @@ supported versions of Windows, you must change the security descriptors of the
 session configurations to allow remote access.
 
 To enable remote access to the session configurations on the computer, use the
-Enable-PSRemoting cmdlet.
+Enable-PSRemoting cmdlet. This cmdlet creates two session configurations:
+- with the name defined as: "PowerShell." + "current PowerShell version"
+- with name "PowerShell.6", untied to any specific PowerShell version.
 
 Also, by default, only members of the Administrators group on the computer
 have Execute permission to the default session configurations, but you can


### PR DESCRIPTION
Update docs with the info about session configurations created by Enable-PSRemoting cmdlet.
Now the command would create two session configurations:
- with the name defined as: "PowerShell." + "current PowerShell version"
- with name "PowerShell.6", untied to any specific PowerShell version.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work