### PR TITLE
ConvertFrom-Json.md - fix duplicate key in JSON

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
+++ b/reference/6/Microsoft.PowerShell.Utility/ConvertFrom-Json.md
@@ -96,7 +96,7 @@ The Join operator is required, because the `ConvertFrom-Json` cmdlet expects a s
 ### Example 4: Convert a JSON string to a hash table
 
 ```powershell
-'{ "key":"value1", "Key":"value2" }' | ConvertFrom-Json -AsHashtable
+'{ "key1":"value1", "key2":"value2" }' | ConvertFrom-Json -AsHashtable
 ```
 
 This command shows an example where the `-AsHashtable` switch can overcome limitations of the command.


### PR DESCRIPTION
Without this fix one gets `ConvertFrom-Json : Cannot convert the JSON string because a dictionary that was converted from the string contains the duplicated keys 'key' and 'Key'.`

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work