### PR TITLE
clarify that disconnect only works with WSMan

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
@@ -21,7 +21,7 @@ continue to run while the session is disconnected.
 
 The Disconnected Sessions feature is available only when the computer at the
 remote end of a connection is running Windows PowerShell 3.0 or a later
-version of Windows PowerShell.
+version of Windows PowerShell and using the WSMan transport.
 
 The Disconnected Sessions feature allows you to close the session in which a
 PSSession was created, and even close Windows PowerShell, and shut down the

--- a/reference/6/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -45,6 +45,8 @@ The **Disconnect-PSSession** cmdlet disconnects a Windows PowerShell session (**
 As a result, the **PSSession** is in a disconnected state.
 You can connect to the disconnected **PSSession** from the current session or from another session on the local computer or a different computer.
 
+Note that this capability only works with PSSessions using the WSMan transport.
+
 The **Disconnect-PSSession** cmdlet disconnects only open **PSSessions** that are connected to the current session.
 **Disconnect-PSSession** cannot disconnect broken or closed **PSSession** objects, or interactive **PSSession** objects started by using the Enter-PSSession cmdlet, and it cannot disconnect **PSSession** objects that are connected to other sessions.
 


### PR DESCRIPTION
This only became a problem when SSH remoting was added in 6.0

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6.1 document
- [X] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version (6.0) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work