### PR TITLE
Try to fix markdown for docs.microsoft.com

### DIFF
--- a/developer/cmdlet/required-development-guidelines.md
+++ b/developer/cmdlet/required-development-guidelines.md
@@ -69,7 +69,7 @@ The verb specified in the Cmdlet attribute must come from the recognized set of 
 
 For more information about the approved verb names, see [Cmdlet Verbs](./approved-verbs-for-windows-powershell-commands.md).
 
-Users need a set of discoverable and expected cmdlet names. Use the appropriate verb so that the user can make a quick assessment of what a cmdlet does and to easily discover the capabilities of the system. For example, the following command-line command gets a list of all the commands on the system whose names begin with "start": __get-command start-*__. Use the nouns in your cmdlets to differentiate your cmdlets from other cmdlets. The noun indicates the resource on which the operation will be performed. The operation itself is represented by the verb.
+Users need a set of discoverable and expected cmdlet names. Use the appropriate verb so that the user can make a quick assessment of what a cmdlet does and to easily discover the capabilities of the system. For example, the following command-line command gets a list of all the commands on the system whose names begin with "start": `get-command start-*`. Use the nouns in your cmdlets to differentiate your cmdlets from other cmdlets. The noun indicates the resource on which the operation will be performed. The operation itself is represented by the verb.
 
 ### Cmdlet Names: Characters that cannot be Used (RD02)
 

--- a/developer/cmdlet/required-development-guidelines.md
+++ b/developer/cmdlet/required-development-guidelines.md
@@ -69,7 +69,7 @@ The verb specified in the Cmdlet attribute must come from the recognized set of 
 
 For more information about the approved verb names, see [Cmdlet Verbs](./approved-verbs-for-windows-powershell-commands.md).
 
-Users need a set of discoverable and expected cmdlet names. Use the appropriate verb so that the user can make a quick assessment of what a cmdlet does and to easily discover the capabilities of the system. For example, the following command-line command gets a list of all the commands on the system whose names begin with "start": **get-command start-\***. Use the nouns in your cmdlets to differentiate your cmdlets from other cmdlets. The noun indicates the resource on which the operation will be performed. The operation itself is represented by the verb.
+Users need a set of discoverable and expected cmdlet names. Use the appropriate verb so that the user can make a quick assessment of what a cmdlet does and to easily discover the capabilities of the system. For example, the following command-line command gets a list of all the commands on the system whose names begin with "start": __get-command start-*__. Use the nouns in your cmdlets to differentiate your cmdlets from other cmdlets. The noun indicates the resource on which the operation will be performed. The operation itself is represented by the verb.
 
 ### Cmdlet Names: Characters that cannot be Used (RD02)
 


### PR DESCRIPTION
The phrase **get-command start-\*** seems to be rendered fine on Github, but regrettably the backslash appears not to be recognized as an escape (of the first asterisk in the group of three) on docs.microsoft.com, where it shows up literally in front of the asterisk it is supposed to escape. For that reason I tentatively replace the double-asterisk markdown with underscores and remove the disputed backslash. This should be equivalent with the base version, though it messes up the text edit window on Github, where, probably due to a bug, the part of the paragraph following the closing pair of underscores is displayed in italics.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work