### PR TITLE
Fix Out-String according to the Contributor Guide

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Out-String.md
@@ -21,8 +21,8 @@ Out-String [-Stream] [-Width <Int32>] [-InputObject <PSObject>] [<CommonParamete
 
 ## DESCRIPTION
 
-The **Out-String** cmdlet converts the objects that Windows PowerShell manages into an array of strings.
-By default, **Out-String** accumulates the strings and returns them as a single string, but you can use the stream parameter to direct **Out-String** to return one string at a time.
+The `Out-String` cmdlet converts the objects that Windows PowerShell manages into an array of strings.
+By default, `Out-String` accumulates the strings and returns them as a single string, but you can use the **Stream** parameter to direct `Out-String` to return one string at a time.
 This cmdlet lets you search and manipulate string output as you would in traditional shells when object manipulation is less convenient.
 
 ## EXAMPLES
@@ -30,21 +30,27 @@ This cmdlet lets you search and manipulate string output as you would in traditi
 ### Example 1
 
 ```powershell
-Get-Content C:\test1\testfile2.txt | out-string
+PS C:\> Get-Content C:\test1\testfile2.txt | Out-String
 ```
 
 This command sends the content of the Testfile2.txt file to the console as a single string.
-It uses the Get-Content cmdlet to get the content of the file.
-The pipeline operator (|) sends the content to **Out-String**, which sends the content to the console as a string.
+It uses the `Get-Content` cmdlet to get the content of the file.
+The pipeline operator (|) sends the content to `Out-String`, which sends the content to the console as a string.
 
 ### Example 2
 
-```
-The first command uses the Get-Culture cmdlet to get the regional settings. The pipeline operator (|) sends the result to the Select-Object cmdlet, which selects all properties (*) of the culture object that **Get-Culture** returned. The command then stores the results in the $c variable.
-PS> $c = Get-Culture | Select-Object *
+The first command uses the `Get-Culture` cmdlet to get the regional settings.
+The pipeline operator (|) sends the result to the `Select-Object` cmdlet,
+which selects all properties (*) of the culture object that `Get-Culture` returned.
+The command then stores the results in the `$C` variable.
 
-The second command uses the **Out-String** cmdlet to convert the **CultureInfo** object to a series of strings (one string for each property). It uses the **InputObject** parameter to pass the $c variable to **Out-String**. The **Width** parameter is set to 100 characters per line to prevent truncation.
-PS> Out-String -InputObject $c -Width 100
+The second command uses the `Out-String` cmdlet to convert the **CultureInfo** object to a series of strings (one string for each property).
+It uses the **InputObject** parameter to pass the `$C` variable to `Out-String`.
+The *Width* parameter is set to 100 characters per line to prevent truncation.
+
+```powershell
+PS C:\> $C = Get-Culture | Select-Object *
+PS C:\> Out-String -InputObject $C -Width 100
 ```
 
 These commands get the regional settings for the current user and convert the data to strings.
@@ -52,18 +58,18 @@ These commands get the regional settings for the current user and convert the da
 ### Example 3
 
 ```powershell
-Get-Alias | Out-String -Stream | Select-String "Get-Command"
+PS C:\> Get-Alias | Out-String -Stream | Select-String "Get-Command"
 ```
 
 This example demonstrates the difference between working with objects and working with strings.
 The command displays aliases that include the phrase "Get-Command".
-It uses the Get-Alias cmdlet to get a set of **AliasInfo** objects (one for each alias in the current session).
+It uses the `Get-Alias` cmdlet to get a set of **AliasInfo** objects (one for each alias in the current session).
 
-The pipeline operator (|) sends the output of the **Get-Alias** cmdlet to the **Out-String** cmdlet, which converts the objects to a series of strings.
-It uses the **Stream** parameter of **Out-String** to send each string individually, instead of concatenating them into a single string.
-Another pipeline operator sends the strings to the Select-String cmdlet, which selects the strings that include "Get-Command" anywhere in the string.
+The pipeline operator (|) sends the output of the `Get-Alias` cmdlet to the `Out-String` cmdlet, which converts the objects to a series of strings.
+It uses the **Stream** parameter of `Out-String` to send each string individually, instead of concatenating them into a single string.
+Another pipeline operator sends the strings to the `Select-String` cmdlet, which selects the strings that include "Get-Command" anywhere in the string.
 
-If you omit the **Stream** parameter, the command displays all of the aliases, because Select-String finds "Get-Command" in the single string that **Out-String** returns, and the formatter displays the string as a table.
+If you omit the **Stream** parameter, the command displays all of the aliases, because `Select-String` finds "Get-Command" in the single string that `Out-String` returns, and the formatter displays the string as a table.
 
 ## PARAMETERS
 
@@ -89,7 +95,7 @@ Accept wildcard characters: False
 Sends the strings for each object separately.
 By default, the strings for each object are accumulated and sent as a single string.
 
-To use the **Stream** parameter, type "**-Stream**" or its alias, "**ost**".
+To use the **Stream** parameter, type `-Stream` or its alias, `ost`.
 
 ```yaml
 Type: SwitchParameter
@@ -107,6 +113,7 @@ Accept wildcard characters: False
 
 Specifies the number of characters in each line of output.
 Any additional characters are truncated, not wrapped.
+The **Width** parameter applies only to objects that are being formatted.
 If you omit this parameter, the width is determined by the characteristics of the host program.
 The default value for the Windows PowerShell console is 80 (characters).
 
@@ -130,18 +137,23 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.PSObject
 
-You can pipe objects to Out-String.
+You can pipe objects to `Out-String`.
 
 ## OUTPUTS
 
 ### System.String
 
-Out-String returns the string that it creates from the input object.
+`Out-String` returns the string that it creates from the input object.
 
 ## NOTES
 
-- The cmdlets that contain the **Out** verb (the **Out** cmdlets) do not format objects; they just render them and send them to the specified display destination. If you send an unformatted object to an **Out** cmdlet, the cmdlet sends it to a formatting cmdlet before rendering it.
-- The **Out** cmdlets do not have parameters that take  names or file paths. To send data to an **Out** cmdlet, use a pipeline operator (|) to send the output of a Windows PowerShell command to the cmdlet. You can also store data in a variable and use the **InputObject** parameter to pass the data to the cmdlet. For more information, see the examples.
+* The cmdlets that contain the **Out** verb that do not format objects;
+they just render them and send them to the specified display destination.
+If you send an unformatted object to an **Out** cmdlet, the cmdlet sends it to a formatting cmdlet before rendering it.
+* The **Out** cmdlets do not have parameters that take names or file paths.
+To send data to an **Out** cmdlet, use a pipeline operator (|) to send the output of a Windows PowerShell command to the cmdlet.
+You can also store data in a variable and use the **InputObject** parameter to pass the data to the cmdlet.
+
 ## RELATED LINKS
 
 [Out-Default](../Microsoft.PowerShell.Core/Out-Default.md)

--- a/reference/4.0/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Out-String.md
@@ -20,50 +20,61 @@ Out-String [-Stream] [-Width <Int32>] [-InputObject <PSObject>] [<CommonParamete
 ```
 
 ## DESCRIPTION
-The **Out-String** cmdlet converts the objects that Windows PowerShell manages into an array of strings.
-By default, **Out-String** accumulates the strings and returns them as a single string, but you can use the stream parameter to direct **Out-String** to return one string at a time.
+
+The `Out-String` cmdlet converts the objects that Windows PowerShell manages into an array of strings.
+By default, `Out-String` accumulates the strings and returns them as a single string, but you can use the **Stream** parameter to direct `Out-String` to return one string at a time.
 This cmdlet lets you search and manipulate string output as you would in traditional shells when object manipulation is less convenient.
 
 ## EXAMPLES
 
 ### Example 1
+
 ```
-PS C:\> get-content C:\test1\testfile2.txt | out-string
+PS C:\> get-content C:\test1\testfile2.txt | Out-String
 ```
 
 This command sends the content of the Testfile2.txt file to the console as a single string.
-It uses the Get-Content cmdlet to get the content of the file.
-The pipeline operator (|) sends the content to **Out-String**, which sends the content to the console as a string.
+It uses the `Get-Content` cmdlet to get the content of the file.
+The pipeline operator (|) sends the content to `Out-String`, which sends the content to the console as a string.
 
 ### Example 2
-```
-The first command uses the Get-Culture cmdlet to get the regional settings. The pipeline operator (|) sends the result to the Select-Object cmdlet, which selects all properties (*) of the culture object that **Get-Culture** returned. The command then stores the results in the $c variable.
-PS C:\> $c = Get-Culture | Select-Object *
 
-The second command uses the **Out-String** cmdlet to convert the **CultureInfo** object to a series of strings (one string for each property). It uses the **InputObject** parameter to pass the $c variable to **Out-String**. The **Width** parameter is set to 100 characters per line to prevent truncation.
-PS C:\> Out-String -InputObject $c -Width 100
+The first command uses the `Get-Culture` cmdlet to get the regional settings.
+The pipeline operator (|) sends the result to the `Select-Object` cmdlet,
+which selects all properties (*) of the culture object that `Get-Culture` returned.
+The command then stores the results in the `$C` variable.
+
+The second command uses the `Out-String` cmdlet to convert the **CultureInfo** object to a series of strings (one string for each property).
+It uses the **InputObject** parameter to pass the `$C` variable to `Out-String`.
+The *Width* parameter is set to 100 characters per line to prevent truncation.
+
+```powershell
+PS C:\> $C = Get-Culture | Select-Object *
+PS C:\> Out-String -InputObject $C -Width 100
 ```
 
 These commands get the regional settings for the current user and convert the data to strings.
 
 ### Example 3
-```
-PS C:\> get-alias | out-string -stream | select-string "Get-Command"
+
+```powershell
+PS C:\> Get-Alias | Out-String -Stream | Select-String "Get-Command"
 ```
 
 This example demonstrates the difference between working with objects and working with strings.
 The command displays aliases that include the phrase "Get-Command".
-It uses the Get-Alias cmdlet to get a set of **AliasInfo** objects (one for each alias in the current session).
+It uses the `Get-Alias` cmdlet to get a set of **AliasInfo** objects (one for each alias in the current session).
 
-The pipeline operator (|) sends the output of the **Get-Alias** cmdlet to the **Out-String** cmdlet, which converts the objects to a series of strings.
-It uses the **Stream** parameter of **Out-String** to send each string individually, instead of concatenating them into a single string.
-Another pipeline operator sends the strings to the Select-String cmdlet, which selects the strings that include "Get-Command" anywhere in the string.
+The pipeline operator (|) sends the output of the `Get-Alias` cmdlet to the `Out-String` cmdlet, which converts the objects to a series of strings.
+It uses the **Stream** parameter of `Out-String` to send each string individually, instead of concatenating them into a single string.
+Another pipeline operator sends the strings to the `Select-String` cmdlet, which selects the strings that include "Get-Command" anywhere in the string.
 
-If you omit the **Stream** parameter, the command displays all of the aliases, because Select-String finds "Get-Command" in the single string that **Out-String** returns, and the formatter displays the string as a table.
+If you omit the **Stream** parameter, the command displays all of the aliases, because `Select-String` finds "Get-Command" in the single string that `Out-String` returns, and the formatter displays the string as a table.
 
 ## PARAMETERS
 
 ### -InputObject
+
 Specifies the objects to be written to a string.
 Enter a variable that contains the objects, or type a command or expression that gets the objects.
 
@@ -80,10 +91,11 @@ Accept wildcard characters: False
 ```
 
 ### -Stream
+
 Sends the strings for each object separately.
 By default, the strings for each object are accumulated and sent as a single string.
 
-To use the **Stream** parameter, type "**-Stream**" or its alias, "**ost**".
+To use the **Stream** parameter, type `-Stream` or its alias, `ost`.
 
 ```yaml
 Type: SwitchParameter
@@ -98,8 +110,10 @@ Accept wildcard characters: False
 ```
 
 ### -Width
+
 Specifies the number of characters in each line of output.
 Any additional characters are truncated, not wrapped.
+The **Width** parameter applies only to objects that are being formatted.
 If you omit this parameter, the width is determined by the characteristics of the host program.
 The default value for the Windows PowerShell console is 80 (characters).
 
@@ -116,23 +130,29 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe objects to Out-String.
+
+You can pipe objects to `Out-String`.
 
 ## OUTPUTS
 
 ### System.String
-Out-String returns the string that it creates from the input object.
+
+`Out-String` returns the string that it creates from the input object.
 
 ## NOTES
-* The cmdlets that contain the **Out** verb (the **Out** cmdlets) do not format objects; they just render them and send them to the specified display destination. If you send an unformatted object to an **Out** cmdlet, the cmdlet sends it to a formatting cmdlet before rendering it.
-* The **Out** cmdlets do not have parameters that take  names or file paths. To send data to an **Out** cmdlet, use a pipeline operator (|) to send the output of a Windows PowerShell command to the cmdlet. You can also store data in a variable and use the **InputObject** parameter to pass the data to the cmdlet. For more information, see the examples.
 
-*
+* The cmdlets that contain the **Out** verb that do not format objects;
+they just render them and send them to the specified display destination.
+If you send an unformatted object to an **Out** cmdlet, the cmdlet sends it to a formatting cmdlet before rendering it.
+* The **Out** cmdlets do not have parameters that take names or file paths.
+To send data to an **Out** cmdlet, use a pipeline operator (|) to send the output of a Windows PowerShell command to the cmdlet.
+You can also store data in a variable and use the **InputObject** parameter to pass the data to the cmdlet.
 
 ## RELATED LINKS
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Out-String.md
@@ -11,6 +11,7 @@ title:  Out-String
 # Out-String
 
 ## SYNOPSIS
+
 Sends objects to the host as a series of strings.
 
 ## SYNTAX
@@ -20,50 +21,61 @@ Out-String [-Stream] [-Width <Int32>] [-InputObject <PSObject>] [<CommonParamete
 ```
 
 ## DESCRIPTION
-The **Out-String** cmdlet converts the objects that Windows PowerShell manages into an array of strings.
-By default, **Out-String** accumulates the strings and returns them as a single string, but you can use the stream parameter to direct **Out-String** to return one string at a time.
+
+The `Out-String` cmdlet converts the objects that Windows PowerShell manages into an array of strings.
+By default, `Out-String` accumulates the strings and returns them as a single string, but you can use the **Stream** parameter to direct `Out-String` to return one string at a time.
 This cmdlet lets you search and manipulate string output as you would in traditional shells when object manipulation is less convenient.
 
 ## EXAMPLES
 
 ### Example 1: Output text to the console as a string
+
 ```
 PS C:\> Get-Content C:\test1\testfile2.txt | Out-String
 ```
 
 This command sends the content of the Testfile2.txt file to the console as a single string.
-It uses the Get-Content cmdlet to get the content of the file.
-The pipeline operator (|) sends the content to **Out-String**, which sends the content to the console as a string.
+It uses the `Get-Content` cmdlet to get the content of the file.
+The pipeline operator (|) sends the content to `Out-String`, which sends the content to the console as a string.
 
-### Example 2: Get the current culture and convert the data to strings.
-```
-The first command uses the Get-Culture cmdlet to get the regional settings. The pipeline operator (|) sends the result to the Select-Object cmdlet, which selects all properties (*) of the culture object that **Get-Culture** returned. The command then stores the results in the $C variable.
+### Example 2: Get the current culture and convert the data to strings
+
+The first command uses the `Get-Culture` cmdlet to get the regional settings.
+The pipeline operator (|) sends the result to the `Select-Object` cmdlet,
+which selects all properties (*) of the culture object that `Get-Culture` returned.
+The command then stores the results in the `$C` variable.
+
+The second command uses the `Out-String` cmdlet to convert the **CultureInfo** object to a series of strings (one string for each property).
+It uses the **InputObject** parameter to pass the `$C` variable to `Out-String`.
+The *Width* parameter is set to 100 characters per line to prevent truncation.
+
+```powershell
 PS C:\> $C = Get-Culture | Select-Object *
-
-The second command uses the **Out-String** cmdlet to convert the **CultureInfo** object to a series of strings (one string for each property). It uses the *InputObject* parameter to pass the $C variable to **Out-String**. The *Width* parameter is set to 100 characters per line to prevent truncation.
 PS C:\> Out-String -InputObject $C -Width 100
 ```
 
 These commands get the regional settings for the current user and convert the data to strings.
 
 ### Example 3: Working with objects
-```
+
+```powershell
 PS C:\> Get-Alias | Out-String -Stream | Select-String "Get-Command"
 ```
 
 This example demonstrates the difference between working with objects and working with strings.
-The command displays aliases that include the phrase Get-Command.
-It uses the Get-Alias cmdlet to get a set of **AliasInfo** objects (one for each alias in the current session).
+The command displays aliases that include the phrase "Get-Command".
+It uses the `Get-Alias` cmdlet to get a set of **AliasInfo** objects (one for each alias in the current session).
 
-The pipeline operator (|) sends the output of the **Get-Alias** cmdlet to the **Out-String** cmdlet, which converts the objects to a series of strings.
-It uses the *Stream* parameter of **Out-String** to send each string individually, instead of concatenating them into a single string.
-Another pipeline operator sends the strings to the Select-String cmdlet, which selects the strings that include **Get-Command** anywhere in the string.
+The pipeline operator (|) sends the output of the `Get-Alias` cmdlet to the `Out-String` cmdlet, which converts the objects to a series of strings.
+It uses the **Stream** parameter of `Out-String` to send each string individually, instead of concatenating them into a single string.
+Another pipeline operator sends the strings to the `Select-String` cmdlet, which selects the strings that include "Get-Command" anywhere in the string.
 
-If you omit the *Stream* parameter, the command displays all of the aliases, because **Select-String** finds **Get-Command** in the single string that **Out-String** returns, and the formatter displays the string as a table.
+If you omit the **Stream** parameter, the command displays all of the aliases, because `Select-String` finds "Get-Command" in the single string that `Out-String` returns, and the formatter displays the string as a table.
 
 ## PARAMETERS
 
 ### -InputObject
+
 Specifies the objects to be written to a string.
 Enter a variable that contains the objects, or type a command or expression that gets the objects.
 
@@ -80,10 +92,11 @@ Accept wildcard characters: False
 ```
 
 ### -Stream
+
 Indicates that the cmdlet sends the strings for each object separately.
 By default, the strings for each object are accumulated and sent as a single string.
 
-To use the *Stream* parameter, type `-Stream` or its alias, `ost`.
+To use the **Stream** parameter, type `-Stream` or its alias, `ost`.
 
 ```yaml
 Type: SwitchParameter
@@ -98,8 +111,10 @@ Accept wildcard characters: False
 ```
 
 ### -Width
+
 Specifies the number of characters in each line of output.
 Any additional characters are truncated, not wrapped.
+The **Width** parameter applies only to objects that are being formatted.
 If you omit this parameter, the width is determined by the characteristics of the host program.
 The default value for the Windows PowerShell console is 80 (characters).
 
@@ -116,23 +131,29 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe objects to **Out-String**.
+
+You can pipe objects to `Out-String`.
 
 ## OUTPUTS
 
 ### System.String
-**Out-String** returns the string that it creates from the input object.
+
+`Out-String` returns the string that it creates from the input object.
 
 ## NOTES
-* The cmdlets that contain the **Out** verb that do not format objects; they just render them and send them to the specified display destination. If you send an unformatted object to an **Out** cmdlet, the cmdlet sends it to a formatting cmdlet before rendering it.
-* The **Out** cmdlets do not have parameters that take names or file paths. To send data to an **Out** cmdlet, use a pipeline operator (|) to send the output of a Windows PowerShell command to the cmdlet. You can also store data in a variable and use the *InputObject* parameter to pass the data to the cmdlet.
 
-*
+* The cmdlets that contain the **Out** verb that do not format objects;
+they just render them and send them to the specified display destination.
+If you send an unformatted object to an **Out** cmdlet, the cmdlet sends it to a formatting cmdlet before rendering it.
+* The **Out** cmdlets do not have parameters that take names or file paths.
+To send data to an **Out** cmdlet, use a pipeline operator (|) to send the output of a Windows PowerShell command to the cmdlet.
+You can also store data in a variable and use the **InputObject** parameter to pass the data to the cmdlet.
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
@@ -157,7 +157,13 @@ You can also store data in a variable and use the **InputObject** parameter to p
 
 ## RELATED LINKS
 
+[Out-Default](../Microsoft.PowerShell.Core/Out-Default.md)
+
 [Out-File](Out-File.md)
+
+[Out-Host](../Microsoft.PowerShell.Core/Out-Host.md)
+
+[Out-Null](../Microsoft.PowerShell.Core/Out-Null.md)
 
 [Out-GridView](Out-GridView.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Out-String.md
@@ -11,6 +11,7 @@ title:  Out-String
 # Out-String
 
 ## SYNOPSIS
+
 Sends objects to the host as a series of strings.
 
 ## SYNTAX
@@ -20,50 +21,61 @@ Out-String [-Stream] [-Width <Int32>] [-InputObject <PSObject>] [<CommonParamete
 ```
 
 ## DESCRIPTION
-The **Out-String** cmdlet converts the objects that Windows PowerShell manages into an array of strings.
-By default, **Out-String** accumulates the strings and returns them as a single string, but you can use the stream parameter to direct **Out-String** to return one string at a time.
+
+The `Out-String` cmdlet converts the objects that Windows PowerShell manages into an array of strings.
+By default, `Out-String` accumulates the strings and returns them as a single string, but you can use the **Stream** parameter to direct `Out-String` to return one string at a time.
 This cmdlet lets you search and manipulate string output as you would in traditional shells when object manipulation is less convenient.
 
 ## EXAMPLES
 
 ### Example 1: Output text to the console as a string
+
 ```
 PS C:\> Get-Content C:\test1\testfile2.txt | Out-String
 ```
 
 This command sends the content of the Testfile2.txt file to the console as a single string.
-It uses the Get-Content cmdlet to get the content of the file.
-The pipeline operator (|) sends the content to **Out-String**, which sends the content to the console as a string.
+It uses the `Get-Content` cmdlet to get the content of the file.
+The pipeline operator (|) sends the content to `Out-String`, which sends the content to the console as a string.
 
-### Example 2: Get the current culture and convert the data to strings.
-```
-The first command uses the Get-Culture cmdlet to get the regional settings. The pipeline operator (|) sends the result to the Select-Object cmdlet, which selects all properties (*) of the culture object that **Get-Culture** returned. The command then stores the results in the $C variable.
+### Example 2: Get the current culture and convert the data to strings
+
+The first command uses the `Get-Culture` cmdlet to get the regional settings.
+The pipeline operator (|) sends the result to the `Select-Object` cmdlet,
+which selects all properties (*) of the culture object that `Get-Culture` returned.
+The command then stores the results in the `$C` variable.
+
+The second command uses the `Out-String` cmdlet to convert the **CultureInfo** object to a series of strings (one string for each property).
+It uses the **InputObject** parameter to pass the `$C` variable to `Out-String`.
+The *Width* parameter is set to 100 characters per line to prevent truncation.
+
+```powershell
 PS C:\> $C = Get-Culture | Select-Object *
-
-The second command uses the **Out-String** cmdlet to convert the **CultureInfo** object to a series of strings (one string for each property). It uses the *InputObject* parameter to pass the $C variable to **Out-String**. The *Width* parameter is set to 100 characters per line to prevent truncation.
 PS C:\> Out-String -InputObject $C -Width 100
 ```
 
 These commands get the regional settings for the current user and convert the data to strings.
 
 ### Example 3: Working with objects
-```
+
+```powershell
 PS C:\> Get-Alias | Out-String -Stream | Select-String "Get-Command"
 ```
 
 This example demonstrates the difference between working with objects and working with strings.
-The command displays aliases that include the phrase Get-Command.
-It uses the Get-Alias cmdlet to get a set of **AliasInfo** objects (one for each alias in the current session).
+The command displays aliases that include the phrase "Get-Command".
+It uses the `Get-Alias` cmdlet to get a set of **AliasInfo** objects (one for each alias in the current session).
 
-The pipeline operator (|) sends the output of the **Get-Alias** cmdlet to the **Out-String** cmdlet, which converts the objects to a series of strings.
-It uses the *Stream* parameter of **Out-String** to send each string individually, instead of concatenating them into a single string.
-Another pipeline operator sends the strings to the Select-String cmdlet, which selects the strings that include **Get-Command** anywhere in the string.
+The pipeline operator (|) sends the output of the `Get-Alias` cmdlet to the `Out-String` cmdlet, which converts the objects to a series of strings.
+It uses the **Stream** parameter of `Out-String` to send each string individually, instead of concatenating them into a single string.
+Another pipeline operator sends the strings to the `Select-String` cmdlet, which selects the strings that include"*Get-Command" anywhere in the string.
 
-If you omit the *Stream* parameter, the command displays all of the aliases, because **Select-String** finds **Get-Command** in the single string that **Out-String** returns, and the formatter displays the string as a table.
+If you omit the **Stream** parameter, the command displays all of the aliases, because `Select-String` finds "Get-Command" in the single string that `Out-String` returns, and the formatter displays the string as a table.
 
 ## PARAMETERS
 
 ### -InputObject
+
 Specifies the objects to be written to a string.
 Enter a variable that contains the objects, or type a command or expression that gets the objects.
 
@@ -80,10 +92,11 @@ Accept wildcard characters: False
 ```
 
 ### -Stream
+
 Indicates that the cmdlet sends the strings for each object separately.
 By default, the strings for each object are accumulated and sent as a single string.
 
-To use the *Stream* parameter, type `-Stream` or its alias, `ost`.
+To use the **Stream** parameter, type `-Stream` or its alias, `ost`.
 
 ```yaml
 Type: SwitchParameter
@@ -98,8 +111,10 @@ Accept wildcard characters: False
 ```
 
 ### -Width
+
 Specifies the number of characters in each line of output.
 Any additional characters are truncated, not wrapped.
+The **Width** parameter applies only to objects that are being formatted.
 If you omit this parameter, the width is determined by the characteristics of the host program.
 The default value for the Windows PowerShell console is 80 (characters).
 
@@ -116,23 +131,29 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe objects to **Out-String**.
+
+You can pipe objects to `Out-String`.
 
 ## OUTPUTS
 
 ### System.String
-**Out-String** returns the string that it creates from the input object.
+
+`Out-String` returns the string that it creates from the input object.
 
 ## NOTES
-* The cmdlets that contain the **Out** verb that do not format objects; they just render them and send them to the specified display destination. If you send an unformatted object to an **Out** cmdlet, the cmdlet sends it to a formatting cmdlet before rendering it.
-* The **Out** cmdlets do not have parameters that take names or file paths. To send data to an **Out** cmdlet, use a pipeline operator (|) to send the output of a Windows PowerShell command to the cmdlet. You can also store data in a variable and use the *InputObject* parameter to pass the data to the cmdlet.
 
-*
+* The cmdlets that contain the **Out** verb that do not format objects;
+they just render them and send them to the specified display destination.
+If you send an unformatted object to an **Out** cmdlet, the cmdlet sends it to a formatting cmdlet before rendering it.
+* The **Out** cmdlets do not have parameters that take names or file paths.
+To send data to an **Out** cmdlet, use a pipeline operator (|) to send the output of a Windows PowerShell command to the cmdlet.
+You can also store data in a variable and use the **InputObject** parameter to pass the data to the cmdlet.
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Out-String.md
@@ -71,14 +71,14 @@ PS> Get-Alias | Out-String -Stream | Select-String "Get-Command"
 ```
 
 This example demonstrates the difference between working with objects and working with strings.
-The command displays aliases that include the phrase Get-Command.
+The command displays aliases that include the phrase "Get-Command".
 It uses the `Get-Alias` cmdlet to get a set of **AliasInfo** objects (one for each alias in the current session).
 
 The pipeline operator (|) sends the output of the `Get-Alias` cmdlet to the `Out-String` cmdlet, which converts the objects to a series of strings.
 It uses the **Stream** parameter of `Out-String` to send each string individually, instead of concatenating them into a single string.
-Another pipeline operator sends the strings to the `Select-String` cmdlet, which selects the strings that include `Get-Command` anywhere in the string.
+Another pipeline operator sends the strings to the `Select-String` cmdlet, which selects the strings that include "Get-Command" anywhere in the string.
 
-If you omit the **Stream** parameter, the command displays all of the aliases, because `Select-String` finds **Get-Command** in the single string that `Out-String` returns, and the formatter displays the string as a table.
+If you omit the **Stream** parameter, the command displays all of the aliases, because `Select-String` finds "Get-Command" in the single string that `Out-String` returns, and the formatter displays the string as a table.
 
 ### Example 4: Using NoNewLine
 

--- a/reference/6/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Out-String.md
@@ -201,7 +201,3 @@ You can also store data in a variable and use the **InputObject** parameter to p
 ## RELATED LINKS
 
 [Out-File](Out-File.md)
-
-[Out-GridView](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Utility/Out-GridView)
-
-[Out-Printer](https://msdn.microsoft.com/en-us/powershell/reference/5.1/Microsoft.PowerShell.Utility/Out-Printer)

--- a/reference/6/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Out-String.md
@@ -2,7 +2,7 @@
 ms.date:  06/09/2017
 schema:  2.0.0
 locale:  en-us
-keywords:  powershell,cmdlet
+keywords:  powershell, cmdlet
 online version:  http://go.microsoft.com/fwlink/?LinkId=821842
 external help file:  Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 title:  Out-String
@@ -11,81 +11,100 @@ title:  Out-String
 # Out-String
 
 ## SYNOPSIS
+
 Sends objects to the host as a series of strings.
 
 ## SYNTAX
 
 ### NoNewLineFormatting (Default)
+
 ```
 Out-String [-NoNewLine] [-Width <Int32>] [-InputObject <PSObject>] [<CommonParameters>]
 ```
 
 ### StreamFormatting
+
 ```
 Out-String [-Stream] [-Width <Int32>] [-InputObject <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Out-String** cmdlet converts the objects that Windows PowerShell manages into an array of strings.
-By default, **Out-String** accumulates the strings and returns them as a single string, but you can use the stream parameter to direct **Out-String** to return one string at a time.
+
+The `Out-String` cmdlet converts the objects that PowerShell manages into an array of strings.
+By default, `Out-String` accumulates the strings and returns them as a single string, but you can use the stream parameter to direct `Out-String` to return one string at a time.
 This cmdlet lets you search and manipulate string output as you would in traditional shells when object manipulation is less convenient.
 
 ## EXAMPLES
 
 ### Example 1: Output text to the console as a string
-```
-PS C:\> Get-Content C:\test1\testfile2.txt | Out-String
+
+```powershell
+PS> Get-Content C:\test1\testfile2.txt | Out-String
 ```
 
 This command sends the content of the Testfile2.txt file to the console as a single string.
-It uses the Get-Content cmdlet to get the content of the file.
-The pipeline operator (|) sends the content to **Out-String**, which sends the content to the console as a string.
+It uses the `Get-Content` cmdlet to get the content of the file.
+The pipeline operator (|) sends the content to `Out-String`, which sends the content to the console as a string.
 
-### Example 2: Get the current culture and convert the data to strings.
+### Example 2: Get the current culture and convert the data to strings
+
+The first command uses the `Get-Culture` cmdlet to get the regional settings.
+The pipeline operator (|) sends the result to the `Select-Object` cmdlet,
+which selects all properties (*) of the culture object that `Get-Culture` returned.
+The command then stores the results in the `$C` variable.
+
+```powershell
+PS> $C = Get-Culture | Select-Object *
 ```
-The first command uses the Get-Culture cmdlet to get the regional settings. The pipeline operator (|) sends the result to the Select-Object cmdlet, which selects all properties (*) of the culture object that **Get-Culture** returned. The command then stores the results in the $C variable.
-PS C:\> $C = Get-Culture | Select-Object *
 
-The second command uses the **Out-String** cmdlet to convert the **CultureInfo** object to a series of strings (one string for each property). It uses the *InputObject* parameter to pass the $C variable to **Out-String**. The *Width* parameter is set to 100 characters per line to prevent truncation.
-PS C:\> Out-String -InputObject $C -Width 100
+The second command uses the `Out-String` cmdlet to convert the **CultureInfo** object to a series of strings (one string for each property).
+It uses the **InputObject** parameter to pass the `$C` variable to `Out-String`.
+The *Width* parameter is set to 100 characters per line to prevent truncation.
+
+```powershell
+PS> Out-String -InputObject $C -Width 100
 ```
 
 These commands get the regional settings for the current user and convert the data to strings.
 
 ### Example 3: Working with objects
-```
-PS C:\> Get-Alias | Out-String -Stream | Select-String "Get-Command"
+
+```powershell
+PS> Get-Alias | Out-String -Stream | Select-String "Get-Command"
 ```
 
 This example demonstrates the difference between working with objects and working with strings.
 The command displays aliases that include the phrase Get-Command.
-It uses the Get-Alias cmdlet to get a set of **AliasInfo** objects (one for each alias in the current session).
+It uses the `Get-Alias` cmdlet to get a set of **AliasInfo** objects (one for each alias in the current session).
 
-The pipeline operator (|) sends the output of the **Get-Alias** cmdlet to the **Out-String** cmdlet, which converts the objects to a series of strings.
-It uses the *Stream* parameter of **Out-String** to send each string individually, instead of concatenating them into a single string.
-Another pipeline operator sends the strings to the Select-String cmdlet, which selects the strings that include **Get-Command** anywhere in the string.
+The pipeline operator (|) sends the output of the `Get-Alias` cmdlet to the `Out-String` cmdlet, which converts the objects to a series of strings.
+It uses the **Stream** parameter of `Out-String` to send each string individually, instead of concatenating them into a single string.
+Another pipeline operator sends the strings to the `Select-String` cmdlet, which selects the strings that include `Get-Command` anywhere in the string.
 
-If you omit the *Stream* parameter, the command displays all of the aliases, because **Select-String** finds **Get-Command** in the single string that **Out-String** returns, and the formatter displays the string as a table.
+If you omit the **Stream** parameter, the command displays all of the aliases, because `Select-String` finds **Get-Command** in the single string that `Out-String` returns, and the formatter displays the string as a table.
 
 ### Example 4: Using NoNewLine
+
 ```
-PS C:\> "a", "b" | Out-String -NoNewLine
+PS> "a", "b" | Out-String -NoNewLine
 ab
 
-PS C:\> @{key='value'} | Out-String
+PS> @{key='value'} | Out-String
 Name   Value
 ----   -----
 key    value
 
-PS C:\> @{key='value'} | Out-String -NoNewLine
+PS> @{key='value'} | Out-String -NoNewLine
 Name Value  -----  key value
 ```
-Not using `-NoNewLine` would have resulted in an output like `a<newline>b<newline>`.
-It should be noted that `-NoNewLine` does not strip newlines embedded within a string but strips out embedded newlines from formatter-generated output. Compare the second and third commands in this examples for clarity.
+
+Not using the **NoNewLine** parameter would have resulted in an output like `a<newline>b<newline>`.
+It should be noted that the **NoNewLine** parameter does not strip newlines embedded within a string but strips out embedded newlines from formatter-generated output. Compare the second and third commands in this examples for clarity.
 
 ## PARAMETERS
 
 ### -InputObject
+
 Specifies the objects to be written to a string.
 Enter a variable that contains the objects, or type a command or expression that gets the objects.
 
@@ -102,10 +121,11 @@ Accept wildcard characters: False
 ```
 
 ### -Stream
+
 Indicates that the cmdlet sends the strings for each object separately.
 By default, the strings for each object are accumulated and sent as a single string.
 
-To use the *Stream* parameter, type `-Stream` or its alias, `ost`.
+To use the **Stream** parameter, type `-Stream` or its alias, `ost`.
 
 ```yaml
 Type: SwitchParameter
@@ -120,10 +140,12 @@ Accept wildcard characters: False
 ```
 
 ### -Width
+
 Specifies the number of characters in each line of output.
 Any additional characters are truncated, not wrapped.
+The **Width** parameter applies only to objects that are being formatted.
 If you omit this parameter, the width is determined by the characteristics of the host program.
-The default value for the Windows PowerShell console is 80 (characters).
+The default value for the PowerShell console is 80 (characters).
 
 ```yaml
 Type: Int32
@@ -138,7 +160,9 @@ Accept wildcard characters: False
 ```
 
 ### -NoNewline
-Removes all newlines from formatter generated output. Note that newlines present as part of string objects are preserved
+
+Removes all newlines from formatter generated output.
+Note that newlines present as part of string objects are preserved.
 
 ```yaml
 Type: SwitchParameter
@@ -153,23 +177,29 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe objects to **Out-String**.
+
+You can pipe objects to `Out-String`.
 
 ## OUTPUTS
 
 ### System.String
-**Out-String** returns the string that it creates from the input object.
+
+`Out-String` returns the string that it creates from the input object.
 
 ## NOTES
-* The cmdlets that contain the **Out** verb that do not format objects; they just render them and send them to the specified display destination. If you send an unformatted object to an **Out** cmdlet, the cmdlet sends it to a formatting cmdlet before rendering it.
-* The **Out** cmdlets do not have parameters that take names or file paths. To send data to an **Out** cmdlet, use a pipeline operator (|) to send the output of a Windows PowerShell command to the cmdlet. You can also store data in a variable and use the *InputObject* parameter to pass the data to the cmdlet.
 
-*
+* The cmdlets that contain the **Out** verb that do not format objects;
+they just render them and send them to the specified display destination.
+If you send an unformatted object to an **Out** cmdlet, the cmdlet sends it to a formatting cmdlet before rendering it.
+* The **Out** cmdlets do not have parameters that take names or file paths.
+To send data to an **Out** cmdlet, use a pipeline operator (|) to send the output of a PowerShell command to the cmdlet.
+You can also store data in a variable and use the **InputObject** parameter to pass the data to the cmdlet.
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Out-String.md
@@ -200,4 +200,10 @@ You can also store data in a variable and use the **InputObject** parameter to p
 
 ## RELATED LINKS
 
+[Out-Default](../Microsoft.PowerShell.Core/Out-Default.md)
+
 [Out-File](Out-File.md)
+
+[Out-Host](../Microsoft.PowerShell.Core/Out-Host.md)
+
+[Out-Null](../Microsoft.PowerShell.Core/Out-Null.md)

--- a/reference/6/Microsoft.PowerShell.Utility/Out-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Out-String.md
@@ -53,15 +53,12 @@ The pipeline operator (|) sends the result to the `Select-Object` cmdlet,
 which selects all properties (*) of the culture object that `Get-Culture` returned.
 The command then stores the results in the `$C` variable.
 
-```powershell
-PS> $C = Get-Culture | Select-Object *
-```
-
 The second command uses the `Out-String` cmdlet to convert the **CultureInfo** object to a series of strings (one string for each property).
 It uses the **InputObject** parameter to pass the `$C` variable to `Out-String`.
 The *Width* parameter is set to 100 characters per line to prevent truncation.
 
 ```powershell
+PS> $C = Get-Culture | Select-Object *
 PS> Out-String -InputObject $C -Width 100
 ```
 


### PR DESCRIPTION
Change a description for the **Width** parameter.
Remove "Windows" from "Windows PowerShell".
Simplify prompt to `PS>`.
Change a formatting of cmdlet, variable, parameter, and property names.
Use semantic line breaks.
Fix fenced code blocks.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [x] Impacts 6.0 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work