### PR TITLE
correct example in about_requires

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -80,10 +80,7 @@ following keys. The value can be a combination of strings and hash tables.
 For example,
 
 ```powershell
-#Requires -Modules PSWorkflow @{
-  ModuleName="PSScheduledJob"
-  ModuleVersion="1.0.0.0"
-}
+#Requires -Modules PSWorkflow, @{ ModuleName="PSScheduledJob"; ModuleVersion="1.0.0.0" }
 ```
 
 -ShellId

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -82,10 +82,7 @@ following keys. The value can be a combination of strings and hash tables.
 For example,
 
 ```powershell
-#Requires -Modules PSWorkflow @{
-  ModuleName="PSScheduledJob"
-  ModuleVersion="1.0.0.0"
-}
+#Requires -Modules PSWorkflow, @{ ModuleName="PSScheduledJob"; ModuleVersion="1.0.0.0" }
 ```
 
 -ShellId

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -82,10 +82,7 @@ following keys. The value can be a combination of strings and hash tables.
 For example,
 
 ```powershell
-#Requires -Modules PSWorkflow @{
-  ModuleName="PSScheduledJob"
-  ModuleVersion="1.0.0.0"
-}
+#Requires -Modules PSWorkflow, @{ ModuleName="PSScheduledJob"; ModuleVersion="1.0.0.0" }
 ```
 
 -ShellId

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -82,10 +82,7 @@ following keys. The value can be a combination of strings and hash tables.
 For example,
 
 ```powershell
-#Requires -Modules PSWorkflow @{
-  ModuleName="PSScheduledJob"
-  ModuleVersion="1.0.0.0"
-}
+#Requires -Modules PSWorkflow, @{ ModuleName="PSScheduledJob"; ModuleVersion="1.0.0.0" }
 ```
 
 -ShellId

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -82,10 +82,7 @@ following keys. The value can be a combination of strings and hash tables.
 For example,
 
 ```powershell
-#Requires -Modules PSWorkflow @{
-  ModuleName="PSScheduledJob"
-  ModuleVersion="1.0.0.0"
-}
+#Requires -Modules PSWorkflow, @{ ModuleName="PSScheduledJob"; ModuleVersion="1.0.0.0" }
 ```
 
 -ShellId


### PR DESCRIPTION
Correct examples of hash table usage within `#Requires`. Multi-line hash tables are not permitted and will cause an exception. `#Requires` must be single line and there must be a comma between multiple modules.

Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work