### PR TITLE
Document Basic Auth constraints on Linux and macOs

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Logging.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Logging.md
@@ -22,7 +22,7 @@ also log details about PowerShell commands.
 
 The location of PowerShell logs is dependent on the target platform.
 On Windows, PowerShell logs to the event log, on Linux, PowerShell logs
-to syslog, and on MacOS, the os_log logging system is used.
+to syslog, and on macOS, the os_log logging system is used.
 
 ## Viewing the PowerShell event log on Windows
 
@@ -32,7 +32,7 @@ The associated ETW provider guid is `{f90714a8-5509-434a-bf6d-b1624c8a19a2}`
 
 ### Registering the PowerShell event provider on Windows
 
-Unlike Linux or MacOS, Windows requires the event provider to be registered
+Unlike Linux or macOS, Windows requires the event provider to be registered
 before logged events can appear in the event log.  For PowerShell, this is
 accomplished by running the `RegisterManifest.ps1` from an elevated
 PowerShell prompt.
@@ -117,9 +117,9 @@ chown root:root /etc/rsyslog.d/40-powershell.conf
 chmod 644 /etc/rsyslog.d/40-powershell.conf
 ```
 
-## Viewing PowerShell log output on MacOS
+## Viewing PowerShell log output on macOS
 
-The easiest method for viewing PowerShell log output on MacOS is using the
+The easiest method for viewing PowerShell log output on macOS is using the
 Console application.
 
 * Search for the Console application and launch it
@@ -146,7 +146,7 @@ sudo log stream --predicate 'process == "pwsh"' --info
 
 ### Persisting PowerShell log output
 
-By default, PowerShell uses the default memory-only logging on MacOS. This can be changed to enable persistance using the `log config` command.
+By default, PowerShell uses the default memory-only logging on macOS. This can be changed to enable persistance using the `log config` command.
 
 The following enables info level logging and persistence
 ```
@@ -158,7 +158,7 @@ The following command reverts PowerShell logging to the default state
 log config --subsystem com.microsoft.powershell --mode=persist:default,level:default
 ```
 
-Once persistence is enabled, the `log show` can be used to export log items. The command provides options for exporting the last N items, items since a given time, or items within a given time span.
+Once persistence is enabled, the `log show` command can be used to export log items. The command provides options for exporting the last N items, items since a given time, or items within a given time span.
 
 For example, the following command exports items since 9am on April 5th of 2018:
 ```
@@ -166,14 +166,12 @@ log show --info --start "2018-04-05 09:00:00" --predicate "process = 'pwsh'"
 ```
 See ```log show --help``` for additional details.
 
-```
-TIP: When executing any of the log commands from a PowerShell prompt or script, use double quotes around the entire predicate string and single quotes within. This avoids the need to escape double quote characters within the predicate string.
-```
+> TIP: When executing any of the log commands from a PowerShell prompt or script, use double quotes around the entire predicate string and single quotes within. This avoids the need to escape double quote characters within the predicate string.
 
 ## Configuring Logging on non-Windows systems
 
 On Windows, logging is configured by creating ETW trace listeners or by using
-the Event Viewer to enable Analytic logging. On Linux and MacOS, logging is
+the Event Viewer to enable Analytic logging. On Linux and macOS, logging is
 configured using the file `powershell.config.json`. The rest of this section
 will discuss configuring PowerShell logging on non-Windows system.
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -229,19 +229,20 @@ connection, the policies on the remote computer are in effect.
 
 When connecting from a Linux or macOs system to Windows, Basic Authentication
 over HTTP is not supported. Basic Authentication can be used over HTTPS by
-installing a certificate on the target server.  the certificate must have a
-CN name that matches the hostname, is not expired, revoke.  A self-signed
-certificate used for testing purposes.
+installing a certificate on the target server. The certificate must have a
+CN name that matches the hostname, is not expired or revoked. A self-signed
+certificate may be used for testing purposes.
 
 See [How To: Configure WINRM for HTTPS](https://support.microsoft.com/en-us/help/2019527/how-to-configure-winrm-for-https)
 for additonal details.
 
-The following command, run from an elevated command prompt, will configure the HTTPS listener with the installed certificate.
+The following command, run from an elevated command prompt, will configure the
+HTTPS listener with the installed certificate.
 ```
 winrm create winrm/config/Listener?Address=*+Transport=HTTPS @{Hostname="<SERVER_DNS_NAME>"; CertificateThumbprint="<CERTIFICATE_THUMBPRINT>"}
 ```
 
-On the Linux or macOs side, select Basic for authentication and -useSSl.
+On the Linux or macOs side, select Basic for authentication and -UseSSl.
 
 ```powershell
 # The specified local user must have administrator rights on the target machine.
@@ -250,15 +251,21 @@ PS> $cred = Get-Credential username
 PS> $session = New-PSSession -Computer <hostname> -Credential $cred -Authentication Basic -UseSSL
 ```
 
-An alternative to Basic Authentication over HTTPS is Negotiate. The results in NTLM authentication with client and server payload encryption over HTTP.  the following illustrates using Negotiate with New-PSSession:
+An alternative to Basic Authentication over HTTPS is Negotiate. This results
+in NTLM authentication between the client and server and payload is encrypted
+over HTTP.
 
+The following illustrates using Negotiate with New-PSSession:
 ```powershell
 # The specified user must have administrator rights on the target machine.
 PS> $cred = Get-Credential username@hostname
 PS> $session = New-PSSession -Computer <hostname> -Credential $cred -Authentication Negotiate
 ```
 
-> Note: Windows Server requires an additional registry setting to enable administrators, other than the built in administrator, to connect using NTLM. Refer to the LocalAccountTokenFilterPolicy registry setting under Negotiate Authentication in [Authentication for Remote Connections](https://msdn.microsoft.com/en-us/library/aa384295(v=vs.85).aspx)
+> Note: Windows Server requires an additional registry setting to enable
+administrators, other than the built in administrator, to connect using
+NTLM. Refer to the LocalAccountTokenFilterPolicy registry setting under
+Negotiate Authentication in [Authentication for Remote Connections](https://msdn.microsoft.com/en-us/library/aa384295(v=vs.85).aspx)
 
 
 # SEE ALSO

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -225,6 +225,41 @@ In general, before you connect and as you are establishing the connection, the
 policies on the local computer are in effect. When you are using the
 connection, the policies on the remote computer are in effect.
 
+## Basic Authentication Limitations on Linux and macOs
+
+When connecting from a Linux or macOs system to Windows, Basic Authentication
+over HTTP is not supported. Basic Authentication can be used over HTTPS by
+installing a certificate on the target server.  the certificate must have a
+CN name that matches the hostname, is not expired, revoke.  A self-signed
+certificate used for testing purposes.
+
+See [How To: Configure WINRM for HTTPS](https://support.microsoft.com/en-us/help/2019527/how-to-configure-winrm-for-https)
+for additonal details.
+
+The following command, run from an elevated command prompt, will configure the HTTPS listener with the installed certificate.
+```
+winrm create winrm/config/Listener?Address=*+Transport=HTTPS @{Hostname="<SERVER_DNS_NAME>"; CertificateThumbprint="<CERTIFICATE_THUMBPRINT>"}
+```
+
+On the Linux or macOs side, select Basic for authentication and -useSSl.
+
+```powershell
+# The specified user must have administrator rights on the target machine.
+PS> $cred = Get-Credential username@hostname
+PS> $session = New-PSSession -Computer <hostname> -Credential $cred -Authentication Basic -UseSSL
+```
+
+An alternative to Basic Authentication over HTTPS is Negotiate. The results in NTLM authentication with client and server payload encryption over HTTP.  the following illustrates using Negotiate with New-PSSession:
+
+```powershell
+# The specified user must have administrator rights on the target machine.
+PS> $cred = Get-Credential username@hostname
+PS> $session = New-PSSession -Computer <hostname> -Credential $cred -Authentication Negotiate
+```
+
+> Note: Windows Server requires an additional registry setting to enable administrators, other than the built in administrator, to connect using NTLM. Refer to the LocalAccountTokenFilterPolicy registry setting under Negotiate Authentication in [Authentication for Remote Connections](https://msdn.microsoft.com/en-us/library/aa384295(v=vs.85).aspx)
+
+
 # SEE ALSO
 
 [about_Remote](about_Remote.md)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -225,9 +225,9 @@ In general, before you connect and as you are establishing the connection, the
 policies on the local computer are in effect. When you are using the
 connection, the policies on the remote computer are in effect.
 
-## Basic Authentication Limitations on Linux and macOs
+## Basic Authentication Limitations on Linux and macOS
 
-When connecting from a Linux or macOs system to Windows, Basic Authentication
+When connecting from a Linux or macOS system to Windows, Basic Authentication
 over HTTP is not supported. Basic Authentication can be used over HTTPS by
 installing a certificate on the target server. The certificate must have a
 CN name that matches the hostname, is not expired or revoked. A self-signed
@@ -237,14 +237,17 @@ See [How To: Configure WINRM for HTTPS](https://support.microsoft.com/en-us/help
 for additonal details.
 
 The following command, run from an elevated command prompt, will configure the
-HTTPS listener with the installed certificate.
+HTTPS listener on Windows with the installed certificate.
 
 ```powershell
 $hostinfo = '@{Hostname="<DNS_NAME>"; CertificateThumbprint="<THUMBPRINT>"}'
 winrm create winrm/config/Listener?Address=*+Transport=HTTPS $hostinfo
 ```
 
-On the Linux or macOs side, select Basic for authentication and -UseSSl.
+On the Linux or macOS side, select Basic for authentication and -UseSSl.
+
+> NOTE: Basic authentication cannot be used with domain accounts; a local account
+is required and the account must be in the Administrators group.
 
 ```powershell
 # The specified local user must have administrator rights on the target machine.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -244,8 +244,9 @@ winrm create winrm/config/Listener?Address=*+Transport=HTTPS @{Hostname="<SERVER
 On the Linux or macOs side, select Basic for authentication and -useSSl.
 
 ```powershell
-# The specified user must have administrator rights on the target machine.
-PS> $cred = Get-Credential username@hostname
+# The specified local user must have administrator rights on the target machine.
+# Specify the unqualified username.
+PS> $cred = Get-Credential username
 PS> $session = New-PSSession -Computer <hostname> -Credential $cred -Authentication Basic -UseSSL
 ```
 


### PR DESCRIPTION
Document the change to PowerShell disabling support for Basic Authentication over HTTP and document alternatives.

Fix https://github.com/PowerShell/PowerShell-Docs/issues/2394

Version(s) of document impacted
------------------------------
- [X] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version (6.1) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work