### PR TITLE
Fixes #2416 update about_comparison_operators to reflect regular expression substitution

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -512,22 +512,85 @@ placeholder represents the characters that will replace them:
 
 By default, the `-replace` operator is case-insensitive. To make it case
 sensitive, use `-creplace`. To make it explicitly case-insensitive, use
-`-ireplace`. Consider the following examples:
+`-ireplace`.
+
+Consider the following examples:
 
 ```powershell
 PS> "book" -replace "B", "C"
+```
+
+```output
 Cook
 ```
 
 ```powershell
-PS> "book" -ireplace "B", "C"
+"book" -ireplace "B", "C"
+```
+
+```output
 Cook
 ```
 
 ```powershell
-PS> "book" -creplace "B", "C"
+"book" -creplace "B", "C"
+```
+
+```output
 book
 ```
+
+#### Substitutions in Regular Expressions
+
+Additionally, capturing groups can be referenced in the \<substitute\> string.
+This is done by using the `$` character before the group identifier.
+
+Two of the ways to reference capturing groups is by **Number** and by **Name**
+
+- By **Number** -
+  Capturing Groups are numbered from left to right.
+
+  ```powershell
+  "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
+  ```
+
+  ```output
+  John.D.Smith@contoso.com
+  ```
+
+- By **Name** -
+  Capturing Groups can also be referenced by name.
+
+  ```powershell
+  "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
+  ```
+
+  ```output
+  FABRIKOM\Administrator
+  ```
+
+> [!WARNING]
+> Since the `$` character is used in string expansion, you will need to use
+> literal strings with substitution, or escape the `$` character.
+> ```powershell
+> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
+> ```
+>
+> ```output
+> Hello Universe
+> ```
+>
+> Additionally, sicne the `$` character is used in substitution, you will need
+> to escape any instances in your string.
+>
+> ```powershell
+> '5.72' -replace '(.+)', '$$$1'
+> ```
+> ```output
+> $5.72
+> ```
+
+To learn more see [Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
 
 ### Type comparison
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -94,13 +94,13 @@ False
 
 C:PS> 1,2,3 -eq 2
 2
-PS C:\> "abc" -eq "abc"
+PS> "abc" -eq "abc"
 True
 
-PS C:\> "abc" -eq "abc", "def"
+PS> "abc" -eq "abc", "def"
 False
 
-PS C:\> "abc", "def" -eq "abc"
+PS> "abc", "def" -eq "abc"
 abc
 ```
 
@@ -109,17 +109,18 @@ abc
 Description: Not equal to. Includes a different value.
 
 Example:
+
 ```powershell
-PS C:\> "abc" -ne "def"
+PS> "abc" -ne "def"
 True
 
-PS C:\> "abc" -ne "abc"
+PS> "abc" -ne "abc"
 False
 
-PS C:\> "abc" -ne "abc", "def"
+PS> "abc" -ne "abc", "def"
 True
 
-PS C:\> "abc", "def" -ne "abc"
+PS> "abc", "def" -ne "abc"
 def
 ```
 
@@ -130,10 +131,10 @@ Description: Greater-than.
 Example:
 
 ```powershell
-PS C:\> 8 -gt 6
+PS> 8 -gt 6
 True
 
-PS C:\> 7, 8, 9 -gt 8
+PS> 7, 8, 9 -gt 8
 9
 ```
 
@@ -144,10 +145,10 @@ Description: Greater-than or equal to.
 Example:
 
 ```powershell
-PS C:\> 8 -ge 8
+PS> 8 -ge 8
 True
 
-PS C:\> 7, 8, 9 -ge 8
+PS> 7, 8, 9 -ge 8
 8
 9
 ```
@@ -160,10 +161,10 @@ Example:
 
 ```powershell
 
-PS C:\> 8 -lt 6
+PS> 8 -lt 6
 False
 
-PS C:\> 7, 8, 9 -lt 8
+PS> 7, 8, 9 -lt 8
 7
 ```
 
@@ -174,10 +175,10 @@ Description: Less-than or equal to.
 Example:
 
 ```powershell
-PS C:\> 6 -le 8
+PS> 6 -le 8
 True
 
-PS C:\> 7, 8, 9 -le 8
+PS> 7, 8, 9 -le 8
 7
 8
 ```
@@ -217,10 +218,10 @@ Description: Match using the wildcard character (\*).
 Example:
 
 ```powershell
-PS C:\> "PowerShell" -like "*shell"
+PS> "PowerShell" -like "*shell"
 True
 
-PS C:\> "PowerShell", "Server" -like "*shell"
+PS> "PowerShell", "Server" -like "*shell"
 PowerShell
 ```
 
@@ -231,10 +232,10 @@ Description: Does not match using the wildcard character (\*).
 Example:
 
 ```powershell
-PS C:\> "PowerShell" -notlike "*shell"
+PS> "PowerShell" -notlike "*shell"
 False
 
-PS C:\> "PowerShell", "Server" -notlike "*shell"
+PS> "PowerShell", "Server" -notlike "*shell"
 Server
 ```
 
@@ -255,11 +256,11 @@ For example, the following command submits a collection of strings to the
 that match. It does not populate the `$Matches` automatic variable.
 
 ```powershell
-PS C:\> "Sunday", "Monday", "Tuesday" -match "sun"
+PS> "Sunday", "Monday", "Tuesday" -match "sun"
 Sunday
 
-PS C:\> $matches
-PS C:\>
+PS> $matches
+PS>
 ```
 
 In contrast, the following command submits a single string to the `-match`
@@ -267,10 +268,10 @@ operator. The `-match` operator returns a Boolean value and populates the
 `$Matches` automatic variable.
 
 ```powershell
-PS C:\> "Sunday" -match "sun"
+PS> "Sunday" -match "sun"
 True
 
-PS C:\> $matches
+PS> $matches
 
 Name                           Value
 ----                           -----
@@ -281,16 +282,16 @@ The `-notmatch` operator populates the `$Matches` automatic variable when the
 input is scalar and the result is False, that it, when it detects a match.
 
 ```powershell
-PS C:\> "Sunday" -notmatch "rain"
+PS> "Sunday" -notmatch "rain"
 True
 
-PS C:\> $matches
-PS C:\>
+PS> $matches
+PS>
 
-PS C:\> "Sunday" -notmatch "day"
+PS> "Sunday" -notmatch "day"
 False
 
-PS C:\> $matches
+PS> $matches
 
 Name                           Value
 ----                           -----
@@ -305,15 +306,15 @@ is scalar, it populates the `$Matches` automatic variable.
 Example:
 
 ```powershell
-PS C:\> "Sunday" -notmatch "sun"
+PS> "Sunday" -notmatch "sun"
 False
 
-PS C:\> $matches
+PS> $matches
 Name Value
 ---- -----
 0    sun
 
-PS C:\> "Sunday", "Monday" -notmatch "sun"
+PS> "Sunday", "Monday" -notmatch "sun"
 Monday
 ```
 
@@ -348,23 +349,23 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "abc", "def" -contains "def"
+PS> "abc", "def" -contains "def"
 True
 
-PS C:\> "Windows", "PowerShell" -contains "Shell"
+PS> "Windows", "PowerShell" -contains "Shell"
 False  #Not an exact match
 
 # Does the list of computers in $DomainServers include $ThisComputer?
-PS C:\> $DomainServers -contains $thisComputer
+PS> $DomainServers -contains $thisComputer
 True
 
-PS C:\> "abc", "def", "ghi" -contains "abc", "def"
+PS> "abc", "def", "ghi" -contains "abc", "def"
 False
 
-PS C:\> $a = "abc", "def"
-PS C:\> "abc", "def", "ghi" -contains $a
+PS> $a = "abc", "def"
+PS> "abc", "def", "ghi" -contains $a
 False
-PS C:\> $a, "ghi" -contains $a
+PS> $a, "ghi" -contains $a
 True
 ```
 
@@ -385,7 +386,7 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "Windows", "PowerShell" -notcontains "Shell"
+PS> "Windows", "PowerShell" -notcontains "Shell"
 True  #Not an exact match
 
 # Get cmdlet parameters, but exclude common parameters
@@ -402,9 +403,9 @@ function get-parms ($cmdlet)
 }
 
 # Find unapproved verbs in the functions in my module
-PS C:\> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS C:\> $myVerbs = Get-Command -Module MyModule | foreach {$_.verb}
-PS C:\> $myVerbs | where {$ApprovedVerbs -notcontains $_}
+PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
+PS> $myVerbs = Get-Command -Module MyModule | foreach {$_.verb}
+PS> $myVerbs | where {$ApprovedVerbs -notcontains $_}
 ForEach
 Sort
 Tee
@@ -430,24 +431,24 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "def" -in "abc", "def"
+PS> "def" -in "abc", "def"
 True
 
-PS C:\> "Shell" -in "Windows", "PowerShell"
+PS> "Shell" -in "Windows", "PowerShell"
 False  #Not an exact match
 
-PS C:\> "Windows" -in "Windows", "PowerShell"
+PS> "Windows" -in "Windows", "PowerShell"
 True  #An exact match
 
-PS C:\> "Windows", "PowerShell" -in "Windows", "PowerShell", "ServerManager"
+PS> "Windows", "PowerShell" -in "Windows", "PowerShell", "ServerManager"
 False  #Using reference equality
 
-PS C:\> $a = "Windows", "PowerShell"
-PS C:\> $a -in $a, "ServerManager"
+PS> $a = "Windows", "PowerShell"
+PS> $a -in $a, "ServerManager"
 True  #Using reference equality
 
-# Does the list of computers in $domainServers include $thisComputer?
-PS C:\> $thisComputer -in  $domainServers
+# Does the list of computers in $DomainServers include $ThisComputer?
+PS> $thisComputer -in  $domainServers
 True
 ```
 
@@ -470,23 +471,23 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "def" -notin "abc", "def"
+PS> "def" -notin "abc", "def"
 False
 
-PS C:\> "ghi" -notin "abc", "def"
+PS> "ghi" -notin "abc", "def"
 True
 
-PS C:\> "Shell" -notin "Windows", "PowerShell"
+PS> "Shell" -notin "Windows", "PowerShell"
 True  #Not an exact match
 
-PS C:\> "Windows" -notin "Windows", "PowerShell"
+PS> "Windows" -notin "Windows", "PowerShell"
 False  #An exact match
 
 # Find unapproved verbs in the functions in my module
-PS C:\> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS C:\> $MyVerbs = Get-Command -Module MyModule | foreach {$_.verb}
+PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
+PS> $MyVerbs = Get-Command -Module MyModule | foreach {$_.verb}
 
-PS C:\> $MyVerbs | where {$_ -notin $ApprovedVerbs}
+PS> $MyVerbs | where {$_ -notin $ApprovedVerbs}
 ForEach
 Sort
 Tee
@@ -512,22 +513,85 @@ placeholder represents the characters that will replace them:
 
 By default, the `-replace` operator is case-insensitive. To make it case
 sensitive, use `-creplace`. To make it explicitly case-insensitive, use
-`-ireplace`. Consider the following examples:
+`-ireplace`.
+
+Consider the following examples:
 
 ```powershell
-PS C:\> "book" -replace "B", "C"
+PS> "book" -replace "B", "C"
+```
+
+```output
 Cook
 ```
 
 ```powershell
-PS C:\> "book" -ireplace "B", "C"
+"book" -ireplace "B", "C"
+```
+
+```output
 Cook
 ```
 
 ```powershell
-PS C:\> "book" -creplace "B", "C"
+"book" -creplace "B", "C"
+```
+
+```output
 book
 ```
+
+#### Substitutions in Regular Expressions
+
+Additionally, capturing groups can be referenced in the \<substitute\> string.
+This is done by using the `$` character before the group identifier.
+
+Two of the ways to reference capturing groups is by **Number** and by **Name**
+
+- By **Number** -
+  Capturing Groups are numbered from left to right.
+
+  ```powershell
+  "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
+  ```
+
+  ```output
+  John.D.Smith@contoso.com
+  ```
+
+- By **Name** -
+  Capturing Groups can also be referenced by name.
+
+  ```powershell
+  "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
+  ```
+
+  ```output
+  FABRIKOM\Administrator
+  ```
+
+> [!WARNING]
+> Since the `$` character is used in string expansion, you will need to use
+> literal strings with substitution, or escape the `$` character.
+> ```powershell
+> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
+> ```
+>
+> ```output
+> Hello Universe
+> ```
+>
+> Additionally, sicne the `$` character is used in substitution, you will need
+> to escape any instances in your string.
+>
+> ```powershell
+> '5.72' -replace '(.+)', '$$$1'
+> ```
+> ```output
+> $5.72
+> ```
+
+To learn more see [Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
 
 ### Type comparison
 
@@ -543,11 +607,11 @@ Syntax:
 Example:
 
 ```powershell
-PS C:\> $a = 1
-PS C:\> $b = "1"
-PS C:\> $a -is [int]
+PS> $a = 1
+PS> $b = "1"
+PS> $a -is [int]
 True
-PS C:\> $a -is $b.GetType()
+PS> $a -is $b.GetType()
 False
 ```
 
@@ -560,11 +624,11 @@ Syntax:
 Example:
 
 ```powershell
-PS C:\> $a = 1
-PS C:\> $b = "1"
-PS C:\> $a -isnot $b.GetType()
+PS> $a = 1
+PS> $b = "1"
+PS> $a -isnot $b.GetType()
 True
-PS C:\> $b -isnot [int]
+PS> $b -isnot [int]
 True
 ```
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -94,13 +94,13 @@ False
 
 C:PS> 1,2,3 -eq 2
 2
-PS C:\> "abc" -eq "abc"
+PS> "abc" -eq "abc"
 True
 
-PS C:\> "abc" -eq "abc", "def"
+PS> "abc" -eq "abc", "def"
 False
 
-PS C:\> "abc", "def" -eq "abc"
+PS> "abc", "def" -eq "abc"
 abc
 ```
 
@@ -109,17 +109,18 @@ abc
 Description: Not equal to. Includes a different value.
 
 Example:
+
 ```powershell
-PS C:\> "abc" -ne "def"
+PS> "abc" -ne "def"
 True
 
-PS C:\> "abc" -ne "abc"
+PS> "abc" -ne "abc"
 False
 
-PS C:\> "abc" -ne "abc", "def"
+PS> "abc" -ne "abc", "def"
 True
 
-PS C:\> "abc", "def" -ne "abc"
+PS> "abc", "def" -ne "abc"
 def
 ```
 
@@ -130,10 +131,10 @@ Description: Greater-than.
 Example:
 
 ```powershell
-PS C:\> 8 -gt 6
+PS> 8 -gt 6
 True
 
-PS C:\> 7, 8, 9 -gt 8
+PS> 7, 8, 9 -gt 8
 9
 ```
 
@@ -144,10 +145,10 @@ Description: Greater-than or equal to.
 Example:
 
 ```powershell
-PS C:\> 8 -ge 8
+PS> 8 -ge 8
 True
 
-PS C:\> 7, 8, 9 -ge 8
+PS> 7, 8, 9 -ge 8
 8
 9
 ```
@@ -160,10 +161,10 @@ Example:
 
 ```powershell
 
-PS C:\> 8 -lt 6
+PS> 8 -lt 6
 False
 
-PS C:\> 7, 8, 9 -lt 8
+PS> 7, 8, 9 -lt 8
 7
 ```
 
@@ -174,10 +175,10 @@ Description: Less-than or equal to.
 Example:
 
 ```powershell
-PS C:\> 6 -le 8
+PS> 6 -le 8
 True
 
-PS C:\> 7, 8, 9 -le 8
+PS> 7, 8, 9 -le 8
 7
 8
 ```
@@ -217,10 +218,10 @@ Description: Match using the wildcard character (\*).
 Example:
 
 ```powershell
-PS C:\> "PowerShell" -like "*shell"
+PS> "PowerShell" -like "*shell"
 True
 
-PS C:\> "PowerShell", "Server" -like "*shell"
+PS> "PowerShell", "Server" -like "*shell"
 PowerShell
 ```
 
@@ -231,10 +232,10 @@ Description: Does not match using the wildcard character (\*).
 Example:
 
 ```powershell
-PS C:\> "PowerShell" -notlike "*shell"
+PS> "PowerShell" -notlike "*shell"
 False
 
-PS C:\> "PowerShell", "Server" -notlike "*shell"
+PS> "PowerShell", "Server" -notlike "*shell"
 Server
 ```
 
@@ -255,11 +256,11 @@ For example, the following command submits a collection of strings to the
 that match. It does not populate the `$Matches` automatic variable.
 
 ```powershell
-PS C:\> "Sunday", "Monday", "Tuesday" -match "sun"
+PS> "Sunday", "Monday", "Tuesday" -match "sun"
 Sunday
 
-PS C:\> $matches
-PS C:\>
+PS> $matches
+PS>
 ```
 
 In contrast, the following command submits a single string to the `-match`
@@ -267,10 +268,10 @@ operator. The `-match` operator returns a Boolean value and populates the
 `$Matches` automatic variable.
 
 ```powershell
-PS C:\> "Sunday" -match "sun"
+PS> "Sunday" -match "sun"
 True
 
-PS C:\> $matches
+PS> $matches
 
 Name                           Value
 ----                           -----
@@ -281,16 +282,16 @@ The `-notmatch` operator populates the `$Matches` automatic variable when the
 input is scalar and the result is False, that it, when it detects a match.
 
 ```powershell
-PS C:\> "Sunday" -notmatch "rain"
+PS> "Sunday" -notmatch "rain"
 True
 
-PS C:\> $matches
-PS C:\>
+PS> $matches
+PS>
 
-PS C:\> "Sunday" -notmatch "day"
+PS> "Sunday" -notmatch "day"
 False
 
-PS C:\> $matches
+PS> $matches
 
 Name                           Value
 ----                           -----
@@ -305,15 +306,15 @@ is scalar, it populates the `$Matches` automatic variable.
 Example:
 
 ```powershell
-PS C:\> "Sunday" -notmatch "sun"
+PS> "Sunday" -notmatch "sun"
 False
 
-PS C:\> $matches
+PS> $matches
 Name Value
 ---- -----
 0    sun
 
-PS C:\> "Sunday", "Monday" -notmatch "sun"
+PS> "Sunday", "Monday" -notmatch "sun"
 Monday
 ```
 
@@ -348,23 +349,23 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "abc", "def" -contains "def"
+PS> "abc", "def" -contains "def"
 True
 
-PS C:\> "Windows", "PowerShell" -contains "Shell"
+PS> "Windows", "PowerShell" -contains "Shell"
 False  #Not an exact match
 
 # Does the list of computers in $DomainServers include $ThisComputer?
-PS C:\> $DomainServers -contains $thisComputer
+PS> $DomainServers -contains $thisComputer
 True
 
-PS C:\> "abc", "def", "ghi" -contains "abc", "def"
+PS> "abc", "def", "ghi" -contains "abc", "def"
 False
 
-PS C:\> $a = "abc", "def"
-PS C:\> "abc", "def", "ghi" -contains $a
+PS> $a = "abc", "def"
+PS> "abc", "def", "ghi" -contains $a
 False
-PS C:\> $a, "ghi" -contains $a
+PS> $a, "ghi" -contains $a
 True
 ```
 
@@ -385,7 +386,7 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "Windows", "PowerShell" -notcontains "Shell"
+PS> "Windows", "PowerShell" -notcontains "Shell"
 True  #Not an exact match
 
 # Get cmdlet parameters, but exclude common parameters
@@ -402,9 +403,9 @@ function get-parms ($cmdlet)
 }
 
 # Find unapproved verbs in the functions in my module
-PS C:\> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS C:\> $myVerbs = Get-Command -Module MyModule | foreach {$_.verb}
-PS C:\> $myVerbs | where {$ApprovedVerbs -notcontains $_}
+PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
+PS> $myVerbs = Get-Command -Module MyModule | foreach {$_.verb}
+PS> $myVerbs | where {$ApprovedVerbs -notcontains $_}
 ForEach
 Sort
 Tee
@@ -430,24 +431,24 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "def" -in "abc", "def"
+PS> "def" -in "abc", "def"
 True
 
-PS C:\> "Shell" -in "Windows", "PowerShell"
+PS> "Shell" -in "Windows", "PowerShell"
 False  #Not an exact match
 
-PS C:\> "Windows" -in "Windows", "PowerShell"
+PS> "Windows" -in "Windows", "PowerShell"
 True  #An exact match
 
-PS C:\> "Windows", "PowerShell" -in "Windows", "PowerShell", "ServerManager"
+PS> "Windows", "PowerShell" -in "Windows", "PowerShell", "ServerManager"
 False  #Using reference equality
 
-PS C:\> $a = "Windows", "PowerShell"
-PS C:\> $a -in $a, "ServerManager"
+PS> $a = "Windows", "PowerShell"
+PS> $a -in $a, "ServerManager"
 True  #Using reference equality
 
-# Does the list of computers in $domainServers include $thisComputer?
-PS C:\> $thisComputer -in  $domainServers
+# Does the list of computers in $DomainServers include $ThisComputer?
+PS> $thisComputer -in  $domainServers
 True
 ```
 
@@ -470,23 +471,23 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "def" -notin "abc", "def"
+PS> "def" -notin "abc", "def"
 False
 
-PS C:\> "ghi" -notin "abc", "def"
+PS> "ghi" -notin "abc", "def"
 True
 
-PS C:\> "Shell" -notin "Windows", "PowerShell"
+PS> "Shell" -notin "Windows", "PowerShell"
 True  #Not an exact match
 
-PS C:\> "Windows" -notin "Windows", "PowerShell"
+PS> "Windows" -notin "Windows", "PowerShell"
 False  #An exact match
 
 # Find unapproved verbs in the functions in my module
-PS C:\> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS C:\> $MyVerbs = Get-Command -Module MyModule | foreach {$_.verb}
+PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
+PS> $MyVerbs = Get-Command -Module MyModule | foreach {$_.verb}
 
-PS C:\> $MyVerbs | where {$_ -notin $ApprovedVerbs}
+PS> $MyVerbs | where {$_ -notin $ApprovedVerbs}
 ForEach
 Sort
 Tee
@@ -512,22 +513,85 @@ placeholder represents the characters that will replace them:
 
 By default, the `-replace` operator is case-insensitive. To make it case
 sensitive, use `-creplace`. To make it explicitly case-insensitive, use
-`-ireplace`. Consider the following examples:
+`-ireplace`.
+
+Consider the following examples:
 
 ```powershell
-PS C:\> "book" -replace "B", "C"
+PS> "book" -replace "B", "C"
+```
+
+```output
 Cook
 ```
 
 ```powershell
-PS C:\> "book" -ireplace "B", "C"
+"book" -ireplace "B", "C"
+```
+
+```output
 Cook
 ```
 
 ```powershell
-PS C:\> "book" -creplace "B", "C"
+"book" -creplace "B", "C"
+```
+
+```output
 book
 ```
+
+#### Substitutions in Regular Expressions
+
+Additionally, capturing groups can be referenced in the \<substitute\> string.
+This is done by using the `$` character before the group identifier.
+
+Two of the ways to reference capturing groups is by **Number** and by **Name**
+
+- By **Number** -
+  Capturing Groups are numbered from left to right.
+
+  ```powershell
+  "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
+  ```
+
+  ```output
+  John.D.Smith@contoso.com
+  ```
+
+- By **Name** -
+  Capturing Groups can also be referenced by name.
+
+  ```powershell
+  "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
+  ```
+
+  ```output
+  FABRIKOM\Administrator
+  ```
+
+> [!WARNING]
+> Since the `$` character is used in string expansion, you will need to use
+> literal strings with substitution, or escape the `$` character.
+> ```powershell
+> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
+> ```
+>
+> ```output
+> Hello Universe
+> ```
+>
+> Additionally, sicne the `$` character is used in substitution, you will need
+> to escape any instances in your string.
+>
+> ```powershell
+> '5.72' -replace '(.+)', '$$$1'
+> ```
+> ```output
+> $5.72
+> ```
+
+To learn more see [Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
 
 ### Type comparison
 
@@ -543,11 +607,11 @@ Syntax:
 Example:
 
 ```powershell
-PS C:\> $a = 1
-PS C:\> $b = "1"
-PS C:\> $a -is [int]
+PS> $a = 1
+PS> $b = "1"
+PS> $a -is [int]
 True
-PS C:\> $a -is $b.GetType()
+PS> $a -is $b.GetType()
 False
 ```
 
@@ -560,11 +624,11 @@ Syntax:
 Example:
 
 ```powershell
-PS C:\> $a = 1
-PS C:\> $b = "1"
-PS C:\> $a -isnot $b.GetType()
+PS> $a = 1
+PS> $b = "1"
+PS> $a -isnot $b.GetType()
 True
-PS C:\> $b -isnot [int]
+PS> $b -isnot [int]
 True
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -94,13 +94,13 @@ False
 
 C:PS> 1,2,3 -eq 2
 2
-PS C:\> "abc" -eq "abc"
+PS> "abc" -eq "abc"
 True
 
-PS C:\> "abc" -eq "abc", "def"
+PS> "abc" -eq "abc", "def"
 False
 
-PS C:\> "abc", "def" -eq "abc"
+PS> "abc", "def" -eq "abc"
 abc
 ```
 
@@ -109,17 +109,18 @@ abc
 Description: Not equal to. Includes a different value.
 
 Example:
+
 ```powershell
-PS C:\> "abc" -ne "def"
+PS> "abc" -ne "def"
 True
 
-PS C:\> "abc" -ne "abc"
+PS> "abc" -ne "abc"
 False
 
-PS C:\> "abc" -ne "abc", "def"
+PS> "abc" -ne "abc", "def"
 True
 
-PS C:\> "abc", "def" -ne "abc"
+PS> "abc", "def" -ne "abc"
 def
 ```
 
@@ -130,10 +131,10 @@ Description: Greater-than.
 Example:
 
 ```powershell
-PS C:\> 8 -gt 6
+PS> 8 -gt 6
 True
 
-PS C:\> 7, 8, 9 -gt 8
+PS> 7, 8, 9 -gt 8
 9
 ```
 
@@ -144,10 +145,10 @@ Description: Greater-than or equal to.
 Example:
 
 ```powershell
-PS C:\> 8 -ge 8
+PS> 8 -ge 8
 True
 
-PS C:\> 7, 8, 9 -ge 8
+PS> 7, 8, 9 -ge 8
 8
 9
 ```
@@ -160,10 +161,10 @@ Example:
 
 ```powershell
 
-PS C:\> 8 -lt 6
+PS> 8 -lt 6
 False
 
-PS C:\> 7, 8, 9 -lt 8
+PS> 7, 8, 9 -lt 8
 7
 ```
 
@@ -174,10 +175,10 @@ Description: Less-than or equal to.
 Example:
 
 ```powershell
-PS C:\> 6 -le 8
+PS> 6 -le 8
 True
 
-PS C:\> 7, 8, 9 -le 8
+PS> 7, 8, 9 -le 8
 7
 8
 ```
@@ -217,10 +218,10 @@ Description: Match using the wildcard character (\*).
 Example:
 
 ```powershell
-PS C:\> "PowerShell" -like "*shell"
+PS> "PowerShell" -like "*shell"
 True
 
-PS C:\> "PowerShell", "Server" -like "*shell"
+PS> "PowerShell", "Server" -like "*shell"
 PowerShell
 ```
 
@@ -231,10 +232,10 @@ Description: Does not match using the wildcard character (\*).
 Example:
 
 ```powershell
-PS C:\> "PowerShell" -notlike "*shell"
+PS> "PowerShell" -notlike "*shell"
 False
 
-PS C:\> "PowerShell", "Server" -notlike "*shell"
+PS> "PowerShell", "Server" -notlike "*shell"
 Server
 ```
 
@@ -255,11 +256,11 @@ For example, the following command submits a collection of strings to the
 that match. It does not populate the `$Matches` automatic variable.
 
 ```powershell
-PS C:\> "Sunday", "Monday", "Tuesday" -match "sun"
+PS> "Sunday", "Monday", "Tuesday" -match "sun"
 Sunday
 
-PS C:\> $matches
-PS C:\>
+PS> $matches
+PS>
 ```
 
 In contrast, the following command submits a single string to the `-match`
@@ -267,10 +268,10 @@ operator. The `-match` operator returns a Boolean value and populates the
 `$Matches` automatic variable.
 
 ```powershell
-PS C:\> "Sunday" -match "sun"
+PS> "Sunday" -match "sun"
 True
 
-PS C:\> $matches
+PS> $matches
 
 Name                           Value
 ----                           -----
@@ -281,16 +282,16 @@ The `-notmatch` operator populates the `$Matches` automatic variable when the
 input is scalar and the result is False, that it, when it detects a match.
 
 ```powershell
-PS C:\> "Sunday" -notmatch "rain"
+PS> "Sunday" -notmatch "rain"
 True
 
-PS C:\> $matches
-PS C:\>
+PS> $matches
+PS>
 
-PS C:\> "Sunday" -notmatch "day"
+PS> "Sunday" -notmatch "day"
 False
 
-PS C:\> $matches
+PS> $matches
 
 Name                           Value
 ----                           -----
@@ -305,15 +306,15 @@ is scalar, it populates the `$Matches` automatic variable.
 Example:
 
 ```powershell
-PS C:\> "Sunday" -notmatch "sun"
+PS> "Sunday" -notmatch "sun"
 False
 
-PS C:\> $matches
+PS> $matches
 Name Value
 ---- -----
 0    sun
 
-PS C:\> "Sunday", "Monday" -notmatch "sun"
+PS> "Sunday", "Monday" -notmatch "sun"
 Monday
 ```
 
@@ -348,23 +349,23 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "abc", "def" -contains "def"
+PS> "abc", "def" -contains "def"
 True
 
-PS C:\> "Windows", "PowerShell" -contains "Shell"
+PS> "Windows", "PowerShell" -contains "Shell"
 False  #Not an exact match
 
 # Does the list of computers in $DomainServers include $ThisComputer?
-PS C:\> $DomainServers -contains $thisComputer
+PS> $DomainServers -contains $thisComputer
 True
 
-PS C:\> "abc", "def", "ghi" -contains "abc", "def"
+PS> "abc", "def", "ghi" -contains "abc", "def"
 False
 
-PS C:\> $a = "abc", "def"
-PS C:\> "abc", "def", "ghi" -contains $a
+PS> $a = "abc", "def"
+PS> "abc", "def", "ghi" -contains $a
 False
-PS C:\> $a, "ghi" -contains $a
+PS> $a, "ghi" -contains $a
 True
 ```
 
@@ -385,7 +386,7 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "Windows", "PowerShell" -notcontains "Shell"
+PS> "Windows", "PowerShell" -notcontains "Shell"
 True  #Not an exact match
 
 # Get cmdlet parameters, but exclude common parameters
@@ -402,9 +403,9 @@ function get-parms ($cmdlet)
 }
 
 # Find unapproved verbs in the functions in my module
-PS C:\> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS C:\> $myVerbs = Get-Command -Module MyModule | foreach {$_.verb}
-PS C:\> $myVerbs | where {$ApprovedVerbs -notcontains $_}
+PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
+PS> $myVerbs = Get-Command -Module MyModule | foreach {$_.verb}
+PS> $myVerbs | where {$ApprovedVerbs -notcontains $_}
 ForEach
 Sort
 Tee
@@ -430,24 +431,24 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "def" -in "abc", "def"
+PS> "def" -in "abc", "def"
 True
 
-PS C:\> "Shell" -in "Windows", "PowerShell"
+PS> "Shell" -in "Windows", "PowerShell"
 False  #Not an exact match
 
-PS C:\> "Windows" -in "Windows", "PowerShell"
+PS> "Windows" -in "Windows", "PowerShell"
 True  #An exact match
 
-PS C:\> "Windows", "PowerShell" -in "Windows", "PowerShell", "ServerManager"
+PS> "Windows", "PowerShell" -in "Windows", "PowerShell", "ServerManager"
 False  #Using reference equality
 
-PS C:\> $a = "Windows", "PowerShell"
-PS C:\> $a -in $a, "ServerManager"
+PS> $a = "Windows", "PowerShell"
+PS> $a -in $a, "ServerManager"
 True  #Using reference equality
 
-# Does the list of computers in $domainServers include $thisComputer?
-PS C:\> $thisComputer -in  $domainServers
+# Does the list of computers in $DomainServers include $ThisComputer?
+PS> $thisComputer -in  $domainServers
 True
 ```
 
@@ -470,23 +471,23 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "def" -notin "abc", "def"
+PS> "def" -notin "abc", "def"
 False
 
-PS C:\> "ghi" -notin "abc", "def"
+PS> "ghi" -notin "abc", "def"
 True
 
-PS C:\> "Shell" -notin "Windows", "PowerShell"
+PS> "Shell" -notin "Windows", "PowerShell"
 True  #Not an exact match
 
-PS C:\> "Windows" -notin "Windows", "PowerShell"
+PS> "Windows" -notin "Windows", "PowerShell"
 False  #An exact match
 
 # Find unapproved verbs in the functions in my module
-PS C:\> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS C:\> $MyVerbs = Get-Command -Module MyModule | foreach {$_.verb}
+PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
+PS> $MyVerbs = Get-Command -Module MyModule | foreach {$_.verb}
 
-PS C:\> $MyVerbs | where {$_ -notin $ApprovedVerbs}
+PS> $MyVerbs | where {$_ -notin $ApprovedVerbs}
 ForEach
 Sort
 Tee
@@ -512,22 +513,85 @@ placeholder represents the characters that will replace them:
 
 By default, the `-replace` operator is case-insensitive. To make it case
 sensitive, use `-creplace`. To make it explicitly case-insensitive, use
-`-ireplace`. Consider the following examples:
+`-ireplace`.
+
+Consider the following examples:
 
 ```powershell
-PS C:\> "book" -replace "B", "C"
+PS> "book" -replace "B", "C"
+```
+
+```output
 Cook
 ```
 
 ```powershell
-PS C:\> "book" -ireplace "B", "C"
+"book" -ireplace "B", "C"
+```
+
+```output
 Cook
 ```
 
 ```powershell
-PS C:\> "book" -creplace "B", "C"
+"book" -creplace "B", "C"
+```
+
+```output
 book
 ```
+
+#### Substitutions in Regular Expressions
+
+Additionally, capturing groups can be referenced in the \<substitute\> string.
+This is done by using the `$` character before the group identifier.
+
+Two of the ways to reference capturing groups is by **Number** and by **Name**
+
+- By **Number** -
+  Capturing Groups are numbered from left to right.
+
+  ```powershell
+  "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
+  ```
+
+  ```output
+  John.D.Smith@contoso.com
+  ```
+
+- By **Name** -
+  Capturing Groups can also be referenced by name.
+
+  ```powershell
+  "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
+  ```
+
+  ```output
+  FABRIKOM\Administrator
+  ```
+
+> [!WARNING]
+> Since the `$` character is used in string expansion, you will need to use
+> literal strings with substitution, or escape the `$` character.
+> ```powershell
+> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
+> ```
+>
+> ```output
+> Hello Universe
+> ```
+>
+> Additionally, sicne the `$` character is used in substitution, you will need
+> to escape any instances in your string.
+>
+> ```powershell
+> '5.72' -replace '(.+)', '$$$1'
+> ```
+> ```output
+> $5.72
+> ```
+
+To learn more see [Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
 
 ### Type comparison
 
@@ -543,11 +607,11 @@ Syntax:
 Example:
 
 ```powershell
-PS C:\> $a = 1
-PS C:\> $b = "1"
-PS C:\> $a -is [int]
+PS> $a = 1
+PS> $b = "1"
+PS> $a -is [int]
 True
-PS C:\> $a -is $b.GetType()
+PS> $a -is $b.GetType()
 False
 ```
 
@@ -560,11 +624,11 @@ Syntax:
 Example:
 
 ```powershell
-PS C:\> $a = 1
-PS C:\> $b = "1"
-PS C:\> $a -isnot $b.GetType()
+PS> $a = 1
+PS> $b = "1"
+PS> $a -isnot $b.GetType()
 True
-PS C:\> $b -isnot [int]
+PS> $b -isnot [int]
 True
 ```
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -94,13 +94,13 @@ False
 
 C:PS> 1,2,3 -eq 2
 2
-PS C:\> "abc" -eq "abc"
+PS> "abc" -eq "abc"
 True
 
-PS C:\> "abc" -eq "abc", "def"
+PS> "abc" -eq "abc", "def"
 False
 
-PS C:\> "abc", "def" -eq "abc"
+PS> "abc", "def" -eq "abc"
 abc
 ```
 
@@ -109,17 +109,18 @@ abc
 Description: Not equal to. Includes a different value.
 
 Example:
+
 ```powershell
-PS C:\> "abc" -ne "def"
+PS> "abc" -ne "def"
 True
 
-PS C:\> "abc" -ne "abc"
+PS> "abc" -ne "abc"
 False
 
-PS C:\> "abc" -ne "abc", "def"
+PS> "abc" -ne "abc", "def"
 True
 
-PS C:\> "abc", "def" -ne "abc"
+PS> "abc", "def" -ne "abc"
 def
 ```
 
@@ -130,10 +131,10 @@ Description: Greater-than.
 Example:
 
 ```powershell
-PS C:\> 8 -gt 6
+PS> 8 -gt 6
 True
 
-PS C:\> 7, 8, 9 -gt 8
+PS> 7, 8, 9 -gt 8
 9
 ```
 
@@ -144,10 +145,10 @@ Description: Greater-than or equal to.
 Example:
 
 ```powershell
-PS C:\> 8 -ge 8
+PS> 8 -ge 8
 True
 
-PS C:\> 7, 8, 9 -ge 8
+PS> 7, 8, 9 -ge 8
 8
 9
 ```
@@ -160,10 +161,10 @@ Example:
 
 ```powershell
 
-PS C:\> 8 -lt 6
+PS> 8 -lt 6
 False
 
-PS C:\> 7, 8, 9 -lt 8
+PS> 7, 8, 9 -lt 8
 7
 ```
 
@@ -174,10 +175,10 @@ Description: Less-than or equal to.
 Example:
 
 ```powershell
-PS C:\> 6 -le 8
+PS> 6 -le 8
 True
 
-PS C:\> 7, 8, 9 -le 8
+PS> 7, 8, 9 -le 8
 7
 8
 ```
@@ -217,10 +218,10 @@ Description: Match using the wildcard character (\*).
 Example:
 
 ```powershell
-PS C:\> "PowerShell" -like "*shell"
+PS> "PowerShell" -like "*shell"
 True
 
-PS C:\> "PowerShell", "Server" -like "*shell"
+PS> "PowerShell", "Server" -like "*shell"
 PowerShell
 ```
 
@@ -231,10 +232,10 @@ Description: Does not match using the wildcard character (\*).
 Example:
 
 ```powershell
-PS C:\> "PowerShell" -notlike "*shell"
+PS> "PowerShell" -notlike "*shell"
 False
 
-PS C:\> "PowerShell", "Server" -notlike "*shell"
+PS> "PowerShell", "Server" -notlike "*shell"
 Server
 ```
 
@@ -255,11 +256,11 @@ For example, the following command submits a collection of strings to the
 that match. It does not populate the `$Matches` automatic variable.
 
 ```powershell
-PS C:\> "Sunday", "Monday", "Tuesday" -match "sun"
+PS> "Sunday", "Monday", "Tuesday" -match "sun"
 Sunday
 
-PS C:\> $matches
-PS C:\>
+PS> $matches
+PS>
 ```
 
 In contrast, the following command submits a single string to the `-match`
@@ -267,10 +268,10 @@ operator. The `-match` operator returns a Boolean value and populates the
 `$Matches` automatic variable.
 
 ```powershell
-PS C:\> "Sunday" -match "sun"
+PS> "Sunday" -match "sun"
 True
 
-PS C:\> $matches
+PS> $matches
 
 Name                           Value
 ----                           -----
@@ -281,16 +282,16 @@ The `-notmatch` operator populates the `$Matches` automatic variable when the
 input is scalar and the result is False, that it, when it detects a match.
 
 ```powershell
-PS C:\> "Sunday" -notmatch "rain"
+PS> "Sunday" -notmatch "rain"
 True
 
-PS C:\> $matches
-PS C:\>
+PS> $matches
+PS>
 
-PS C:\> "Sunday" -notmatch "day"
+PS> "Sunday" -notmatch "day"
 False
 
-PS C:\> $matches
+PS> $matches
 
 Name                           Value
 ----                           -----
@@ -305,15 +306,15 @@ is scalar, it populates the `$Matches` automatic variable.
 Example:
 
 ```powershell
-PS C:\> "Sunday" -notmatch "sun"
+PS> "Sunday" -notmatch "sun"
 False
 
-PS C:\> $matches
+PS> $matches
 Name Value
 ---- -----
 0    sun
 
-PS C:\> "Sunday", "Monday" -notmatch "sun"
+PS> "Sunday", "Monday" -notmatch "sun"
 Monday
 ```
 
@@ -348,23 +349,23 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "abc", "def" -contains "def"
+PS> "abc", "def" -contains "def"
 True
 
-PS C:\> "Windows", "PowerShell" -contains "Shell"
+PS> "Windows", "PowerShell" -contains "Shell"
 False  #Not an exact match
 
 # Does the list of computers in $DomainServers include $ThisComputer?
-PS C:\> $DomainServers -contains $thisComputer
+PS> $DomainServers -contains $thisComputer
 True
 
-PS C:\> "abc", "def", "ghi" -contains "abc", "def"
+PS> "abc", "def", "ghi" -contains "abc", "def"
 False
 
-PS C:\> $a = "abc", "def"
-PS C:\> "abc", "def", "ghi" -contains $a
+PS> $a = "abc", "def"
+PS> "abc", "def", "ghi" -contains $a
 False
-PS C:\> $a, "ghi" -contains $a
+PS> $a, "ghi" -contains $a
 True
 ```
 
@@ -385,7 +386,7 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "Windows", "PowerShell" -notcontains "Shell"
+PS> "Windows", "PowerShell" -notcontains "Shell"
 True  #Not an exact match
 
 # Get cmdlet parameters, but exclude common parameters
@@ -402,9 +403,9 @@ function get-parms ($cmdlet)
 }
 
 # Find unapproved verbs in the functions in my module
-PS C:\> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS C:\> $myVerbs = Get-Command -Module MyModule | foreach {$_.verb}
-PS C:\> $myVerbs | where {$ApprovedVerbs -notcontains $_}
+PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
+PS> $myVerbs = Get-Command -Module MyModule | foreach {$_.verb}
+PS> $myVerbs | where {$ApprovedVerbs -notcontains $_}
 ForEach
 Sort
 Tee
@@ -430,24 +431,24 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "def" -in "abc", "def"
+PS> "def" -in "abc", "def"
 True
 
-PS C:\> "Shell" -in "Windows", "PowerShell"
+PS> "Shell" -in "Windows", "PowerShell"
 False  #Not an exact match
 
-PS C:\> "Windows" -in "Windows", "PowerShell"
+PS> "Windows" -in "Windows", "PowerShell"
 True  #An exact match
 
-PS C:\> "Windows", "PowerShell" -in "Windows", "PowerShell", "ServerManager"
+PS> "Windows", "PowerShell" -in "Windows", "PowerShell", "ServerManager"
 False  #Using reference equality
 
-PS C:\> $a = "Windows", "PowerShell"
-PS C:\> $a -in $a, "ServerManager"
+PS> $a = "Windows", "PowerShell"
+PS> $a -in $a, "ServerManager"
 True  #Using reference equality
 
-# Does the list of computers in $domainServers include $thisComputer?
-PS C:\> $thisComputer -in  $domainServers
+# Does the list of computers in $DomainServers include $ThisComputer?
+PS> $thisComputer -in  $domainServers
 True
 ```
 
@@ -470,23 +471,23 @@ Syntax:
 Examples:
 
 ```powershell
-PS C:\> "def" -notin "abc", "def"
+PS> "def" -notin "abc", "def"
 False
 
-PS C:\> "ghi" -notin "abc", "def"
+PS> "ghi" -notin "abc", "def"
 True
 
-PS C:\> "Shell" -notin "Windows", "PowerShell"
+PS> "Shell" -notin "Windows", "PowerShell"
 True  #Not an exact match
 
-PS C:\> "Windows" -notin "Windows", "PowerShell"
+PS> "Windows" -notin "Windows", "PowerShell"
 False  #An exact match
 
 # Find unapproved verbs in the functions in my module
-PS C:\> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
-PS C:\> $MyVerbs = Get-Command -Module MyModule | foreach {$_.verb}
+PS> $ApprovedVerbs = Get-Verb | foreach {$_.verb}
+PS> $MyVerbs = Get-Command -Module MyModule | foreach {$_.verb}
 
-PS C:\> $MyVerbs | where {$_ -notin $ApprovedVerbs}
+PS> $MyVerbs | where {$_ -notin $ApprovedVerbs}
 ForEach
 Sort
 Tee
@@ -512,22 +513,85 @@ placeholder represents the characters that will replace them:
 
 By default, the `-replace` operator is case-insensitive. To make it case
 sensitive, use `-creplace`. To make it explicitly case-insensitive, use
-`-ireplace`. Consider the following examples:
+`-ireplace`.
+
+Consider the following examples:
 
 ```powershell
-PS C:\> "book" -replace "B", "C"
+PS> "book" -replace "B", "C"
+```
+
+```output
 Cook
 ```
 
 ```powershell
-PS C:\> "book" -ireplace "B", "C"
+"book" -ireplace "B", "C"
+```
+
+```output
 Cook
 ```
 
 ```powershell
-PS C:\> "book" -creplace "B", "C"
+"book" -creplace "B", "C"
+```
+
+```output
 book
 ```
+
+#### Substitutions in Regular Expressions
+
+Additionally, capturing groups can be referenced in the \<substitute\> string.
+This is done by using the `$` character before the group identifier.
+
+Two of the ways to reference capturing groups is by **Number** and by **Name**
+
+- By **Number** -
+  Capturing Groups are numbered from left to right.
+
+  ```powershell
+  "John D. Smith" -replace "(\w+) (\w+)\. (\w+)", '$1.$2.$3@contoso.com'
+  ```
+
+  ```output
+  John.D.Smith@contoso.com
+  ```
+
+- By **Name** -
+  Capturing Groups can also be referenced by name.
+
+  ```powershell
+  "CONTOSO\Administrator" -replace '\w+\\(?<user>\w+)', 'FABRIKAM\${user}'
+  ```
+
+  ```output
+  FABRIKOM\Administrator
+  ```
+
+> [!WARNING]
+> Since the `$` character is used in string expansion, you will need to use
+> literal strings with substitution, or escape the `$` character.
+> ```powershell
+> 'Hello World' -replace '(\w+) \w+', "`$1 Universe"
+> ```
+>
+> ```output
+> Hello Universe
+> ```
+>
+> Additionally, sicne the `$` character is used in substitution, you will need
+> to escape any instances in your string.
+>
+> ```powershell
+> '5.72' -replace '(.+)', '$$$1'
+> ```
+> ```output
+> $5.72
+> ```
+
+To learn more see [Substitutions in Regular Expressions](/dotnet/standard/base-types/substitutions-in-regular-expressions)
 
 ### Type comparison
 
@@ -543,11 +607,11 @@ Syntax:
 Example:
 
 ```powershell
-PS C:\> $a = 1
-PS C:\> $b = "1"
-PS C:\> $a -is [int]
+PS> $a = 1
+PS> $b = "1"
+PS> $a -is [int]
 True
-PS C:\> $a -is $b.GetType()
+PS> $a -is $b.GetType()
 False
 ```
 
@@ -560,11 +624,11 @@ Syntax:
 Example:
 
 ```powershell
-PS C:\> $a = 1
-PS C:\> $b = "1"
-PS C:\> $a -isnot $b.GetType()
+PS> $a = 1
+PS> $b = "1"
+PS> $a -isnot $b.GetType()
 True
-PS C:\> $b -isnot [int]
+PS> $b -isnot [int]
 True
 ```
 


### PR DESCRIPTION
…ession substitution

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [X] Impacts 6.0 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work