### PR TITLE
Correcting text describing the inheritance order

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Classes.md
@@ -616,8 +616,21 @@ You can, however, use interfaces for that purpose.
 
 Inheritance implementation is defined by the `:` operator;
 which means to extend this class or implements these interfaces.
-The base class should always be leftmost in the class declaration;
-interface declarations always come after the base class.
+The derived class should always be leftmost in the class declaration.
+
+### EXAMPLE: SIMPLE INHERITANCE SYNTAX
+
+This example shows the simple PowerShell class inheritance syntax.
+
+```powershell
+Class Derived : Base {...}
+```
+
+This example shows inheritance with interface declaration comeing after the base class.
+
+```powershell
+Class Derived : Base.Interface {...}
+```
 
 ### EXAMPLE: SIMPLE INHERITANCE IN POWERSHELL CLASSES
 


### PR DESCRIPTION
Correcting previous wording and add a couple syntax examples.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work