### PR TITLE
Added missed 'Call' word

### DIFF
--- a/dsc/configurations.md
+++ b/dsc/configurations.md
@@ -69,7 +69,7 @@ In this example, you specify the name of the node by passing it as the **Compute
 ## Compiling the configuration
 
 Before you can enact a configuration, you have to compile it into a MOF document.
-You do this by calling the configuration like you would a PowerShell function.
+You do this by calling the configuration like you would call a PowerShell function.
 The last line of the example containing only the name of the configuration, calls the configuration.
 
 >**Note:** To call a configuration, the function must be in global scope (as with any other PowerShell function).


### PR DESCRIPTION
The word 'Call' was missed, hence the first point in the 'Compiling the Configuration' section was incomplete.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work