### PR TITLE
Fix -replace operator example.

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -501,7 +501,7 @@ administrative tasks, such as renaming files. For example, the following
 command changes the file name extensions of all .gif files to .jpg:
 
 ```powershell
-Get-ChildItem | Rename-Item -NewName { $_ -replace '.gif$','.jpg$' }
+Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
 ```
 
 The syntax of the `-replace` operator is as follows, where the \<original>

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -501,7 +501,7 @@ administrative tasks, such as renaming files. For example, the following
 command changes the file name extensions of all .gif files to .jpg:
 
 ```powershell
-Get-ChildItem | Rename-Item -NewName { $_ -replace '.gif$','.jpg$' }
+Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
 ```
 
 The syntax of the `-replace` operator is as follows, where the \<original>

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -501,7 +501,7 @@ administrative tasks, such as renaming files. For example, the following
 command changes the file name extensions of all .gif files to .jpg:
 
 ```powershell
-Get-ChildItem | Rename-Item -NewName { $_ -replace '.gif$','.jpg$' }
+Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
 ```
 
 The syntax of the `-replace` operator is as follows, where the \<original>

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -501,7 +501,7 @@ administrative tasks, such as renaming files. For example, the following
 command changes the file name extensions of all .gif files to .jpg:
 
 ```powershell
-Get-ChildItem | Rename-Item -NewName { $_ -replace '.gif$','.jpg$' }
+Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
 ```
 
 The syntax of the `-replace` operator is as follows, where the \<original>

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -501,7 +501,7 @@ administrative tasks, such as renaming files. For example, the following
 command changes the file name extensions of all .gif files to .jpg:
 
 ```powershell
-Get-ChildItem | Rename-Item -NewName { $_ -replace '.gif$','.jpg$' }
+Get-ChildItem *.txt | Rename-Item -NewName { $_.name -replace '\.txt$','.log' }
 ```
 
 The syntax of the `-replace` operator is as follows, where the \<original>


### PR DESCRIPTION
Fix -replace operator example and bring it in accordance with Rename-Item cmdlet example.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work