### PR TITLE
Updated Home-brew instructions

### DIFF
--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
@@ -4,19 +4,29 @@ PowerShell Core supports macOS 10.12 and higher.
 All packages are available on our GitHub [releases][] page.
 Once the package is installed, run `pwsh` from a terminal.
 
-### Installation via Homebrew on macOS 10.12
+### Installation via Homebrew on macOS 10.12 and 10.13
 
 [Homebrew][brew] is the preferred package manager for macOS.
-If the `brew` command is not found, you need to install Homebrew following [their instructions][brew].
+From a terminal window, type `brew` to run Homebrew.  If the `brew` command is not found, you need to install Homebrew following [their instructions][brew].
 
-Once you've installed Homebrew, installing PowerShell is easy.
-First, install [Homebrew-Cask][cask], so you can install more packages:
-
+> [!NOTE]
+> If you installed Homebrew in the past, it's always a good idea to run 'brew update-reset' && 'brew update'.
 ```sh
-brew tap caskroom/cask
+brew update-reset
+brew update
 ```
 
-Now, you can install PowerShell:
+> Older versions of Homebrew used the tap 'caskroom/cask', which has been deprecated, and migrated into 'homebrew/cask'.  More information can be found at [Homebrew-cask][cask]. Use the 'brew tap' command to list your current taps.  If you see 'caskroom/cask' you can use 'brew update' to have Homebrew migrate the taps.
+
+```sh
+brew tap
+brew update
+```
+
+
+Once you've installed/updated Homebrew, installing PowerShell is easy.
+
+To install PowerShell:
 
 ```sh
 brew cask install powershell
@@ -27,6 +37,12 @@ Finally, verify that your install is working properly:
 ```sh
 pwsh
 ```
+
+To exit PowerShell, and return to bash, use the 'exit' command. 
+```sh
+exit
+```
+
 
 When new versions of PowerShell are released,
 simply update Homebrew's formulae and upgrade PowerShell:
@@ -41,8 +57,8 @@ brew cask upgrade powershell
 > but then the PowerShell shell must be exited and restarted to complete the upgrade
 > and refresh the values shown in $PSVersionTable.
 
-[brew]: http://brew.sh/
-[cask]: https://caskroom.github.io/
+
+
 
 ### Installation via Direct Download
 
@@ -121,5 +137,15 @@ PowerShell respects the [XDG Base Directory Specification][xdg-bds] on macOS.
 Because macOS is a derivation of BSD, the prefix `/usr/local` is used instead of `/opt`.
 Thus, `$PSHOME` is `/usr/local/microsoft/powershell/6.0.2/`, and the symlink is placed at `/usr/local/bin/pwsh`.
 
+## Additional Resources
+
+* [Homebrew Web][brew]
+* [Homebrew Github Repository][GitHub]
+* [Homebrew-Cask][cask]
+
+
+[brew]: http://brew.sh/
+[GitHub]: https://github.com/Homebrew
+[Cask]: https://github.com/Homebrew/homebrew-cask
 [releases]: https://github.com/PowerShell/PowerShell/releases/latest
 [xdg-bds]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html


### PR DESCRIPTION
1. Homebrew has deprecated the separate Cask setup, and integrated casks into the main homebrew setup.  Updated instructions to reflect this.
2. Added instructions to run 'brew upgrade' for situations where an older installation of Homebrew existed. 
3. Added an "Additional Resources" section at the bottom for links.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work