### PR TITLE
OpenSUSE Easy way to add product feed/repository

### DIFF
--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Linux.md
@@ -1,7 +1,7 @@
 # Installing PowerShell Core on Linux
 
 Supports [Ubuntu 14.04][u14], [Ubuntu 16.04][u16], [Ubuntu 17.10][u17], [Debian 8][deb8], [Debian 9][deb9],
-[CentOS 7][cos], [Red Hat Enterprise Linux (RHEL) 7][rhel7], [OpenSUSE 42.2][opensuse], [Fedora 27][fedora],
+[CentOS 7][cos], [Red Hat Enterprise Linux (RHEL) 7][rhel7], [OpenSUSE 42.2/42.3][opensuse], [Fedora 27][fedora],
 [Fedora 28][fedora], and [Arch Linux][arch].
 
 For Linux distributions that are not officially supported,
@@ -490,7 +490,7 @@ sudo zypper install powershell
 pwsh
 ```
 
-### Installation via Direct Download - OpenSUSE 42.2
+### Installation via Direct Download - OpenSUSE 42.2/42.3
 
 Download the RPM package `powershell-6.0.2-1.rhel.7.x86_64.rpm`
 from the [releases][] page onto the OpenSUSE machine.
@@ -507,7 +507,7 @@ sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
 sudo zypper install https://github.com/PowerShell/PowerShell/releases/download/v6.0.2/powershell-6.0.2-1.rhel.7.x86_64.rpm
 ```
 
-### Uninstallation - OpenSUSE 42.2
+### Uninstallation - OpenSUSE 42.2/42.3
 
 ```sh
 sudo zypper remove powershell
@@ -720,7 +720,7 @@ on different Linux distributions.
 | Ubuntu 18.04       | libc6, libgcc1, libgssapi-krb5-2, liblttng-ust0, libstdc++6, <br> libcurl3, libunwind8, libuuid1, zlib1g, libssl1.0.0, libicu60 |
 | Debian 8 (Jessie)  | libc6, libgcc1, libgssapi-krb5-2, liblttng-ust0, libstdc++6, <br> libcurl3, libunwind8, libuuid1, zlib1g, libssl1.0.0, libicu52 |
 | Debian 9 (Stretch) | libc6, libgcc1, libgssapi-krb5-2, liblttng-ust0, libstdc++6, <br> libcurl3, libunwind8, libuuid1, zlib1g, libssl1.0.2, libicu57 |
-| CentOS 7 <br> Oracle Linux 7 <br> RHEL 7 <br> OpenSUSE 42.2 | libunwind, libcurl, openssl-libs, libicu |
+| CentOS 7 <br> Oracle Linux 7 <br> RHEL 7 <br> OpenSUSE 42.2/OpenSUSE 42.3 | libunwind, libcurl, openssl-libs, libicu |
 | Fedora 27 <br> Fedora 28 | libunwind, libcurl, openssl-libs, libicu, compat-openssl10 |
 
 To deploy PowerShell binaries on Linux distributions that are not officially supported,

--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Linux.md
@@ -449,7 +449,7 @@ sudo yum install https://github.com/PowerShell/PowerShell/releases/download/v6.0
 sudo yum remove powershell
 ```
 
-## OpenSUSE 42.2
+## OpenSUSE 42.2/42.3
 
 When installing PowerShell Core, `zypper` may report the following error:
 
@@ -469,7 +469,7 @@ zypper search --file-list --match-exact '/usr/lib64/libcurl.so.4'
 Then choose the `break powershell-6.0.1-1.rhel.7.x86_64 by ignoring some of its dependencies`
 solution when installing the PowerShell package.
 
-### Installation via Package Repository (preferred) - OpenSUSE 42.2
+### Installation via Package Repository (preferred) - OpenSUSE 42.2/42.3
 
 PowerShell Core for Linux is published to official Microsoft repositories for easy installation (and updates).
 
@@ -477,8 +477,8 @@ PowerShell Core for Linux is published to official Microsoft repositories for ea
 # Register the Microsoft signature key
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
 
-# Add the Microsoft Product feed
-curl https://packages.microsoft.com/config/rhel/7/prod.repo | sudo tee /etc/zypp/repos.d/microsoft.repo
+# Add the Microsoft Repository
+zypper ar https://packages.microsoft.com/rhel/7/prod/
 
 # Update the list of products
 sudo zypper update


### PR DESCRIPTION
You do not have to do curl and do all that staff, zypper tool in OpenSUSE does it for you. I have updated this document to reflect the easier way of adding repository, which also help with updating PowerShell in the feature. In the feature if there is update to this repository zypper will automatically install new version and remove old one.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work