### PR TITLE
Fixes #1162 - Clarifying version introduced for Get-ComputerInfo

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ComputerInfo.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ComputerInfo.md
@@ -7,8 +7,9 @@ online version:  http://go.microsoft.com/fwlink/?LinkId=822226
 external help file:  Microsoft.PowerShell.Commands.Management.dll-Help.xml
 title:  Get-ComputerInfo
 ---
-
 # Get-ComputerInfo
+
+> Version Introduced: Windows PowerShell 5.1
 
 ## SYNOPSIS
 Gets a consolidated object of system and operating system properties.

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ComputerInfo.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ComputerInfo.md
@@ -11,8 +11,6 @@ title:  Get-ComputerInfo
 
 ## SYNOPSIS
 
-> Version Introduced: Windows PowerShell 5.1
-
 Gets a consolidated object of system and operating system properties.
 
 ## SYNTAX
@@ -22,7 +20,8 @@ Get-ComputerInfo [[-Property] <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-ComputerInfo** cmdlet gets a consolidated object of system and operating system properties.
+
+The **Get-ComputerInfo** cmdlet gets a consolidated object of system and operating system properties. This cmdlet was introduced in Windows PowerShell 5.1. On Windows Servers, it is only supported on Server 2012 and higher.
 
 ## EXAMPLES
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ComputerInfo.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ComputerInfo.md
@@ -9,9 +9,10 @@ title:  Get-ComputerInfo
 ---
 # Get-ComputerInfo
 
+## SYNOPSIS
+
 > Version Introduced: Windows PowerShell 5.1
 
-## SYNOPSIS
 Gets a consolidated object of system and operating system properties.
 
 ## SYNTAX

--- a/reference/6/Microsoft.PowerShell.Management/Get-ComputerInfo.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-ComputerInfo.md
@@ -7,8 +7,9 @@ online version:  http://go.microsoft.com/fwlink/?LinkId=822226
 external help file:  Microsoft.PowerShell.Commands.Management.dll-Help.xml
 title:  Get-ComputerInfo
 ---
-
 # Get-ComputerInfo
+
+> Version Introduced: Windows PowerShell 5.1
 
 ## SYNOPSIS
 Gets a consolidated object of system and operating system properties.

--- a/reference/6/Microsoft.PowerShell.Management/Get-ComputerInfo.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-ComputerInfo.md
@@ -11,8 +11,6 @@ title:  Get-ComputerInfo
 
 ## SYNOPSIS
 
-> Version Introduced: Windows PowerShell 5.1
-
 Gets a consolidated object of system and operating system properties.
 
 ## SYNTAX
@@ -22,7 +20,8 @@ Get-ComputerInfo [[-Property] <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-ComputerInfo** cmdlet gets a consolidated object of system and operating system properties.
+
+The **Get-ComputerInfo** cmdlet gets a consolidated object of system and operating system properties. This cmdlet was introduced in Windows PowerShell 5.1.
 
 ## EXAMPLES
 

--- a/reference/6/Microsoft.PowerShell.Management/Get-ComputerInfo.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-ComputerInfo.md
@@ -9,9 +9,10 @@ title:  Get-ComputerInfo
 ---
 # Get-ComputerInfo
 
+## SYNOPSIS
+
 > Version Introduced: Windows PowerShell 5.1
 
-## SYNOPSIS
 Gets a consolidated object of system and operating system properties.
 
 ## SYNTAX


### PR DESCRIPTION
Version(s) of document impacted
------------------------------
- [X] Impacts 6.0 document
- [X] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version (list version here) of PowerShell
- [X] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work