### PR TITLE
Add -Not Feature to Where-Object

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/6/Microsoft.PowerShell.Core/Where-Object.md
@@ -20,6 +20,11 @@ Selects objects from a collection based on their property values.
 Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-EQ] [<CommonParameters>]
 ```
 
+### NotSet
+```
+Where-Object [-Property] <string> -Not [-InputObject <psobject>] [<CommonParameters>]
+```
+
 ### ScriptBlockSet
 ```
 Where-Object [-InputObject <PSObject>] [-FilterScript] <ScriptBlock> [<CommonParameters>]
@@ -846,6 +851,25 @@ This parameter was introduced in Windows PowerShell 3.0.
 Type: SwitchParameter
 Parameter Sets: NotEqualSet
 Aliases: INE
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Not
+Indicates that this cmdlet gets objects if the property does not exist or has a value of null or false.
+
+For example: `Get-Service | where -Not "DependentServices"`
+
+This parameter was introduced in Windows PowerShell 6.1.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Not
+Aliases: 
 
 Required: True
 Position: Named


### PR DESCRIPTION
Add documentation for new parameter -Not on Where-Object added in PowerShell/PowerShell#6464  

Fix #2199

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work