### PR TITLE
Update docs for *-Service cmdlet remoting

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Get-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-Service.md
@@ -16,33 +16,40 @@ Gets the services on the computer.
 ## SYNTAX
 
 ### Default (Default)
+
 ```
 Get-Service [[-Name] <String[]>] [-DependentServices] [-RequiredServices]
  [-Include <String[]>] [-Exclude <String[]>] [<CommonParameters>]
 ```
 
 ### DisplayName
+
 ```
 Get-Service [-DependentServices] [-RequiredServices] -DisplayName <String[]>
  [-Include <String[]>] [-Exclude <String[]>] [<CommonParameters>]
 ```
 
 ### InputObject
+
 ```
 Get-Service [-DependentServices] [-RequiredServices] [-Include <String[]>]
  [-Exclude <String[]>] [-InputObject <ServiceController[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-Service** cmdlet gets objects that represent the services on a local computer, including running and stopped services.
 
-You can direct this cmdlet to get only particular services by specifying the service name or display name of the services, or you can pipe service objects to this cmdlet.
+The **Get-Service** cmdlet gets objects that represent the services on a computer,
+including running and stopped services.
+
+You can direct this cmdlet to get only particular services by specifying the service name or
+the display name of the services, or you can pipe service objects to this cmdlet.
 
 ## EXAMPLES
 
 ### Example 1: Get all services on the computer
-```
-PS C:\> Get-Service
+
+```powershell
+Get-Service
 ```
 
 This command gets all of the services on the computer.
@@ -50,30 +57,34 @@ It behaves as though you typed `Get-Service *`.
 The default display shows the status, service name, and display name of each service.
 
 ### Example 2: Get services that begin with a search string
-```
-PS C:\> Get-Service "wmi*"
+
+```powershell
+Get-Service "wmi*"
 ```
 
 This command retrieves services with service names that begin with WMI (the acronym for Windows Management Instrumentation).
 
 ### Example 3: Display services that include a search string
-```
-PS C:\> Get-Service -Displayname "*network*"
+
+```powershell
+Get-Service -Displayname "*network*"
 ```
 
 This command displays services with a display name that includes the word network.
 Searching the display name finds network-related services even when the service name does not include "Net", such as xmlprov, the Network Provisioning Service.
 
 ### Example 4: Get services that begin with a search string and an exclusion
-```
-PS C:\> Get-Service -Name "win*" -Exclude "WinRM"
+
+```powershell
+Get-Service -Name "win*" -Exclude "WinRM"
 ```
 
 These commands get only the services with service names that begin with win, except for the WinRM service.
 
 ### Example 5: Display services that are currently active
-```
-PS C:\> Get-Service | Where-Object {$_.Status -eq "Running"}
+
+```powershell
+Get-Service | Where-Object {$_.Status -eq "Running"}
 ```
 
 This command displays only the services that are currently active.
@@ -84,26 +95,25 @@ Status is only one property of service objects.
 To see all of the properties, type `Get-Service | Get-Member`.
 
 ### Example 6: List the services on the computer that have dependent services
+
+```powershell
+Get-Service |
+  Where-Object {$_.DependentServices} |
+    Format-List -Property Name, DependentServices, @{
+      Label="NoOfDependentServices"; Expression={$_.dependentservices.count}
+    }
 ```
-PS C:\> Get-Service | Where-Object {$_.DependentServices} | Format-List -Property Name, DependentServices, @{Label="NoOfDependentServices"; Expression={$_.dependentservices.count}}
 
-
-
-
-
-
-
-
+```Output
 Name                  : AudioEndpointBuilder
 DependentServices     : {AudioSrv}
 NoOfDependentServices : 1
+
 Name                  : Dhcp
 DependentServices     : {WinHttpAutoProxySvc}
 NoOfDependentServices : 1
 ...
 ```
-
-This example lists the services on the computer that have dependent services.
 
 The first command uses the **Get-Service** cmdlet to get the services on the computer.
 A pipeline operator (|) sends the services to the **Where-Object** cmdlet, which selects the services whose **DependentServices** property is not null.
@@ -112,9 +122,12 @@ Another pipeline operator sends the results to the Format-List cmdlet.
 The command uses its *Property* parameter to display the name of the service, the name of the dependent services, and a calculated property that displays the number of dependent services that each service has.
 
 ### Example 7: Sort services by property value
+
+```powershell
+Get-Service "s*" | Sort-Object status
 ```
-PS C:\> Get-Service "s*" | Sort-Object status
 
+```Output
 Status   Name               DisplayName
 ------   ----               -----------
 Stopped  stisvc             Windows Image Acquisition (WIA)
@@ -130,24 +143,6 @@ Running  SamSs              Security Accounts Manager
 Running  SharedAccess       Windows Firewall/Internet Connectio...
 Running  SENS               System Event Notification
 Running  seclogon           Secondary Logon
-
-PS C:\> Get-Service "s*" | Sort-Object status -Descending
-
-Status   Name               DisplayName
-------   ----               -----------
-Running  ShellHWDetection   Shell Hardware Detection
-Running  SharedAccess       Windows Firewall/Internet Connectio...
-Running  Spooler            Print Spooler
-Running  SSDPSRV            SSDP Discovery Service
-Running  srservice          System Restore Service
-Running  SCardSvr           Smart Card
-Running  SamSs              Security Accounts Manager
-Running  Schedule           Task Scheduler
-Running  SENS               System Event Notification
-Running  seclogon           Secondary Logon
-Stopped  SysmonLog          Performance Logs and Alerts
-Stopped  SwPrv              MS Software Shadow Copy Provider
-Stopped  stisvc             Windows Image Acquisition (WIA)
 ```
 
 This command shows that when you sort services in ascending order by the value of their **Status** property, stopped services appear before running services.
@@ -156,8 +151,9 @@ This happens because the value of Status is an enumeration, in which Stopped has
 To list running services first, use the *Descending* parameter of the Sort-Object cmdlet.
 
 ### Example 8: Get the dependent services of a service
-```
-PS C:\> Get-Service "WinRM" -RequiredServices
+
+```powershell
+Get-Service "WinRM" -RequiredServices
 ```
 
 This command gets the services that the WinRM service requires.
@@ -165,8 +161,9 @@ This command gets the services that the WinRM service requires.
 The command returns the value of the **ServicesDependedOn** property of the service.
 
 ### Example 9: Get a service through the pipeline operator
-```
-PS C:\> "WinRM" | Get-Service
+
+```powershell
+"WinRM" | Get-Service
 ```
 
 This command gets the WinRM service on the local computer.
@@ -175,6 +172,7 @@ This example shows that you can pipe a service name string (enclosed in quotatio
 ## PARAMETERS
 
 ### -DependentServices
+
 Indicates that this cmdlet gets only the services that depend upon the specified service.
 
 By default, this cmdlet gets all services.
@@ -192,6 +190,7 @@ Accept wildcard characters: False
 ```
 
 ### -DisplayName
+
 Specifies, as a string array, the display names of services to be retrieved.
 Wildcards are permitted.
 By default, this cmdlet gets all services on the computer.
@@ -209,6 +208,7 @@ Accept wildcard characters: True
 ```
 
 ### -Exclude
+
 Specifies, as a string array, a service or services that this cmdlet excludes from the operation.
 The value of this parameter qualifies the *Name* parameter.
 Enter a name element or pattern, such as "s*".
@@ -227,6 +227,7 @@ Accept wildcard characters: True
 ```
 
 ### -Include
+
 Specifies, as a string array, a service or services that this cmdlet includes in the operation.
 The value of this parameter qualifies the *Name* parameter.
 Enter a name element or pattern, such as "s*".
@@ -245,6 +246,7 @@ Accept wildcard characters: True
 ```
 
 ### -InputObject
+
 Specifies **ServiceController** objects representing the services to be retrieved.
 Enter a variable that contains the objects, or type a command or expression that gets the objects.
 You can also pipe a service object to this cmdlet.
@@ -262,6 +264,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Specifies the service names of services to be retrieved.
 Wildcards are permitted.
 By default, this cmdlet gets all of the services on the computer.
@@ -279,6 +282,7 @@ Accept wildcard characters: True
 ```
 
 ### -RequiredServices
+
 Indicates that this cmdlet gets only the services that this service requires.
 
 This parameter gets the value of the **ServicesDependedOn** property of the service.
@@ -297,33 +301,35 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.ServiceProcess.ServiceController, System.String
+
 You can pipe a service object or a service name to this cmdlet.
 
 ## OUTPUTS
 
 ### System.ServiceProcess.ServiceController
+
 This cmdlet returns objects that represent the services on the computer.
 
 ## NOTES
-* You can also refer to **Get-Service** by its built-in alias, "gsv". For more information, see about_Aliases.
 
-  This cmdlet can display services only when the current user has permission to see them.
+You can also refer to **Get-Service** by its built-in alias, "gsv". For more information, see about_Aliases.
+
+This cmdlet can display services only when the current user has permission to see them.
 If this cmdlet does not display services, you might not have permission to see them.
 
-  To find the service name and display name of each service on your system, type `Get-Service`.
+To find the service name and display name of each service on your system, type `Get-Service`.
 The service names appear in the Name column, and the display names appear in the DisplayName column.
 
-  When you sort in ascending order by status value, "Stopped" services appear before "Running" services.
+When you sort in ascending order by status value, "Stopped" services appear before "Running" services.
 The Status property of a service is an enumerated value in which the names of the statuses represent integer values.
 The sort is based on the integer value, not the name.
 "Running" appears before "Stopped" because "Stopped" has a value of "1", and "Running" has a value of "4".
-
-*
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Management/Set-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/Set-Service.md
@@ -52,71 +52,44 @@ The default is Workstation.
 ### Example 2: Change the startup type of services
 
 ```powershell
-Get-WMIObject win32_service -Filter "name = 'SysmonLog'"
+Set-Service -Name BITS -StartupType Automatic
+Get-Service BITS | Select-Object Name, StartType, Status
 ```
 
 ```Output
-ExitCode  : 0
-Name      : SysmonLog
-ProcessId : 0
-StartMode : Manual
-State     : Stopped
-Status    : OK
-Set-Service -Name "sysmonlog" -StartupType automatic
-Get-WMIObject win32_service -Filter "name = 'SysmonLog'"
-ExitCode  : 0
-Name      : SysmonLog
-ProcessId : 0
-StartMode : Auto
-State     : Stopped
-Status    : OK
-
-```powershell
-Get-WMIObject win32_service | Format-Table Name, StartMode -auto
+Name StartType  Status
+---- ---------  ------
+BITS      Auto Stopped
 ```
 
-```Output
-Name                                  StartMode
-----                                  ---------
-AdtAgent                              Auto
-Alerter                               Disabled
-ALG                                   Manual
-AppMgmt                               Manual
-...
-```
-
-These commands get the startup type of the Performance Logs and Alerts (SysmonLog) service, set the start mode to automatic, and then display the result of the change.
-
-These commands use the **Get-WmiObject** cmdlet to get the **Win32_Service** object for the service, because the **ServiceController** object that **Get-Service** returns does not include the start mode.
-
-The first command uses the **Get-WmiObject** cmdlet to get the Windows Management Instrumentation (WMI) object that represents the **SysmonLog** service.
-The default output of this command displays the start mode of the service.
-
-The second command uses Set-Service to change the start mode to automatic.
-Then, the first command is repeated to display the change.
-
-The final command displays the start mode of all services on the computer.
+These commands get the startup type of the Background Intelligent Transfer Service (BITS) service, set the start mode to automatic, and then display the result of the change.
 
 ### Example 3: Change the description of a service
 
 ```powershell
-Set-Service -Name "Schedule" -Description "Configures and schedules tasks."
-Get-WMIObject win32_service | Where-Object {$_.Name -eq "Schedule"} | Format-List Name, Description
+Get-CimInstance Win32_Service -Filter 'Name = "BITS"'  | Format-List  Name, Description
 ```
 
-These commands change the description of the Task Scheduler service and then display the result.
+```Output
+Name        : BITS
+Description : Transfers files in the background using idle network bandwidth. If the service is
+              disabled, then any applications that depend on BITS, such as Windows Update or MSN
+              Explorer, will be unable to automatically download programs and other information.
+```
 
-These commands use the **Get-WmiObject** cmdlet to get the **Win32_Service** object for the service, because the **ServiceController** object that **Get-Service** returns does not include the service description.
+```powershell
+Set-Service -Name BITS -Description "Transfers files in the background using idle network bandwidth."
+Get-CimInstance Win32_Service -Filter 'Name = "BITS"'  | Format-List  Name, Description
+```
 
-The first command changes the description.
-It identifies the service by using the service name of the service, Schedule.
+```Output
+Name        : BITS
+Description : Transfers files in the background using idle network bandwidth.
+```
 
-The second command uses the **Get-WmiObject** cmdlet to get an instance of the WMI **Win32_Service** that represents the Task Scheduler service.
-The first element in the command gets all instances of the **Win32_service** class.
+These commands change the description of the BITS service and then display the result.
 
-The pipeline operator (|) passes the result to the Where-Object cmdlet, which selects instances with a value of Schedule in the **Name** property.
-
-Another pipeline operator sends the result to the Format-List cmdlet, which formats the output as a list that has only the **Name** and **Description** properties.
+These commands use the **Get-CimInstance** cmdlet to get the **Win32_Service** object for the service, because the **ServiceController** object that **Get-Service** returns does not include the service description.
 
 ### Example 4: Start a service
 
@@ -188,7 +161,7 @@ Specifies a new description for the service.
 
 The service description appears in Services in Computer Management.
 Description is not a property of the **ServiceController** object that Get-Service gets.
-To see the service description, use Get-WmiObject to get a **Win32_Service** object that represents the service.
+To see the service description, use Get-CimInstance to get a **Win32_Service** object that represents the service.
 
 ```yaml
 Type: String

--- a/reference/6/Microsoft.PowerShell.Management/Set-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/Set-Service.md
@@ -16,6 +16,7 @@ Starts, stops, and suspends a service, and changes its properties.
 ## SYNTAX
 
 ### Name (Default)
+
 ```
 Set-Service [-Name] <String> [-DisplayName <String>] [-Description <String>]
  [-StartupType <ServiceStartMode>] [-Status <String>] [-PassThru]
@@ -23,14 +24,16 @@ Set-Service [-Name] <String> [-DisplayName <String>] [-Description <String>]
 ```
 
 ### InputObject
+
 ```
-Set-Service [-DisplayName <String>] [-Description <String>]
- [-StartupType <ServiceStartMode>] [-Status <String>] [-InputObject <ServiceController>] [-PassThru]
+Set-Service [-DisplayName <String>] [-Description <String>] [-StartupType <ServiceStartMode>]
+ [-Status <String>] [-InputObject <ServiceController>] [-PassThru]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Set-Service** cmdlet changes the properties of a local or remote service.
+
+The **Set-Service** cmdlet changes the properties of a service.
 This includes the status, description, display name, and start mode.
 You can use this cmdlet to start, stop, or suspend, or pause, a service.
 To identify the service, enter its service name or submit a service object, or pipe a service name or service object to **Set-Service**.
@@ -38,25 +41,29 @@ To identify the service, enter its service name or submit a service object, or p
 ## EXAMPLES
 
 ### Example 1: Change a display name
-```
-PS C:\> Set-Service -Name "lanmanworkstation" -DisplayName "LanMan Workstation"
+
+```powershell
+Set-Service -Name "lanmanworkstation" -DisplayName "LanMan Workstation"
 ```
 
 This command changes the display name of the lanmanworkstation service to LanMan Workstation.
 The default is Workstation.
 
 ### Example 2: Change the startup type of services
-```
-PS C:\> Get-WMIObject win32_service -Filter "name = 'SysmonLog'"
 
+```powershell
+Get-WMIObject win32_service -Filter "name = 'SysmonLog'"
+```
+
+```Output
 ExitCode  : 0
 Name      : SysmonLog
 ProcessId : 0
 StartMode : Manual
 State     : Stopped
 Status    : OK
-PS C:\> Set-Service -Name "sysmonlog" -StartupType automatic
-PS C:\> Get-WMIObject win32_service -Filter "name = 'SysmonLog'"
+Set-Service -Name "sysmonlog" -StartupType automatic
+Get-WMIObject win32_service -Filter "name = 'SysmonLog'"
 ExitCode  : 0
 Name      : SysmonLog
 ProcessId : 0
@@ -64,8 +71,11 @@ StartMode : Auto
 State     : Stopped
 Status    : OK
 
-PS C:\> Get-WMIObject win32_service | Format-Table Name, StartMode -auto
+```powershell
+Get-WMIObject win32_service | Format-Table Name, StartMode -auto
+```
 
+```Output
 Name                                  StartMode
 ----                                  ---------
 AdtAgent                              Auto
@@ -88,9 +98,10 @@ Then, the first command is repeated to display the change.
 The final command displays the start mode of all services on the computer.
 
 ### Example 3: Change the description of a service
-```
-PS C:\> Set-Service -Name "Schedule" -Description "Configures and schedules tasks."
-PS C:\> Get-WMIObject win32_service | Where-Object {$_.Name -eq "Schedule"} | Format-List Name, Description
+
+```powershell
+Set-Service -Name "Schedule" -Description "Configures and schedules tasks."
+Get-WMIObject win32_service | Where-Object {$_.Name -eq "Schedule"} | Format-List Name, Description
 ```
 
 These commands change the description of the Task Scheduler service and then display the result.
@@ -108,16 +119,18 @@ The pipeline operator (|) passes the result to the Where-Object cmdlet, which se
 Another pipeline operator sends the result to the Format-List cmdlet, which formats the output as a list that has only the **Name** and **Description** properties.
 
 ### Example 4: Start a service
-```
-PS C:\> Set-Service -Name "winrm" -Status Running -PassThru
+
+```powershell
+Set-Service -Name "winrm" -Status Running -PassThru
 ```
 
 This command starts the WinRM service.
 The command uses the Status parameter to specify the desired status, which is running, and the *PassThru* parameter to direct **Set-Service** to return an object that represents the WinRM service.
 
 ### Example 5: Suspend a service
-```
-PS C:\> Get-Service -Name "schedule" | Set-Service -Status paused
+
+```powershell
+Get-Service -Name "schedule" | Set-Service -Status paused
 ```
 
 This command suspends the Schedule service.
@@ -125,9 +138,10 @@ It uses **Get-Service** to get the service.
 A pipeline operator (|) sends the service to **Set-Service**, which changes its status to Paused.
 
 ### Example 6: Stop a service
-```
-PS C:\> $s = Get-Service -Name "schedule"
-PS C:\> Set-Service -InputObject $s -Status stopped
+
+```powershell
+$s = Get-Service -Name "schedule"
+Set-Service -InputObject $s -Status stopped
 ```
 
 These commands stop the Schedule service.
@@ -138,10 +152,25 @@ The command stores the service in the $s variable.
 The second command changes the status of the Schedule service to Stopped.
 It uses the *InputObject* parameter to submit the service stored in the $s variable, and it uses the *Status* parameter to specify the desired status.
 
-### Example 7: Change credential of a service
+### Example 7: Stop a service on a remote system
+
+```powershell
+$Cred = Get-Credential
+$s = Get-Service -Name "schedule"
+Invoke-Command -ComputerName 'server01.contoso.com' -Credential $Cred -ScriptBlock {
+  Set-Service -InputObject $s -Status 'Stopped'
+}
 ```
-PS C:\> $credential = Get-Credential
-PS C:\> Set-Service -Name "schedule" -Credential $credential
+
+These commands stop the Schedule service on a remote system.
+
+For more information see [Invoke-Command](../Microsoft.PowerShell.Core/Invoke-Command.md).
+
+### Example 8: Change credential of a service
+
+```powershell
+$credential = Get-Credential
+Set-Service -Name "schedule" -Credential $credential
 ```
 
 These commands changes credentials of the Schedule service.
@@ -154,6 +183,7 @@ The second command changes the credentials of the Schedule service.
 ## PARAMETERS
 
 ### -Description
+
 Specifies a new description for the service.
 
 The service description appears in Services in Computer Management.
@@ -173,6 +203,7 @@ Accept wildcard characters: False
 ```
 
 ### -DisplayName
+
 Specifies a new display name for the service.
 
 ```yaml
@@ -188,6 +219,7 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
+
 Specifies a **ServiceController** object that represents the service to change.
 Enter a variable that contains the object, or type a command or expression that gets the object, such as a **Get-Service** command.
 You can also pipe a service object to Set-Service.
@@ -205,6 +237,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Specifies the service name of the service to be changed.
 Wildcard characters are not permitted.
 You can also pipe a service name to **Set-Service**.
@@ -222,6 +255,7 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
+
 Specifies the credentials under which the service should be run.
 
 
@@ -238,6 +272,7 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns objects that represent the services that were changed.
 By default, this cmdlet does not generate any output.
 
@@ -254,6 +289,7 @@ Accept wildcard characters: False
 ```
 
 ### -StartupType
+
 Specifies the start mode of the service.
 The acceptable values for this parameter are:
 
@@ -278,6 +314,7 @@ Accept wildcard characters: False
 ```
 
 ### -Status
+
 Specifies the status for the service.
 The acceptable values for this parameter are:
 
@@ -302,6 +339,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -317,6 +355,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -333,22 +372,26 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.ServiceProcess.ServiceController, System.String
+
 You can pipe a service object or a string that contains a service name to Set-Service.
 
 ## OUTPUTS
 
 ### System.ServiceProcess.ServiceController
+
 This cmdlet does not return any objects.
 
 ## NOTES
-* To use **Set-Service** on Windows Vista and later versions of the Windows operating system, start Windows PowerShell by using the Run as administrator option.
-* **Set-Service** can control services only when the current user has permission to do this. If a command does not work correctly, you might not have the required permissions.
-* To find the service names and display names of the services on your system, type `Get-Service`. The service names appear in the **Name** column and the display names appear in the **DisplayName** column.
+
+Use of **Set-Service** requires elevated permissions. Start  PowerShell by using the Run as administrator option.
+**Set-Service** can control services only when the current user has permission to do this. If a command does not work correctly, you might not have the required permissions.
+To find the service names and display names of the services on your system, type `Get-Service`. The service names appear in the **Name** column and the display names appear in the **DisplayName** column.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->

Found from LiveFyre feedback.

See breaking changes in v6 - the computername parameter was remove for consistency

- Get-Service
- Set-Service 

The documentation shows the correct syntax but talks about how you can manage remote services.

Need to document implicit remoting or Invoke-Command as a replacement for -ComputerName remoting.

Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [x] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work