### PR TITLE
Incorrectly documents -credential parameter

### DIFF
--- a/reference/6/PackageManagement/Register-PackageSource.md
+++ b/reference/6/PackageManagement/Register-PackageSource.md
@@ -55,7 +55,7 @@ If you do not add the *Trusted* parameter, by default, the package is not truste
 ## PARAMETERS
 
 ### -Credential
-Specifies a user account that has permission to install package providers.
+Specifies a user account that has permission to access the authenticated location.
 
 ```yaml
 Type: PSCredential


### PR DESCRIPTION
The current documentation says that -credential is for admin credentials to add a package source.  I believe it is instead the credentials required to access an authenticated feed location.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6.1 document
- [X] Impacts 6.0 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work