### PR TITLE
update documentation to reflect that -ConfigurationName can be used with SSH

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -68,7 +68,8 @@ Enter-PSSession -ContainerId <String> [-ConfigurationName <String>] [-RunAsAdmin
 
 ### HostName
 ```
-Enter-PSSession [-HostName] <string> [-Port <int>] [-UserName <string>] [-KeyFilePath <string>] [-SSHTransport] [<CommonParameters>]
+Enter-PSSession [-HostName] <string> [-Port <int>] [-UserName <string>] [-KeyFilePath <string>] [-SSHTransport]
+ [-ConfigurationName <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -304,6 +305,9 @@ Specifies the session configuration that is used for the interactive session.
 Enter a configuration name or the fully qualified resource URI for a session configuration.
 If you specify only the configuration name, the following schema URI is prepended: http://schemas.microsoft.com/powershell.
 
+When used with SSH, this specifies the subsystem to use on the target as defined in sshd_config.
+The default value for SSH is the `powershell` subsystem.
+
 The session configuration for a session is located on the remote computer.
 If the specified session configuration does not exist on the remote computer, the command fails.
 
@@ -313,7 +317,7 @@ For more information, see about_Preference_Variables.
 
 ```yaml
 Type: String
-Parameter Sets: ComputerName, Uri, VMId, VMName, ContainerId
+Parameter Sets: ComputerName, Uri, VMId, VMName, ContainerId, HostName
 Aliases:
 
 Required: False

--- a/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -116,9 +116,9 @@ Invoke-Command [-ConfigurationName <String>] [-ThrottleLimit <Int32>] [-AsJob] [
 
 ### HostName
 ```
-Invoke-Command -ScriptBlock <scriptblock> -HostName <string[]> [-Port <int>] [-AsJob]
-[-HideComputerName] [-UserName <string>] [-KeyFilePath <string>] [-SSHTransport] [-RemoteDebug]
-[-InputObject <psobject>] [-ArgumentList <Object[]>] [<CommonParameters>]
+Invoke-Command [-ConfigurationName <String>] -ScriptBlock <scriptblock> -HostName <string[]> [-Port <int>]
+ [-AsJob] [-HideComputerName] [-UserName <string>] [-KeyFilePath <string>] [-SSHTransport] [-RemoteDebug]
+ [-InputObject <psobject>] [-ArgumentList <Object[]>] [<CommonParameters>]
 ```
 
 ### FilePathHostName
@@ -703,6 +703,9 @@ Specifies the session configuration that is used for the new **PSSession**.
 Enter a configuration name or the fully qualified resource URI for a session configuration.
 If you specify only the configuration name, the following schema URI is prepended: http://schemas.microsoft.com/PowerShell.
 
+When used with SSH, this specifies the subsystem to use on the target as defined in sshd_config.
+The default value for SSH is the `powershell` subsystem.
+
 The session configuration for a session is located on the remote computer.
 If the specified session configuration does not exist on the remote computer, the command fails.
 
@@ -712,7 +715,7 @@ For more information, see about_Preference_Variables.
 
 ```yaml
 Type: String
-Parameter Sets: ComputerName, FilePathComputerName, Uri, FilePathUri, VMId, VMName, FilePathVMId, FilePathVMName, ContainerId, FilePathContainerId
+Parameter Sets: ComputerName, FilePathComputerName, Uri, FilePathUri, VMId, VMName, FilePathVMId, FilePathVMName, ContainerId, FilePathContainerId, HostName
 Aliases:
 
 Required: False
@@ -1245,7 +1248,7 @@ Accept wildcard characters: False
 ```
 
 ### -SSHConnection
-This parameter takes an array of hashtables where each hashtable contains one or more connection parameters needed to establish a Secure Shell (SSH) connection (HostName, Port, UserName, KeyFilePath).
+This parameter takes an array of hashtables where each hashtable contains one or more connection parameters needed to establish a Secure Shell (SSH) connection (HostName, Port, UserName, KeyFilePath, Subsystem).
 
 The hashtable connection parameters are the same as defined for the HostName parameter set.
 

--- a/reference/6/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/New-PSSession.md
@@ -57,7 +57,8 @@ New-PSSession [-Name <String[]>] [-ConfigurationName <String>] -ContainerId <Str
 
 ### HostName
 ```
-New-PSSession [-HostName] <string[]> [-Name <string[]>] [-Port <int>] [-UserName <string>] [-KeyFilePath <string>] [-SSHTransport] [<CommonParameters>]
+New-PSSession [-HostName] <string[]> [-Name <string[]>] [-Port <int>] [-UserName <string>] [-KeyFilePath <string>
+ [-ConfigurationName <String>] [-SSHTransport] [<CommonParameters>]
 ```
 
 ### SSHConnection
@@ -367,6 +368,9 @@ Specifies the session configuration that is used for the new **PSSession**.
 Enter a configuration name or the fully qualified resource URI for a session configuration.
 If you specify only the configuration name, the following schema URI is prepended: http://schemas.microsoft.com/PowerShell.
 
+When used with SSH, this specifies the subsystem to use on the target as defined in sshd_config.
+The default value for SSH is the `powershell` subsystem.
+
 The session configuration for a session is located on the remote computer.
 If the specified session configuration does not exist on the remote computer, the command fails.
 
@@ -376,7 +380,7 @@ For more information, see [about_Preference_Variables](About/about_Preference_Va
 
 ```yaml
 Type: String
-Parameter Sets: ComputerName, VMName, Uri, VMId, ContainerId
+Parameter Sets: ComputerName, VMName, Uri, VMId, ContainerId, HostName
 Aliases:
 
 Required: False
@@ -770,7 +774,7 @@ Accept wildcard characters: False
 ```
 
 ### -SSHConnection
-This parameter takes an array of hashtables where each hashtable contains one or more connection parameters needed to establish a Secure Shell (SSH) connection (HostName, Port, UserName, KeyFilePath).
+This parameter takes an array of hashtables where each hashtable contains one or more connection parameters needed to establish a Secure Shell (SSH) connection (HostName, Port, UserName, KeyFilePath, Subsystem).
 
 The hashtable connection parameters are the same as defined for the **HostName** parameter set.
 


### PR DESCRIPTION
Update documentation to reflect code change https://github.com/PowerShell/PowerShell/pull/6603

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version (6.1) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work