### PR TITLE
Fix reference to an environment variable

### DIFF
--- a/developer/module/installing-a-powershell-module.md
+++ b/developer/module/installing-a-powershell-module.md
@@ -127,7 +127,7 @@ The user-specific Modules directory is added to the value of the **PSModulePath*
 If you want a module to be available to all user accounts on the computer, install the module in the Program Files location.
 
 ```
-$EnvProgramFiles\WindowsPowerShell\Modules\<Module Folder>\<Module Files>
+$Env:ProgramFiles\WindowsPowerShell\Modules\<Module Folder>\<Module Files>
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Inserted a (presumably lost) colon (:) into an environment variable reference.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work