### PR TITLE
remove example of creating user attached to Microsoft account

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
+++ b/reference/5.1/Microsoft.PowerShell.LocalAccounts/New-LocalUser.md
@@ -62,15 +62,6 @@ The command stores the password as a secure string in the $Password variable.
 The second command creates a local user account by using the password stored in $Password.
 The command specifies a user name, full name, and description for the user account.
 
-### Example 3: Create a user account that is connected to a Microsoft account
-```
-PS C:\> New-LocalUser -Name "MicrosoftAccount\usr name@Outlook.com" -Description "Description of this account."
-```
-
-This command creates a local user account that is connected to a Microsoft account.
-This example uses a placeholder value for the user name of an account at Outlook.com.
-Because the account is connected to a Microsoft account, do not specify a password.
-
 ## PARAMETERS
 
 ### -AccountExpires
@@ -169,8 +160,6 @@ Accept wildcard characters: False
 
 ### -Name
 Specifies the user name for the user account.
-
-If you create a local user account that is connected to a Microsoft account, specify the user name in the following format: `MicrosoftAccount\\`\<user name\>@`Outlook.com` for a user of a Microsoft account on Outlook.com.
 
 If you create a local user account for the local system, the user name can contain up to 20 uppercase characters or lowercase characters.
 A user name cannot contain the following characters:


### PR DESCRIPTION
The example of creating a local user attached to a Microsoft account doesn't actually work

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [x] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work