### PR TITLE
Fix Export-ModuleMember help.

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/Export-ModuleMember.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Export-ModuleMember.md
@@ -22,43 +22,38 @@ Export-ModuleMember [[-Function] <String[]>] [-Cmdlet <String[]>] [-Variable <St
 
 ## DESCRIPTION
 
-The Export-ModuleMember cmdlet specifies the module members (such as cmdlets, functions, variables, and aliases) that are exported from a script module (.psm1) file, or from a dynamic module created by using the New-Module cmdlet.
+The **Export-ModuleMember** cmdlet specifies the module members that are exported from a script module (.psm1) file, or from a dynamic module created by using the New-Module cmdlet.
+Module members include cmdlets, functions, variables, and aliases.
 This cmdlet can be used only in a script module file or a dynamic module.
 
-If a script module does not include an Export-ModuleMember command, the functions in the script module are exported, but the variables and aliases are not.
-When a script module includes Export-ModuleMember commands, only the members specified in the Export-ModuleMember commands are exported.
-You can also use Export-ModuleMember to suppress or export members that the script module imports from other modules.
+If a script module does not include an **Export-ModuleMember** command, the functions and aliases in the script module are exported, but the variables are not.
+When a script module includes **Export-ModuleMember** commands, only the members specified in the **Export-ModuleMember** commands are exported.
+You can also use **Export-ModuleMember** to suppress or export members that the script module imports from other modules.
 
-An Export-ModuleMember command is optional, but it is a best practice.
+An **Export-ModuleMember** command is optional, but it is a best practice.
 Even if the command confirms the default values, it demonstrates the intention of the module author.
 
 ## EXAMPLES
 
-### Example 1
-
+### Example 1: Export functions and aliases in a script module
 ```
-PS> Export-ModuleMember -function * -alias *
+PS C:\> Export-ModuleMember -Function * -Alias *
 ```
 
-This command exports the aliases defined in the script module, along with the functions defined in the script module.
+This command exports all the functions and aliases defined in the script module.
 
-To export the aliases, which are not exported by default, you must also explicitly specify the functions.
-Otherwise, only the aliases will be exported.
-
-### Example 2
-
+### Example 2: Export specific aliases and functions
 ```
-PS> Export-ModuleMember -function Get-Test, New-Test, Start-Test -alias gtt, ntt, stt
+PS C:\> Export-ModuleMember -Function Get-Test, New-Test, Start-Test -Alias gtt, ntt, stt
 ```
 
 This command exports three aliases and three functions defined in the script module.
 
 You can use this command format to specify the names of module members.
 
-### Example 3
-
+### Example 3: Export no members
 ```
-PS> Export-ModuleMember
+PS C:\> Export-ModuleMember
 ```
 
 This command specifies that no members defined in the script module are exported.
@@ -66,92 +61,100 @@ This command specifies that no members defined in the script module are exported
 This command prevents the module members from being exported, but it does not hide the members.
 Users can read and copy module members or use the call operator (&) to invoke module members that are not exported.
 
-### Example 4
-
+### Example 4: Export a specific variable
 ```
-PS> Export-ModuleMember -variable increment
+PS C:\> Export-ModuleMember -Variable increment
 ```
 
 This command exports only the $increment variable from the script module.
 No other members are exported.
 
-If you want to export a variable, in addition to exporting the functions in a module, the Export-ModuleMember command must include the names of all of the functions and the name of the variable.
+If you want to export a variable, in addition to exporting the functions in a module, the **Export-ModuleMember** command must include the names of all of the functions and the name of the variable.
 
-### Example 5
-
+### Example 5: Multiple export commands
 ```
-PS> # From TestModule.psm1
-function new-test
-   { <function code> }
-export-modulemember -function new-test
-function validate-test
-   { <function code> }
-function start-test
-   { <function code> }
-set-alias stt start-test
-export-modulemember -function *-test -alias stt
+PS C:\> # From TestModule.psm1
+Function New-Test
+{
+    Write-Output 'I am New-Test function'
+}
+Export-ModuleMember -Function New-Test
+
+function Validate-Test
+{
+    Write-Output 'I am Validate-Test function'
+}
+function Start-Test
+{
+    Write-Output 'I am Start-Test function'
+}
+Set-Alias stt Start-Test
+Export-ModuleMember -Function Start-Test -Alias stt
 ```
 
-These commands show how multiple Export-ModuleMember commands are interpreted in a script module (.psm1) file.
+These commands show how multiple **Export-ModuleMember** commands are interpreted in a script module (.psm1) file.
 
 These commands create three functions and one alias, and then they export two of the functions and the alias.
 
-Without the Export-ModuleMember commands, all three of the functions would be exported, but the alias would not be exported.
-With the Export-ModuleMember commands, only the Get-Test and Start-Test functions and the STT alias are exported.
+Without the **Export-ModuleMember** commands, all three of the functions and the alias would be exported.
+With the **Export-ModuleMember** commands, only the **Get-Test** and **Start-Test** functions and the STT alias are exported.
 
-### Example 6
-
+### Example 6: Export members in a dynamic module
 ```
-PS> new-module -script {function SayHello {"Hello!"}; set-alias Hi SayHello; Export-ModuleMember -alias Hi -function SayHello}
+PS C:\> New-Module -Script {function SayHello {"Hello!"}; Set-Alias Hi SayHello; Export-ModuleMember -Alias Hi -Function SayHello}
 ```
 
-This command shows how to use Export-ModuleMember in a dynamic module that is created by using the New-Module cmdlet.
+This command shows how to use Export-ModuleMember in a dynamic module that is created by using the **New-Module** cmdlet.
 
-In this example, Export-ModuleMember is used to export both the "Hi" alias and the "SayHello" function in the dynamic module.
+In this example, **Export-ModuleMember** is used to export both the Hi alias and the **SayHello** function in the dynamic module.
 
-### Example 7
-
+### Example 7: Declare and export a function in a single command
 ```
-PS> function export
+PS C:\> # From TestModule.psm1
+
+function Export
 {
-  param ([parameter(mandatory=$true)] [validateset("function","variable")] $type,
-  [parameter(mandatory=$true)] $name,
-  [parameter(mandatory=$true)] $value)
-  if ($type -eq "function")
-   {
-     Set-item "function:script:$name" $value
-     Export-ModuleMember $name
-   }
-else
-   {
-     Set-Variable -scope Script $name $value
-     Export-ModuleMember -variable $name
-   }
+  param (
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("function","variable")]
+    $Type,
+    [Parameter(Mandatory=$true)]
+    $Name,
+    [Parameter(Mandatory=$true)]
+    $Value
+    )
+
+    if ($Type -eq "function")
+    {
+        Set-item "function:script:$Name" $Value
+        Export-ModuleMember $Name
+    }
+    else
+    {
+    Set-Variable -scope Script $Name $Value
+    Export-ModuleMember -variable $Name
+    }
 }
-export function New-Test
-   {
-...
-   }
-function helper
-{
-...
-}
-export variable interval 0
-$interval = 2
+
+Export function New-Test {Write-Output 'I am New-Test function'}
+function helper {Write-Output 'I am helper function'}
+
+Export variable Interval 0
+$Interval = 2
 ```
 
-This example includes a function named Export that declares a function or creates a variable, and then writes an Export-ModuleMember command for the function or variable.
+This example includes a function named **Export** that declares a function or creates a variable, and then writes an `Export-ModuleMember` command for the function or variable.
 This lets you declare and export a function or variable in a single command.
 
-To use the Export function, include it in your script module.
-To export a function, type "Export" before the Function keyword.
+To use the **Export** function, include it in your script module.
+To export a function, type `Export` before the **Function** keyword.
 
 To export a variable, use the following format to declare the variable and set its value:
 
-export variable \<variable-name\> \<value\>
+`Export variable \<variable-name\> \<value\>`
 
 The commands in the example show the correct format.
-In this example, only the New-Test function and the $Interval variable are exported.
+In this example, only the **New-Test** function and the $Interval variable are exported.
 
 ## PARAMETERS
 
@@ -238,7 +241,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.String
 
-You can pipe function name strings to Export-ModuleMember.
+You can pipe function name strings to this cmdlet.
 
 ## OUTPUTS
 
@@ -248,9 +251,7 @@ This cmdlet does not generate any output.
 
 ## NOTES
 
-- To exclude a member from the list of exported members, add an Export-ModuleMember command that lists all other members but omits the member that you want to exclude.
-
-- 
+* To exclude a member from the list of exported members, add an **Export-ModuleMember** command that lists all other members but omits the member that you want to exclude.
 
 ## RELATED LINKS
 

--- a/reference/4.0/Microsoft.PowerShell.Core/Export-ModuleMember.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Export-ModuleMember.md
@@ -11,6 +11,7 @@ title:  Export-ModuleMember
 # Export-ModuleMember
 
 ## SYNOPSIS
+
 Specifies the module members that are exported.
 
 ## SYNTAX
@@ -21,38 +22,40 @@ Export-ModuleMember [[-Function] <String[]>] [-Cmdlet <String[]>] [-Variable <St
 ```
 
 ## DESCRIPTION
-The Export-ModuleMember cmdlet specifies the module members (such as cmdlets, functions, variables, and aliases) that are exported from a script module (.psm1) file, or from a dynamic module created by using the New-Module cmdlet.
+
+The **Export-ModuleMember** cmdlet specifies the module members that are exported from a script module (.psm1) file, or from a dynamic module created by using the New-Module cmdlet.
+Module members include cmdlets, functions, variables, and aliases.
 This cmdlet can be used only in a script module file or a dynamic module.
 
-If a script module does not include an Export-ModuleMember command, the functions in the script module are exported, but the variables and aliases are not.
-When a script module includes Export-ModuleMember commands, only the members specified in the Export-ModuleMember commands are exported.
-You can also use Export-ModuleMember to suppress or export members that the script module imports from other modules.
+If a script module does not include an **Export-ModuleMember** command, the functions and aliases in the script module are exported, but the variables are not.
+When a script module includes **Export-ModuleMember** commands, only the members specified in the **Export-ModuleMember** commands are exported.
+You can also use **Export-ModuleMember** to suppress or export members that the script module imports from other modules.
 
-An Export-ModuleMember command is optional, but it is a best practice.
+An **Export-ModuleMember** command is optional, but it is a best practice.
 Even if the command confirms the default values, it demonstrates the intention of the module author.
 
 ## EXAMPLES
 
-### Example 1
+### Example 1: Export functions and aliases in a script module
+
 ```
-PS C:\> Export-ModuleMember -function * -alias *
+PS C:\> Export-ModuleMember -Function * -Alias *
 ```
 
-This command exports the aliases defined in the script module, along with the functions defined in the script module.
+This command exports all the functions and aliases defined in the script module.
 
-To export the aliases, which are not exported by default, you must also explicitly specify the functions.
-Otherwise, only the aliases will be exported.
+### Example 2: Export specific aliases and functions
 
-### Example 2
 ```
-PS C:\> Export-ModuleMember -function Get-Test, New-Test, Start-Test -alias gtt, ntt, stt
+PS C:\> Export-ModuleMember -Function Get-Test, New-Test, Start-Test -Alias gtt, ntt, stt
 ```
 
 This command exports three aliases and three functions defined in the script module.
 
 You can use this command format to specify the names of module members.
 
-### Example 3
+### Example 3: Export no members
+
 ```
 PS C:\> Export-ModuleMember
 ```
@@ -62,92 +65,109 @@ This command specifies that no members defined in the script module are exported
 This command prevents the module members from being exported, but it does not hide the members.
 Users can read and copy module members or use the call operator (&) to invoke module members that are not exported.
 
-### Example 4
+### Example 4: Export a specific variable
+
 ```
-PS C:\> Export-ModuleMember -variable increment
+PS C:\> Export-ModuleMember -Variable increment
 ```
 
 This command exports only the $increment variable from the script module.
 No other members are exported.
 
-If you want to export a variable, in addition to exporting the functions in a module, the Export-ModuleMember command must include the names of all of the functions and the name of the variable.
+If you want to export a variable, in addition to exporting the functions in a module, the **Export-ModuleMember** command must include the names of all of the functions and the name of the variable.
 
-### Example 5
+### Example 5: Multiple export commands
+
 ```
 PS C:\> # From TestModule.psm1
-function new-test
-   { <function code> }
-export-modulemember -function new-test
-function validate-test
-   { <function code> }
-function start-test
-   { <function code> }
-set-alias stt start-test
-export-modulemember -function *-test -alias stt
+Function New-Test
+{
+    Write-Output 'I am New-Test function'
+}
+Export-ModuleMember -Function New-Test
+
+function Validate-Test
+{
+    Write-Output 'I am Validate-Test function'
+}
+function Start-Test
+{
+    Write-Output 'I am Start-Test function'
+}
+Set-Alias stt Start-Test
+Export-ModuleMember -Function Start-Test -Alias stt
 ```
 
-These commands show how multiple Export-ModuleMember commands are interpreted in a script module (.psm1) file.
+These commands show how multiple **Export-ModuleMember** commands are interpreted in a script module (.psm1) file.
 
 These commands create three functions and one alias, and then they export two of the functions and the alias.
 
-Without the Export-ModuleMember commands, all three of the functions would be exported, but the alias would not be exported.
-With the Export-ModuleMember commands, only the Get-Test and Start-Test functions and the STT alias are exported.
+Without the **Export-ModuleMember** commands, all three of the functions and the alias would be exported.
+With the **Export-ModuleMember** commands, only the **Get-Test** and **Start-Test** functions and the STT alias are exported.
 
-### Example 6
+### Example 6: Export members in a dynamic module
+
 ```
-PS C:\> new-module -script {function SayHello {"Hello!"}; set-alias Hi SayHello; Export-ModuleMember -alias Hi -function SayHello}
+PS C:\> New-Module -Script {function SayHello {"Hello!"}; Set-Alias Hi SayHello; Export-ModuleMember -Alias Hi -Function SayHello}
 ```
 
-This command shows how to use Export-ModuleMember in a dynamic module that is created by using the New-Module cmdlet.
+This command shows how to use Export-ModuleMember in a dynamic module that is created by using the **New-Module** cmdlet.
 
-In this example, Export-ModuleMember is used to export both the "Hi" alias and the "SayHello" function in the dynamic module.
+In this example, **Export-ModuleMember** is used to export both the Hi alias and the **SayHello** function in the dynamic module.
 
-### Example 7
+### Example 7: Declare and export a function in a single command
+
 ```
-PS C:\> function export
+PS C:\> # From TestModule.psm1
+
+function Export
 {
-  param ([parameter(mandatory=$true)] [validateset("function","variable")] $type,
-  [parameter(mandatory=$true)] $name,
-  [parameter(mandatory=$true)] $value)
-  if ($type -eq "function")
-   {
-     Set-item "function:script:$name" $value
-     Export-ModuleMember $name
-   }
-else
-   {
-     Set-Variable -scope Script $name $value
-     Export-ModuleMember -variable $name
-   }
+  param (
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("function","variable")]
+    $Type,
+    [Parameter(Mandatory=$true)]
+    $Name,
+    [Parameter(Mandatory=$true)]
+    $Value
+    )
+
+    if ($Type -eq "function")
+    {
+        Set-item "function:script:$Name" $Value
+        Export-ModuleMember $Name
+    }
+    else
+    {
+    Set-Variable -scope Script $Name $Value
+    Export-ModuleMember -variable $Name
+    }
 }
-export function New-Test
-   {
-...
-   }
-function helper
-{
-...
-}
-export variable interval 0
-$interval = 2
+
+Export function New-Test {Write-Output 'I am New-Test function'}
+function helper {Write-Output 'I am helper function'}
+
+Export variable Interval 0
+$Interval = 2
 ```
 
-This example includes a function named Export that declares a function or creates a variable, and then writes an Export-ModuleMember command for the function or variable.
+This example includes a function named **Export** that declares a function or creates a variable, and then writes an `Export-ModuleMember` command for the function or variable.
 This lets you declare and export a function or variable in a single command.
 
-To use the Export function, include it in your script module.
-To export a function, type "Export" before the Function keyword.
+To use the **Export** function, include it in your script module.
+To export a function, type `Export` before the **Function** keyword.
 
 To export a variable, use the following format to declare the variable and set its value:
 
-export variable \<variable-name\> \<value\>
+`Export variable \<variable-name\> \<value\>`
 
 The commands in the example show the correct format.
-In this example, only the New-Test function and the $Interval variable are exported.
+In this example, only the **New-Test** function and the $Interval variable are exported.
 
 ## PARAMETERS
 
 ### -Alias
+
 Specifies the aliases that are exported from the script module file.
 Enter the alias names.
 Wildcards are permitted.
@@ -165,6 +185,7 @@ Accept wildcard characters: False
 ```
 
 ### -Cmdlet
+
 Specifies the cmdlets that are exported from the script module file.
 Enter the cmdlet names.
 Wildcards are permitted.
@@ -184,6 +205,7 @@ Accept wildcard characters: False
 ```
 
 ### -Function
+
 Specifies the functions that are exported from the script module file.
 Enter the function names.
 Wildcards are permitted.
@@ -202,6 +224,7 @@ Accept wildcard characters: False
 ```
 
 ### -Variable
+
 Specifies the variables that are exported from the script module file.
 Enter the variable names (without a dollar sign).
 Wildcards are permitted.
@@ -219,22 +242,24 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
-You can pipe function name strings to Export-ModuleMember.
+
+You can pipe function name strings to this cmdlet.
 
 ## OUTPUTS
 
 ### None
+
 This cmdlet does not generate any output.
 
 ## NOTES
-* To exclude a member from the list of exported members, add an Export-ModuleMember command that lists all other members but omits the member that you want to exclude.
 
-*
+* To exclude a member from the list of exported members, add an **Export-ModuleMember** command that lists all other members but omits the member that you want to exclude.
 
 ## RELATED LINKS
 

--- a/reference/5.0/Microsoft.PowerShell.Core/Export-ModuleMember.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Export-ModuleMember.md
@@ -11,6 +11,7 @@ title:  Export-ModuleMember
 # Export-ModuleMember
 
 ## SYNOPSIS
+
 Specifies the module members that are exported.
 
 ## SYNTAX
@@ -21,11 +22,12 @@ Export-ModuleMember [[-Function] <String[]>] [-Cmdlet <String[]>] [-Variable <St
 ```
 
 ## DESCRIPTION
+
 The **Export-ModuleMember** cmdlet specifies the module members that are exported from a script module (.psm1) file, or from a dynamic module created by using the New-Module cmdlet.
 Module members include cmdlets, functions, variables, and aliases.
 This cmdlet can be used only in a script module file or a dynamic module.
 
-If a script module does not include an **Export-ModuleMember** command, the functions in the script module are exported, but the variables and aliases are not.
+If a script module does not include an **Export-ModuleMember** command, the functions and aliases in the script module are exported, but the variables are not.
 When a script module includes **Export-ModuleMember** commands, only the members specified in the **Export-ModuleMember** commands are exported.
 You can also use **Export-ModuleMember** to suppress or export members that the script module imports from other modules.
 
@@ -34,17 +36,16 @@ Even if the command confirms the default values, it demonstrates the intention o
 
 ## EXAMPLES
 
-### Example 1: Export aliases and functions in a script module
+### Example 1: Export functions and aliases in a script module
+
 ```
 PS C:\> Export-ModuleMember -Function * -Alias *
 ```
 
-This command exports the aliases defined in the script module, together with the functions defined in the script module.
-
-To export the aliases, which are not exported by default, you must also explicitly specify the functions.
-Otherwise, the cmdlet exports only the aliases.
+This command exports all the functions and aliases defined in the script module.
 
 ### Example 2: Export specific aliases and functions
+
 ```
 PS C:\> Export-ModuleMember -Function Get-Test, New-Test, Start-Test -Alias gtt, ntt, stt
 ```
@@ -54,6 +55,7 @@ This command exports three aliases and three functions defined in the script mod
 You can use this command format to specify the names of module members.
 
 ### Example 3: Export no members
+
 ```
 PS C:\> Export-ModuleMember
 ```
@@ -64,6 +66,7 @@ This command prevents the module members from being exported, but it does not hi
 Users can read and copy module members or use the call operator (&) to invoke module members that are not exported.
 
 ### Example 4: Export a specific variable
+
 ```
 PS C:\> Export-ModuleMember -Variable increment
 ```
@@ -74,27 +77,36 @@ No other members are exported.
 If you want to export a variable, in addition to exporting the functions in a module, the **Export-ModuleMember** command must include the names of all of the functions and the name of the variable.
 
 ### Example 5: Multiple export commands
+
 ```
 PS C:\> # From TestModule.psm1
-function new-test
-   { <function code> }
-export-modulemember -function new-test
-function validate-test
-   { <function code> }
-function start-test
-   { <function code> }
-set-alias stt start-test
-export-modulemember -function *-test -alias stt
+Function New-Test
+{
+    Write-Output 'I am New-Test function'
+}
+Export-ModuleMember -Function New-Test
+
+function Validate-Test
+{
+    Write-Output 'I am Validate-Test function'
+}
+function Start-Test
+{
+    Write-Output 'I am Start-Test function'
+}
+Set-Alias stt Start-Test
+Export-ModuleMember -Function Start-Test -Alias stt
 ```
 
 These commands show how multiple **Export-ModuleMember** commands are interpreted in a script module (.psm1) file.
 
 These commands create three functions and one alias, and then they export two of the functions and the alias.
 
-Without the **Export-ModuleMember** commands, all three of the functions would be exported, but the alias would not be exported.
+Without the **Export-ModuleMember** commands, all three of the functions and the alias would be exported.
 With the **Export-ModuleMember** commands, only the **Get-Test** and **Start-Test** functions and the STT alias are exported.
 
 ### Example 6: Export members in a dynamic module
+
 ```
 PS C:\> New-Module -Script {function SayHello {"Hello!"}; Set-Alias Hi SayHello; Export-ModuleMember -Alias Hi -Function SayHello}
 ```
@@ -104,44 +116,50 @@ This command shows how to use Export-ModuleMember in a dynamic module that is cr
 In this example, **Export-ModuleMember** is used to export both the Hi alias and the **SayHello** function in the dynamic module.
 
 ### Example 7: Declare and export a function in a single command
+
 ```
-PS C:\> function export
+PS C:\> # From TestModule.psm1
+
+function Export
 {
-  param ([parameter(mandatory=$true)] [validateset("function","variable")] $type,
-  [parameter(mandatory=$true)] $name,
-  [parameter(mandatory=$true)] $value)
-  if ($type -eq "function")
-   {
-     Set-item "function:script:$name" $value
-     Export-ModuleMember $name
-   }
-else
-   {
-     Set-Variable -scope Script $name $value
-     Export-ModuleMember -variable $name
-   }
+  param (
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("function","variable")]
+    $Type,
+    [Parameter(Mandatory=$true)]
+    $Name,
+    [Parameter(Mandatory=$true)]
+    $Value
+    )
+
+    if ($Type -eq "function")
+    {
+        Set-item "function:script:$Name" $Value
+        Export-ModuleMember $Name
+    }
+    else
+    {
+    Set-Variable -scope Script $Name $Value
+    Export-ModuleMember -variable $Name
+    }
 }
-export function New-Test
-   {
-...
-   }
-function helper
-{
-...
-}
-export variable interval 0
-$interval = 2
+
+Export function New-Test {Write-Output 'I am New-Test function'}
+function helper {Write-Output 'I am helper function'}
+
+Export variable Interval 0
+$Interval = 2
 ```
 
-This example includes a function named **export** that declares a function or creates a variable, and then writes an **Export-ModuleMember** command for the function or variable.
+This example includes a function named **Export** that declares a function or creates a variable, and then writes an `Export-ModuleMember` command for the function or variable.
 This lets you declare and export a function or variable in a single command.
 
-To use the **export** function, include it in your script module.
-To export a function, type `export` before the **Function** keyword.
+To use the **Export** function, include it in your script module.
+To export a function, type `Export` before the **Function** keyword.
 
 To export a variable, use the following format to declare the variable and set its value:
 
-`export variable \<variable-name\> \<value\>`
+`Export variable \<variable-name\> \<value\>`
 
 The commands in the example show the correct format.
 In this example, only the **New-Test** function and the $Interval variable are exported.
@@ -149,6 +167,7 @@ In this example, only the **New-Test** function and the $Interval variable are e
 ## PARAMETERS
 
 ### -Alias
+
 Specifies the aliases that are exported from the script module file.
 Enter the alias names.
 Wildcard characters are permitted.
@@ -166,6 +185,7 @@ Accept wildcard characters: False
 ```
 
 ### -Cmdlet
+
 Specifies the cmdlets that are exported from the script module file.
 Enter the cmdlet names.
 Wildcard characters are permitted.
@@ -185,6 +205,7 @@ Accept wildcard characters: False
 ```
 
 ### -Function
+
 Specifies the functions that are exported from the script module file.
 Enter the function names.
 Wildcard characters are permitted.
@@ -203,6 +224,7 @@ Accept wildcard characters: False
 ```
 
 ### -Variable
+
 Specifies the variables that are exported from the script module file.
 Enter the variable names, without a dollar sign.
 Wildcard characters are permitted.
@@ -220,22 +242,24 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
+
 You can pipe function name strings to this cmdlet.
 
 ## OUTPUTS
 
 ### None
+
 This cmdlet does not generate any output.
 
 ## NOTES
-* To exclude a member from the list of exported members, add an **Export-ModuleMember** command that lists all other members but omits the member that you want to exclude.
 
-*
+* To exclude a member from the list of exported members, add an **Export-ModuleMember** command that lists all other members but omits the member that you want to exclude.
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Export-ModuleMember.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Export-ModuleMember.md
@@ -11,6 +11,7 @@ title:  Export-ModuleMember
 # Export-ModuleMember
 
 ## SYNOPSIS
+
 Specifies the module members that are exported.
 
 ## SYNTAX
@@ -21,11 +22,12 @@ Export-ModuleMember [[-Function] <String[]>] [-Cmdlet <String[]>] [-Variable <St
 ```
 
 ## DESCRIPTION
+
 The **Export-ModuleMember** cmdlet specifies the module members that are exported from a script module (.psm1) file, or from a dynamic module created by using the New-Module cmdlet.
 Module members include cmdlets, functions, variables, and aliases.
 This cmdlet can be used only in a script module file or a dynamic module.
 
-If a script module does not include an **Export-ModuleMember** command, the functions in the script module are exported, but the variables and aliases are not.
+If a script module does not include an **Export-ModuleMember** command, the functions and aliases in the script module are exported, but the variables are not.
 When a script module includes **Export-ModuleMember** commands, only the members specified in the **Export-ModuleMember** commands are exported.
 You can also use **Export-ModuleMember** to suppress or export members that the script module imports from other modules.
 
@@ -34,17 +36,16 @@ Even if the command confirms the default values, it demonstrates the intention o
 
 ## EXAMPLES
 
-### Example 1: Export aliases and functions in a script module
+### Example 1: Export functions and aliases in a script module
+
 ```
 PS C:\> Export-ModuleMember -Function * -Alias *
 ```
 
-This command exports the aliases defined in the script module, together with the functions defined in the script module.
-
-To export the aliases, which are not exported by default, you must also explicitly specify the functions.
-Otherwise, the cmdlet exports only the aliases.
+This command exports all the functions and aliases defined in the script module.
 
 ### Example 2: Export specific aliases and functions
+
 ```
 PS C:\> Export-ModuleMember -Function Get-Test, New-Test, Start-Test -Alias gtt, ntt, stt
 ```
@@ -54,6 +55,7 @@ This command exports three aliases and three functions defined in the script mod
 You can use this command format to specify the names of module members.
 
 ### Example 3: Export no members
+
 ```
 PS C:\> Export-ModuleMember
 ```
@@ -64,6 +66,7 @@ This command prevents the module members from being exported, but it does not hi
 Users can read and copy module members or use the call operator (&) to invoke module members that are not exported.
 
 ### Example 4: Export a specific variable
+
 ```
 PS C:\> Export-ModuleMember -Variable increment
 ```
@@ -74,27 +77,36 @@ No other members are exported.
 If you want to export a variable, in addition to exporting the functions in a module, the **Export-ModuleMember** command must include the names of all of the functions and the name of the variable.
 
 ### Example 5: Multiple export commands
+
 ```
 PS C:\> # From TestModule.psm1
-function new-test
-   { <function code> }
-export-modulemember -function new-test
-function validate-test
-   { <function code> }
-function start-test
-   { <function code> }
-set-alias stt start-test
-export-modulemember -function *-test -alias stt
+Function New-Test
+{
+    Write-Output 'I am New-Test function'
+}
+Export-ModuleMember -Function New-Test
+
+function Validate-Test
+{
+    Write-Output 'I am Validate-Test function'
+}
+function Start-Test
+{
+    Write-Output 'I am Start-Test function'
+}
+Set-Alias stt Start-Test
+Export-ModuleMember -Function Start-Test -Alias stt
 ```
 
 These commands show how multiple **Export-ModuleMember** commands are interpreted in a script module (.psm1) file.
 
 These commands create three functions and one alias, and then they export two of the functions and the alias.
 
-Without the **Export-ModuleMember** commands, all three of the functions would be exported, but the alias would not be exported.
+Without the **Export-ModuleMember** commands, all three of the functions and the alias would be exported.
 With the **Export-ModuleMember** commands, only the **Get-Test** and **Start-Test** functions and the STT alias are exported.
 
 ### Example 6: Export members in a dynamic module
+
 ```
 PS C:\> New-Module -Script {function SayHello {"Hello!"}; Set-Alias Hi SayHello; Export-ModuleMember -Alias Hi -Function SayHello}
 ```
@@ -104,44 +116,50 @@ This command shows how to use Export-ModuleMember in a dynamic module that is cr
 In this example, **Export-ModuleMember** is used to export both the Hi alias and the **SayHello** function in the dynamic module.
 
 ### Example 7: Declare and export a function in a single command
+
 ```
-PS C:\> function export
+PS C:\> # From TestModule.psm1
+
+function Export
 {
-  param ([parameter(mandatory=$true)] [validateset("function","variable")] $type,
-  [parameter(mandatory=$true)] $name,
-  [parameter(mandatory=$true)] $value)
-  if ($type -eq "function")
-   {
-     Set-item "function:script:$name" $value
-     Export-ModuleMember $name
-   }
-else
-   {
-     Set-Variable -scope Script $name $value
-     Export-ModuleMember -variable $name
-   }
+  param (
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("function","variable")]
+    $Type,
+    [Parameter(Mandatory=$true)]
+    $Name,
+    [Parameter(Mandatory=$true)]
+    $Value
+    )
+
+    if ($Type -eq "function")
+    {
+        Set-item "function:script:$Name" $Value
+        Export-ModuleMember $Name
+    }
+    else
+    {
+    Set-Variable -scope Script $Name $Value
+    Export-ModuleMember -variable $Name
+    }
 }
-export function New-Test
-   {
-...
-   }
-function helper
-{
-...
-}
-export variable interval 0
-$interval = 2
+
+Export function New-Test {Write-Output 'I am New-Test function'}
+function helper {Write-Output 'I am helper function'}
+
+Export variable Interval 0
+$Interval = 2
 ```
 
-This example includes a function named **export** that declares a function or creates a variable, and then writes an **Export-ModuleMember** command for the function or variable.
+This example includes a function named **Export** that declares a function or creates a variable, and then writes an `Export-ModuleMember` command for the function or variable.
 This lets you declare and export a function or variable in a single command.
 
-To use the **export** function, include it in your script module.
-To export a function, type `export` before the **Function** keyword.
+To use the **Export** function, include it in your script module.
+To export a function, type `Export` before the **Function** keyword.
 
 To export a variable, use the following format to declare the variable and set its value:
 
-`export variable \<variable-name\> \<value\>`
+`Export variable \<variable-name\> \<value\>`
 
 The commands in the example show the correct format.
 In this example, only the **New-Test** function and the $Interval variable are exported.
@@ -149,6 +167,7 @@ In this example, only the **New-Test** function and the $Interval variable are e
 ## PARAMETERS
 
 ### -Alias
+
 Specifies the aliases that are exported from the script module file.
 Enter the alias names.
 Wildcard characters are permitted.
@@ -166,6 +185,7 @@ Accept wildcard characters: False
 ```
 
 ### -Cmdlet
+
 Specifies the cmdlets that are exported from the script module file.
 Enter the cmdlet names.
 Wildcard characters are permitted.
@@ -185,6 +205,7 @@ Accept wildcard characters: False
 ```
 
 ### -Function
+
 Specifies the functions that are exported from the script module file.
 Enter the function names.
 Wildcard characters are permitted.
@@ -203,6 +224,7 @@ Accept wildcard characters: False
 ```
 
 ### -Variable
+
 Specifies the variables that are exported from the script module file.
 Enter the variable names, without a dollar sign.
 Wildcard characters are permitted.
@@ -220,6 +242,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -230,12 +253,12 @@ You can pipe function name strings to this cmdlet.
 ## OUTPUTS
 
 ### None
+
 This cmdlet does not generate any output.
 
 ## NOTES
-* To exclude a member from the list of exported members, add an **Export-ModuleMember** command that lists all other members but omits the member that you want to exclude.
 
-*
+* To exclude a member from the list of exported members, add an **Export-ModuleMember** command that lists all other members but omits the member that you want to exclude.
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Core/Export-ModuleMember.md
+++ b/reference/6/Microsoft.PowerShell.Core/Export-ModuleMember.md
@@ -11,6 +11,7 @@ title:  Export-ModuleMember
 # Export-ModuleMember
 
 ## SYNOPSIS
+
 Specifies the module members that are exported.
 
 ## SYNTAX
@@ -21,11 +22,12 @@ Export-ModuleMember [[-Function] <String[]>] [-Cmdlet <String[]>] [-Variable <St
 ```
 
 ## DESCRIPTION
+
 The **Export-ModuleMember** cmdlet specifies the module members that are exported from a script module (.psm1) file, or from a dynamic module created by using the New-Module cmdlet.
 Module members include cmdlets, functions, variables, and aliases.
 This cmdlet can be used only in a script module file or a dynamic module.
 
-If a script module does not include an **Export-ModuleMember** command, the functions in the script module are exported, but the variables and aliases are not.
+If a script module does not include an **Export-ModuleMember** command, the functions and aliases in the script module are exported, but the variables are not.
 When a script module includes **Export-ModuleMember** commands, only the members specified in the **Export-ModuleMember** commands are exported.
 You can also use **Export-ModuleMember** to suppress or export members that the script module imports from other modules.
 
@@ -34,17 +36,16 @@ Even if the command confirms the default values, it demonstrates the intention o
 
 ## EXAMPLES
 
-### Example 1: Export aliases and functions in a script module
+### Example 1: Export functions and aliases in a script module
+
 ```
 PS C:\> Export-ModuleMember -Function * -Alias *
 ```
 
-This command exports the aliases defined in the script module, together with the functions defined in the script module.
-
-To export the aliases, which are not exported by default, you must also explicitly specify the functions.
-Otherwise, the cmdlet exports only the aliases.
+This command exports all the functions and aliases defined in the script module.
 
 ### Example 2: Export specific aliases and functions
+
 ```
 PS C:\> Export-ModuleMember -Function Get-Test, New-Test, Start-Test -Alias gtt, ntt, stt
 ```
@@ -54,6 +55,7 @@ This command exports three aliases and three functions defined in the script mod
 You can use this command format to specify the names of module members.
 
 ### Example 3: Export no members
+
 ```
 PS C:\> Export-ModuleMember
 ```
@@ -64,6 +66,7 @@ This command prevents the module members from being exported, but it does not hi
 Users can read and copy module members or use the call operator (&) to invoke module members that are not exported.
 
 ### Example 4: Export a specific variable
+
 ```
 PS C:\> Export-ModuleMember -Variable increment
 ```
@@ -74,27 +77,36 @@ No other members are exported.
 If you want to export a variable, in addition to exporting the functions in a module, the **Export-ModuleMember** command must include the names of all of the functions and the name of the variable.
 
 ### Example 5: Multiple export commands
+
 ```
 PS C:\> # From TestModule.psm1
-function new-test
-   { <function code> }
-export-modulemember -function new-test
-function validate-test
-   { <function code> }
-function start-test
-   { <function code> }
-set-alias stt start-test
-export-modulemember -function *-test -alias stt
+Function New-Test
+{
+    Write-Output 'I am New-Test function'
+}
+Export-ModuleMember -Function New-Test
+
+function Validate-Test
+{
+    Write-Output 'I am Validate-Test function'
+}
+function Start-Test
+{
+    Write-Output 'I am Start-Test function'
+}
+Set-Alias stt Start-Test
+Export-ModuleMember -Function Start-Test -Alias stt
 ```
 
 These commands show how multiple **Export-ModuleMember** commands are interpreted in a script module (.psm1) file.
 
 These commands create three functions and one alias, and then they export two of the functions and the alias.
 
-Without the **Export-ModuleMember** commands, all three of the functions would be exported, but the alias would not be exported.
+Without the **Export-ModuleMember** commands, all three of the functions and the alias would be exported.
 With the **Export-ModuleMember** commands, only the **Get-Test** and **Start-Test** functions and the STT alias are exported.
 
 ### Example 6: Export members in a dynamic module
+
 ```
 PS C:\> New-Module -Script {function SayHello {"Hello!"}; Set-Alias Hi SayHello; Export-ModuleMember -Alias Hi -Function SayHello}
 ```
@@ -104,44 +116,50 @@ This command shows how to use Export-ModuleMember in a dynamic module that is cr
 In this example, **Export-ModuleMember** is used to export both the Hi alias and the **SayHello** function in the dynamic module.
 
 ### Example 7: Declare and export a function in a single command
+
 ```
-PS C:\> function export
+PS C:\> # From TestModule.psm1
+
+function Export
 {
-  param ([parameter(mandatory=$true)] [validateset("function","variable")] $type,
-  [parameter(mandatory=$true)] $name,
-  [parameter(mandatory=$true)] $value)
-  if ($type -eq "function")
-   {
-     Set-item "function:script:$name" $value
-     Export-ModuleMember $name
-   }
-else
-   {
-     Set-Variable -scope Script $name $value
-     Export-ModuleMember -variable $name
-   }
+  param (
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("function","variable")]
+    $Type,
+    [Parameter(Mandatory=$true)]
+    $Name,
+    [Parameter(Mandatory=$true)]
+    $Value
+    )
+
+    if ($Type -eq "function")
+    {
+        Set-item "function:script:$Name" $Value
+        Export-ModuleMember $Name
+    }
+    else
+    {
+    Set-Variable -scope Script $Name $Value
+    Export-ModuleMember -variable $Name
+    }
 }
-export function New-Test
-   {
-...
-   }
-function helper
-{
-...
-}
-export variable interval 0
-$interval = 2
+
+Export function New-Test {Write-Output 'I am New-Test function'}
+function helper {Write-Output 'I am helper function'}
+
+Export variable Interval 0
+$Interval = 2
 ```
 
-This example includes a function named **export** that declares a function or creates a variable, and then writes an **Export-ModuleMember** command for the function or variable.
+This example includes a function named **Export** that declares a function or creates a variable, and then writes an `Export-ModuleMember` command for the function or variable.
 This lets you declare and export a function or variable in a single command.
 
-To use the **export** function, include it in your script module.
-To export a function, type `export` before the **Function** keyword.
+To use the **Export** function, include it in your script module.
+To export a function, type `Export` before the **Function** keyword.
 
 To export a variable, use the following format to declare the variable and set its value:
 
-`export variable \<variable-name\> \<value\>`
+`Export variable \<variable-name\> \<value\>`
 
 The commands in the example show the correct format.
 In this example, only the **New-Test** function and the $Interval variable are exported.
@@ -149,6 +167,7 @@ In this example, only the **New-Test** function and the $Interval variable are e
 ## PARAMETERS
 
 ### -Alias
+
 Specifies the aliases that are exported from the script module file.
 Enter the alias names.
 Wildcard characters are permitted.
@@ -166,6 +185,7 @@ Accept wildcard characters: False
 ```
 
 ### -Cmdlet
+
 Specifies the cmdlets that are exported from the script module file.
 Enter the cmdlet names.
 Wildcard characters are permitted.
@@ -185,6 +205,7 @@ Accept wildcard characters: False
 ```
 
 ### -Function
+
 Specifies the functions that are exported from the script module file.
 Enter the function names.
 Wildcard characters are permitted.
@@ -203,6 +224,7 @@ Accept wildcard characters: False
 ```
 
 ### -Variable
+
 Specifies the variables that are exported from the script module file.
 Enter the variable names, without a dollar sign.
 Wildcard characters are permitted.
@@ -220,22 +242,24 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
+
 You can pipe function name strings to this cmdlet.
 
 ## OUTPUTS
 
 ### None
+
 This cmdlet does not generate any output.
 
 ## NOTES
-* To exclude a member from the list of exported members, add an **Export-ModuleMember** command that lists all other members but omits the member that you want to exclude.
 
-*
+* To exclude a member from the list of exported members, add an **Export-ModuleMember** command that lists all other members but omits the member that you want to exclude.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
Fixed:
- Aliases are exported by default
- Examples description and code
- Markdown formatting

Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
