### PR TITLE
Fix OUTPUTS in Get-ControlPanelItem.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
@@ -150,9 +150,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 You can pipe a name or name pattern to the Get-ControlPanelItem cmdlet.
+
 ## OUTPUTS
 
 ### Microsoft.PowerShell.Commands.ControlPanelItem
+This cmdlet gets control panel items on the local computer.
 
 ## NOTES
 

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
@@ -164,6 +164,7 @@ You can pipe a name or name pattern to the Get-ControlPanelItem cmdlet.
 ## OUTPUTS
 
 ### Microsoft.PowerShell.Commands.ControlPanelItem
+This cmdlet gets control panel items on the local computer.
 
 ## NOTES
 

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
@@ -164,7 +164,7 @@ You can pipe a name or name pattern to this cmdlet.
 ## OUTPUTS
 
 ### Microsoft.PowerShell.Commands.ControlPanelItem
-This cmdlet does not generate any output.
+This cmdlet gets control panel items on the local computer.
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ControlPanelItem.md
@@ -164,7 +164,7 @@ You can pipe a name or name pattern to this cmdlet.
 ## OUTPUTS
 
 ### Microsoft.PowerShell.Commands.ControlPanelItem
-This cmdlet does not generate any output.
+This cmdlet gets control panel items on the local computer.
 
 ## NOTES
 


### PR DESCRIPTION
X "This cmdlet does not generate any output."
O "This cmdlet gets control panel items on the local computer."

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in the listed version of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work