### PR TITLE
clixml is also computer dependent

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -72,9 +72,9 @@ $Credential = Import-CliXml $CredXmlPath
 ```
 
 The **Export-CliXml** cmdlet encrypts credential objects by using the Windows Data Protection APIhttp://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx.
-This ensures that only your user account can decrypt the contents of the credential object.
+This ensures that only your user account on only that computer can decrypt the contents of the credential object. The exported CliXml file can neither be used on a different computer nor by a different user.
 
-In this example, given a credential that you've stored in the $Credential variable by running the Get-Credential cmdlet, you can run the **Export-CliXml** cmdlet to save the credential to disk.In the example, the file in which the credential is stored is represented by TestScript.ps1.credential.
+In this example, given a credential that you've stored in the $Credential variable by running the Get-Credential cmdlet, you can run the **Export-CliXml** cmdlet to save the credential to disk. In the example, the file in which the credential is stored is represented by TestScript.ps1.credential.
 Replace TestScript with the name of the script with which you are loading the credential.
 
 In the second command, pipe the credential object to **Export-CliXml**, and save it to the path, $CredXmlPath, that you specified in the first command.


### PR DESCRIPTION
Add missing Information about missing computer dependency of the encrypted clixml.

Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [x] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work