### PR TITLE
Fix typo in the -HostName parameter description.

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -425,7 +425,7 @@ Specifies a computer name for a Secure Shell (SSH) based connection.
 This is similar to the *ComputerName* parameter except that the connection to the remote computer is made using SSH rather than Windows WinRM.
 This parameter supports specifying the user name and/or port as part of the host name parameter value using
 the form `user@hostname:port`.
-The user name and/or port specified as part of the host name takes precedent over the `-UserName` and `-Port` parameters, if specified.
+The user name and/or port specified as part of the host name takes precedence over the `-UserName` and `-Port` parameters, if specified.
 This allows passing multiple computer names to this parameter where some have specific user names and/or ports, while others use the user name and/or port from the `-UserName` and `-Port` parameters.
 
 This parameter was introduced in PowerShell 6.0.

--- a/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -1173,7 +1173,7 @@ Accept wildcard characters: False
 Specifies an array of computer names for a Secure Shell (SSH) based connection. This is similar to the ComputerName parameter except that the connection to the remote computer is made using SSH rather than Windows WinRM.
 This parameter supports specifying the user name and/or port as part of the host name parameter value using
 the form `user@hostname:port`.
-The user name and/or port specified as part of the host name takes precedent over the `-UserName` and `-Port` parameters, if specified.
+The user name and/or port specified as part of the host name takes precedence over the `-UserName` and `-Port` parameters, if specified.
 This allows passing multiple computer names to this parameter where some have specific user names and/or ports, while others use the user name and/or port from the `-UserName` and `-Port` parameters.
 
 This parameter was introduced in PowerShell 6.0.

--- a/reference/6/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/New-PSSession.md
@@ -699,7 +699,7 @@ Accept wildcard characters: False
 Specifies an array of computer names for a Secure Shell (SSH) based connection. This is similar to the ComputerName parameter except that the connection to the remote computer is made using SSH rather than Windows WinRM.
 This parameter supports specifying the user name and/or port as part of the host name parameter value using
 the form `user@hostname:port`.
-The user name and/or port specified as part of the host name takes precedent over the `-UserName` and `-Port` parameters, if specified.
+The user name and/or port specified as part of the host name takes precedence over the `-UserName` and `-Port` parameters, if specified.
 This allows passing multiple computer names to this parameter where some have specific user names and/or ports, while others use the user name and/or port from the `-UserName` and `-Port` parameters.
 
 This parameter was introduced in PowerShell 6.0.


### PR DESCRIPTION
Fix typo in the -HostName parameter description.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work