### PR TITLE
Fix typo in Invoke-RestMethod.md (fixed #1456)

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -570,7 +570,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## Inputs
 
 ### System.Object
-You can pipe the body of a web request to `Invoke-Rest-Method`.
+You can pipe the body of a web request to `Invoke-RestMethod`.
 
 ## Outputs
 

--- a/reference/4.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -570,7 +570,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## Inputs
 
 ### System.Object
-You can pipe the body of a web request to `Invoke-Rest-Method`.
+You can pipe the body of a web request to `Invoke-RestMethod`.
 
 ## Outputs
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -606,7 +606,7 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## Inputs
 
 ### System.Object
-You can pipe the body of a web request to `Invoke-Rest-Method`.
+You can pipe the body of a web request to `Invoke-RestMethod`.
 
 ## Outputs
 

--- a/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -854,7 +854,7 @@ This cmdlet supports the common parameters: **-Debug**, **-ErrorAction**, **-Err
 ## Inputs
 
 ### System.Object
-You can pipe the body of a web request to `Invoke-Rest-Method`.
+You can pipe the body of a web request to `Invoke-RestMethod`.
 
 ## Outputs
 


### PR DESCRIPTION
Fixed #1456 
Only v5.1 was already fixed with #1436

Version(s) of document impacted
------------------------------
- [x] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in the above versions of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work