### PR TITLE
Closes #4783 - Addressed lack of documentation on RequiredVersion, in Windows PowerShell 5.0

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -56,7 +56,7 @@ does not run the script.
 
 ### Parameters
 
--Version \<N\>[.\<n\>]
+#### -Version \<N\>[.\<n\>]
 
 Specifies the minimum version of Windows PowerShell that the script requires.
 Enter a major version number and optional minor version number.
@@ -67,7 +67,7 @@ For example:
 #Requires -Version 3.0
 ```
 
--PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
+#### -PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
 
 Specifies a Windows PowerShell snap-in that the script requires. Enter the
 snap-in name and an optional version number.
@@ -78,7 +78,7 @@ For example:
 #Requires -PSSnapin DiskSnapin -Version 1.2
 ```
 
--Modules \<Module-Name\> | \<Hashtable\>
+#### -Modules \<Module-Name\> | \<Hashtable\>
 
 Specifies Windows PowerShell modules that the script requires. Enter the
 module name and an optional version number. The Modules parameter is
@@ -91,17 +91,25 @@ terminating error.
 For each module, type the module name (\<String\>) or a hash table with the
 following keys. The value can be a combination of strings and hash tables.
 
-- ModuleName. This key is required.
-- ModuleVersion. This key is required.
-- GUID. This key is optional.
+- `ModuleName` - __[Required]__ Specifies the *ModuleName*.
+- `ModuleVersion` - __[Required]__ Specifies an maximum allowed *ModuleVersion*
+- `GUID` - __[Optional]__ Specifies a required module *GUID*
 
 For example,
 
 ```powershell
-#Requires -Modules PSWorkflow, @{ ModuleName="PSScheduledJob"; ModuleVersion="1.0.0.0" }
+#Requires -Modules @{ ModuleName="Hyper-V"; RequiredVersion="1.1.0.0" }
 ```
 
--ShellId
+Requires that `Hyper-V` (version `1.1.0.0` or **less**) is installed
+
+```powershell
+#Requires -Modules PSWorkflow, PSScheduledJob
+```
+
+Requires that any version of `PSScheduledJob` and `PSWorkflow` are installed.
+
+#### -ShellId
 
 Specifies the shell that the script requires. Enter the shell ID.
 
@@ -113,7 +121,7 @@ For example,
 
 You can find current ShellId by querying `$ShellId` automatic variable.
 
-### EXAMPLES
+### Examples
 
 The following script has two `#Requires` statements. If the requirements
 specified in both statements are not met, the script does not run. Each

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -57,7 +57,7 @@ does not run the script.
 
 ### Parameters
 
--Version \<N\>[.\<n\>]
+#### -Version \<N\>[.\<n\>]
 
 Specifies the minimum version of Windows PowerShell that the script requires.
 Enter a major version number and optional minor version number.
@@ -68,7 +68,7 @@ For example:
 #Requires -Version 3.0
 ```
 
--PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
+#### -PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
 
 Specifies a Windows PowerShell snap-in that the script requires. Enter the
 snap-in name and an optional version number.
@@ -79,7 +79,7 @@ For example:
 #Requires -PSSnapin DiskSnapin -Version 1.2
 ```
 
--Modules \<Module-Name\> | \<Hashtable\>
+#### -Modules \<Module-Name\> | \<Hashtable\>
 
 Specifies Windows PowerShell modules that the script requires. Enter the
 module name and an optional version number. The Modules parameter is
@@ -92,17 +92,25 @@ terminating error.
 For each module, type the module name (\<String\>) or a hash table with the
 following keys. The value can be a combination of strings and hash tables.
 
-- ModuleName. This key is required.
-- ModuleVersion. This key is required.
-- GUID. This key is optional.
+- `ModuleName` - __[Required]__ Specifies the *ModuleName*.
+- `ModuleVersion` - __[Required]__ Specifies an maximum allowed *ModuleVersion*
+- `GUID` - __[Optional]__ Specifies a required module *GUID*
 
 For example,
 
 ```powershell
-#Requires -Modules PSWorkflow, @{ ModuleName="PSScheduledJob"; ModuleVersion="1.0.0.0" }
+#Requires -Modules @{ ModuleName="Hyper-V"; RequiredVersion="1.1.0.0" }
 ```
 
--ShellId
+Requires that `Hyper-V` (version `1.1.0.0` or **less**) is installed
+
+```powershell
+#Requires -Modules PSWorkflow, PSScheduledJob
+```
+
+Requires that any version of `PSScheduledJob` and `PSWorkflow` are installed.
+
+#### -ShellId
 
 Specifies the shell that the script requires. Enter the shell ID.
 
@@ -114,7 +122,7 @@ For example,
 
 You can find current ShellId by querying `$ShellId` automatic variable.
 
--RunAsAdministrator
+#### -RunAsAdministrator
 
 When this switch parameter is added to your requires statement, it specifies
 that the Windows PowerShell session in which you are running the script must

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -57,7 +57,7 @@ does not run the script.
 
 ### Parameters
 
--Version \<N\>[.\<n\>]
+#### -Version \<N\>[.\<n\>]
 
 Specifies the minimum version of Windows PowerShell that the script requires.
 Enter a major version number and optional minor version number.
@@ -68,7 +68,7 @@ For example:
 #Requires -Version 3.0
 ```
 
--PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
+#### -PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
 
 Specifies a Windows PowerShell snap-in that the script requires. Enter the
 snap-in name and an optional version number.
@@ -79,7 +79,7 @@ For example:
 #Requires -PSSnapin DiskSnapin -Version 1.2
 ```
 
--Modules \<Module-Name\> | \<Hashtable\>
+#### -Modules \<Module-Name\> | \<Hashtable\>
 
 Specifies Windows PowerShell modules that the script requires. Enter the
 module name and an optional version number. The Modules parameter is
@@ -92,17 +92,56 @@ terminating error.
 For each module, type the module name (\<String\>) or a hash table with the
 following keys. The value can be a combination of strings and hash tables.
 
-- ModuleName. This key is required.
-- ModuleVersion. This key is required.
-- GUID. This key is optional.
+- `ModuleName` - __[Required]__ Specifies the *ModuleName*.
+- `GUID` - __[Optional]__ Specifies the *GUID* of the Module.
+- It is also **Required** to specify **one** of the two below keys,
+  they cannot be used together.
+  - `ModuleVersion` - __[Required]__ Specify a Minimum acceptable version.
+  - `RequiredVersion` - __[Required]__ Specify an exact, required version.
+
+> [!NOTE]
+> `RequiredVersion` was added in Windows Powershell 5.0.
 
 For example,
 
+Require that `Hyper-V` (version `1.1.0.0` or greater) is installed
+
 ```powershell
-#Requires -Modules PSWorkflow, @{ ModuleName="PSScheduledJob"; ModuleVersion="1.0.0.0" }
+#Requires -Modules @{ ModuleName="Hyper-V"; ModuleVersion="1.1.0.0" }
 ```
 
--ShellId
+Requires that `Hyper-V` (**only** version `1.1.0.0`) is installed
+
+```powershell
+#Requires -Modules @{ ModuleName="Hyper-V"; RequiredVersion="1.1.0.0" }
+```
+
+Requires that any version of `PSScheduledJob` and `PSWorkflow`, is installed.
+
+```powershell
+#Requires -Modules PSWorkflow, PSScheduledJob
+```
+
+When using the `RequiredVersion` key, ensure your version string exactly matches
+the version string you wish to require.
+
+```powershell
+Get-Module Hyper-V
+```
+
+```output
+ModuleType Version    Name     ExportedCommands
+---------- -------    ----     ------------------
+Binary     2.0.0.0    hyper-v  {Add-VMAssignableDevice, ...}
+```
+
+This will **FAIL**, because "2.0.0" does not exactly match "2.0.0.0"
+
+```powershell
+#Requires -Modules @{ ModuleName="Hyper-V"; RequiredVersion="2.0.0" }
+```
+
+#### -ShellId
 
 Specifies the shell that the script requires. Enter the shell ID.
 
@@ -114,7 +153,7 @@ For example,
 
 You can find current ShellId by querying `$ShellId` automatic variable.
 
--RunAsAdministrator
+#### -RunAsAdministrator
 
 When this switch parameter is added to your requires statement, it specifies
 that the Windows PowerShell session in which you are running the script must

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -57,7 +57,7 @@ does not run the script.
 
 ### Parameters
 
--Version \<N\>[.\<n\>]
+#### -Version \<N\>[.\<n\>]
 
 Specifies the minimum version of Windows PowerShell that the script requires.
 Enter a major version number and optional minor version number.
@@ -68,7 +68,7 @@ For example:
 #Requires -Version 3.0
 ```
 
--PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
+#### -PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
 
 Specifies a Windows PowerShell snap-in that the script requires. Enter the
 snap-in name and an optional version number.
@@ -79,7 +79,7 @@ For example:
 #Requires -PSSnapin DiskSnapin -Version 1.2
 ```
 
--Modules \<Module-Name\> | \<Hashtable\>
+#### -Modules \<Module-Name\> | \<Hashtable\>
 
 Specifies Windows PowerShell modules that the script requires. Enter the
 module name and an optional version number. The Modules parameter is
@@ -92,17 +92,56 @@ terminating error.
 For each module, type the module name (\<String\>) or a hash table with the
 following keys. The value can be a combination of strings and hash tables.
 
-- ModuleName. This key is required.
-- ModuleVersion. This key is required.
-- GUID. This key is optional.
+- `ModuleName` - __[Required]__ Specifies the *ModuleName*.
+- `GUID` - __[Optional]__ Specifies the *GUID* of the Module.
+- It is also **Required** to specify **one** of the two below keys,
+  they cannot be used together.
+  - `ModuleVersion` - __[Required]__ Specify a Minimum acceptable version.
+  - `RequiredVersion` - __[Required]__ Specify an exact, required version.
+
+> [!NOTE]
+> `RequiredVersion` was added in Windows Powershell 5.0.
 
 For example,
 
+Require that `Hyper-V` (version `1.1.0.0` or greater) is installed
+
 ```powershell
-#Requires -Modules PSWorkflow, @{ ModuleName="PSScheduledJob"; ModuleVersion="1.0.0.0" }
+#Requires -Modules @{ ModuleName="Hyper-V"; ModuleVersion="1.1.0.0" }
 ```
 
--ShellId
+Requires that `Hyper-V` (**only** version `1.1.0.0`) is installed
+
+```powershell
+#Requires -Modules @{ ModuleName="Hyper-V"; RequiredVersion="1.1.0.0" }
+```
+
+Requires that any version of `PSScheduledJob` and `PSWorkflow`, is installed.
+
+```powershell
+#Requires -Modules PSWorkflow, PSScheduledJob
+```
+
+When using the `RequiredVersion` key, ensure your version string exactly matches
+the version string you wish to require.
+
+```powershell
+Get-Module Hyper-V
+```
+
+```output
+ModuleType Version    Name     ExportedCommands
+---------- -------    ----     ------------------
+Binary     2.0.0.0    hyper-v  {Add-VMAssignableDevice, ...}
+```
+
+This will **FAIL**, because "2.0.0" does not exactly match "2.0.0.0"
+
+```powershell
+#Requires -Modules @{ ModuleName="Hyper-V"; RequiredVersion="2.0.0" }
+```
+
+#### -ShellId
 
 Specifies the shell that the script requires. Enter the shell ID.
 
@@ -114,7 +153,7 @@ For example,
 
 You can find current ShellId by querying `$ShellId` automatic variable.
 
--RunAsAdministrator
+#### -RunAsAdministrator
 
 When this switch parameter is added to your requires statement, it specifies
 that the Windows PowerShell session in which you are running the script must

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Requires.md
@@ -55,9 +55,9 @@ does not run the script.
   state had to be met before the script could even execute. Then the first line
   of the script invalidated the required state.
 
-### PARAMETERS
+### Parameters
 
--Version \<N\>[.\<n\>]
+#### -Version \<N\>[.\<n\>]
 
 Specifies the minimum version of Windows PowerShell that the script requires.
 Enter a major version number and optional minor version number.
@@ -68,7 +68,7 @@ For example:
 #Requires -Version 3.0
 ```
 
--PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
+#### -PSSnapin \<PSSnapin-Name\> [-Version \<N\>[.\<n\>]]
 
 Specifies a Windows PowerShell snap-in that the script requires. Enter the
 snap-in name and an optional version number.
@@ -79,7 +79,7 @@ For example:
 #Requires -PSSnapin DiskSnapin -Version 1.2
 ```
 
--Modules \<Module-Name\> | \<Hashtable\>
+#### -Modules \<Module-Name\> | \<Hashtable\>
 
 Specifies Windows PowerShell modules that the script requires. Enter the
 module name and an optional version number. The Modules parameter is
@@ -92,17 +92,56 @@ terminating error.
 For each module, type the module name (\<String\>) or a hash table with the
 following keys. The value can be a combination of strings and hash tables.
 
-- ModuleName. This key is required.
-- ModuleVersion. This key is required.
-- GUID. This key is optional.
+- `ModuleName` - __[Required]__ Specifies the *ModuleName*.
+- `GUID` - __[Optional]__ Specifies the *GUID* of the Module.
+- It is also **Required** to specify **one** of the two below keys,
+  they cannot be used together.
+  - `ModuleVersion` - __[Required]__ Specify a Minimum acceptable version.
+  - `RequiredVersion` - __[Required]__ Specify an exact, required version.
+
+> [!NOTE]
+> `RequiredVersion` was added in Windows Powershell 5.0.
 
 For example,
 
+Require that `Hyper-V` (version `1.1.0.0` or greater) is installed
+
 ```powershell
-#Requires -Modules PSWorkflow, @{ ModuleName="PSScheduledJob"; ModuleVersion="1.0.0.0" }
+#Requires -Modules @{ ModuleName="Hyper-V"; ModuleVersion="1.1.0.0" }
 ```
 
--ShellId
+Requires that `Hyper-V` (**only** version `1.1.0.0`) is installed
+
+```powershell
+#Requires -Modules @{ ModuleName="Hyper-V"; RequiredVersion="1.1.0.0" }
+```
+
+Requires that any version of `PSScheduledJob` and `PSWorkflow`, is installed.
+
+```powershell
+#Requires -Modules PSWorkflow, PSScheduledJob
+```
+
+When using the `RequiredVersion` key, ensure your version string exactly matches
+the version string you wish to require.
+
+```powershell
+Get-Module Hyper-V
+```
+
+```output
+ModuleType Version    Name     ExportedCommands
+---------- -------    ----     ------------------
+Binary     2.0.0.0    hyper-v  {Add-VMAssignableDevice, ...}
+```
+
+This will **FAIL**, because "2.0.0" does not exactly match "2.0.0.0"
+
+```powershell
+#Requires -Modules @{ ModuleName="Hyper-V"; RequiredVersion="2.0.0" }
+```
+
+#### -ShellId
 
 Specifies the shell that the script requires. Enter the shell ID.
 
@@ -114,7 +153,7 @@ For example,
 
 You can find current ShellId by querying `$ShellId` automatic variable.
 
--RunAsAdministrator
+#### -RunAsAdministrator
 
 When this switch parameter is added to your requires statement, it specifies
 that the Windows PowerShell session in which you are running the script must


### PR DESCRIPTION
…troduced in Windows PowerShell 5.0

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [X] Impacts 6.0 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work