### PR TITLE
Update AutoRemoveJob in Receive-Job.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/Receive-Job.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Receive-Job.md
@@ -337,6 +337,8 @@ If the job has more results, the job is still deleted, but **Receive-Job** displ
 This parameter works only on custom job types.
 It is designed for instances of job types that save the job or the type outside of the session, such as instances of scheduled jobs.
 
+This parameter cannot be used without the **Wait** parameter.
+
 This parameter is introduced in Windows PowerShell 3.0.
 
 ```yaml

--- a/reference/4.0/Microsoft.PowerShell.Core/Receive-Job.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Receive-Job.md
@@ -159,6 +159,8 @@ If the job has more results, the job is still deleted, but **Receive-Job** displ
 This parameter works only on custom job types.
 It is designed for instances of job types that save the job or the type outside of the session, such as instances of scheduled jobs.
 
+This parameter cannot be used without the **Wait** parameter.
+
 This parameter is introduced in Windows PowerShell 3.0.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/Receive-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Receive-Job.md
@@ -158,6 +158,8 @@ If the job has more results, the job is still deleted, but **Receive-Job** displ
 This parameter works only on custom job types.
 It is designed for instances of job types that save the job or the type outside of the session, such as instances of scheduled jobs.
 
+This parameter cannot be used without the **Wait** parameter.
+
 This parameter was introduced in Windows PowerShell 3.0.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/Receive-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Receive-Job.md
@@ -158,6 +158,8 @@ If the job has more results, the job is still deleted, but **Receive-Job** displ
 This parameter works only on custom job types.
 It is designed for instances of job types that save the job or the type outside of the session, such as instances of scheduled jobs.
 
+This parameter cannot be used without the **Wait** parameter.
+
 This parameter was introduced in Windows PowerShell 3.0.
 
 ```yaml

--- a/reference/6/Microsoft.PowerShell.Core/Receive-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Receive-Job.md
@@ -158,6 +158,8 @@ If the job has more results, the job is still deleted, but **Receive-Job** displ
 This parameter works only on custom job types.
 It is designed for instances of job types that save the job or the type outside of the session, such as instances of scheduled jobs.
 
+This parameter cannot be used without the **Wait** parameter.
+
 This parameter was introduced in Windows PowerShell 3.0.
 
 ```yaml


### PR DESCRIPTION
The **AutoRemoveJob** parameter cannot be used without the **Wait** parameter. See the following example:

```powershell
PS> Receive-Job (Start-Job -ScriptBlock { Get-Process }) -AutoRemoveJob
Receive-Job : The -AutoRemoveJob parameter cannot be used without the -Wait parameter
At line:1 char:1
+ Receive-Job (Start-Job -ScriptBlock { Get-Process }) -AutoRemoveJob
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Receive-Job], PSInvalidOperationException
    + FullyQualifiedErrorId : InvalidOperation,Microsoft.PowerShell.Commands.ReceiveJobCommand
```

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
