### PR TITLE
Fix tense and mode of a participle from context

### DIFF
--- a/developer/cmdlet/required-development-guidelines.md
+++ b/developer/cmdlet/required-development-guidelines.md
@@ -105,7 +105,7 @@ When you name cmdlets, do not use any of the following special characters.
 
 ### Parameters Names that cannot be Used (RD03)
 
-Windows PowerShell provides a common set a parameters to all cmdlets plus additional parameters that are adding in specific situations. When designing your own cmdlets you cannot use the following names: Confirm, Debug, ErrorAction, ErrorVariable, OutBuffer, OutVariable, WarningAction, WarningVariable, WhatIf, UseTransaction, and Verbose. For more information about these parameters, see [Common Parameter Names](./common-parameter-names.md).
+Windows PowerShell provides a common set a parameters to all cmdlets plus additional parameters that are added in specific situations. When designing your own cmdlets you cannot use the following names: Confirm, Debug, ErrorAction, ErrorVariable, OutBuffer, OutVariable, WarningAction, WarningVariable, WhatIf, UseTransaction, and Verbose. For more information about these parameters, see [Common Parameter Names](./common-parameter-names.md).
 
 ### Support Confirmation Requests (RD04)
 


### PR DESCRIPTION
Changed the participle _adding_ to _added_ which appears to be required in the present context.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work