### PR TITLE
update doc on new -workingdirectory parameter

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_pwsh.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_pwsh.md
@@ -31,6 +31,7 @@ pwsh[.exe]
 [-NoProfile]
 [-OutputFormat {Text | XML}]
 [-WindowStyle <style>]
+[-WorkingDirectory <DirectoryPath>]
 [-File <FilePath> [<Args>]]
 [-Command { - | <script-block> [-args <arg-array>]
 | <string> [<CommandParameters>] } ]
@@ -107,6 +108,12 @@ Determines how output from PowerShell is formatted. Valid values are "Text"
 Sets the window style for the session. Valid values are Normal, Minimized,
 Maximized and Hidden.
 
+#### -WorkingDirectory <DirectoryPath>
+
+Sets the initial working directory when starting PowerShell.  Any valid
+PowerShell file path is supported.
+
+To start PowerShell in your home directory, use: pwsh -WorkingDirectory ~
 #### -Command
 
 Executes the specified commands (and any parameters) as though they were typed
@@ -147,4 +154,6 @@ pwsh -Version
 pwsh -Command {Get-Command -Name Get-Command}
 
 pwsh -Command "& {Get-Command -Name Get-Command}"
+
+pwsh -WorkingDirectory ~/Downloads
 ```


### PR DESCRIPTION
Update docs based on code change to add -workingdirectory parameter to pwsh
https://github.com/PowerShell/PowerShell/pull/6612
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version (6.1) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work