### PR TITLE
C20192: Asterisk issue due to a character that needs to be escaped

### DIFF
--- a/wmf/5.0/dsc_statestatus.md
+++ b/wmf/5.0/dsc_statestatus.md
@@ -1,10 +1,7 @@
 ---
 ms.date:  06/12/2017
-
-
 keywords:  wmf,powershell,setup
 ---
-
 # Unified and Consistent State and Status Representation
 
 A series of enhancements have been made in this release for automations built LCM state and DSC status. These include unified and consistent state and status representations, manageable datetime property of status objects returned by Get-DscConfigurationStatus cmdlet and enhanced LCM state details property returned by Get-DscLocalConfigurationManager cmdlet.
@@ -14,12 +11,12 @@ The representation of LCM state and DSC operation status are revisited and unifi
 2.  LCM stop processing further resources once it encounters a resource that requests reboot.
 3.  A resource that requests reboot is not in desired state until reboot actually happens.
 4.  After encountering a resource that fails, LCM keeps processing further resources as long as they are not dependent on the failure one.
-5.  The overall status returned by Get-DscConfigurationStatus cmdlet is the super set of all resources’ status.
+5.  The overall status returned by Get-DscConfigurationStatus cmdlet is the super set of all resources' status.
 6.  The PendingReboot state is a superset of PendingConfiguration state.
 
 The table below illustrates the resultant state and status related properties under a few typical scenarios.
 
-| **Scenario**                    | **LCMState**\*       | **Status** | **Reboot Requested**  | **ResourcesInDesiredState**  | **ResourcesNotInDesiredState** |
+| Scenario                    | LCMState       | Status | Reboot Requested  | ResourcesInDesiredState  | ResourcesNotInDesiredState |
 |---------------------------------|----------------------|------------|---------------|------------------------------|--------------------------------|
 | S**^**                          | Idle                 | Success    | $false        | S                            | $null                          |
 | F**^**                          | PendingConfiguration | Failure    | $false        | $null                        | F                              |
@@ -48,11 +45,13 @@ $ResourcesInDesiredState = (Get-DscConfigurationStatus).ResourcesInDesiredState
 
 $ResourcesNotInDesiredState = (Get-DscConfigurationStatus).ResourcesNotInDesiredState
 ```
+
 ## Enhancement in Get-DscConfigurationStatus cmdlet
 
 A few enhancements have been made to Get-DscConfigurationStatus cmdlet in this release. Previously, the StartDate property of objects returned by the cmdlet is of String type. Now, it is of Datetime type, which enables complex selecting and filtering easier based on the intrinsic properties of a Datetime object.
+
 ```powershell
-(Get-DscConfigurationStatus).StartDate | fl \*
+(Get-DscConfigurationStatus).StartDate | fl *
 DateTime : Friday, November 13, 2015 1:39:44 PM
 Date : 11/13/2015 12:00:00 AM
 Day : 13
@@ -70,14 +69,16 @@ Year : 2015
 ```
 
 Following is an example that returns all DSC operation records happened on the same day of week as today.
+
 ```powershell
-(Get-DscConfigurationStatus –All) | where { $\_.startdate.dayofweek -eq (Get-Date).DayOfWeek }
+(Get-DscConfigurationStatus –All) | where { $_.startdate.dayofweek -eq (Get-Date).DayOfWeek }
 ```
 
 Records of operations that do not make changes to node’s configuration (i.e. read only operations) are eliminated. Therefore, Test-DscConfiguration, Get-DscConfiguration operations are no longer adulterated in returned objects from Get-DscConfigurationStatus cmdlet.
 Records of meta configuration setting operation is added to the return of Get-DscConfigurationStatus cmdlet.
 
 Following is an example of result returned from Get-DscConfigurationStatus –All cmdlet.
+
 ```powershell
 All configuration operations:
 
@@ -91,12 +92,15 @@ Success 11/13/2015 11:20:44 AM LocalConfigurationManager False
 ```
 
 ## Enhancement in Get-DscLocalConfigurationManager cmdlet
-A new field of LCMStateDetail is added to the object returned from Get-DscLocalConfigurationManager cmdlet. This field is populated when LCMState is “Busy”. It can be retrieved by following cmdlet:
+
+A new field of LCMStateDetail is added to the object returned from Get-DscLocalConfigurationManager cmdlet. This field is populated when LCMState is "Busy". It can be retrieved by following cmdlet:
+
 ```powershell
 (Get-DscLocalConfigurationManager).LCMStateDetail
 ```
 
 Following is an example output of a continuous monitoring on a configuration that requires two reboots on a remote node.
+
 ```powershell
 Start a configuration that requires two reboots
 

--- a/wmf/5.0/dsc_statestatus.md
+++ b/wmf/5.0/dsc_statestatus.md
@@ -19,7 +19,7 @@ The representation of LCM state and DSC operation status are revisited and unifi
 
 The table below illustrates the resultant state and status related properties under a few typical scenarios.
 
-| **Scenario**                    | **LCMState\***       | **Status** | **Reboot Requested**  | **ResourcesInDesiredState**  | **ResourcesNotInDesiredState** |
+| **Scenario**                    | **LCMState**\*       | **Status** | **Reboot Requested**  | **ResourcesInDesiredState**  | **ResourcesNotInDesiredState** |
 |---------------------------------|----------------------|------------|---------------|------------------------------|--------------------------------|
 | S**^**                          | Idle                 | Success    | $false        | S                            | $null                          |
 | F**^**                          | PendingConfiguration | Failure    | $false        | $null                        | F                              |


### PR DESCRIPTION
Hello, @sdwheeler,

Localization team has reported source content issue that causes localized version to have broken format compared to en-us version.  

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.

Many thanks in advance.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work