### PR TITLE
Where-ObjectFilterScript parameter is confusing

### DIFF
--- a/reference/docs-conceptual/getting-started/cookbooks/Removing-Objects-from-the-Pipeline--Where-Object-.md
+++ b/reference/docs-conceptual/getting-started/cookbooks/Removing-Objects-from-the-Pipeline--Where-Object-.md
@@ -8,7 +8,7 @@ ms.assetid:  01df8b22-2d22-4e2c-a18d-c004cd3cc284
 
 In Windows PowerShell, you often generate and pass along more objects to a pipeline than you want. You can specify the properties of particular objects to display by using the **Format** cmdlets, but this does not help with the problem of removing entire objects from the display. You may want to filter objects before the end of a pipeline, so you can perform actions on only a subset of the initially-generated objects.
 
-Windows PowerShell includes a **Where-Object** cmdlet that allows you to test each object in the pipeline and only pass it along the pipeline if it meets a particular test condition. Objects that do not pass the test are removed from the pipeline. You supply the test condition as the value of the **Where-ObjectFilterScript** parameter.
+Windows PowerShell includes a **Where-Object** cmdlet that allows you to test each object in the pipeline and only pass it along the pipeline if it meets a particular test condition. Objects that do not pass the test are removed from the pipeline. You supply the test condition as the value of the **Where-Object -FilterScript** parameter.
 
 ### Performing Simple Tests with Where-Object
 

--- a/reference/docs-conceptual/getting-started/cookbooks/Removing-Objects-from-the-Pipeline--Where-Object-.md
+++ b/reference/docs-conceptual/getting-started/cookbooks/Removing-Objects-from-the-Pipeline--Where-Object-.md
@@ -8,7 +8,7 @@ ms.assetid:  01df8b22-2d22-4e2c-a18d-c004cd3cc284
 
 In Windows PowerShell, you often generate and pass along more objects to a pipeline than you want. You can specify the properties of particular objects to display by using the **Format** cmdlets, but this does not help with the problem of removing entire objects from the display. You may want to filter objects before the end of a pipeline, so you can perform actions on only a subset of the initially-generated objects.
 
-Windows PowerShell includes a **Where-Object** cmdlet that allows you to test each object in the pipeline and only pass it along the pipeline if it meets a particular test condition. Objects that do not pass the test are removed from the pipeline. You supply the test condition as the value of the **Where-Object -FilterScript** parameter.
+Windows PowerShell includes a `Where-Object` cmdlet that allows you to test each object in the pipeline and only pass it along the pipeline if it meets a particular test condition. Objects that do not pass the test are removed from the pipeline. You supply the test condition as the value of the `Where-Object` **FilterScript** parameter.
 
 ### Performing Simple Tests with Where-Object
 


### PR DESCRIPTION
I have not seen a parameter described in this way. Where-ObjectFilterScript looks like a cmdlet/function whereas Where-Object -FilterScript look more like a parameter

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work