### PR TITLE
Remove duplicate sentences in developer\format\creating-*.md

### DIFF
--- a/developer/format/creating-a-list-view.md
+++ b/developer/format/creating-a-list-view.md
@@ -16,7 +16,6 @@ A list view displays data in a single column (in sequential order). The data dis
 ## A List View Display
 
 The following output shows how Windows PowerShell displays the properties of [System.Serviceprocess.Servicecontroller?Displayproperty=Fullname](/dotnet/api/System.ServiceProcess.ServiceController) objects that are returned by the [Get-Service](/powershell/module/microsoft.powershell.management/get-service) cmdlet. In this example, three objects were returned, with each object separated from the preceding object by a blank line.
-The following output shows how Windows PowerShell displays the properties of [System.Serviceprocess.Servicecontroller?Displayproperty=Fullname](/dotnet/api/System.ServiceProcess.ServiceController) objects that are returned by the [Get-Service](/powershell/module/microsoft.powershell.management/get-service) cmdlet. In this example, three objects were returned, with each object separated from the preceding object by a blank line.
 
 ```powershell
 Get-Service | format-list

--- a/developer/format/creating-a-table-view.md
+++ b/developer/format/creating-a-table-view.md
@@ -16,7 +16,6 @@ A table view displays data in one or more columns. Each row in the table represe
 ## A Table View Display
 
 The following example shows how Windows PowerShell displays the [System.Serviceprocess.Servicecontroller](/dotnet/api/System.ServiceProcess.ServiceController) object that is returned by the [Get-Service](/powershell/module/microsoft.powershell.management/get-service) cmdlet. For this object, Windows PowerShell has defined a table view that displays the `Status` property, the `Name` property (this property is an alias property for the `ServiceName` property), and the `DisplayName` property. Each row in the table represents an object returned by the cmdlet.
-The following example shows how Windows PowerShell displays the [System.Serviceprocess.Servicecontroller](/dotnet/api/System.ServiceProcess.ServiceController) object that is returned by the [Get-Service](/powershell/module/Microsoft.PowerShell.Management/Get-Service) cmdlet. For this object, Windows PowerShell has defined a table view that displays the `Status` property, the `Name` property (this property is an alias property for the `ServiceName` property), and the `DisplayName` property. Each row in the table represents an object returned by the cmdlet.
 
 ```output
 Status   Name               DisplayName

--- a/developer/format/creating-a-wide-view.md
+++ b/developer/format/creating-a-wide-view.md
@@ -16,7 +16,6 @@ A wide view displays a single value for each object that is displayed. The displ
 ## A Wide View Display
 
 The following example shows how Windows PowerShell displays the [System.Diagnostics.Process](/dotnet/api/System.Diagnostics.Process) object that is returned by the [Get-Process](/powershell/module/Microsoft.PowerShell.Management/Get-Process) cmdlet when its output is piped to the [Format-Wide](/powershell/module/Microsoft.PowerShell.Utility/Format-Wide) cmdlet. (By default, the [Get-Process](/powershell/module/Microsoft.PowerShell.Management/Get-Process) cmdlet returns a table view.) In this example, the two columns are used to display the name of the process for each returned object. The name of the object's property is not displayed, only the value of the property.
-The following example shows how Windows PowerShell displays the [System.Diagnostics.Process](/dotnet/api/System.Diagnostics.Process) object that is returned by the [Get-Process](/powershell/module/Microsoft.PowerShell.Management/Get-Process) cmdlet when its output is piped to the [Format-Wide](/powershell/module/Microsoft.PowerShell.Utility/Format-Wide) cmdlet. (By default, the [Get-Process](/powershell/module/Microsoft.PowerShell.Management/Get-Process) cmdlet returns a table view.) In this example, the two columns are used to display the name of the process for each returned object. The name of the object's property is not displayed, only the value of the property.
 
 ```
 Get-Process | format-wide


### PR DESCRIPTION
These duplicates might be due to failure of auto-conversion from MSDN to Microsoft Docs.