### PR TITLE
Tidy up class name casing

### DIFF
--- a/developer/module/importing-a-powershell-module.md
+++ b/developer/module/importing-a-powershell-module.md
@@ -49,14 +49,14 @@ To support automatic importing of modules, the `Get-Command` cmdlet gets all cmd
 
 ## The Importing Process
 
-When a module is imported, a new session state is created for the module, and a [System.Management.Automation.Psmoduleinfo](/dotnet/api/System.Management.Automation.PSModuleInfo) object is created in memory. A session-state is created for each module that is imported (this includes the root module and any nested modules). The members that are exported from the root module, including any members that were exported to the root module by any nested modules, are then imported into the caller's session state.
+When a module is imported, a new session state is created for the module, and a [System.Management.Automation.PSModuleInfo](/dotnet/api/System.Management.Automation.PSModuleInfo) object is created in memory. A session-state is created for each module that is imported (this includes the root module and any nested modules). The members that are exported from the root module, including any members that were exported to the root module by any nested modules, are then imported into the caller's session state.
 
 The metadata of members that are exported from a module have a ModuleName property. This property is populated with the name of the module that exported them.
 
 > [!WARNING]
 > If the name of an exported member uses an unapproved verb or if the name of the member uses restricted characters, a warning is displayed when the [Import-Module](/powershell/module/Microsoft.PowerShell.Core/Import-Module) cmdlet is run.
 
-By default, the [Import-Module](/powershell/module/Microsoft.PowerShell.Core/Import-Module) cmdlet does not return any objects to the pipeline. However, the cmdlet supports a `PassThru` parameter that can be used to return a [System.Management.Automation.Psmoduleinfo](/dotnet/api/System.Management.Automation.PSModuleInfo) object for each module that is imported. To send output to the host, users should run the [Write-Host](/powershell/module/Microsoft.PowerShell.Utility/Write-Host) cmdlet.
+By default, the [Import-Module](/powershell/module/Microsoft.PowerShell.Core/Import-Module) cmdlet does not return any objects to the pipeline. However, the cmdlet supports a `PassThru` parameter that can be used to return a [System.Management.Automation.PSModuleInfo](/dotnet/api/System.Management.Automation.PSModuleInfo) object for each module that is imported. To send output to the host, users should run the [Write-Host](/powershell/module/Microsoft.PowerShell.Utility/Write-Host) cmdlet.
 
 ## Restricting  the Members That Are Imported
 


### PR DESCRIPTION
Adjusting the casing of class System.Management.Automation.PSModuleInfo (in particular, only the class name, not the namespace) to the spelling used in the reference (mandatory for case-sensitive framework languages).

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work