### PR TITLE
Fedora 28 was released, Fedora 26 and 25 were EOL'ed.

### DIFF
--- a/reference/docs-conceptual/PowerShell-Core-Support.md
+++ b/reference/docs-conceptual/PowerShell-Core-Support.md
@@ -43,7 +43,7 @@ PowerShell Core is officially supported on the following platforms:
 * CentOS 7
 * Red Hat Enterprise Linux 7
 * OpenSUSE 42.2
-* Fedora 25, 26
+* Fedora 27, 28
 * macOS 10.12+
 
 Our community has also contributed packages for the following platforms,

--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Linux.md
@@ -1,8 +1,8 @@
 # Installing PowerShell Core on Linux
 
 Supports [Ubuntu 14.04][u14], [Ubuntu 16.04][u16], [Ubuntu 17.04][u17], [Debian 8][deb8], [Debian 9][deb9],
-[CentOS 7][cos], [Red Hat Enterprise Linux (RHEL) 7][rhel7], [OpenSUSE 42.2][opensuse], [Fedora 25][fed25],
-[Fedora 26][fed26], and [Arch Linux][arch].
+[CentOS 7][cos], [Red Hat Enterprise Linux (RHEL) 7][rhel7], [OpenSUSE 42.2][opensuse], [Fedora 27][fedora],
+[Fedora 28][fedora], and [Arch Linux][arch].
 
 For Linux distributions that are not officially supported,
 you can try using the [PowerShell AppImage][lai].
@@ -20,8 +20,7 @@ Once the package is installed, run `pwsh` from a terminal.
 [cos]: #centos-7
 [rhel7]: #red-hat-enterprise-linux-rhel-7
 [opensuse]: #opensuse-422
-[fed25]: #fedora-25
-[fed26]: #fedora-26
+[fedora]: #fedora
 [arch]: #arch-linux
 [lai]: #linux-appimage
 [tar]: #binary-archives
@@ -443,60 +442,9 @@ sudo zypper install https://github.com/PowerShell/PowerShell/releases/download/v
 sudo zypper remove powershell
 ```
 
-## Fedora 25
+## Fedora
 
-### Installation via Package Repository (preferred) - Fedora 25
-
-PowerShell Core for Linux is published to official Microsoft repositories for easy installation (and updates).
-
-```sh
-# Register the Microsoft signature key
-sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-
-# Register the Microsoft RedHat repository
-curl https://packages.microsoft.com/config/rhel/7/prod.repo | sudo tee /etc/yum.repos.d/microsoft.repo
-
-# Update the list of products
-sudo dnf update
-
-# Install PowerShell
-sudo dnf install -y powershell
-
-# Start PowerShell
-pwsh
-```
-
-### Installation via Direct Download - Fedora 25
-
-Download the RPM package
-`powershell-6.0.2-1.rhel.7.x86_64.rpm`
-from the [releases][] page onto the Fedora machine.
-
-```sh
-wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0/powershell-6.0.0-1.rhel.7.x86_64.rpm
-```
-
-Then execute the following in the terminal:
-
-```sh
-sudo dnf install powershell-6.0.2-1.rhel.7.x86_64.rpm
-```
-
-You can also install the RPM without the intermediate step of downloading it:
-
-```sh
-sudo dnf install https://github.com/PowerShell/PowerShell/releases/download/v6.0.2/powershell-6.0.2-1.rhel.7.x86_64.rpm
-```
-
-### Uninstallation - Fedora 25
-
-```sh
-sudo dnf remove powershell
-```
-
-## Fedora 26
-
-### Installation via Package Repository (preferred) - Fedora 26
+### Installation via Package Repository (preferred) - Fedora 27, Fedora 28
 
 PowerShell Core for Linux is published to official Microsoft repositories for easy installation (and updates).
 
@@ -520,7 +468,7 @@ sudo dnf install -y powershell
 pwsh
 ```
 
-### Installation via Direct Download - Fedora 26
+### Installation via Direct Download - Fedora 27, Fedora 28
 
 Download the RPM package
 `powershell-6.0.2-1.rhel.7.x86_64.rpm`
@@ -529,7 +477,6 @@ from the [releases][] page onto the Fedora machine.
 Then execute the following in the terminal:
 
 ```sh
-sudo dnf update
 sudo dnf install compat-openssl10
 sudo dnf install powershell-6.0.2-1.rhel.7.x86_64.rpm
 ```
@@ -537,12 +484,11 @@ sudo dnf install powershell-6.0.2-1.rhel.7.x86_64.rpm
 You can also install the RPM without the intermediate step of downloading it:
 
 ```sh
-sudo dnf update
 sudo dnf install compat-openssl10
 sudo dnf install https://github.com/PowerShell/PowerShell/releases/download/v6.0.2/powershell-6.0.2-1.rhel.7.x86_64.rpm
 ```
 
-### Uninstallation - Fedora 26
+### Uninstallation - Fedora 27, Fedora 28
 
 ```sh
 sudo dnf remove powershell
@@ -687,8 +633,8 @@ on different Linux distributions.
 | Ubuntu 17.04       | libc6, libgcc1, libgssapi-krb5-2, liblttng-ust0, libstdc++6, <br> libcurl3, libunwind8, libuuid1, zlib1g, libssl1.0.0, libicu57 |
 | Debian 8 (Jessie)  | libc6, libgcc1, libgssapi-krb5-2, liblttng-ust0, libstdc++6, <br> libcurl3, libunwind8, libuuid1, zlib1g, libssl1.0.0, libicu52 |
 | Debian 9 (Stretch) | libc6, libgcc1, libgssapi-krb5-2, liblttng-ust0, libstdc++6, <br> libcurl3, libunwind8, libuuid1, zlib1g, libssl1.0.2, libicu57 |
-| CentOS 7 <br> Oracle Linux 7 <br> RHEL 7 <br> OpenSUSE 42.2 <br> Fedora 25 | libunwind, libcurl, openssl-libs, libicu |
-| Fedora 26          | libunwind, libcurl, openssl-libs, libicu, compat-openssl10 |
+| CentOS 7 <br> Oracle Linux 7 <br> RHEL 7 <br> OpenSUSE 42.2 | libunwind, libcurl, openssl-libs, libicu |
+| Fedora 27 <br> Fedora 28 | libunwind, libcurl, openssl-libs, libicu, compat-openssl10 |
 
 To deploy PowerShell binaries on Linux distributions that are not officially supported,
 you need to install the necessary dependencies for the target OS in separate steps.


### PR DESCRIPTION

Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
- [x] I have no idea what this question is about, the `Installing-PowerShell-Core-on-Linux.md` only seems to live in `reference/docs-conceptual/setup`, nowhere else.