### PR TITLE
Fix indentation (removing material from a list)

### DIFF
--- a/developer/module/installing-a-powershell-module.md
+++ b/developer/module/installing-a-powershell-module.md
@@ -192,33 +192,32 @@ To install multiple versions of the same module, use the following procedure.
 
 3. Add the module root folder path to the value of the **PSModulePath** environment variable, as shown in the following examples.
 
-   To import a particular version of the module, the end-user can use the `MinimumVersion` or `RequiredVersion` parameters of the [Import-Module](/powershell/module/Microsoft.PowerShell.Core/Import-Module) cmdlet.
+To import a particular version of the module, the end-user can use the `MinimumVersion` or `RequiredVersion` parameters of the [Import-Module](/powershell/module/Microsoft.PowerShell.Core/Import-Module) cmdlet.
 
-   For example, if the Fabrikam module is available in versions 8.0 and 9.0, the Fabrikam module directory structure might resemble the following.
+For example, if the Fabrikam module is available in versions 8.0 and 9.0, the Fabrikam module directory structure might resemble the following.
 
-   ```
-   C:\Program Files
-   Fabrikam Manager
-    Fabrikam8
-      Fabrikam
-        Fabrikam.psd1 (module manifest: ModuleVersion = "8.0")
-        Fabrikam.dll (module assembly)
-    Fabrikam9
-      Fabrikam
-        Fabrikam.psd1 (module manifest: ModuleVersion = "9.0")
-        Fabrikam.dll (module assembly)
+ ```
+C:\Program Files
+Fabrikam Manager
+  Fabrikam8
+    Fabrikam
+      Fabrikam.psd1 (module manifest: ModuleVersion = "8.0")
+      Fabrikam.dll (module assembly)
+  Fabrikam9
+    Fabrikam
+      Fabrikam.psd1 (module manifest: ModuleVersion = "9.0")
+      Fabrikam.dll (module assembly)
+```
 
-   ```
+The installer adds both of the module paths to the **PSModulePath** environment variable value.
 
-   The installer adds both of the module paths to the **PSModulePath** environment variable value.
+```powershell
+$p = [Environment]::GetEnvironmentVariable("PSModulePath")
+$p += ";C:\Program Files\Fabrikam\Fabrikam8;C:\Program Files\Fabrikam\Fabrikam9"
+[Environment]::SetEnvironmentVariable("PSModulePath",$p)
+```
 
-   ```powershell
-   $p = [Environment]::GetEnvironmentVariable("PSModulePath")
-   $p += ";C:\Program Files\Fabrikam\Fabrikam8;C:\Program Files\Fabrikam\Fabrikam9"
-   [Environment]::SetEnvironmentVariable("PSModulePath",$p)
-   ```
-
-   When these steps are complete, the **ListAvailable** parameter of the [Get-Module](/powershell/module/Microsoft.PowerShell.Core/Get-Module) cmdlet gets both of the Fabrikam modules. To import a particular module, use the `MiminumVersion` or `RequiredVersion` parameters of the [Import-Module](/powershell/module/Microsoft.PowerShell.Core/Import-Module) cmdlet.
+When these steps are complete, the **ListAvailable** parameter of the [Get-Module](/powershell/module/Microsoft.PowerShell.Core/Get-Module) cmdlet gets both of the Fabrikam modules. To import a particular module, use the `MiminumVersion` or `RequiredVersion` parameters of the [Import-Module](/powershell/module/Microsoft.PowerShell.Core/Import-Module) cmdlet.
 
 If both modules are imported into the same session, and the modules contain cmdlets with the same names, the cmdlets that are imported last are effective in the session.
 


### PR DESCRIPTION
Moved all text and displays following the first paragraph of item 3 of the list out of the list (where they are located by presumably erroneous indentation).

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work