### PR TITLE
Resolve inconsistencies about Common Files Modules

### DIFF
--- a/developer/module/installing-a-powershell-module.md
+++ b/developer/module/installing-a-powershell-module.md
@@ -162,7 +162,7 @@ $p += "C:\Program Files\Fabrikam Technolgies\Fabrikam Manager\Modules\"
 
 If a module is used by multiple components of a product or by multiple versions of a product, install the module in a module-specific subdirectory of the %ProgramFiles%\Common Files\Modules subdirectory.
 
-In the following example, the Fabrikam module is installed in a Fabrikam subdirectory of the %ProgramFiles%\WindowsPowerShell\Modules subdirectory. Note that each module resides in its own subdirectory in the Modules subdirectory.
+In the following example, the Fabrikam module is installed in a Fabrikam subdirectory of the %ProgramFiles%\Common Files\Modules subdirectory. Note that each module resides in its own subdirectory in the Modules subdirectory.
 
 ```
 C:\Program Files
@@ -174,12 +174,17 @@ C:\Program Files
 
 ```
 
-Then, the installer adds the subdirectory path to the value of the **PSModulePath** environment variable.
+Then, the installer assures the value of the **PSModulePath** environment variable includes the path of the common files modules subdirectory.
 
 ```powershell
+$m = $env:ProgramFiles + '\Common Files\Modules'
 $p = [Environment]::GetEnvironmentVariable("PSModulePath")
-$p += ";C:\Program Files\ WindowsPowerShell \Modules\"
-[Environment]::SetEnvironmentVariable("PSModulePath",$p)
+$q = $p -split ';'
+if ($q -notContains $m) {
+    $q += ";$m"
+}
+$p = $q -join ';'
+[Environment]::SetEnvironmentVariable("PSModulePath", $p)
 ```
 
 ## Installing Multiple Versions of a Module


### PR DESCRIPTION
The second paragraph of section “Installing Modules in the Common Files Directory” and the PowerShell sample code at its end both refer to installation in %ProgramFiles%\WindowsPowerShell\Modules (as covered in the preceding section, “Installing Modules for all Users in Program Files”) while the section title and the first paragraph are about installing modules in %ProgramFiles%\Common Files\Modules. The proposed change resolves this inconsistency.

It further proposes to first check the %PsModulePath% directory list before adding the Common Files Module directory.

Note to the reviewers: I’m not an expert on the designated meaning of system directories (like %ProgramFiles%\Common Files\Modules), and may have misunderstood the first paragraph, resulting in this change proposal to be plainly wrong.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work