### PR TITLE
Update information on here-string closing quotation mark indentation.

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
@@ -220,8 +220,7 @@ Single-quotes:
 '@
 ```
 
-In either format, the closing quotation mark must be the first character in
-the line.
+In either format, the closing quotation mark can be the first character in the line or it can be indented with spaces.
 
 A here-string contains all the text between the two hidden characters. In the
 here-string, all quotation marks are interpreted literally. For example:

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Quoting_Rules.md
@@ -220,7 +220,8 @@ Single-quotes:
 '@
 ```
 
-In either format, the closing quotation mark can be the first character in the line or it can be indented with spaces.
+In either format, the closing quotation mark can be the first character in
+the line or it can be indented with spaces.
 
 A here-string contains all the text between the two hidden characters. In the
 here-string, all quotation marks are interpreted literally. For example:


### PR DESCRIPTION

Fix #2471 

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work