### PR TITLE
Update Example 1 in Format-Table.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Format-Table.md
@@ -30,17 +30,17 @@ To add a calculated property, use the **Property** or **GroupBy** parameter.
 
 ## EXAMPLES
 
-### Example 1: Format PowerShell snap-ins
+### Example 1: Format PowerShell host
 ```powershell
-PS C:\> Get-PSSnapin | Format-Table -Auto
+Get-Host | Format-Table -AutoSize
 ```
 
-This command formats information about Windows PowerShell snap-ins in a table.
+This command displays information about the host program for PowerShell in a table.
 By default, they are formatted in a list.
-The Get-PSSnapin cmdlet gets objects representing the snap-ins.
-The pipeline operator (|) passes the object to the `Format-Table` command.
-`Format-Table` formats the objects in a table.
-The **Autosize** parameter adjusts the column widths to minimize truncation.
+The `Get-Host` cmdlet gets objects representing the host.
+The pipeline operator (|) passes the object to the `Format-Table` cmdlet.
+The `Format-Table` cmdlet formats the objects in a table.
+The **AutoSize** parameter adjusts the column widths to minimize truncation.
 
 ### Example 2: Format processes by BasePriority
 ```powershell

--- a/reference/4.0/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Format-Table.md
@@ -30,17 +30,17 @@ To add a calculated property, use the **Property** or **GroupBy** parameter.
 
 ## EXAMPLES
 
-### Example 1: Format PowerShell snap-ins
+### Example 1: Format PowerShell host
 ```powershell
-PS C:\> Get-PSSnapin | Format-Table -Auto
+Get-Host | Format-Table -AutoSize
 ```
 
-This command formats information about Windows PowerShell snap-ins in a table.
+This command displays information about the host program for PowerShell in a table.
 By default, they are formatted in a list.
-The Get-PSSnapin cmdlet gets objects representing the snap-ins.
-The pipeline operator (|) passes the object to the `Format-Table` command.
-`Format-Table` formats the objects in a table.
-The **Autosize** parameter adjusts the column widths to minimize truncation.
+The `Get-Host` cmdlet gets objects representing the host.
+The pipeline operator (|) passes the object to the `Format-Table` cmdlet.
+The `Format-Table` cmdlet formats the objects in a table.
+The **AutoSize** parameter adjusts the column widths to minimize truncation.
 
 ### Example 2: Format processes by BasePriority
 ```powershell

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-Table.md
@@ -30,17 +30,17 @@ To add a calculated property, use the **Property** or **GroupBy** parameter.
 
 ## EXAMPLES
 
-### Example 1: Format PowerShell snap-ins
+### Example 1: Format PowerShell host
 ```powershell
-PS C:\> Get-PSSnapin | Format-Table -Auto
+Get-Host | Format-Table -AutoSize
 ```
 
-This command formats information about Windows PowerShell snap-ins in a table.
+This command displays information about the host program for PowerShell in a table.
 By default, they are formatted in a list.
-The Get-PSSnapin cmdlet gets objects representing the snap-ins.
-The pipeline operator (|) passes the object to the `Format-Table` command.
-`Format-Table` formats the objects in a table.
-The **Autosize** parameter adjusts the column widths to minimize truncation.
+The `Get-Host` cmdlet gets objects representing the host.
+The pipeline operator (|) passes the object to the `Format-Table` cmdlet.
+The `Format-Table` cmdlet formats the objects in a table.
+The **AutoSize** parameter adjusts the column widths to minimize truncation.
 
 ### Example 2: Format processes by BasePriority
 ```powershell

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Table.md
@@ -30,17 +30,17 @@ To add a calculated property, use the **Property** or **GroupBy** parameter.
 
 ## EXAMPLES
 
-### Example 1: Format PowerShell snap-ins
+### Example 1: Format PowerShell host
 ```powershell
-PS C:\> Get-PSSnapin | Format-Table -Auto
+Get-Host | Format-Table -AutoSize
 ```
 
-This command formats information about Windows PowerShell snap-ins in a table.
+This command displays information about the host program for PowerShell in a table.
 By default, they are formatted in a list.
-The Get-PSSnapin cmdlet gets objects representing the snap-ins.
-The pipeline operator (|) passes the object to the `Format-Table` command.
-`Format-Table` formats the objects in a table.
-The **Autosize** parameter adjusts the column widths to minimize truncation.
+The `Get-Host` cmdlet gets objects representing the host.
+The pipeline operator (|) passes the object to the `Format-Table` cmdlet.
+The `Format-Table` cmdlet formats the objects in a table.
+The **AutoSize** parameter adjusts the column widths to minimize truncation.
 
 ### Example 2: Format processes by BasePriority
 ```powershell

--- a/reference/6/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Format-Table.md
@@ -30,17 +30,17 @@ To add a calculated property, use the **Property** or **GroupBy** parameter.
 
 ## EXAMPLES
 
-### Example 1: Format PowerShell snap-ins
+### Example 1: Format PowerShell host
 ```powershell
-PS C:\> Get-PSSnapin | Format-Table -Auto
+Get-Host | Format-Table -AutoSize
 ```
 
-This command formats information about Windows PowerShell snap-ins in a table.
+This command displays information about the host program for PowerShell in a table.
 By default, they are formatted in a list.
-The Get-PSSnapin cmdlet gets objects representing the snap-ins.
-The pipeline operator (|) passes the object to the `Format-Table` command.
-`Format-Table` formats the objects in a table.
-The **Autosize** parameter adjusts the column widths to minimize truncation.
+The `Get-Host` cmdlet gets objects representing the host.
+The pipeline operator (|) passes the object to the `Format-Table` cmdlet.
+The `Format-Table` cmdlet formats the objects in a table.
+The **AutoSize** parameter adjusts the column widths to minimize truncation.
 
 ### Example 2: Format processes by BasePriority
 ```powershell


### PR DESCRIPTION
* Replaced `Get-PSSnapin`, not supported in v6.0, with `Get-Host`
* Fixed some minor wording and formatting

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
