### PR TITLE
Corrected an Example in ConvertTo-JSON

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -71,7 +71,7 @@ You can also use the Invoke-RestMethod cmdlet, which automatically converts JSON
 ### Example 3: Convert a JSON string to a custom object
 
 ```powershell
-(Get-Content JsonFile.JSON) -join '`n' | ConvertFrom-Json
+(Get-Content JsonFile.JSON) -join "`n" | ConvertFrom-Json
 ```
 
 This example shows how to use the **ConvertFrom-Json** cmdlet to convert a JSON file to a PowerShell custom object.


### PR DESCRIPTION
Updated Example 3 to use double quotes instead of single quotes for the newline escape character. The newline escape character is interpreted literally when used with single quotes, and does not work as expected in this case.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work