### PR TITLE
Update Select-Object for 5.0 and 5.1

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Select-Object.md
@@ -412,13 +412,16 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -SkipLast
 
+Skips (does not select) the specified number of items from the end of the list or array. Works in the same way as using **Skip** together with **Last** parameter.
+
+Unlike the **Index** parameter, which starts counting at 0, the **SkipLast** parameter begins at 1.
 
 ```yaml
 Type: Int32

--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-Object.md
@@ -410,7 +410,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-Object.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-Object.md
@@ -417,6 +417,9 @@ Accept wildcard characters: False
 
 ### -SkipLast
 
+Skips (does not select) the specified number of items from the end of the list or array. Works in the same way as using **Skip** together with **Last** parameter.
+
+Unlike the **Index** parameter, which starts counting at 0, the **SkipLast** parameter begins at 1.
 
 ```yaml
 Type: Int32


### PR DESCRIPTION
Following #2732 here's the update to 5.0 and 5.1 version of `Select-Object`

Fixes #2716

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [x] This PR partially fixes the issue, and PR #2732 already did the rest