### PR TITLE
Modification for Measure-Object help file for -AllStats switch.

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Measure-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Measure-Object.md
@@ -93,6 +93,20 @@ This example demonstrates how the **Measure-Object** can measure Boolean values.
 In this case, it uses the PSIsContainer Boolean property to measure the incidence of folders (vs.
 files) in the current directory.
 
+### Example 7: Measure all the values
+```
+PS C:\> 1..5 | Measure-Object -AllStats
+Count             : 5
+Average           : 3
+Sum               : 15
+Maximum           : 5
+Minimum           : 1
+StandardDeviation : 1.58113883008419
+Property          :
+
+This command displays all the statitics for the inputobject.
+```
+
 ## PARAMETERS
 
 ### -Average
@@ -223,6 +237,21 @@ Accept wildcard characters: False
 
 ### -Sum
 Indicates that the cmdlet displays the sum of the values of the specified properties.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: GenericMeasure
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllStats
+Indicates that the cmdlet displays all the statitics of the specified properties.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
Modification for Measure-Object help file for -AllStats switch based on issue [#6278](https://github.com/PowerShell/PowerShell/pull/7220)

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (6.1.x) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work