### PR TITLE
Delete Duplicate Paragraphs in New-PSDrive

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/New-PSDrive.md
+++ b/reference/6/Microsoft.PowerShell.Management/New-PSDrive.md
@@ -41,10 +41,6 @@ When your command is scoped locally (no dot-sourcing), the *Persist* parameter d
 If you are running **New-PSDrive** inside a script, and you want the drive to persist indefinitely, you must dot-source the script.
 For best results, to force a new drive to persist indefinitely, add the *Scope* parameter to your command, and set its value to Global.
 - External drives.
-When an external drive is connected to the computer, Windows PowerShell automatically adds a PSDrive to the file system that represents the new drive.
-You do not have to restart Windows PowerShell.
-Similarly, when an external drive is disconnected from the computer, Windows PowerShell automatically deletes the **PSDrive** that represents the removed drive.
-- External drives.
 When an external drive is connected to the computer, Windows PowerShell automatically adds a **PSDrive** to the file system that represents the new drive.
 You do not have to restart Windows PowerShell.
 Similarly, when an external drive is disconnected from the computer, Windows PowerShell automatically deletes the **PSDrive** that represents the removed drive.


### PR DESCRIPTION
Paragraph regarding external drive is duplicated with one minor typographical difference: The word PS-Drive is bolded in one paragraph and not the other. So remove the paragraph lacking the bold.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work