### PR TITLE
Update Where-Object.md

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/6/Microsoft.PowerShell.Core/Where-Object.md
@@ -312,7 +312,8 @@ Get-Command | where {$_.OutputType}
 ```powershell
 # Use Where-Object to get objects that are containers.
 # This gets objects that have the **PSIsContainer** property with a value of $True and excludes all others.
-Get-ChildItem | where PS>  Get-ChildItem | where {$_.PS>  Get-ChildItem | where {!$_.PS>  Get-ChildItem | where PSIsContainer -eq $False
+Get-ChildItem | where PSIsContainer
+Get-ChildItem | where {$_.PSIsContainer}
 ```
 
 ```powershell


### PR DESCRIPTION
There was a formatting issue where 4 commands were listed on one line and were incomplete. Completed the first two commands and removed the second two commands. The second two commands were related to finding objects that were not containers and were already listed in the next section of the commands.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work