### PR TITLE
Update MacOS instructions to use brew cask upgrade

### DIFF
--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS-and-Linux.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS-and-Linux.md
@@ -606,10 +606,10 @@ When new versions of PowerShell are released, simply update Homebrew's formulae 
 
 ```sh
 brew update
-brew cask reinstall powershell
+brew cask upgrade powershell
 ```
 
-> Note: because of [this issue in Cask](https://github.com/caskroom/homebrew-cask/issues/29301), you currently have to do a reinstall to upgrade.
+> Note: The commands above can be called from within a PowerShell (pwsh) host, but then the PowerShell shell must be exited and re-entered to complete the upgrade and refresh the values shown in $PSVersionTable.
 
 [brew]: http://brew.sh/
 [cask]: https://caskroom.github.io/


### PR DESCRIPTION
I just tested on my Macbook and confirmed that
```brew update
brew cask upgrade
```
successfully updated my instance from PS Core 6.0.1 to 6.0.2

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work