### PR TITLE
Add missing underscore in the code of last example

### DIFF
--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Split.md
@@ -431,7 +431,7 @@ on the value of a variable.
 ```powershell
 $i = 1
 $c = "LastName, FirstName; Address, City, State, Zip"
-$c -split {if ($i -lt 1) {$_-eq ","} else {$_-eq ";"}}
+$c -split {if ($i -lt 1) {$_ -eq ","} else {$_ -eq ";"}}
 ```
 
 ```Output

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Split.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Split.md
@@ -431,7 +431,7 @@ on the value of a variable.
 ```powershell
 $i = 1
 $c = "LastName, FirstName; Address, City, State, Zip"
-$c -split {if ($i -lt 1) {$-eq ","} else {$-eq ";"}}
+$c -split {if ($i -lt 1) {$_-eq ","} else {$_-eq ";"}}
 ```
 
 ```Output


### PR DESCRIPTION
Example code breaks because underscore character is missing from automatic variable $_ in the last example of about_split cmdlet help.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version 6.0, 6.1 of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work