### PR TITLE
Add mac preview instructions

### DIFF
--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
@@ -4,7 +4,7 @@ PowerShell Core supports macOS 10.12 and higher.
 All packages are available on our GitHub [releases][] page.
 Once the package is installed, run `pwsh` from a terminal.
 
-### Installation via Homebrew on macOS 10.12 and 10.13
+### Installation via Homebrew on macOS 10.12+
 
 [Homebrew][brew] is the preferred package manager for macOS.
 From a terminal window, type `brew` to run Homebrew.  If the `brew` command is not found, you need to install Homebrew following [their instructions][brew].
@@ -59,6 +59,44 @@ brew cask upgrade powershell
 
 
 
+
+### Installing Preview via Homebrew on macOS 10.12+
+
+[Homebrew][brew] is the preferred package manager for macOS.
+If the `brew` command is not found, you need to install Homebrew following [their instructions][brew].
+
+Once you've installed Homebrew, installing PowerShell is easy.
+
+Then, you must tap the `versions` casks repository to get the preview package:
+
+```sh
+brew tap homebrew/cask-versions
+```
+
+Now, you can install PowerShell:
+
+```sh
+brew cask install powershell-preview
+```
+
+Finally, verify that your install is working properly:
+
+```sh
+pwsh-preview
+```
+
+When new versions of PowerShell are released,
+simply update Homebrew's formulae and upgrade PowerShell:
+
+```sh
+brew update
+brew cask upgrade powershell-preview
+```
+
+> [!NOTE]
+> The commands above can be called from within a PowerShell (pwsh) host,
+> but then the PowerShell shell must be exited and restarted to complete the upgrade
+> and refresh the values shown in $PSVersionTable.
 
 ### Installation via Direct Download
 

--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
@@ -23,7 +23,6 @@ brew tap
 brew update
 ```
 
-
 Once you've installed/updated Homebrew, installing PowerShell is easy.
 
 To install PowerShell:
@@ -43,7 +42,6 @@ To exit PowerShell, and return to bash, use the 'exit' command.
 exit
 ```
 
-
 When new versions of PowerShell are released,
 simply update Homebrew's formulae and upgrade PowerShell:
 
@@ -57,15 +55,17 @@ brew cask upgrade powershell
 > but then the PowerShell shell must be exited and restarted to complete the upgrade
 > and refresh the values shown in $PSVersionTable.
 
-
-
-
 ### Installing Preview via Homebrew on macOS 10.12+
 
-[Homebrew][brew] is the preferred package manager for macOS.
-If the `brew` command is not found, you need to install Homebrew following [their instructions][brew].
+Homebrew][brew] is the preferred package manager for macOS.
+From a terminal window, type `brew` to run Homebrew.  If the `brew` command is not found, you need to install Homebrew following [their instructions][brew].
 
-Once you've installed Homebrew, installing PowerShell is easy.
+> [!NOTE]
+> If you installed Homebrew in the past, it's always a good idea to run 'brew update-reset' && 'brew update'.
+```sh
+brew update-reset
+brew update
+```
 
 Then, you must tap the `versions` casks repository to get the preview package:
 
@@ -73,7 +73,7 @@ Then, you must tap the `versions` casks repository to get the preview package:
 brew tap homebrew/cask-versions
 ```
 
-Now, you can install PowerShell:
+To install PowerShell Preview:
 
 ```sh
 brew cask install powershell-preview
@@ -86,7 +86,7 @@ pwsh-preview
 ```
 
 When new versions of PowerShell are released,
-simply update Homebrew's formulae and upgrade PowerShell:
+simply update Homebrew's formulae and upgrade PowerShell Preview:
 
 ```sh
 brew update

--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
@@ -57,7 +57,7 @@ brew cask upgrade powershell
 
 ### Installing Preview via Homebrew on macOS 10.12+
 
-Homebrew][brew] is the preferred package manager for macOS.
+[Homebrew][brew] is the preferred package manager for macOS.
 From a terminal window, type `brew` to run Homebrew.  If the `brew` command is not found, you need to install Homebrew following [their instructions][brew].
 
 > [!NOTE]


### PR DESCRIPTION
tapping the main cask repo is no longer needed

add instructions to install powershell-preview for macOS

fixes #2727 
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work