### PR TITLE
C13038: Missing asterisk due to incorrect structure

### DIFF
--- a/reference/docs-conceptual/getting-started/cookbooks/Getting-WMI-Objects--Get-WmiObject-.md
+++ b/reference/docs-conceptual/getting-started/cookbooks/Getting-WMI-Objects--Get-WmiObject-.md
@@ -115,7 +115,7 @@ TotalVirtualMemorySize TotalVisibleMemory FreePhysicalMemory FreeVirtualMemory F
 ```
 
 > [!NOTE]
-> Wildcards work with property names in **Format-Table**, so the final pipeline element can be reduced to **Format-Table -Property Total,Free**
+> Wildcards work with property names in **Format-Table**, so the final pipeline element can be reduced to `Format-Table -Property Total,Free`
 
 The memory data might be more readable if you format it as a list by typing:
 

--- a/reference/docs-conceptual/getting-started/cookbooks/Getting-WMI-Objects--Get-WmiObject-.md
+++ b/reference/docs-conceptual/getting-started/cookbooks/Getting-WMI-Objects--Get-WmiObject-.md
@@ -115,7 +115,7 @@ TotalVirtualMemorySize TotalVisibleMemory FreePhysicalMemory FreeVirtualMemory F
 ```
 
 > [!NOTE]
-> Wildcards work with property names in **Format-Table**, so the final pipeline element can be reduced to **Format-Table -Property Total*,Free*
+> Wildcards work with property names in **Format-Table**, so the final pipeline element can be reduced to **Format-Table -Property Total,Free**
 
 The memory data might be more readable if you format it as a list by typing:
 


### PR DESCRIPTION
Hello, @DCtheGeek,

Localization team has reported source content issue that causes localized version to have different format compared to en-us version.

Please, help to check my proposed file change into the article and help to merge if you agree with fix. If not, please, let me know either if you would like me to fix it in another way within this PR, if you prefer to fix it in another PR or if I should close this PR as by-design. In case of using another PR, please, let me know of your PR number, so we can confirm and close this PR.

Many thanks in advance.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work