### PR TITLE
Workaround for buggy Subsystem parameter

### DIFF
--- a/reference/docs-conceptual/core-powershell/SSH-Remoting-in-PowerShell-Core.md
+++ b/reference/docs-conceptual/core-powershell/SSH-Remoting-in-PowerShell-Core.md
@@ -55,7 +55,23 @@ In addition you will need to enable password authentication and optionally key b
     ```
     Subsystem    powershell c:/program files/powershell/6.0.0/pwsh.exe -sshs -NoLogo -NoProfile
     ```
+    
+    **!!! Currently, there is an open Bug in OpenSSH preventing this from working:**
+    
+    See [subsystem executable paths with "spaces" do not work](https://github.com/PowerShell/Win32-OpenSSH/issues/784)
+    
+    A workaround is to create a symlink to the Powershell Core installation directory in a place that can be found without a space character in the path:
 
+    ```powershell
+    PS> mklink /D c:\pwsh "C:\Program Files\PowerShell\6.0.0"
+    ```
+
+    and reference that in the Subsystem:
+ 
+    ```
+    Subsystem    powershell c:\pwsh\pwsh.exe -sshs -NoLogo -NoProfile
+    ```
+    
     - Optionally enable key authentication
 
     ```


### PR DESCRIPTION
In current releases of OpenSSH the Subsystem parameter of sshd_config does not work as described in this documentation. I suggest adding the workaround to the description as OpenSSH has an open bug for this and is expected to fix the issue on their side so that the parameter works as expected and as originally written here.