### PR TITLE
Update Select-Object.md

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-Object.md
@@ -333,7 +333,7 @@ Accept wildcard characters: False
 Specifies that if a subset of the input objects has identical properties and values, only a single member of the subset will be selected.
 
 This parameter is case-sensitive.
-As a result, strings that differ only in character casing are considered to be unique.
+As a result, strings that differ in character casing are NOT considered to be unique.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
Select-Object
Parameter -unique should be:

This parameter is case-sensitive.
As a result, strings that differ in character casing are NOT considered to be unique.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (5.0) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work