### PR TITLE
Update Example 4 in Get-Command.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Get-Command.md
@@ -73,12 +73,11 @@ This command gets all of the cmdlets, sorts them alphabetically by the noun in t
 This display can help you find the cmdlets for a task.
 
 ### Example 4
-
+```powershell
+Get-Command -Module Microsoft.PowerShell.Security, Microsoft.PowerShell.Utility
 ```
-PS> Get-Command -Module Microsoft.PowerShell.Security, PSScheduledJob
-```
 
-This command uses the **Module** parameter to get the commands in the Microsoft.PowerShell.Security and  PSScheduledJob modules.
+This command uses the **Module** parameter to get the commands in the Microsoft.PowerShell.Security and Microsoft.PowerShell.Utility modules.
 
 ### Example 5
 

--- a/reference/4.0/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Get-Command.md
@@ -70,11 +70,11 @@ This command gets all of the cmdlets, sorts them alphabetically by the noun in t
 This display can help you find the cmdlets for a task.
 
 ### Example 4
-```
-PS C:\> Get-Command -Module Microsoft.PowerShell.Security, PSScheduledJob
+```powershell
+Get-Command -Module Microsoft.PowerShell.Security, Microsoft.PowerShell.Utility
 ```
 
-This command uses the **Module** parameter to get the commands in the Microsoft.PowerShell.Security and  PSScheduledJob modules.
+This command uses the **Module** parameter to get the commands in the Microsoft.PowerShell.Security and Microsoft.PowerShell.Utility modules.
 
 ### Example 5
 ```

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-Command.md
@@ -75,11 +75,11 @@ This command gets all of the cmdlets, sorts them alphabetically by the noun in t
 This display can help you find the cmdlets for a task.
 
 ### Example 4: Get commands in a module
-```
-PS C:\> Get-Command -Module Microsoft.PowerShell.Security, PSScheduledJob
+```powershell
+Get-Command -Module Microsoft.PowerShell.Security, Microsoft.PowerShell.Utility
 ```
 
-This command uses the *Module* parameter to get the commands in the Microsoft.PowerShell.Security and PSScheduledJob modules.
+This command uses the **Module** parameter to get the commands in the Microsoft.PowerShell.Security and Microsoft.PowerShell.Utility modules.
 
 ### Example 5: Get information about a cmdlet
 ```

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-Command.md
@@ -75,11 +75,11 @@ This command gets all of the cmdlets, sorts them alphabetically by the noun in t
 This display can help you find the cmdlets for a task.
 
 ### Example 4: Get commands in a module
-```
-PS C:\> Get-Command -Module Microsoft.PowerShell.Security, PSScheduledJob
+```powershell
+Get-Command -Module Microsoft.PowerShell.Security, Microsoft.PowerShell.Utility
 ```
 
-This command uses the *Module* parameter to get the commands in the Microsoft.PowerShell.Security and PSScheduledJob modules.
+This command uses the **Module** parameter to get the commands in the Microsoft.PowerShell.Security and Microsoft.PowerShell.Utility modules.
 
 ### Example 5: Get information about a cmdlet
 ```

--- a/reference/6/Microsoft.PowerShell.Core/Get-Command.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Command.md
@@ -75,11 +75,11 @@ This command gets all of the cmdlets, sorts them alphabetically by the noun in t
 This display can help you find the cmdlets for a task.
 
 ### Example 4: Get commands in a module
-```
-PS C:\> Get-Command -Module Microsoft.PowerShell.Security, PSScheduledJob
+```powershell
+Get-Command -Module Microsoft.PowerShell.Security, Microsoft.PowerShell.Utility
 ```
 
-This command uses the *Module* parameter to get the commands in the Microsoft.PowerShell.Security and PSScheduledJob modules.
+This command uses the **Module** parameter to get the commands in the Microsoft.PowerShell.Security and Microsoft.PowerShell.Utility modules.
 
 ### Example 5: Get information about a cmdlet
 ```


### PR DESCRIPTION
PSScheduledJob -> Microsoft.PowerShell.Utility

`Get-Command` can not get PSScheduledJob, which is not included in PowerShell 6.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
