### PR TITLE
fixed formatting of <> chars

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_psreadline.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_psreadline.md
@@ -33,13 +33,13 @@ The following functions are available in the class
 
 ## Cursor movement
 
-- EndOfLine   (Cmd: <End>  Emacs: <End> or <Ctrl+E>)
+- EndOfLine   (Cmd: \<End\>  Emacs: \<End\> or \<Ctrl+E\>)
 
   If the input has multiple lines, move to the end of the current line, or if
   already at the end of the line, move to the end of the input. If the input
   has a single line, move to the end of the input.
 
-- BeginningOfLine  (Cmd: <Home>  Emacs: <Home> or <Ctrl+A>)
+- BeginningOfLine  (Cmd: \<Home\>  Emacs: \<Home\> or \<Ctrl+A\>)
 
   If the input has multiple lines, move to the start of the current line, or
   if already at the start of the line, move to the start of the input. If the
@@ -53,41 +53,41 @@ The following functions are available in the class
 
   Move the cursor to the previous line if the input has multiple lines.
 
-- ForwardChar  (Cmd: <RightArrow>  Emacs: <RightArrow> or <Ctrl+F>)
+- ForwardChar  (Cmd: \<RightArrow\>  Emacs: \<RightArrow\> or \<Ctrl+F\>)
 
   Move the cursor one character to the right. This might move the cursor to
   the next line of multi-line input.
 
-- BackwardChar  (Cmd: <LeftArrow>  Emacs: <LeftArrow> or <Ctrl+B>)
+- BackwardChar  (Cmd: \<LeftArrow\>  Emacs: \<LeftArrow\> or \<Ctrl+B\>)
 
   Move the cursor one character to the left. This might move the cursor to the
   previous line of multi-line input.
 
-- ForwardWord  (Cmd: unbound  Emacs: <Alt+F>)
+- ForwardWord  (Cmd: unbound  Emacs: \<Alt+F\>)
 
   Move the cursor forward to the end of the current word, or if between words,
   to the end of the next word. You can set word delimiter characters with:
 
   ```powershell
-  Set-PSReadlineOption -WordDelimiters <string of delimiter characters>
+  Set-PSReadlineOption -WordDelimiters \<string of delimiter characters\>
   ```
 
-- NextWord  (Cmd: <Ctrl+RightArrow>  Emacs: unbound)
+- NextWord  (Cmd: \<Ctrl+RightArrow\>  Emacs: unbound)
 
   Move the cursor forward to the start of the next word. You can set word
   delimiter characters with:
 
   ```powershell
-  Set-PSReadlineOption -WordDelimiters <string of delimiter characters>
+  Set-PSReadlineOption -WordDelimiters \<string of delimiter characters\>
   ```
 
-- BackwardWord  (Cmd: <Ctrl+LeftArrow>  Emacs: <Alt+B>)
+- BackwardWord  (Cmd: \<Ctrl+LeftArrow\>  Emacs: \<Alt+B\>)
 
   Move the cursor back to the start of the current word, or if between words,
   the start of the previous word. You can set word delimiter characters with:
 
   ```powershell
-  Set-PSReadlineOption -WordDelimiters <string of delimiter characters>
+  Set-PSReadlineOption -WordDelimiters \<string of delimiter characters\>
   ```
 
 - ShellForwardWord  (Cmd: unbound  Emacs: unbound)
@@ -105,11 +105,11 @@ The following functions are available in the class
   Like BackwardWord except word boundaries are defined by PowerShell token
   boundaries.
 
-- GotoBrace  (Cmd: <Ctrl+}>  Emacs: unbound)
+- GotoBrace  (Cmd: \<Ctrl+}\>  Emacs: unbound)
 
   Go to the matching parenthesis, curly brace, or square bracket.
 
-- AddLine  (Cmd: <Shift-Enter>  Emacs: <Shift-Enter>)
+- AddLine  (Cmd: \<Shift-Enter\>  Emacs: \<Shift-Enter\>)
 
   The continuation prompt is displayed on the next line and PSReadline waits
   for keys to edit the current input. This is useful to enter multi-line input
@@ -122,31 +122,31 @@ The following functions are available in the class
   Cancel all editing to the line, leave the line of input on the screen but
   return from PSReadline without executing the input.
 
-- RevertLine  (Cmd: <ESC>  Emacs: <Alt+R>)
+- RevertLine  (Cmd: \<ESC\>  Emacs: \<Alt+R\>)
 
   Reverts all of the input since the last input was accepted and run. This is
   equivalent to using the Undo command until there is nothing left to undo.
 
-- BackwardDeleteChar  (Cmd: <Backspace>  Emacs: <Backspace> or <Ctrl+H>)
+- BackwardDeleteChar  (Cmd: \<Backspace\>  Emacs: \<Backspace\> or \<Ctrl+H\>)
 
   Delete the character before the cursor.
 
-- DeleteChar  (Cmd: <Delete>  Emacs: <Delete>)
+- DeleteChar  (Cmd: \<Delete\>  Emacs: \<Delete\>)
 
   Delete the character under the cursor.
 
-- DeleteCharOrExit  (Cmd: unbound  Emacs: <Ctrl+D>)
+- DeleteCharOrExit  (Cmd: unbound  Emacs: \<Ctrl+D\>)
 
   Like DeleteChar, unless the line is empty, in which case exit the process.
 
-- AcceptLine  (Cmd: <Enter>  Emacs: <Enter> or <Ctrl+M>)
+- AcceptLine  (Cmd: \<Enter\>  Emacs: \<Enter\> or \<Ctrl+M\>)
 
   Attempt to execute the current input. If the current input is incomplete
   (for example, there is a missing closing parenthesis, bracket, or quote),
   then the continuation prompt is displayed on the next line, and PSReadline
   waits for keys to edit the current input.
 
-- AcceptAndGetNext  (Cmd: unbound  Emacs: <Ctrl+O>)
+- AcceptAndGetNext  (Cmd: unbound  Emacs: \<Ctrl+O\>)
 
   Like AcceptLine, but after the line completes, start editing the next line
   from history.
@@ -165,31 +165,31 @@ The following functions are available in the class
   AcceptLine or ValidateAndAcceptLine again while the error message is
   displayed.
 
-- BackwardDeleteLine  (Cmd: <Ctrl+Home>  Emacs: unbound)
+- BackwardDeleteLine  (Cmd: \<Ctrl+Home\>  Emacs: unbound)
 
   Delete the text from the start of the input to the cursor.
 
-- ForwardDeleteLine  (Cmd: <Ctrl+End>  Emacs: unbound)
+- ForwardDeleteLine  (Cmd: \<Ctrl+End\>  Emacs: unbound)
 
   Delete the text from the cursor to the end of the input.
 
-- SelectBackwardChar  (Cmd: <Shift+LeftArrow>  Emacs: <Shift+LeftArrow>)
+- SelectBackwardChar  (Cmd: \<Shift+LeftArrow\>  Emacs: \<Shift+LeftArrow\>)
 
   Adjust the current selection to include the previous character.
 
-- SelectForwardChar  (Cmd: <Shift+RightArrow>  Emacs: <Shift+RightArrow>)
+- SelectForwardChar  (Cmd: \<Shift+RightArrow\>  Emacs: \<Shift+RightArrow\>)
 
   Adjust the current selection to include the next character.
 
-- SelectBackwardWord  (Cmd: <Shift+Ctrl+LeftArrow> Emacs: <Alt+Shift+B>)
+- SelectBackwardWord  (Cmd: \<Shift+Ctrl+LeftArrow\> Emacs: \<Alt+Shift+B\>)
 
   Adjust the current selection to include the previous word.
 
-- SelectForwardWord  (Cmd: unbound  Emacs: <Alt+Shift+F>)
+- SelectForwardWord  (Cmd: unbound  Emacs: \<Alt+Shift+F\>)
 
   Adjust the current selection to include the next word using ForwardWord.
 
-- SelectNextWord  (Cmd: <Shift+Ctrl+RightArrow> Emacs: unbound)
+- SelectNextWord  (Cmd: \<Shift+Ctrl+RightArrow\> Emacs: unbound)
 
   Adjust the current selection to include the next word using NextWord.
 
@@ -207,29 +207,29 @@ The following functions are available in the class
   Adjust the current selection to include the previous word using
   ShellBackwardWord.
 
-- SelectBackwardsLine  (Cmd: <Shift+Home>  Emacs: <Shift+Home>)
+- SelectBackwardsLine  (Cmd: \<Shift+Home\>  Emacs: \<Shift+Home\>)
 
   Adjust the current selection to include from the cursor to the start of the
   line.
 
-- SelectLine  (Cmd: <Shift+End>  Emacs: <Shift+End>)
+- SelectLine  (Cmd: \<Shift+End\>  Emacs: \<Shift+End\>)
 
   Adjust the current selection to include from the cursor to the end of the
   line.
 
-- SelectAll  (Cmd: <Ctrl+A>  Emacs: unbound)
+- SelectAll  (Cmd: \<Ctrl+A\>  Emacs: unbound)
 
   Select the entire line. Moves the cursor to the end of the line.
 
-- SelfInsert  (Cmd: <a>, <b>, ...  Emacs: <a>, <b>, ...)
+- SelfInsert  (Cmd: \<a\>, \<b\>, ...  Emacs: \<a\>, \<b\>, ...)
 
   Insert the key entered.
 
-- Redo   (Cmd: <Ctrl+Y>  Emacs: unbound)
+- Redo   (Cmd: \<Ctrl+Y\>  Emacs: unbound)
 
   Redo an insertion or deletion that was undone by Undo.
 
-- Undo   (Cmd: <Ctrl+Z>  Emacs: <Ctrl+_>)
+- Undo   (Cmd: \<Ctrl+Z\>  Emacs: \<Ctrl+_\>)
 
   Undo a previous insertion or deletion.
 
@@ -240,61 +240,61 @@ The following functions are available in the class
   Clears history in PSReadline. This does not affect PowerShell
   history.
 
-- PreviousHistory  (Cmd: <UpArrow>  Emacs: <UpArrow> or <Ctrl+P>)
+- PreviousHistory  (Cmd: \<UpArrow\>  Emacs: \<UpArrow\> or \<Ctrl+P\>)
 
   Replace the current input with the previous item from PSReadline history.
 
-- NextHistory  (Cmd: <DownArrow>  Emacs: <DownArrow> or <Ctrl+N>)
+- NextHistory  (Cmd: \<DownArrow\>  Emacs: \<DownArrow\> or \<Ctrl+N\>)
 
   Replace the current input with the next item from PSReadline history.
 
-- ForwardSearchHistory  (Cmd: <Ctrl+S>  Emacs: <Ctrl+S>)
+- ForwardSearchHistory  (Cmd: \<Ctrl+S\>  Emacs: \<Ctrl+S\>)
 
   Search forward from the current history line interactively.
 
-- ReverseSearchHistory  (Cmd: <Ctrl+R>  Emacs: <Ctrl+R>)
+- ReverseSearchHistory  (Cmd: \<Ctrl+R\>  Emacs: \<Ctrl+R\>)
 
   Search backward from the current history line interactively.
 
-- HistorySearchBackward  (Cmd: <F8>  Emacs: unbound)
+- HistorySearchBackward  (Cmd: \<F8\>  Emacs: unbound)
 
   Replace the current input with the previous item from PSReadline history
   that matches the characters between the start and the input and the cursor.
 
-- HistorySearchForward  (Cmd: <Shift+F8>  Emacs: unbound)
+- HistorySearchForward  (Cmd: \<Shift+F8\>  Emacs: unbound)
 
   Replace the current input with the next item from PSReadline history that
   matches the characters between the start and the input and the cursor.
 
-- BeginningOfHistory  (Cmd: unbound  Emacs: <Alt+<>)
+- BeginningOfHistory  (Cmd: unbound  Emacs: \<Alt+\<\>)
 
   Replace the current input with the last item from PSReadline history.
 
-- EndOfHistory  (Cmd: unbound  Emacs: <Alt+>>)
+- EndOfHistory  (Cmd: unbound  Emacs: \<Alt+\>\>)
 
   Replace the current input with the last item in PSReadline history, which is
   the possibly empty input that was entered before any history commands.
 
 ## Tab Completion
 
-- TabCompleteNext  (Cmd: <Tab>  Emacs: unbound)
+- TabCompleteNext  (Cmd: \<Tab\>  Emacs: unbound)
 
   Attempt to complete the text surrounding the cursor with the next
   available completion.
 
-- TabCompletePrevious  (Cmd: <Shift-Tab>  Emacs: unbound)
+- TabCompletePrevious  (Cmd: \<Shift-Tab\>  Emacs: unbound)
 
   Attempt to complete the text surrounding the cursor with the next
   previous completion.
 
-- Complete  (Cmd: unbound  Emacs: <Tab>)
+- Complete  (Cmd: unbound  Emacs: \<Tab\>)
 
   Attempt to perform completion on the text surrounding the cursor. If there
   are multiple possible completions, the longest unambiguous prefix is used
   for completion. If you are trying to complete the longest unambiguous
   completion, a list of possible completions is displayed.
 
-- MenuComplete  (Cmd: <Ctrl+Space>  Emacs: <Ctrl+Space>)
+- MenuComplete  (Cmd: \<Ctrl+Space\>  Emacs: \<Ctrl+Space\>)
 
   Attempt to perform completion on the text surrounding the cursor. If there
   are multiple possible completions, a list of possible completions is
@@ -302,16 +302,16 @@ The following functions are available in the class
   keys, or Tab/Shift+Tab. Escape and Ctrl+G cancel the menu selection, and
   revert the line to the state before invoking MenuComplete.
 
-- PossibleCompletions  (Cmd: unbound  Emacs: <Alt+Equals>)
+- PossibleCompletions  (Cmd: unbound  Emacs: \<Alt+Equals\>)
 
   Display the list of possible completions.
 
-- SetMark  (Cmd: unbound  Emacs: <Alt+Space>)
+- SetMark  (Cmd: unbound  Emacs: \<Alt+Space\>)
 
   Mark the current location of the cursor for use in a subsequent editing
   command.
 
-- ExchangePointAndMark  (Cmd: unbound  Emacs: <Ctrl+X,Ctrl+X>)
+- ExchangePointAndMark  (Cmd: unbound  Emacs: \<Ctrl+X,Ctrl+X\>)
 
   The cursor is placed at the location of the mark and the mark is moved
   to the location of the cursor.
@@ -327,23 +327,23 @@ appends the previous kill, instead of adding a new item or replacing an item
 in the kill ring. This is how you can cut a part of a line, for example, with
 multiple KillWord operations, then yank them back elsewhere as a single yank.
 
-- KillLine  (Cmd: unbound  Emacs: <Ctrl+K>)
+- KillLine  (Cmd: unbound  Emacs: \<Ctrl+K\>)
 
   Clear the input from the cursor to the end of the line. The cleared text is
   placed in the kill ring.
 
-- BackwardKillLine  (Cmd: unbound  Emacs: <Ctrl+U> or <Ctrl+X,Backspace>)
+- BackwardKillLine  (Cmd: unbound  Emacs: \<Ctrl+U\> or \<Ctrl+X,Backspace\>)
 
   Clear the input from the start of the input to the cursor. The cleared text
   is placed in the kill ring.
 
-- KillWord  (Cmd: unbound  Emacs: <Alt+D>)
+- KillWord  (Cmd: unbound  Emacs: \<Alt+D\>)
 
   Clear the input from the cursor to the end of the current word. If the
   cursor is between words, the input is cleared from the cursor to the end of
   the next word. The cleared text is placed in the kill ring.
 
-- BackwardKillWord  (Cmd: unbound  Emacs: <Alt+Backspace>)
+- BackwardKillWord  (Cmd: unbound  Emacs: \<Alt+Backspace\>)
 
   Clear the input from the start of the current word to the cursor. If the
   cursor is between words, the input is cleared from the start of the previous
@@ -359,7 +359,7 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
   Like BackwardKillWord, except word boundaries are defined by PowerShell
   token boundaries.
 
-- UnixWordRubout  (Cmd: unbound  Emacs: <Ctrl+W>)
+- UnixWordRubout  (Cmd: unbound  Emacs: \<Ctrl+W\>)
 
   Like BackwardKillWord, except word boundaries are defined by white space.
 
@@ -367,25 +367,25 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
 
   Kill the text between the cursor and the mark.
 
-- Copy   (Cmd: <Ctrl+Shift+C>  Emacs: unbound)
+- Copy   (Cmd: \<Ctrl+Shift+C\>  Emacs: unbound)
 
   Copy selected region to the system clipboard. If no region is selected, copy
   the whole line.
 
-- CopyOrCancelLine  (Cmd: <Ctrl+C>  Emacs: <Ctrl+C>)
+- CopyOrCancelLine  (Cmd: \<Ctrl+C\>  Emacs: \<Ctrl+C\>)
 
   Either copy selected text to the clipboard, or if no text is selected,
   cancel editing the line with CancelLine.
 
-- Cut    (Cmd: <Ctrl+X>  Emacs: unbound)
+- Cut    (Cmd: \<Ctrl+X\>  Emacs: unbound)
 
   Delete selected region placing deleted text in the system clipboard.
 
-- Yank   (Cmd: unbound  Emacs: <Ctrl+Y>)
+- Yank   (Cmd: unbound  Emacs: \<Ctrl+Y\>)
 
   Add the most-recently killed text to the input.
 
-- YankPop  (Cmd: unbound  Emacs: <Alt+Y>)
+- YankPop  (Cmd: unbound  Emacs: \<Alt+Y\>)
 
   If the previous operation was Yank or YankPop, replace the previously-yanked
   text with the next killed text from the kill ring.
@@ -394,12 +394,12 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
 
   The contents of the kill ring are cleared.
 
-- Paste  (Cmd: <Ctrl+V>  Emacs: unbound)
+- Paste  (Cmd: \<Ctrl+V\>  Emacs: unbound)
 
   This is similar to Yank, but uses the system clipboard instead of the kill
   ring.
 
-- YankLastArg  (Cmd: <Alt+.>  Emacs: <Alt+.>, <Alt+_>)
+- YankLastArg  (Cmd: \<Alt+.\>  Emacs: \<Alt+.\>, \<Alt+_\>)
 
   Insert the last argument from the previous command in history. Repeated
   operations replace the last inserted argument with the last argument from
@@ -413,7 +413,7 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
 
   Arguments are based on PowerShell tokens.
 
-- YankNthArg  (Cmd: unbound  Emacs: <Alt+Ctrl+Y>)
+- YankNthArg  (Cmd: unbound  Emacs: \<Alt+Ctrl+Y\>)
 
   Insert the first argument (not the command name) of the previous command in
   history.
@@ -425,28 +425,28 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
 
 ## Miscellaneous
 
-- Abort  (Cmd: unbound  Emacs: <Ctrl+G>)
+- Abort  (Cmd: unbound  Emacs: \<Ctrl+G\>)
 
   Abort the current action; for example, stop interactive history search. Does
   not cancel input like CancelLine.
 
-- CharacterSearch  (Cmd: <F3>  Emacs: <Ctrl+]>)
+- CharacterSearch  (Cmd: \<F3\>  Emacs: \<Ctrl+]\>)
 
   Read a key and search forwards for that character. With an argument, search
   forwards for the nth occurrence of that argument. With a negative argument,
   searches backwards.
 
-- CharacterSearchBackward  (Cmd: <Shift+F3>  Emacs: <Alt+Ctrl+]>)
+- CharacterSearchBackward  (Cmd: \<Shift+F3\>  Emacs: \<Alt+Ctrl+]\>)
 
   Like CharacterSearch, but searches backwards. With a negative argument,
   searches forwards.
 
-- ClearScreen  (Cmd: <Ctrl+L>  Emacs: <Ctrl+L>)
+- ClearScreen  (Cmd: \<Ctrl+L\>  Emacs: \<Ctrl+L\>)
 
   Clears the screen and displays the current prompt and input at the top of
   the screen.
 
-- DigitArgument  (Cmd: unbound  Emacs: <Alt+[0..9]>,,<Alt+->)
+- DigitArgument  (Cmd: unbound  Emacs: \<Alt+[0..9]\>,,\<Alt+-\>)
 
   Used to pass numeric arguments to functions like CharacterSearch or
   YankNthArg. Alt+- toggles the argument to be negative/non-negative. To enter
@@ -466,35 +466,35 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
   prompt. Useful for custom key handlers that change state, such as changing
   the current directory.
 
-- WhatIsKey  (Cmd: <Alt+?>  Emacs: <Alt+?>)
+- WhatIsKey  (Cmd: \<Alt+?\>  Emacs: \<Alt+?\>)
 
   Read a key or chord and display the key binding.
 
-- ShowKeyBindings  (Cmd: <Ctrl+Alt+?>  Emacs: <Ctrl+Alt+?>)
+- ShowKeyBindings  (Cmd: \<Ctrl+Alt+?\>  Emacs: \<Ctrl+Alt+?\>)
 
   Show all of the currently-bound keys.
 
-- ScrollDisplayUp  (Cmd: <PageUp>  Emacs: <PageUp>)
+- ScrollDisplayUp  (Cmd: \<PageUp\>  Emacs: \<PageUp\>)
 
   Scroll the display up one screen.
 
-- ScrollDisplayUpLine  (Cmd: <Ctrl+PageUp>  Emacs: <Ctrl+PageUp>)
+- ScrollDisplayUpLine  (Cmd: \<Ctrl+PageUp\>  Emacs: \<Ctrl+PageUp\>)
 
   Scroll the display up one line.
 
-- ScrollDisplayDown  (Cmd: <PageDown>  Emacs: <PageDown>)
+- ScrollDisplayDown  (Cmd: \<PageDown\>  Emacs: \<PageDown\>)
 
   Scroll the display down one screen.
 
-- ScrollDisplayDownLine  (Cmd: <Ctrl+PageDown>  Emacs: <Ctrl+PageDown>)
+- ScrollDisplayDownLine  (Cmd: \<Ctrl+PageDown\>  Emacs: \<Ctrl+PageDown\>)
 
   Scroll the display down one line.
 
-- ScrollDisplayTop  (Cmd: unbound  Emacs: <Ctrl+Home>)
+- ScrollDisplayTop  (Cmd: unbound  Emacs: \<Ctrl+Home\>)
 
   Scroll the display to the top.
 
-- ScrollDisplayToCursor  (Cmd: unbound  Emacs: <Ctrl+End>)
+- ScrollDisplayToCursor  (Cmd: unbound  Emacs: \<Ctrl+End\>)
 
   Scroll the display to the cursor.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_psreadline.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_psreadline.md
@@ -33,13 +33,13 @@ The following functions are available in the class
 
 ## Cursor movement
 
-- EndOfLine   (Cmd: <End>  Emacs: <End> or <Ctrl+E>)
+- EndOfLine   (Cmd: \<End\>  Emacs: \<End\> or \<Ctrl+E\>)
 
   If the input has multiple lines, move to the end of the current line, or if
   already at the end of the line, move to the end of the input. If the input
   has a single line, move to the end of the input.
 
-- BeginningOfLine  (Cmd: <Home>  Emacs: <Home> or <Ctrl+A>)
+- BeginningOfLine  (Cmd: \<Home\>  Emacs: \<Home\> or \<Ctrl+A\>)
 
   If the input has multiple lines, move to the start of the current line, or
   if already at the start of the line, move to the start of the input. If the
@@ -53,41 +53,41 @@ The following functions are available in the class
 
   Move the cursor to the previous line if the input has multiple lines.
 
-- ForwardChar  (Cmd: <RightArrow>  Emacs: <RightArrow> or <Ctrl+F>)
+- ForwardChar  (Cmd: \<RightArrow\>  Emacs: \<RightArrow\> or \<Ctrl+F\>)
 
   Move the cursor one character to the right. This might move the cursor to
   the next line of multi-line input.
 
-- BackwardChar  (Cmd: <LeftArrow>  Emacs: <LeftArrow> or <Ctrl+B>)
+- BackwardChar  (Cmd: \<LeftArrow\>  Emacs: \<LeftArrow\> or \<Ctrl+B\>)
 
   Move the cursor one character to the left. This might move the cursor to the
   previous line of multi-line input.
 
-- ForwardWord  (Cmd: unbound  Emacs: <Alt+F>)
+- ForwardWord  (Cmd: unbound  Emacs: \<Alt+F\>)
 
   Move the cursor forward to the end of the current word, or if between words,
   to the end of the next word. You can set word delimiter characters with:
 
   ```powershell
-  Set-PSReadlineOption -WordDelimiters <string of delimiter characters>
+  Set-PSReadlineOption -WordDelimiters \<string of delimiter characters\>
   ```
 
-- NextWord  (Cmd: <Ctrl+RightArrow>  Emacs: unbound)
+- NextWord  (Cmd: \<Ctrl+RightArrow\>  Emacs: unbound)
 
   Move the cursor forward to the start of the next word. You can set word
   delimiter characters with:
 
   ```powershell
-  Set-PSReadlineOption -WordDelimiters <string of delimiter characters>
+  Set-PSReadlineOption -WordDelimiters \<string of delimiter characters\>
   ```
 
-- BackwardWord  (Cmd: <Ctrl+LeftArrow>  Emacs: <Alt+B>)
+- BackwardWord  (Cmd: \<Ctrl+LeftArrow\>  Emacs: \<Alt+B\>)
 
   Move the cursor back to the start of the current word, or if between words,
   the start of the previous word. You can set word delimiter characters with:
 
   ```powershell
-  Set-PSReadlineOption -WordDelimiters <string of delimiter characters>
+  Set-PSReadlineOption -WordDelimiters \<string of delimiter characters\>
   ```
 
 - ShellForwardWord  (Cmd: unbound  Emacs: unbound)
@@ -105,11 +105,11 @@ The following functions are available in the class
   Like BackwardWord except word boundaries are defined by PowerShell token
   boundaries.
 
-- GotoBrace  (Cmd: <Ctrl+}>  Emacs: unbound)
+- GotoBrace  (Cmd: \<Ctrl+}\>  Emacs: unbound)
 
   Go to the matching parenthesis, curly brace, or square bracket.
 
-- AddLine  (Cmd: <Shift-Enter>  Emacs: <Shift-Enter>)
+- AddLine  (Cmd: \<Shift-Enter\>  Emacs: \<Shift-Enter\>)
 
   The continuation prompt is displayed on the next line and PSReadline waits
   for keys to edit the current input. This is useful to enter multi-line input
@@ -122,31 +122,31 @@ The following functions are available in the class
   Cancel all editing to the line, leave the line of input on the screen but
   return from PSReadline without executing the input.
 
-- RevertLine  (Cmd: <ESC>  Emacs: <Alt+R>)
+- RevertLine  (Cmd: \<ESC\>  Emacs: \<Alt+R\>)
 
   Reverts all of the input since the last input was accepted and run. This is
   equivalent to using the Undo command until there is nothing left to undo.
 
-- BackwardDeleteChar  (Cmd: <Backspace>  Emacs: <Backspace> or <Ctrl+H>)
+- BackwardDeleteChar  (Cmd: \<Backspace\>  Emacs: \<Backspace\> or \<Ctrl+H\>)
 
   Delete the character before the cursor.
 
-- DeleteChar  (Cmd: <Delete>  Emacs: <Delete>)
+- DeleteChar  (Cmd: \<Delete\>  Emacs: \<Delete\>)
 
   Delete the character under the cursor.
 
-- DeleteCharOrExit  (Cmd: unbound  Emacs: <Ctrl+D>)
+- DeleteCharOrExit  (Cmd: unbound  Emacs: \<Ctrl+D\>)
 
   Like DeleteChar, unless the line is empty, in which case exit the process.
 
-- AcceptLine  (Cmd: <Enter>  Emacs: <Enter> or <Ctrl+M>)
+- AcceptLine  (Cmd: \<Enter\>  Emacs: \<Enter\> or \<Ctrl+M\>)
 
   Attempt to execute the current input. If the current input is incomplete
   (for example, there is a missing closing parenthesis, bracket, or quote),
   then the continuation prompt is displayed on the next line, and PSReadline
   waits for keys to edit the current input.
 
-- AcceptAndGetNext  (Cmd: unbound  Emacs: <Ctrl+O>)
+- AcceptAndGetNext  (Cmd: unbound  Emacs: \<Ctrl+O\>)
 
   Like AcceptLine, but after the line completes, start editing the next line
   from history.
@@ -165,31 +165,31 @@ The following functions are available in the class
   AcceptLine or ValidateAndAcceptLine again while the error message is
   displayed.
 
-- BackwardDeleteLine  (Cmd: <Ctrl+Home>  Emacs: unbound)
+- BackwardDeleteLine  (Cmd: \<Ctrl+Home\>  Emacs: unbound)
 
   Delete the text from the start of the input to the cursor.
 
-- ForwardDeleteLine  (Cmd: <Ctrl+End>  Emacs: unbound)
+- ForwardDeleteLine  (Cmd: \<Ctrl+End\>  Emacs: unbound)
 
   Delete the text from the cursor to the end of the input.
 
-- SelectBackwardChar  (Cmd: <Shift+LeftArrow>  Emacs: <Shift+LeftArrow>)
+- SelectBackwardChar  (Cmd: \<Shift+LeftArrow\>  Emacs: \<Shift+LeftArrow\>)
 
   Adjust the current selection to include the previous character.
 
-- SelectForwardChar  (Cmd: <Shift+RightArrow>  Emacs: <Shift+RightArrow>)
+- SelectForwardChar  (Cmd: \<Shift+RightArrow\>  Emacs: \<Shift+RightArrow\>)
 
   Adjust the current selection to include the next character.
 
-- SelectBackwardWord  (Cmd: <Shift+Ctrl+LeftArrow> Emacs: <Alt+Shift+B>)
+- SelectBackwardWord  (Cmd: \<Shift+Ctrl+LeftArrow\> Emacs: \<Alt+Shift+B\>)
 
   Adjust the current selection to include the previous word.
 
-- SelectForwardWord  (Cmd: unbound  Emacs: <Alt+Shift+F>)
+- SelectForwardWord  (Cmd: unbound  Emacs: \<Alt+Shift+F\>)
 
   Adjust the current selection to include the next word using ForwardWord.
 
-- SelectNextWord  (Cmd: <Shift+Ctrl+RightArrow> Emacs: unbound)
+- SelectNextWord  (Cmd: \<Shift+Ctrl+RightArrow\> Emacs: unbound)
 
   Adjust the current selection to include the next word using NextWord.
 
@@ -207,29 +207,29 @@ The following functions are available in the class
   Adjust the current selection to include the previous word using
   ShellBackwardWord.
 
-- SelectBackwardsLine  (Cmd: <Shift+Home>  Emacs: <Shift+Home>)
+- SelectBackwardsLine  (Cmd: \<Shift+Home\>  Emacs: \<Shift+Home\>)
 
   Adjust the current selection to include from the cursor to the start of the
   line.
 
-- SelectLine  (Cmd: <Shift+End>  Emacs: <Shift+End>)
+- SelectLine  (Cmd: \<Shift+End\>  Emacs: \<Shift+End\>)
 
   Adjust the current selection to include from the cursor to the end of the
   line.
 
-- SelectAll  (Cmd: <Ctrl+A>  Emacs: unbound)
+- SelectAll  (Cmd: \<Ctrl+A\>  Emacs: unbound)
 
   Select the entire line. Moves the cursor to the end of the line.
 
-- SelfInsert  (Cmd: <a>, <b>, ...  Emacs: <a>, <b>, ...)
+- SelfInsert  (Cmd: \<a\>, \<b\>, ...  Emacs: \<a\>, \<b\>, ...)
 
   Insert the key entered.
 
-- Redo   (Cmd: <Ctrl+Y>  Emacs: unbound)
+- Redo   (Cmd: \<Ctrl+Y\>  Emacs: unbound)
 
   Redo an insertion or deletion that was undone by Undo.
 
-- Undo   (Cmd: <Ctrl+Z>  Emacs: <Ctrl+_>)
+- Undo   (Cmd: \<Ctrl+Z\>  Emacs: \<Ctrl+_\>)
 
   Undo a previous insertion or deletion.
 
@@ -240,61 +240,61 @@ The following functions are available in the class
   Clears history in PSReadline. This does not affect PowerShell
   history.
 
-- PreviousHistory  (Cmd: <UpArrow>  Emacs: <UpArrow> or <Ctrl+P>)
+- PreviousHistory  (Cmd: \<UpArrow\>  Emacs: \<UpArrow\> or \<Ctrl+P\>)
 
   Replace the current input with the previous item from PSReadline history.
 
-- NextHistory  (Cmd: <DownArrow>  Emacs: <DownArrow> or <Ctrl+N>)
+- NextHistory  (Cmd: \<DownArrow\>  Emacs: \<DownArrow\> or \<Ctrl+N\>)
 
   Replace the current input with the next item from PSReadline history.
 
-- ForwardSearchHistory  (Cmd: <Ctrl+S>  Emacs: <Ctrl+S>)
+- ForwardSearchHistory  (Cmd: \<Ctrl+S\>  Emacs: \<Ctrl+S\>)
 
   Search forward from the current history line interactively.
 
-- ReverseSearchHistory  (Cmd: <Ctrl+R>  Emacs: <Ctrl+R>)
+- ReverseSearchHistory  (Cmd: \<Ctrl+R\>  Emacs: \<Ctrl+R\>)
 
   Search backward from the current history line interactively.
 
-- HistorySearchBackward  (Cmd: <F8>  Emacs: unbound)
+- HistorySearchBackward  (Cmd: \<F8\>  Emacs: unbound)
 
   Replace the current input with the previous item from PSReadline history
   that matches the characters between the start and the input and the cursor.
 
-- HistorySearchForward  (Cmd: <Shift+F8>  Emacs: unbound)
+- HistorySearchForward  (Cmd: \<Shift+F8\>  Emacs: unbound)
 
   Replace the current input with the next item from PSReadline history that
   matches the characters between the start and the input and the cursor.
 
-- BeginningOfHistory  (Cmd: unbound  Emacs: <Alt+<>)
+- BeginningOfHistory  (Cmd: unbound  Emacs: \<Alt+\<\>)
 
   Replace the current input with the last item from PSReadline history.
 
-- EndOfHistory  (Cmd: unbound  Emacs: <Alt+>>)
+- EndOfHistory  (Cmd: unbound  Emacs: \<Alt+\>\>)
 
   Replace the current input with the last item in PSReadline history, which is
   the possibly empty input that was entered before any history commands.
 
 ## Tab Completion
 
-- TabCompleteNext  (Cmd: <Tab>  Emacs: unbound)
+- TabCompleteNext  (Cmd: \<Tab\>  Emacs: unbound)
 
   Attempt to complete the text surrounding the cursor with the next
   available completion.
 
-- TabCompletePrevious  (Cmd: <Shift-Tab>  Emacs: unbound)
+- TabCompletePrevious  (Cmd: \<Shift-Tab\>  Emacs: unbound)
 
   Attempt to complete the text surrounding the cursor with the next
   previous completion.
 
-- Complete  (Cmd: unbound  Emacs: <Tab>)
+- Complete  (Cmd: unbound  Emacs: \<Tab\>)
 
   Attempt to perform completion on the text surrounding the cursor. If there
   are multiple possible completions, the longest unambiguous prefix is used
   for completion. If you are trying to complete the longest unambiguous
   completion, a list of possible completions is displayed.
 
-- MenuComplete  (Cmd: <Ctrl+Space>  Emacs: <Ctrl+Space>)
+- MenuComplete  (Cmd: \<Ctrl+Space\>  Emacs: \<Ctrl+Space\>)
 
   Attempt to perform completion on the text surrounding the cursor. If there
   are multiple possible completions, a list of possible completions is
@@ -302,16 +302,16 @@ The following functions are available in the class
   keys, or Tab/Shift+Tab. Escape and Ctrl+G cancel the menu selection, and
   revert the line to the state before invoking MenuComplete.
 
-- PossibleCompletions  (Cmd: unbound  Emacs: <Alt+Equals>)
+- PossibleCompletions  (Cmd: unbound  Emacs: \<Alt+Equals\>)
 
   Display the list of possible completions.
 
-- SetMark  (Cmd: unbound  Emacs: <Alt+Space>)
+- SetMark  (Cmd: unbound  Emacs: \<Alt+Space\>)
 
   Mark the current location of the cursor for use in a subsequent editing
   command.
 
-- ExchangePointAndMark  (Cmd: unbound  Emacs: <Ctrl+X,Ctrl+X>)
+- ExchangePointAndMark  (Cmd: unbound  Emacs: \<Ctrl+X,Ctrl+X\>)
 
   The cursor is placed at the location of the mark and the mark is moved
   to the location of the cursor.
@@ -327,23 +327,23 @@ appends the previous kill, instead of adding a new item or replacing an item
 in the kill ring. This is how you can cut a part of a line, for example, with
 multiple KillWord operations, then yank them back elsewhere as a single yank.
 
-- KillLine  (Cmd: unbound  Emacs: <Ctrl+K>)
+- KillLine  (Cmd: unbound  Emacs: \<Ctrl+K\>)
 
   Clear the input from the cursor to the end of the line. The cleared text is
   placed in the kill ring.
 
-- BackwardKillLine  (Cmd: unbound  Emacs: <Ctrl+U> or <Ctrl+X,Backspace>)
+- BackwardKillLine  (Cmd: unbound  Emacs: \<Ctrl+U\> or \<Ctrl+X,Backspace\>)
 
   Clear the input from the start of the input to the cursor. The cleared text
   is placed in the kill ring.
 
-- KillWord  (Cmd: unbound  Emacs: <Alt+D>)
+- KillWord  (Cmd: unbound  Emacs: \<Alt+D\>)
 
   Clear the input from the cursor to the end of the current word. If the
   cursor is between words, the input is cleared from the cursor to the end of
   the next word. The cleared text is placed in the kill ring.
 
-- BackwardKillWord  (Cmd: unbound  Emacs: <Alt+Backspace>)
+- BackwardKillWord  (Cmd: unbound  Emacs: \<Alt+Backspace\>)
 
   Clear the input from the start of the current word to the cursor. If the
   cursor is between words, the input is cleared from the start of the previous
@@ -359,7 +359,7 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
   Like BackwardKillWord, except word boundaries are defined by PowerShell
   token boundaries.
 
-- UnixWordRubout  (Cmd: unbound  Emacs: <Ctrl+W>)
+- UnixWordRubout  (Cmd: unbound  Emacs: \<Ctrl+W\>)
 
   Like BackwardKillWord, except word boundaries are defined by white space.
 
@@ -367,25 +367,25 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
 
   Kill the text between the cursor and the mark.
 
-- Copy   (Cmd: <Ctrl+Shift+C>  Emacs: unbound)
+- Copy   (Cmd: \<Ctrl+Shift+C\>  Emacs: unbound)
 
   Copy selected region to the system clipboard. If no region is selected, copy
   the whole line.
 
-- CopyOrCancelLine  (Cmd: <Ctrl+C>  Emacs: <Ctrl+C>)
+- CopyOrCancelLine  (Cmd: \<Ctrl+C\>  Emacs: \<Ctrl+C\>)
 
   Either copy selected text to the clipboard, or if no text is selected,
   cancel editing the line with CancelLine.
 
-- Cut    (Cmd: <Ctrl+X>  Emacs: unbound)
+- Cut    (Cmd: \<Ctrl+X\>  Emacs: unbound)
 
   Delete selected region placing deleted text in the system clipboard.
 
-- Yank   (Cmd: unbound  Emacs: <Ctrl+Y>)
+- Yank   (Cmd: unbound  Emacs: \<Ctrl+Y\>)
 
   Add the most-recently killed text to the input.
 
-- YankPop  (Cmd: unbound  Emacs: <Alt+Y>)
+- YankPop  (Cmd: unbound  Emacs: \<Alt+Y\>)
 
   If the previous operation was Yank or YankPop, replace the previously-yanked
   text with the next killed text from the kill ring.
@@ -394,12 +394,12 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
 
   The contents of the kill ring are cleared.
 
-- Paste  (Cmd: <Ctrl+V>  Emacs: unbound)
+- Paste  (Cmd: \<Ctrl+V\>  Emacs: unbound)
 
   This is similar to Yank, but uses the system clipboard instead of the kill
   ring.
 
-- YankLastArg  (Cmd: <Alt+.>  Emacs: <Alt+.>, <Alt+_>)
+- YankLastArg  (Cmd: \<Alt+.\>  Emacs: \<Alt+.\>, \<Alt+_\>)
 
   Insert the last argument from the previous command in history. Repeated
   operations replace the last inserted argument with the last argument from
@@ -413,7 +413,7 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
 
   Arguments are based on PowerShell tokens.
 
-- YankNthArg  (Cmd: unbound  Emacs: <Alt+Ctrl+Y>)
+- YankNthArg  (Cmd: unbound  Emacs: \<Alt+Ctrl+Y\>)
 
   Insert the first argument (not the command name) of the previous command in
   history.
@@ -425,28 +425,28 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
 
 ## Miscellaneous
 
-- Abort  (Cmd: unbound  Emacs: <Ctrl+G>)
+- Abort  (Cmd: unbound  Emacs: \<Ctrl+G\>)
 
   Abort the current action; for example, stop interactive history search. Does
   not cancel input like CancelLine.
 
-- CharacterSearch  (Cmd: <F3>  Emacs: <Ctrl+]>)
+- CharacterSearch  (Cmd: \<F3\>  Emacs: \<Ctrl+]\>)
 
   Read a key and search forwards for that character. With an argument, search
   forwards for the nth occurrence of that argument. With a negative argument,
   searches backwards.
 
-- CharacterSearchBackward  (Cmd: <Shift+F3>  Emacs: <Alt+Ctrl+]>)
+- CharacterSearchBackward  (Cmd: \<Shift+F3\>  Emacs: \<Alt+Ctrl+]\>)
 
   Like CharacterSearch, but searches backwards. With a negative argument,
   searches forwards.
 
-- ClearScreen  (Cmd: <Ctrl+L>  Emacs: <Ctrl+L>)
+- ClearScreen  (Cmd: \<Ctrl+L\>  Emacs: \<Ctrl+L\>)
 
   Clears the screen and displays the current prompt and input at the top of
   the screen.
 
-- DigitArgument  (Cmd: unbound  Emacs: <Alt+[0..9]>,,<Alt+->)
+- DigitArgument  (Cmd: unbound  Emacs: \<Alt+[0..9]\>,,\<Alt+-\>)
 
   Used to pass numeric arguments to functions like CharacterSearch or
   YankNthArg. Alt+- toggles the argument to be negative/non-negative. To enter
@@ -466,35 +466,35 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
   prompt. Useful for custom key handlers that change state, such as changing
   the current directory.
 
-- WhatIsKey  (Cmd: <Alt+?>  Emacs: <Alt+?>)
+- WhatIsKey  (Cmd: \<Alt+?\>  Emacs: \<Alt+?\>)
 
   Read a key or chord and display the key binding.
 
-- ShowKeyBindings  (Cmd: <Ctrl+Alt+?>  Emacs: <Ctrl+Alt+?>)
+- ShowKeyBindings  (Cmd: \<Ctrl+Alt+?\>  Emacs: \<Ctrl+Alt+?\>)
 
   Show all of the currently-bound keys.
 
-- ScrollDisplayUp  (Cmd: <PageUp>  Emacs: <PageUp>)
+- ScrollDisplayUp  (Cmd: \<PageUp\>  Emacs: \<PageUp\>)
 
   Scroll the display up one screen.
 
-- ScrollDisplayUpLine  (Cmd: <Ctrl+PageUp>  Emacs: <Ctrl+PageUp>)
+- ScrollDisplayUpLine  (Cmd: \<Ctrl+PageUp\>  Emacs: \<Ctrl+PageUp\>)
 
   Scroll the display up one line.
 
-- ScrollDisplayDown  (Cmd: <PageDown>  Emacs: <PageDown>)
+- ScrollDisplayDown  (Cmd: \<PageDown\>  Emacs: \<PageDown\>)
 
   Scroll the display down one screen.
 
-- ScrollDisplayDownLine  (Cmd: <Ctrl+PageDown>  Emacs: <Ctrl+PageDown>)
+- ScrollDisplayDownLine  (Cmd: \<Ctrl+PageDown\>  Emacs: \<Ctrl+PageDown\>)
 
   Scroll the display down one line.
 
-- ScrollDisplayTop  (Cmd: unbound  Emacs: <Ctrl+Home>)
+- ScrollDisplayTop  (Cmd: unbound  Emacs: \<Ctrl+Home\>)
 
   Scroll the display to the top.
 
-- ScrollDisplayToCursor  (Cmd: unbound  Emacs: <Ctrl+End>)
+- ScrollDisplayToCursor  (Cmd: unbound  Emacs: \<Ctrl+End\>)
 
   Scroll the display to the cursor.
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_psreadline.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_psreadline.md
@@ -33,13 +33,13 @@ The following functions are available in the class
 
 ## Cursor movement
 
-- EndOfLine   (Cmd: <End>  Emacs: <End> or <Ctrl+E>)
+- EndOfLine   (Cmd: \<End\>  Emacs: \<End\> or \<Ctrl+E\>)
 
   If the input has multiple lines, move to the end of the current line, or if
   already at the end of the line, move to the end of the input. If the input
   has a single line, move to the end of the input.
 
-- BeginningOfLine  (Cmd: <Home>  Emacs: <Home> or <Ctrl+A>)
+- BeginningOfLine  (Cmd: \<Home\>  Emacs: \<Home\> or \<Ctrl+A\>)
 
   If the input has multiple lines, move to the start of the current line, or
   if already at the start of the line, move to the start of the input. If the
@@ -53,41 +53,41 @@ The following functions are available in the class
 
   Move the cursor to the previous line if the input has multiple lines.
 
-- ForwardChar  (Cmd: <RightArrow>  Emacs: <RightArrow> or <Ctrl+F>)
+- ForwardChar  (Cmd: \<RightArrow\>  Emacs: \<RightArrow\> or \<Ctrl+F\>)
 
   Move the cursor one character to the right. This might move the cursor to
   the next line of multi-line input.
 
-- BackwardChar  (Cmd: <LeftArrow>  Emacs: <LeftArrow> or <Ctrl+B>)
+- BackwardChar  (Cmd: \<LeftArrow\>  Emacs: \<LeftArrow\> or \<Ctrl+B\>)
 
   Move the cursor one character to the left. This might move the cursor to the
   previous line of multi-line input.
 
-- ForwardWord  (Cmd: unbound  Emacs: <Alt+F>)
+- ForwardWord  (Cmd: unbound  Emacs: \<Alt+F\>)
 
   Move the cursor forward to the end of the current word, or if between words,
   to the end of the next word. You can set word delimiter characters with:
 
   ```powershell
-  Set-PSReadlineOption -WordDelimiters <string of delimiter characters>
+  Set-PSReadlineOption -WordDelimiters \<string of delimiter characters\>
   ```
 
-- NextWord  (Cmd: <Ctrl+RightArrow>  Emacs: unbound)
+- NextWord  (Cmd: \<Ctrl+RightArrow\>  Emacs: unbound)
 
   Move the cursor forward to the start of the next word. You can set word
   delimiter characters with:
 
   ```powershell
-  Set-PSReadlineOption -WordDelimiters <string of delimiter characters>
+  Set-PSReadlineOption -WordDelimiters \<string of delimiter characters\>
   ```
 
-- BackwardWord  (Cmd: <Ctrl+LeftArrow>  Emacs: <Alt+B>)
+- BackwardWord  (Cmd: \<Ctrl+LeftArrow\>  Emacs: \<Alt+B\>)
 
   Move the cursor back to the start of the current word, or if between words,
   the start of the previous word. You can set word delimiter characters with:
 
   ```powershell
-  Set-PSReadlineOption -WordDelimiters <string of delimiter characters>
+  Set-PSReadlineOption -WordDelimiters \<string of delimiter characters\>
   ```
 
 - ShellForwardWord  (Cmd: unbound  Emacs: unbound)
@@ -105,11 +105,11 @@ The following functions are available in the class
   Like BackwardWord except word boundaries are defined by PowerShell token
   boundaries.
 
-- GotoBrace  (Cmd: <Ctrl+}>  Emacs: unbound)
+- GotoBrace  (Cmd: \<Ctrl+}\>  Emacs: unbound)
 
   Go to the matching parenthesis, curly brace, or square bracket.
 
-- AddLine  (Cmd: <Shift-Enter>  Emacs: <Shift-Enter>)
+- AddLine  (Cmd: \<Shift-Enter\>  Emacs: \<Shift-Enter\>)
 
   The continuation prompt is displayed on the next line and PSReadline waits
   for keys to edit the current input. This is useful to enter multi-line input
@@ -122,31 +122,31 @@ The following functions are available in the class
   Cancel all editing to the line, leave the line of input on the screen but
   return from PSReadline without executing the input.
 
-- RevertLine  (Cmd: <ESC>  Emacs: <Alt+R>)
+- RevertLine  (Cmd: \<ESC\>  Emacs: \<Alt+R\>)
 
   Reverts all of the input since the last input was accepted and run. This is
   equivalent to using the Undo command until there is nothing left to undo.
 
-- BackwardDeleteChar  (Cmd: <Backspace>  Emacs: <Backspace> or <Ctrl+H>)
+- BackwardDeleteChar  (Cmd: \<Backspace\>  Emacs: \<Backspace\> or \<Ctrl+H\>)
 
   Delete the character before the cursor.
 
-- DeleteChar  (Cmd: <Delete>  Emacs: <Delete>)
+- DeleteChar  (Cmd: \<Delete\>  Emacs: \<Delete\>)
 
   Delete the character under the cursor.
 
-- DeleteCharOrExit  (Cmd: unbound  Emacs: <Ctrl+D>)
+- DeleteCharOrExit  (Cmd: unbound  Emacs: \<Ctrl+D\>)
 
   Like DeleteChar, unless the line is empty, in which case exit the process.
 
-- AcceptLine  (Cmd: <Enter>  Emacs: <Enter> or <Ctrl+M>)
+- AcceptLine  (Cmd: \<Enter\>  Emacs: \<Enter\> or \<Ctrl+M\>)
 
   Attempt to execute the current input. If the current input is incomplete
   (for example, there is a missing closing parenthesis, bracket, or quote),
   then the continuation prompt is displayed on the next line, and PSReadline
   waits for keys to edit the current input.
 
-- AcceptAndGetNext  (Cmd: unbound  Emacs: <Ctrl+O>)
+- AcceptAndGetNext  (Cmd: unbound  Emacs: \<Ctrl+O\>)
 
   Like AcceptLine, but after the line completes, start editing the next line
   from history.
@@ -165,31 +165,31 @@ The following functions are available in the class
   AcceptLine or ValidateAndAcceptLine again while the error message is
   displayed.
 
-- BackwardDeleteLine  (Cmd: <Ctrl+Home>  Emacs: unbound)
+- BackwardDeleteLine  (Cmd: \<Ctrl+Home\>  Emacs: unbound)
 
   Delete the text from the start of the input to the cursor.
 
-- ForwardDeleteLine  (Cmd: <Ctrl+End>  Emacs: unbound)
+- ForwardDeleteLine  (Cmd: \<Ctrl+End\>  Emacs: unbound)
 
   Delete the text from the cursor to the end of the input.
 
-- SelectBackwardChar  (Cmd: <Shift+LeftArrow>  Emacs: <Shift+LeftArrow>)
+- SelectBackwardChar  (Cmd: \<Shift+LeftArrow\>  Emacs: \<Shift+LeftArrow\>)
 
   Adjust the current selection to include the previous character.
 
-- SelectForwardChar  (Cmd: <Shift+RightArrow>  Emacs: <Shift+RightArrow>)
+- SelectForwardChar  (Cmd: \<Shift+RightArrow\>  Emacs: \<Shift+RightArrow\>)
 
   Adjust the current selection to include the next character.
 
-- SelectBackwardWord  (Cmd: <Shift+Ctrl+LeftArrow> Emacs: <Alt+Shift+B>)
+- SelectBackwardWord  (Cmd: \<Shift+Ctrl+LeftArrow\> Emacs: \<Alt+Shift+B\>)
 
   Adjust the current selection to include the previous word.
 
-- SelectForwardWord  (Cmd: unbound  Emacs: <Alt+Shift+F>)
+- SelectForwardWord  (Cmd: unbound  Emacs: \<Alt+Shift+F\>)
 
   Adjust the current selection to include the next word using ForwardWord.
 
-- SelectNextWord  (Cmd: <Shift+Ctrl+RightArrow> Emacs: unbound)
+- SelectNextWord  (Cmd: \<Shift+Ctrl+RightArrow\> Emacs: unbound)
 
   Adjust the current selection to include the next word using NextWord.
 
@@ -207,29 +207,29 @@ The following functions are available in the class
   Adjust the current selection to include the previous word using
   ShellBackwardWord.
 
-- SelectBackwardsLine  (Cmd: <Shift+Home>  Emacs: <Shift+Home>)
+- SelectBackwardsLine  (Cmd: \<Shift+Home\>  Emacs: \<Shift+Home\>)
 
   Adjust the current selection to include from the cursor to the start of the
   line.
 
-- SelectLine  (Cmd: <Shift+End>  Emacs: <Shift+End>)
+- SelectLine  (Cmd: \<Shift+End\>  Emacs: \<Shift+End\>)
 
   Adjust the current selection to include from the cursor to the end of the
   line.
 
-- SelectAll  (Cmd: <Ctrl+A>  Emacs: unbound)
+- SelectAll  (Cmd: \<Ctrl+A\>  Emacs: unbound)
 
   Select the entire line. Moves the cursor to the end of the line.
 
-- SelfInsert  (Cmd: <a>, <b>, ...  Emacs: <a>, <b>, ...)
+- SelfInsert  (Cmd: \<a\>, \<b\>, ...  Emacs: \<a\>, \<b\>, ...)
 
   Insert the key entered.
 
-- Redo   (Cmd: <Ctrl+Y>  Emacs: unbound)
+- Redo   (Cmd: \<Ctrl+Y\>  Emacs: unbound)
 
   Redo an insertion or deletion that was undone by Undo.
 
-- Undo   (Cmd: <Ctrl+Z>  Emacs: <Ctrl+_>)
+- Undo   (Cmd: \<Ctrl+Z\>  Emacs: \<Ctrl+_\>)
 
   Undo a previous insertion or deletion.
 
@@ -240,61 +240,61 @@ The following functions are available in the class
   Clears history in PSReadline. This does not affect PowerShell
   history.
 
-- PreviousHistory  (Cmd: <UpArrow>  Emacs: <UpArrow> or <Ctrl+P>)
+- PreviousHistory  (Cmd: \<UpArrow\>  Emacs: \<UpArrow\> or \<Ctrl+P\>)
 
   Replace the current input with the previous item from PSReadline history.
 
-- NextHistory  (Cmd: <DownArrow>  Emacs: <DownArrow> or <Ctrl+N>)
+- NextHistory  (Cmd: \<DownArrow\>  Emacs: \<DownArrow\> or \<Ctrl+N\>)
 
   Replace the current input with the next item from PSReadline history.
 
-- ForwardSearchHistory  (Cmd: <Ctrl+S>  Emacs: <Ctrl+S>)
+- ForwardSearchHistory  (Cmd: \<Ctrl+S\>  Emacs: \<Ctrl+S\>)
 
   Search forward from the current history line interactively.
 
-- ReverseSearchHistory  (Cmd: <Ctrl+R>  Emacs: <Ctrl+R>)
+- ReverseSearchHistory  (Cmd: \<Ctrl+R\>  Emacs: \<Ctrl+R\>)
 
   Search backward from the current history line interactively.
 
-- HistorySearchBackward  (Cmd: <F8>  Emacs: unbound)
+- HistorySearchBackward  (Cmd: \<F8\>  Emacs: unbound)
 
   Replace the current input with the previous item from PSReadline history
   that matches the characters between the start and the input and the cursor.
 
-- HistorySearchForward  (Cmd: <Shift+F8>  Emacs: unbound)
+- HistorySearchForward  (Cmd: \<Shift+F8\>  Emacs: unbound)
 
   Replace the current input with the next item from PSReadline history that
   matches the characters between the start and the input and the cursor.
 
-- BeginningOfHistory  (Cmd: unbound  Emacs: <Alt+<>)
+- BeginningOfHistory  (Cmd: unbound  Emacs: \<Alt+\<\>)
 
   Replace the current input with the last item from PSReadline history.
 
-- EndOfHistory  (Cmd: unbound  Emacs: <Alt+>>)
+- EndOfHistory  (Cmd: unbound  Emacs: \<Alt+\>\>)
 
   Replace the current input with the last item in PSReadline history, which is
   the possibly empty input that was entered before any history commands.
 
 ## Tab Completion
 
-- TabCompleteNext  (Cmd: <Tab>  Emacs: unbound)
+- TabCompleteNext  (Cmd: \<Tab\>  Emacs: unbound)
 
   Attempt to complete the text surrounding the cursor with the next
   available completion.
 
-- TabCompletePrevious  (Cmd: <Shift-Tab>  Emacs: unbound)
+- TabCompletePrevious  (Cmd: \<Shift-Tab\>  Emacs: unbound)
 
   Attempt to complete the text surrounding the cursor with the next
   previous completion.
 
-- Complete  (Cmd: unbound  Emacs: <Tab>)
+- Complete  (Cmd: unbound  Emacs: \<Tab\>)
 
   Attempt to perform completion on the text surrounding the cursor. If there
   are multiple possible completions, the longest unambiguous prefix is used
   for completion. If you are trying to complete the longest unambiguous
   completion, a list of possible completions is displayed.
 
-- MenuComplete  (Cmd: <Ctrl+Space>  Emacs: <Ctrl+Space>)
+- MenuComplete  (Cmd: \<Ctrl+Space\>  Emacs: \<Ctrl+Space\>)
 
   Attempt to perform completion on the text surrounding the cursor. If there
   are multiple possible completions, a list of possible completions is
@@ -302,16 +302,16 @@ The following functions are available in the class
   keys, or Tab/Shift+Tab. Escape and Ctrl+G cancel the menu selection, and
   revert the line to the state before invoking MenuComplete.
 
-- PossibleCompletions  (Cmd: unbound  Emacs: <Alt+Equals>)
+- PossibleCompletions  (Cmd: unbound  Emacs: \<Alt+Equals\>)
 
   Display the list of possible completions.
 
-- SetMark  (Cmd: unbound  Emacs: <Alt+Space>)
+- SetMark  (Cmd: unbound  Emacs: \<Alt+Space\>)
 
   Mark the current location of the cursor for use in a subsequent editing
   command.
 
-- ExchangePointAndMark  (Cmd: unbound  Emacs: <Ctrl+X,Ctrl+X>)
+- ExchangePointAndMark  (Cmd: unbound  Emacs: \<Ctrl+X,Ctrl+X\>)
 
   The cursor is placed at the location of the mark and the mark is moved
   to the location of the cursor.
@@ -327,23 +327,23 @@ appends the previous kill, instead of adding a new item or replacing an item
 in the kill ring. This is how you can cut a part of a line, for example, with
 multiple KillWord operations, then yank them back elsewhere as a single yank.
 
-- KillLine  (Cmd: unbound  Emacs: <Ctrl+K>)
+- KillLine  (Cmd: unbound  Emacs: \<Ctrl+K\>)
 
   Clear the input from the cursor to the end of the line. The cleared text is
   placed in the kill ring.
 
-- BackwardKillLine  (Cmd: unbound  Emacs: <Ctrl+U> or <Ctrl+X,Backspace>)
+- BackwardKillLine  (Cmd: unbound  Emacs: \<Ctrl+U\> or \<Ctrl+X,Backspace\>)
 
   Clear the input from the start of the input to the cursor. The cleared text
   is placed in the kill ring.
 
-- KillWord  (Cmd: unbound  Emacs: <Alt+D>)
+- KillWord  (Cmd: unbound  Emacs: \<Alt+D\>)
 
   Clear the input from the cursor to the end of the current word. If the
   cursor is between words, the input is cleared from the cursor to the end of
   the next word. The cleared text is placed in the kill ring.
 
-- BackwardKillWord  (Cmd: unbound  Emacs: <Alt+Backspace>)
+- BackwardKillWord  (Cmd: unbound  Emacs: \<Alt+Backspace\>)
 
   Clear the input from the start of the current word to the cursor. If the
   cursor is between words, the input is cleared from the start of the previous
@@ -359,7 +359,7 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
   Like BackwardKillWord, except word boundaries are defined by PowerShell
   token boundaries.
 
-- UnixWordRubout  (Cmd: unbound  Emacs: <Ctrl+W>)
+- UnixWordRubout  (Cmd: unbound  Emacs: \<Ctrl+W\>)
 
   Like BackwardKillWord, except word boundaries are defined by white space.
 
@@ -367,25 +367,25 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
 
   Kill the text between the cursor and the mark.
 
-- Copy   (Cmd: <Ctrl+Shift+C>  Emacs: unbound)
+- Copy   (Cmd: \<Ctrl+Shift+C\>  Emacs: unbound)
 
   Copy selected region to the system clipboard. If no region is selected, copy
   the whole line.
 
-- CopyOrCancelLine  (Cmd: <Ctrl+C>  Emacs: <Ctrl+C>)
+- CopyOrCancelLine  (Cmd: \<Ctrl+C\>  Emacs: \<Ctrl+C\>)
 
   Either copy selected text to the clipboard, or if no text is selected,
   cancel editing the line with CancelLine.
 
-- Cut    (Cmd: <Ctrl+X>  Emacs: unbound)
+- Cut    (Cmd: \<Ctrl+X\>  Emacs: unbound)
 
   Delete selected region placing deleted text in the system clipboard.
 
-- Yank   (Cmd: unbound  Emacs: <Ctrl+Y>)
+- Yank   (Cmd: unbound  Emacs: \<Ctrl+Y\>)
 
   Add the most-recently killed text to the input.
 
-- YankPop  (Cmd: unbound  Emacs: <Alt+Y>)
+- YankPop  (Cmd: unbound  Emacs: \<Alt+Y\>)
 
   If the previous operation was Yank or YankPop, replace the previously-yanked
   text with the next killed text from the kill ring.
@@ -394,12 +394,12 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
 
   The contents of the kill ring are cleared.
 
-- Paste  (Cmd: <Ctrl+V>  Emacs: unbound)
+- Paste  (Cmd: \<Ctrl+V\>  Emacs: unbound)
 
   This is similar to Yank, but uses the system clipboard instead of the kill
   ring.
 
-- YankLastArg  (Cmd: <Alt+.>  Emacs: <Alt+.>, <Alt+_>)
+- YankLastArg  (Cmd: \<Alt+.\>  Emacs: \<Alt+.\>, \<Alt+_\>)
 
   Insert the last argument from the previous command in history. Repeated
   operations replace the last inserted argument with the last argument from
@@ -413,7 +413,7 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
 
   Arguments are based on PowerShell tokens.
 
-- YankNthArg  (Cmd: unbound  Emacs: <Alt+Ctrl+Y>)
+- YankNthArg  (Cmd: unbound  Emacs: \<Alt+Ctrl+Y\>)
 
   Insert the first argument (not the command name) of the previous command in
   history.
@@ -425,28 +425,28 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
 
 ## Miscellaneous
 
-- Abort  (Cmd: unbound  Emacs: <Ctrl+G>)
+- Abort  (Cmd: unbound  Emacs: \<Ctrl+G\>)
 
   Abort the current action; for example, stop interactive history search. Does
   not cancel input like CancelLine.
 
-- CharacterSearch  (Cmd: <F3>  Emacs: <Ctrl+]>)
+- CharacterSearch  (Cmd: \<F3\>  Emacs: \<Ctrl+]\>)
 
   Read a key and search forwards for that character. With an argument, search
   forwards for the nth occurrence of that argument. With a negative argument,
   searches backwards.
 
-- CharacterSearchBackward  (Cmd: <Shift+F3>  Emacs: <Alt+Ctrl+]>)
+- CharacterSearchBackward  (Cmd: \<Shift+F3\>  Emacs: \<Alt+Ctrl+]\>)
 
   Like CharacterSearch, but searches backwards. With a negative argument,
   searches forwards.
 
-- ClearScreen  (Cmd: <Ctrl+L>  Emacs: <Ctrl+L>)
+- ClearScreen  (Cmd: \<Ctrl+L\>  Emacs: \<Ctrl+L\>)
 
   Clears the screen and displays the current prompt and input at the top of
   the screen.
 
-- DigitArgument  (Cmd: unbound  Emacs: <Alt+[0..9]>,,<Alt+->)
+- DigitArgument  (Cmd: unbound  Emacs: \<Alt+[0..9]\>,,\<Alt+-\>)
 
   Used to pass numeric arguments to functions like CharacterSearch or
   YankNthArg. Alt+- toggles the argument to be negative/non-negative. To enter
@@ -466,35 +466,35 @@ multiple KillWord operations, then yank them back elsewhere as a single yank.
   prompt. Useful for custom key handlers that change state, such as changing
   the current directory.
 
-- WhatIsKey  (Cmd: <Alt+?>  Emacs: <Alt+?>)
+- WhatIsKey  (Cmd: \<Alt+?\>  Emacs: \<Alt+?\>)
 
   Read a key or chord and display the key binding.
 
-- ShowKeyBindings  (Cmd: <Ctrl+Alt+?>  Emacs: <Ctrl+Alt+?>)
+- ShowKeyBindings  (Cmd: \<Ctrl+Alt+?\>  Emacs: \<Ctrl+Alt+?\>)
 
   Show all of the currently-bound keys.
 
-- ScrollDisplayUp  (Cmd: <PageUp>  Emacs: <PageUp>)
+- ScrollDisplayUp  (Cmd: \<PageUp\>  Emacs: \<PageUp\>)
 
   Scroll the display up one screen.
 
-- ScrollDisplayUpLine  (Cmd: <Ctrl+PageUp>  Emacs: <Ctrl+PageUp>)
+- ScrollDisplayUpLine  (Cmd: \<Ctrl+PageUp\>  Emacs: \<Ctrl+PageUp\>)
 
   Scroll the display up one line.
 
-- ScrollDisplayDown  (Cmd: <PageDown>  Emacs: <PageDown>)
+- ScrollDisplayDown  (Cmd: \<PageDown\>  Emacs: \<PageDown\>)
 
   Scroll the display down one screen.
 
-- ScrollDisplayDownLine  (Cmd: <Ctrl+PageDown>  Emacs: <Ctrl+PageDown>)
+- ScrollDisplayDownLine  (Cmd: \<Ctrl+PageDown\>  Emacs: \<Ctrl+PageDown\>)
 
   Scroll the display down one line.
 
-- ScrollDisplayTop  (Cmd: unbound  Emacs: <Ctrl+Home>)
+- ScrollDisplayTop  (Cmd: unbound  Emacs: \<Ctrl+Home\>)
 
   Scroll the display to the top.
 
-- ScrollDisplayToCursor  (Cmd: unbound  Emacs: <Ctrl+End>)
+- ScrollDisplayToCursor  (Cmd: unbound  Emacs: \<Ctrl+End\>)
 
   Scroll the display to the cursor.
 


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->

Formatting broken because of unescaped characters.

This fixes Issue #2611 

Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work