### PR TITLE
Fix Get-ChildItem's syntax block (add attribute values)

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -11,6 +11,7 @@ title:  Get-ChildItem
 # Get-ChildItem
 
 ## Synopsis
+
 Gets the items and child items in one or more specified locations.
 
 ## Syntax
@@ -18,22 +19,20 @@ Gets the items and child items in one or more specified locations.
 ### Items (Default)
 
 ```powershell
-Get-ChildItem [[-Path] <String[]>] [[-Filter] <String>] [-Include <String[]>] [-Exclude <String[]>] [-Recurse]
- [-Force] [-Name] [-UseTransaction]
- [-Attributes <System.Management.Automation.FlagsExpression`1[System.IO.FileAttributes]>] [-Directory] [-File]
- [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]
+Get-ChildItem [[-Path] <String[]>] [[-Filter] <String>] [-Attributes {ReadOnly | Hidden | System | Directory |
+Archive | Device | Normal | Temporary | SparseFile | ReparsePoint | Compressed | Offline | NotContentIndexed |
+Encrypted | IntegrityStream | NoScrubData}] [-Directory] [-Exclude <String[]>] [-File] [-Force]
+[-Hidden] [-Include <String[]>] [-Name] [-ReadOnly] [-Recurse] [-System] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### Literal Items
 
 ```powershell
-Get-ChildItem -LiteralPath <String[]> [[-Filter] <String>] [-Include <String[]>] [-Exclude <String[]>]
- [-Recurse] [-Force] [-Name] [-UseTransaction]
- [-Attributes <System.Management.Automation.FlagsExpression`1[System.IO.FileAttributes]>] [-Directory] [-File]
- [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]
+Get-ChildItem -LiteralPath <String[]> [[-Filter] <String>] [-Attributes {ReadOnly | Hidden | System | Directory | Archive | Device | Normal | Temporary | SparseFile | ReparsePoint | Compressed | Offline | NotContentIndexed | Encrypted | IntegrityStream | NoScrubData}] [-Directory] [-Exclude <String[]>] [-File] [-Force] [-Hidden] [-Include <String[]>] [-Name] [-ReadOnly] [-Recurse] [-System] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## Description
+
 The `Get-ChildItem` cmdlet gets the items in one or more specified locations.
 If the item is a container, it gets the items inside the container, known as child items.
 You can use the `-Recurse` parameter to get items in all child containers.
@@ -43,6 +42,7 @@ A location can be a file system location, such as a directory, or a location exp
 ## Examples
 
 ### Example 1
+
 ```powershell
 Get-ChildItem
 ```
@@ -55,6 +55,7 @@ The default display lists the mode (attributes), last write time, file size (len
 The valid values for mode are `d` (directory), `a` (archive), `r` (read-only), `h` (hidden), and `s` (system).
 
 ### Example 2
+
 ```powershell
 Get-ChildItem -Path *.txt -Recurse -Force
 ```
@@ -68,6 +69,7 @@ Use the `-Include` parameter to specify the .txt file type.
 For example, `Get-ChildItem -Path .\* -Include *.txt -Recurse`
 
 ### Example 3
+
 ```powershell
 Get-ChildItem -Path C:\Windows\Logs\* -Include *.txt -Exclude A*
 ```
@@ -77,6 +79,7 @@ It uses the wildcard character (`*`) to indicate the contents of the Logs subdir
 Because the command does not include the `-Recurse` parameter, `Get-ChildItem` does not include the content of directory automatically; you need to specify it.
 
 ### Example 4
+
 ```powershell
 Get-ChildItem -Path HKLM:\Software
 ```
@@ -84,6 +87,7 @@ Get-ChildItem -Path HKLM:\Software
 This command gets all of the registry keys in the HKEY_LOCAL_MACHINE\SOFTWARE key in the registry of the local computer.
 
 ### Example 5
+
 ```powershell
 Get-ChildItem -Name
 ```
@@ -91,6 +95,7 @@ Get-ChildItem -Name
 This command gets only the names of items in the current directory.
 
 ### Example 6
+
 ```powershell
 Import-Module Microsoft.PowerShell.Security
 Get-ChildItem -Path Cert:\* -Recurse -CodeSigningCert
@@ -110,6 +115,7 @@ This parameter gets only certificates that have code-signing authority.
 For more information about the Certificate provider and the Cert: drive, go to [Certificate Provider](../microsoft.powershell.security/providers/certificate-provider.md) or use the `Update-Help` cmdlet to download the help files for the Microsoft.PowerShell.Security module and then type `Get-Help Certificate`.
 
 ### Example 7
+
 ```powershell
 Get-ChildItem -Path C:\Windows -Include *mouse* -Exclude *.png
 ```
@@ -119,9 +125,11 @@ This command gets all of the items in the C:\Windows directory and its subdirect
 ## Parameters
 
 ### -Attributes
+
 Gets files and folders with the specified attributes. This parameter supports all attributes and lets you specify complex combinations of attributes.
 
 For example, to get non-system files (not directories) that are encrypted or compressed, type:
+
 ```powershell
 Get-ChildItem -Attributes !Directory+!System+Encrypted, !Directory+!System+Compressed
 ```
@@ -129,13 +137,16 @@ Get-ChildItem -Attributes !Directory+!System+Encrypted, !Directory+!System+Compr
 To find files and folders with commonly used attributes, you can use the `-Attributes` parameter, or the `-Directory`, `-File`, `-Hidden`, `-ReadOnly`, and `-System` switch parameters.
 
 The `-Attributes` parameter supports the following attributes:
+
 - Archive
 - Compressed
 - Device
 - Directory
 - Encrypted
 - Hidden
+- IntegrityStream
 - Normal
+- NoScrubData
 - NotContentIndexed
 - Offline
 - ReadOnly
@@ -146,7 +157,8 @@ The `-Attributes` parameter supports the following attributes:
 
 For a description of these attributes, see the [FileAttributes Enumeration](http://go.microsoft.com/fwlink/?LinkId=201508).
 
-Use the following operators to combine attributes.
+Use the following operators to combine attributes:
+
 - `!`   (NOT)
 - `+`   (AND)
 - `,`   (OR)
@@ -154,6 +166,7 @@ Use the following operators to combine attributes.
 No spaces are permitted between an operator and its attribute. However, spaces are permitted before commas.
 
 You can use the following abbreviations for commonly used attributes:
+
 - `D`   (Directory)
 - `H`   (Hidden)
 - `R`   (Read-only)
@@ -172,6 +185,7 @@ Accept wildcard characters: False
 ```
 
 ### -Directory
+
 Gets directories (folders).
 
 To get only directories, use the `-Directory` parameter and omit the `-File` parameter. To exclude directories, use the `-File` parameter and omit the `-Directory` parameter, or use the `-Attributes` parameter.
@@ -191,6 +205,7 @@ Accept wildcard characters: False
 ```
 
 ### -File
+
 Gets files.
 
 To get only files, use the `-File` parameter and omit the Directory parameter. To exclude files, use the `-Directory` parameter and omit the `-File` parameter, or use the `-Attributes` parameter.
@@ -210,6 +225,7 @@ Accept wildcard characters: False
 ```
 
 ### -Hidden
+
 Gets only hidden files and directories (folders).  By default, `Get-ChildItem` gets only non-hidden items, but you can use the `-Force` parameter to include hidden items in the results.
 
 To get only hidden items, use the `-Hidden` parameter, its "`h`" or "`ah`" aliases, or the Hidden value of the `-Attributes` parameter. To exclude hidden items, omit the `-Hidden` parameter or use the `-Attributes` parameter.
@@ -227,6 +243,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReadOnly
+
 Gets only read-only files and directories (folders).
 
 To get only read-only items, use the `-ReadOnly` parameter, its "`ar`" alias, or the ReadOnly value of the `-Attributes` parameter. To exclude read-only items, use the `-Attributes` parameter.
@@ -244,6 +261,7 @@ Accept wildcard characters: False
 ```
 
 ### -System
+
 Gets only system files and directories (folders).
 
 To get only system files and folders, use the `-System` parameter, its "`as`" alias, or the System value of the `-Attributes` parameter. To exclude system files and folders, use the `-Attributes` parameter.
@@ -261,6 +279,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 Allows the cmdlet to get items that cannot otherwise not be accessed by the user, such as hidden or system files.
 Implementation varies among providers.
 For more information, see [about_Provider](../Microsoft.PowerShell.Core/About/about_Providers.md).
@@ -280,6 +299,7 @@ Accept wildcard characters: False
 ```
 
 ### -UseTransaction
+
 Includes the command in the active transaction.
 This parameter is valid only when a transaction is in progress.
 For more information, see about_Transactions.
@@ -297,6 +317,7 @@ Accept wildcard characters: False
 ```
 
 ### -Exclude
+
 Omits the specified items.
 The value of this parameter qualifies the `-Path` parameter.
 Enter a path element or pattern, such as "*.txt".
@@ -315,6 +336,7 @@ Accept wildcard characters: True
 ```
 
 ### -Filter
+
 Specifies a filter in the provider's format or language.
 The value of this parameter qualifies the `-Path` parameter.
 The syntax of the filter, including the use of wildcards, depends on the provider.
@@ -333,6 +355,7 @@ Accept wildcard characters: True
 ```
 
 ### -Include
+
 Gets only the specified items.
 The value of this parameter qualifies the `-Path` parameter.
 Enter a path element or pattern, such as "*.txt".
@@ -353,6 +376,7 @@ Accept wildcard characters: True
 ```
 
 ### -LiteralPath
+
 Specifies a path to one or more locations.
 Unlike the `-Path` parameter, the value of the `-LiteralPath` parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
@@ -372,6 +396,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Gets only the names of the items in the locations.
 If you pipe the output of this command to another command, only the item names are sent.
 
@@ -388,6 +413,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specifies a path to one or more locations.
 Wildcards are permitted.
 The default location is the current directory (`.`).
@@ -405,9 +431,8 @@ Accept wildcard characters: True
 ```
 
 ### -Recurse
-Gets the items in the specified locations and in all child items of the locations.
 
-In Windows PowerShell 2.0 and earlier versions of Windows PowerShell, the `-Recurse` parameter works only when the value of the `-Path` parameter is a container that has child items, such as C:\Windows or C:\Windows\*, and not when it is an item does not have child items, such as C:\Windows\*.exe.
+Gets the items in the specified locations and in all child items of the locations.
 
 ```yaml
 Type: SwitchParameter
@@ -428,17 +453,21 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## Inputs
 
 ### System.String
+
 You can pipe a string that contains a path to `Get-ChildItem`.
 
 ## Outputs
 
 ### System.Object
+
 The type of object that `Get-ChildItem` returns is determined by the objects in the provider drive path.
 
 ### System.String
+
 If you use the `-Name` parameter, `Get-ChildItem` returns the object names as strings.
 
 ## Notes
+
 You can also refer to `Get-ChildItem` by its built-in aliases, "`ls`", "`dir`", and "`gci`". For more information, see about_Aliases.
 
 `Get-ChildItem` does not get hidden items by default.
@@ -447,7 +476,6 @@ To get hidden items, use the `-Force` parameter.
 The `Get-ChildItem` cmdlet is designed to work with the data exposed by any provider.
 To list the providers available in your session, type "`Get-PSProvider`".
 For more information, see [about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
-
 
 ## Related Links
 

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -11,6 +11,7 @@ title:  Get-ChildItem
 # Get-ChildItem
 
 ## Synopsis
+
 Gets the items and child items in one or more specified locations.
 
 ## Syntax
@@ -18,22 +19,20 @@ Gets the items and child items in one or more specified locations.
 ### Items (Default)
 
 ```powershell
-Get-ChildItem [[-Path] <String[]>] [[-Filter] <String>] [-Include <String[]>] [-Exclude <String[]>] [-Recurse]
- [-Force] [-Name] [-UseTransaction]
- [-Attributes <System.Management.Automation.FlagsExpression`1[System.IO.FileAttributes]>] [-Directory] [-File]
- [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]
+Get-ChildItem [[-Path] <String[]>] [[-Filter] <String>] [-Attributes {ReadOnly | Hidden | System | Directory |
+Archive | Device | Normal | Temporary | SparseFile | ReparsePoint | Compressed | Offline | NotContentIndexed |
+Encrypted | IntegrityStream | NoScrubData}] [-Directory] [-Exclude <String[]>] [-File] [-Force]
+[-Hidden] [-Include <String[]>] [-Name] [-ReadOnly] [-Recurse] [-System] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### Literal Items
 
 ```powershell
-Get-ChildItem -LiteralPath <String[]> [[-Filter] <String>] [-Include <String[]>] [-Exclude <String[]>]
- [-Recurse] [-Force] [-Name] [-UseTransaction]
- [-Attributes <System.Management.Automation.FlagsExpression`1[System.IO.FileAttributes]>] [-Directory] [-File]
- [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]
+Get-ChildItem -LiteralPath <String[]> [[-Filter] <String>] [-Attributes {ReadOnly | Hidden | System | Directory | Archive | Device | Normal | Temporary | SparseFile | ReparsePoint | Compressed | Offline | NotContentIndexed | Encrypted | IntegrityStream | NoScrubData}] [-Directory] [-Exclude <String[]>] [-File] [-Force] [-Hidden] [-Include <String[]>] [-Name] [-ReadOnly] [-Recurse] [-System] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## Description
+
 The `Get-ChildItem` cmdlet gets the items in one or more specified locations.
 If the item is a container, it gets the items inside the container, known as child items.
 You can use the `-Recurse` parameter to get items in all child containers.
@@ -43,6 +42,7 @@ A location can be a file system location, such as a directory, or a location exp
 ## Examples
 
 ### Example 1
+
 ```powershell
 Get-ChildItem
 ```
@@ -55,6 +55,7 @@ The default display lists the mode (attributes), last write time, file size (len
 The valid values for mode are `d` (directory), `a` (archive), `r` (read-only), `h` (hidden), and `s` (system).
 
 ### Example 2
+
 ```powershell
 Get-ChildItem -Path *.txt -Recurse -Force
 ```
@@ -68,6 +69,7 @@ Use the `-Include` parameter to specify the .txt file type.
 For example, `Get-ChildItem -Path .\* -Include *.txt -Recurse`
 
 ### Example 3
+
 ```powershell
 Get-ChildItem -Path C:\Windows\Logs\* -Include *.txt -Exclude A*
 ```
@@ -77,6 +79,7 @@ It uses the wildcard character (`*`) to indicate the contents of the Logs subdir
 Because the command does not include the `-Recurse` parameter, `Get-ChildItem` does not include the content of directory automatically; you need to specify it.
 
 ### Example 4
+
 ```powershell
 Get-ChildItem -Path HKLM:\Software
 ```
@@ -84,6 +87,7 @@ Get-ChildItem -Path HKLM:\Software
 This command gets all of the registry keys in the HKEY_LOCAL_MACHINE\SOFTWARE key in the registry of the local computer.
 
 ### Example 5
+
 ```powershell
 Get-ChildItem -Name
 ```
@@ -91,6 +95,7 @@ Get-ChildItem -Name
 This command gets only the names of items in the current directory.
 
 ### Example 6
+
 ```powershell
 Import-Module Microsoft.PowerShell.Security
 Get-ChildItem -Path Cert:\* -Recurse -CodeSigningCert
@@ -110,6 +115,7 @@ This parameter gets only certificates that have code-signing authority.
 For more information about the Certificate provider and the Cert: drive, go to [Certificate Provider](../microsoft.powershell.security/providers/certificate-provider.md) or use the `Update-Help` cmdlet to download the help files for the Microsoft.PowerShell.Security module and then type `Get-Help Certificate`.
 
 ### Example 7
+
 ```powershell
 Get-ChildItem -Path C:\Windows -Include *mouse* -Exclude *.png
 ```
@@ -119,9 +125,11 @@ This command gets all of the items in the C:\Windows directory and its subdirect
 ## Parameters
 
 ### -Attributes
+
 Gets files and folders with the specified attributes. This parameter supports all attributes and lets you specify complex combinations of attributes.
 
 For example, to get non-system files (not directories) that are encrypted or compressed, type:
+
 ```powershell
 Get-ChildItem -Attributes !Directory+!System+Encrypted, !Directory+!System+Compressed
 ```
@@ -129,13 +137,16 @@ Get-ChildItem -Attributes !Directory+!System+Encrypted, !Directory+!System+Compr
 To find files and folders with commonly used attributes, you can use the `-Attributes` parameter, or the `-Directory`, `-File`, `-Hidden`, `-ReadOnly`, and `-System` switch parameters.
 
 The `-Attributes` parameter supports the following attributes:
+
 - Archive
 - Compressed
 - Device
 - Directory
 - Encrypted
 - Hidden
+- IntegrityStream
 - Normal
+- NoScrubData
 - NotContentIndexed
 - Offline
 - ReadOnly
@@ -146,7 +157,8 @@ The `-Attributes` parameter supports the following attributes:
 
 For a description of these attributes, see the [FileAttributes Enumeration](http://go.microsoft.com/fwlink/?LinkId=201508).
 
-Use the following operators to combine attributes.
+Use the following operators to combine attributes:
+
 - `!`   (NOT)
 - `+`   (AND)
 - `,`   (OR)
@@ -154,6 +166,7 @@ Use the following operators to combine attributes.
 No spaces are permitted between an operator and its attribute. However, spaces are permitted before commas.
 
 You can use the following abbreviations for commonly used attributes:
+
 - `D`   (Directory)
 - `H`   (Hidden)
 - `R`   (Read-only)
@@ -172,6 +185,7 @@ Accept wildcard characters: False
 ```
 
 ### -Directory
+
 Gets directories (folders).
 
 To get only directories, use the `-Directory` parameter and omit the `-File` parameter. To exclude directories, use the `-File` parameter and omit the `-Directory` parameter, or use the `-Attributes` parameter.
@@ -191,6 +205,7 @@ Accept wildcard characters: False
 ```
 
 ### -Exclude
+
 Omits the specified items.
 The value of this parameter qualifies the `-Path` parameter.
 Enter a path element or pattern, such as "*.txt".
@@ -209,6 +224,7 @@ Accept wildcard characters: True
 ```
 
 ### -File
+
 Gets files.
 
 To get only files, use the `-File` parameter and omit the Directory parameter. To exclude files, use the `-Directory` parameter and omit the `-File` parameter, or use the `-Attributes` parameter.
@@ -228,6 +244,7 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
+
 Specifies a filter in the provider's format or language.
 The value of this parameter qualifies the `-Path` parameter.
 The syntax of the filter, including the use of wildcards, depends on the provider.
@@ -246,6 +263,7 @@ Accept wildcard characters: True
 ```
 
 ### -Force
+
 Allows the cmdlet to get items that cannot otherwise not be accessed by the user, such as hidden or system files.
 Implementation varies among providers.
 For more information, see [about_Provider](../Microsoft.PowerShell.Core/About/about_Providers.md).
@@ -265,6 +283,7 @@ Accept wildcard characters: False
 ```
 
 ### -Hidden
+
 Gets only hidden files and directories (folders).  By default, `Get-ChildItem` gets only non-hidden items, but you can use the `-Force` parameter to include hidden items in the results.
 
 To get only hidden items, use the `-Hidden` parameter, its "`h`" or "`ah`" aliases, or the Hidden value of the `-Attributes` parameter. To exclude hidden items, omit the `-Hidden` parameter or use the `-Attributes` parameter.
@@ -282,6 +301,7 @@ Accept wildcard characters: False
 ```
 
 ### -Include
+
 Gets only the specified items.
 The value of this parameter qualifies the `-Path` parameter.
 Enter a path element or pattern, such as "*.txt".
@@ -302,6 +322,7 @@ Accept wildcard characters: True
 ```
 
 ### -LiteralPath
+
 Specifies a path to one or more locations.
 Unlike the `-Path` parameter, the value of the `-LiteralPath` parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
@@ -321,6 +342,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Gets only the names of the items in the locations.
 If you pipe the output of this command to another command, only the item names are sent.
 
@@ -337,6 +359,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specifies a path to one or more locations.
 Wildcards are permitted.
 The default location is the current directory (`.`).
@@ -354,6 +377,7 @@ Accept wildcard characters: True
 ```
 
 ### -ReadOnly
+
 Gets only read-only files and directories (folders).
 
 To get only read-only items, use the `-ReadOnly` parameter, its "`ar`" alias, or the ReadOnly value of the `-Attributes` parameter. To exclude read-only items, use the `-Attributes` parameter.
@@ -371,9 +395,8 @@ Accept wildcard characters: False
 ```
 
 ### -Recurse
-Gets the items in the specified locations and in all child items of the locations.
 
-In Windows PowerShell 2.0 and earlier versions of Windows PowerShell, the `-Recurse` parameter works only when the value of the `-Path` parameter is a container that has child items, such as C:\Windows or C:\Windows\*, and not when it is an item does not have child items, such as C:\Windows\*.exe.
+Gets the items in the specified locations and in all child items of the locations.
 
 ```yaml
 Type: SwitchParameter
@@ -388,6 +411,7 @@ Accept wildcard characters: False
 ```
 
 ### -System
+
 Gets only system files and directories (folders).
 
 To get only system files and folders, use the `-System` parameter, its "`as`" alias, or the System value of the `-Attributes` parameter. To exclude system files and folders, use the `-Attributes` parameter.
@@ -405,6 +429,7 @@ Accept wildcard characters: False
 ```
 
 ### -UseTransaction
+
 Includes the command in the active transaction.
 This parameter is valid only when a transaction is in progress.
 For more information, see about_Transactions.
@@ -422,22 +447,27 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](../Microsoft.PowerShell.Core/About/about_CommonParameters.md).
 
 ## Inputs
 
 ### System.String
+
 You can pipe a string that contains a path to `Get-ChildItem`.
 
 ## Outputs
 
 ### System.Object
+
 The type of object that `Get-ChildItem` returns is determined by the objects in the provider drive path.
 
 ### System.String
+
 If you use the `-Name` parameter, `Get-ChildItem` returns the object names as strings.
 
 ## Notes
+
 You can also refer to `Get-ChildItem` by its built-in aliases, "`ls`", "`dir`", and "`gci`". For more information, see about_Aliases.
 
 `Get-ChildItem` does not get hidden items by default.

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -11,6 +11,7 @@ title:  Get-ChildItem
 # Get-ChildItem
 
 ## Synopsis
+
 Gets the items and child items in one or more specified locations.
 
 ## Syntax
@@ -18,22 +19,20 @@ Gets the items and child items in one or more specified locations.
 ### Items (Default)
 
 ```powershell
-Get-ChildItem [[-Path] <String[]>] [[-Filter] <String>] [-Include <String[]>] [-Exclude <String[]>] [-Recurse]
- [-Force] [-Name] [-UseTransaction]
- [-Attributes <System.Management.Automation.FlagsExpression`1[System.IO.FileAttributes]>] [-Directory] [-File]
- [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]
+Get-ChildItem [[-Path] <String[]>] [[-Filter] <String>] [-Attributes {ReadOnly | Hidden | System | Directory |
+Archive | Device | Normal | Temporary | SparseFile | ReparsePoint | Compressed | Offline | NotContentIndexed |
+Encrypted | IntegrityStream | NoScrubData}] [-Depth <UInt32>] [-Directory] [-Exclude <String[]>] [-File] [-Force]
+[-Hidden] [-Include <String[]>] [-Name] [-ReadOnly] [-Recurse] [-System] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### Literal Items
 
 ```powershell
-Get-ChildItem -LiteralPath <String[]> [[-Filter] <String>] [-Include <String[]>] [-Exclude <String[]>]
- [-Recurse] [-Force] [-Name] [-UseTransaction]
- [-Attributes <System.Management.Automation.FlagsExpression`1[System.IO.FileAttributes]>] [-Directory] [-File]
- [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]
+Get-ChildItem -LiteralPath <String[]> [[-Filter] <String>] [-Attributes {ReadOnly | Hidden | System | Directory | Archive | Device | Normal | Temporary | SparseFile | ReparsePoint | Compressed | Offline | NotContentIndexed | Encrypted | IntegrityStream | NoScrubData}] [-Depth <UInt32>] [-Directory] [-Exclude <String[]>] [-File] [-Force] [-Hidden] [-Include <String[]>] [-Name] [-ReadOnly] [-Recurse] [-System] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## Description
+
 The `Get-ChildItem` cmdlet gets the items in one or more specified locations.
 If the item is a container, it gets the items inside the container, known as child items.
 You can use the `-Recurse` parameter to get items in all child containers and use the `-Depth` parameter to limit the number of levels to recurse.
@@ -43,6 +42,7 @@ A location can be a file system location, such as a directory, or a location exp
 ## Examples
 
 ### Example 1: Get child items in the current directory
+
 ```powershell
 Get-ChildItem
 ```
@@ -55,6 +55,7 @@ The default display lists the mode (attributes), last write time, file size (len
 The valid values for mode are `d` (directory), `a` (archive), `r` (read-only), `h` (hidden), and `s` (system).
 
 ### Example 2: Get all files with the specified file extension in the current directory and subdirectories
+
 ```powershell
 Get-ChildItem -Path *.txt -Recurse -Force
 ```
@@ -68,6 +69,7 @@ Use the `-Include` parameter to specify the .txt file type.
 For example, `Get-ChildItem -Path .\* -Include *.txt -Recurse`
 
 ### Example 3: Get all child items using an inclusion and exclusion
+
 ```powershell
 Get-ChildItem -Path C:\Windows\Logs\* -Include *.txt -Exclude A*
 ```
@@ -77,6 +79,7 @@ It uses the wildcard character (`*`) to indicate the contents of the Logs subdir
 Because the command does not include the `-Recurse` parameter, `Get-ChildItem` does not include the content of directory automatically; you need to specify it.
 
 ### Example 4: Get all registry keys in a specific key
+
 ```powershell
 Get-ChildItem -Path HKLM:\Software
 ```
@@ -84,6 +87,7 @@ Get-ChildItem -Path HKLM:\Software
 This command gets all of the registry keys in the HKEY_LOCAL_MACHINE\SOFTWARE key in the registry of the local computer.
 
 ### Example 5: Get the name of items in the current directory
+
 ```powershell
 Get-ChildItem -Name
 ```
@@ -91,6 +95,7 @@ Get-ChildItem -Name
 This command gets only the names of items in the current directory.
 
 ### Example 6: Get all certificates in a certification drive that have code-signing authority
+
 ```powershell
 Import-Module Microsoft.PowerShell.Security
 Get-ChildItem -Path Cert:\* -Recurse -CodeSigningCert
@@ -110,6 +115,7 @@ This parameter gets only certificates that have code-signing authority.
 For more information about the Certificate provider and the Cert: drive, go to [Certificate Provider](../microsoft.powershell.security/providers/certificate-provider.md) or use the `Update-Help` cmdlet to download the help files for the Microsoft.PowerShell.Security module and then type `Get-Help Certificate`.
 
 ### Example 7: Get all items in the specified directory and its subdirectories that have an inclusion and exclusion
+
 ```powershell
 Get-ChildItem -Path C:\Windows -Include *mouse* -Exclude *.png
 ```
@@ -117,6 +123,7 @@ Get-ChildItem -Path C:\Windows -Include *mouse* -Exclude *.png
 This command gets all of the items in the C:\Windows directory and its subdirectories that have "mouse" in the file name, except for those with a .png file name extension.
 
 ### Example 8: Get all items in the specified directory and its subdirectories limited by the Depth parameter
+
 ```
 PS C:\> Get-ChildItem -Path C:\Windows -Depth 2
 ```
@@ -126,9 +133,11 @@ This command gets all of the items in the C:\Windows directory and its subdirect
 ## Parameters
 
 ### -Attributes
+
 Gets files and folders with the specified attributes. This parameter supports all attributes and lets you specify complex combinations of attributes.
 
 For example, to get non-system files (not directories) that are encrypted or compressed, type:
+
 ```powershell
 Get-ChildItem -Attributes !Directory+!System+Encrypted, !Directory+!System+Compressed
 ```
@@ -136,13 +145,16 @@ Get-ChildItem -Attributes !Directory+!System+Encrypted, !Directory+!System+Compr
 To find files and folders with commonly used attributes, you can use the `-Attributes` parameter, or the `-Directory`, `-File`, `-Hidden`, `-ReadOnly`, and `-System` switch parameters.
 
 The `-Attributes` parameter supports the following attributes:
+
 - Archive
 - Compressed
 - Device
 - Directory
 - Encrypted
 - Hidden
+- IntegrityStream
 - Normal
+- NoScrubData
 - NotContentIndexed
 - Offline
 - ReadOnly
@@ -153,7 +165,8 @@ The `-Attributes` parameter supports the following attributes:
 
 For a description of these attributes, see the [FileAttributes Enumeration](http://go.microsoft.com/fwlink/?LinkId=201508).
 
-Use the following operators to combine attributes.
+Use the following operators to combine attributes:
+
 - `!`   (NOT)
 - `+`   (AND)
 - `,`   (OR)
@@ -161,6 +174,7 @@ Use the following operators to combine attributes.
 No spaces are permitted between an operator and its attribute. However, spaces are permitted before commas.
 
 You can use the following abbreviations for commonly used attributes:
+
 - `D`   (Directory)
 - `H`   (Hidden)
 - `R`   (Read-only)
@@ -179,6 +193,7 @@ Accept wildcard characters: False
 ```
 
 ### -Depth
+
 This parameter, added in Powershell 5.0 enables you to control the depth of recursion. You use both the `-Recurse` and the `-Depth` parameter to limit the recursion.
 
 ```yaml
@@ -194,6 +209,7 @@ Accept wildcard characters: False
 ```
 
 ### -Directory
+
 Gets directories (folders).
 
 To get only directories, use the `-Directory` parameter and omit the `-File` parameter. To exclude directories, use the `-File` parameter and omit the `-Directory` parameter, or use the `-Attributes` parameter.
@@ -213,6 +229,7 @@ Accept wildcard characters: False
 ```
 
 ### -Exclude
+
 Omits the specified items.
 The value of this parameter qualifies the `-Path` parameter.
 Enter a path element or pattern, such as "*.txt".
@@ -231,6 +248,7 @@ Accept wildcard characters: True
 ```
 
 ### -File
+
 Gets files.
 
 To get only files, use the `-File` parameter and omit the Directory parameter. To exclude files, use the `-Directory` parameter and omit the `-File` parameter, or use the `-Attributes` parameter.
@@ -250,6 +268,7 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
+
 Specifies a filter in the provider's format or language.
 The value of this parameter qualifies the `-Path` parameter.
 The syntax of the filter, including the use of wildcards, depends on the provider.
@@ -268,6 +287,7 @@ Accept wildcard characters: True
 ```
 
 ### -Force
+
 Allows the cmdlet to get items that cannot otherwise not be accessed by the user, such as hidden or system files.
 Implementation varies among providers.
 For more information, see [about_Provider](../Microsoft.PowerShell.Core/About/about_Providers.md).
@@ -287,6 +307,7 @@ Accept wildcard characters: False
 ```
 
 ### -Hidden
+
 Gets only hidden files and directories (folders).  By default, `Get-ChildItem` gets only non-hidden items, but you can use the `-Force` parameter to include hidden items in the results.
 
 To get only hidden items, use the `-Hidden` parameter, its "`h`" or "`ah`" aliases, or the Hidden value of the `-Attributes` parameter. To exclude hidden items, omit the `-Hidden` parameter or use the `-Attributes` parameter.
@@ -304,6 +325,7 @@ Accept wildcard characters: False
 ```
 
 ### -Include
+
 Gets only the specified items.
 The value of this parameter qualifies the `-Path` parameter.
 Enter a path element or pattern, such as "*.txt".
@@ -324,6 +346,7 @@ Accept wildcard characters: True
 ```
 
 ### -LiteralPath
+
 Specifies a path to one or more locations.
 Unlike the `-Path` parameter, the value of the `-LiteralPath` parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
@@ -343,6 +366,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Gets only the names of the items in the locations.
 If you pipe the output of this command to another command, only the item names are sent.
 
@@ -359,6 +383,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specifies a path to one or more locations.
 Wildcards are permitted.
 The default location is the current directory (`.`).
@@ -376,6 +401,7 @@ Accept wildcard characters: True
 ```
 
 ### -ReadOnly
+
 Gets only read-only files and directories (folders).
 
 To get only read-only items, use the `-ReadOnly` parameter, its "`ar`" alias, or the ReadOnly value of the `-Attributes` parameter. To exclude read-only items, use the `-Attributes` parameter.
@@ -393,9 +419,8 @@ Accept wildcard characters: False
 ```
 
 ### -Recurse
-Gets the items in the specified locations and in all child items of the locations.
 
-In Windows PowerShell 2.0 and earlier versions of Windows PowerShell, the `-Recurse` parameter works only when the value of the `-Path` parameter is a container that has child items, such as C:\Windows or C:\Windows\*, and not when it is an item does not have child items, such as C:\Windows\*.exe.
+Gets the items in the specified locations and in all child items of the locations.
 
 ```yaml
 Type: SwitchParameter
@@ -410,6 +435,7 @@ Accept wildcard characters: False
 ```
 
 ### -System
+
 Gets only system files and directories (folders).
 
 To get only system files and folders, use the `-System` parameter, its "`as`" alias, or the System value of the `-Attributes` parameter. To exclude system files and folders, use the `-Attributes` parameter.
@@ -427,6 +453,7 @@ Accept wildcard characters: False
 ```
 
 ### -UseTransaction
+
 Includes the command in the active transaction.
 This parameter is valid only when a transaction is in progress.
 For more information, see about_Transactions.
@@ -450,17 +477,21 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## Inputs
 
 ### System.String
+
 You can pipe a string that contains a path to `Get-ChildItem`.
 
 ## Outputs
 
 ### System.Object
+
 The type of object that `Get-ChildItem` returns is determined by the objects in the provider drive path.
 
 ### System.String
+
 If you use the `-Name` parameter, `Get-ChildItem` returns the object names as strings.
 
 ## Notes
+
 You can also refer to `Get-ChildItem` by its built-in aliases, "`ls`", "`dir`", and "`gci`". For more information, see about_Aliases.
 
 `Get-ChildItem` does not get hidden items by default.

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -11,6 +11,7 @@ title:  Get-ChildItem
 # Get-ChildItem
 
 ## Synopsis
+
 Gets the items and child items in one or more specified locations.
 
 ## Syntax
@@ -18,22 +19,20 @@ Gets the items and child items in one or more specified locations.
 ### Items (Default)
 
 ```powershell
-Get-ChildItem [[-Path] <String[]>] [[-Filter] <String>] [-Include <String[]>] [-Exclude <String[]>] [-Recurse]
- [-Force] [-Name] [-UseTransaction]
- [-Attributes <System.Management.Automation.FlagsExpression`1[System.IO.FileAttributes]>] [-Directory] [-File]
- [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]
+Get-ChildItem [[-Path] <String[]>] [[-Filter] <String>] [-Attributes {ReadOnly | Hidden | System | Directory |
+Archive | Device | Normal | Temporary | SparseFile | ReparsePoint | Compressed | Offline | NotContentIndexed |
+Encrypted | IntegrityStream | NoScrubData}] [-Depth <UInt32>] [-Directory] [-Exclude <String[]>] [-File] [-Force]
+[-Hidden] [-Include <String[]>] [-Name] [-ReadOnly] [-Recurse] [-System] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### Literal Items
 
 ```powershell
-Get-ChildItem -LiteralPath <String[]> [[-Filter] <String>] [-Include <String[]>] [-Exclude <String[]>]
- [-Recurse] [-Force] [-Name] [-UseTransaction]
- [-Attributes <System.Management.Automation.FlagsExpression`1[System.IO.FileAttributes]>] [-Directory] [-File]
- [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]
+Get-ChildItem -LiteralPath <String[]> [[-Filter] <String>] [-Attributes {ReadOnly | Hidden | System | Directory | Archive | Device | Normal | Temporary | SparseFile | ReparsePoint | Compressed | Offline | NotContentIndexed | Encrypted | IntegrityStream | NoScrubData}] [-Depth <UInt32>] [-Directory] [-Exclude <String[]>] [-File] [-Force] [-Hidden] [-Include <String[]>] [-Name] [-ReadOnly] [-Recurse] [-System] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## Description
+
 The `Get-ChildItem` cmdlet gets the items in one or more specified locations.
 If the item is a container, it gets the items inside the container, known as child items.
 You can use the `-Recurse` parameter to get items in all child containers and use the `-Depth` parameter to limit the number of levels to recurse.
@@ -43,6 +42,7 @@ A location can be a file system location, such as a directory, or a location exp
 ## Examples
 
 ### Example 1: Get child items in the current directory
+
 ```powershell
 Get-ChildItem
 ```
@@ -55,6 +55,7 @@ The default display lists the mode (attributes), last write time, file size (len
 The valid values for mode are `d` (directory), `a` (archive), `r` (read-only), `h` (hidden), and `s` (system).
 
 ### Example 2: Get all files with the specified file extension in the current directory and subdirectories
+
 ```powershell
 Get-ChildItem -Path *.txt -Recurse -Force
 ```
@@ -68,6 +69,7 @@ Use the `-Include` parameter to specify the .txt file type.
 For example, `Get-ChildItem -Path .\* -Include *.txt -Recurse`
 
 ### Example 3: Get all child items using an inclusion and exclusion
+
 ```powershell
 Get-ChildItem -Path C:\Windows\Logs\* -Include *.txt -Exclude A*
 ```
@@ -77,6 +79,7 @@ It uses the wildcard character (`*`) to indicate the contents of the Logs subdir
 Because the command does not include the `-Recurse` parameter, `Get-ChildItem` does not include the content of directory automatically; you need to specify it.
 
 ### Example 4: Get all registry keys in a specific key
+
 ```powershell
 Get-ChildItem -Path HKLM:\Software
 ```
@@ -84,6 +87,7 @@ Get-ChildItem -Path HKLM:\Software
 This command gets all of the registry keys in the HKEY_LOCAL_MACHINE\SOFTWARE key in the registry of the local computer.
 
 ### Example 5: Get the name of items in the current directory
+
 ```powershell
 Get-ChildItem -Name
 ```
@@ -91,6 +95,7 @@ Get-ChildItem -Name
 This command gets only the names of items in the current directory.
 
 ### Example 6: Get all certificates in a certification drive that have code-signing authority
+
 ```powershell
 Import-Module Microsoft.PowerShell.Security
 Get-ChildItem -Path Cert:\* -Recurse -CodeSigningCert
@@ -110,6 +115,7 @@ This parameter gets only certificates that have code-signing authority.
 For more information about the Certificate provider and the Cert: drive, go to [Certificate Provider](../microsoft.powershell.security/providers/certificate-provider.md) or use the `Update-Help` cmdlet to download the help files for the Microsoft.PowerShell.Security module and then type `Get-Help Certificate`.
 
 ### Example 7: Get all items in the specified directory and its subdirectories that have an inclusion and exclusion
+
 ```powershell
 Get-ChildItem -Path C:\Windows -Include *mouse* -Exclude *.png
 ```
@@ -117,6 +123,7 @@ Get-ChildItem -Path C:\Windows -Include *mouse* -Exclude *.png
 This command gets all of the items in the C:\Windows directory and its subdirectories that have "mouse" in the file name, except for those with a .png file name extension.
 
 ### Example 8: Get all items in the specified directory and its subdirectories limited by the Depth parameter
+
 ```
 PS C:\> Get-ChildItem -Path C:\Windows -Depth 2
 ```
@@ -126,9 +133,11 @@ This command gets all of the items in the C:\Windows directory and its subdirect
 ## Parameters
 
 ### -Attributes
+
 Gets files and folders with the specified attributes. This parameter supports all attributes and lets you specify complex combinations of attributes.
 
 For example, to get non-system files (not directories) that are encrypted or compressed, type:
+
 ```powershell
 Get-ChildItem -Attributes !Directory+!System+Encrypted, !Directory+!System+Compressed
 ```
@@ -136,13 +145,16 @@ Get-ChildItem -Attributes !Directory+!System+Encrypted, !Directory+!System+Compr
 To find files and folders with commonly used attributes, you can use the `-Attributes` parameter, or the `-Directory`, `-File`, `-Hidden`, `-ReadOnly`, and `-System` switch parameters.
 
 The `-Attributes` parameter supports the following attributes:
+
 - Archive
 - Compressed
 - Device
 - Directory
 - Encrypted
 - Hidden
+- IntegrityStream
 - Normal
+- NoScrubData
 - NotContentIndexed
 - Offline
 - ReadOnly
@@ -153,7 +165,8 @@ The `-Attributes` parameter supports the following attributes:
 
 For a description of these attributes, see the [FileAttributes Enumeration](http://go.microsoft.com/fwlink/?LinkId=201508).
 
-Use the following operators to combine attributes.
+Use the following operators to combine attributes:
+
 - `!`   (NOT)
 - `+`   (AND)
 - `,`   (OR)
@@ -161,6 +174,7 @@ Use the following operators to combine attributes.
 No spaces are permitted between an operator and its attribute. However, spaces are permitted before commas.
 
 You can use the following abbreviations for commonly used attributes:
+
 - `D`   (Directory)
 - `H`   (Hidden)
 - `R`   (Read-only)
@@ -179,7 +193,8 @@ Accept wildcard characters: False
 ```
 
 ### -Depth
-This parameter, added in Powershell 5.0 enables you to control the depth of recursion. You use both the `-Recurse` and the `-Depth` parameter to limit the recursion.
+
+This parameter, added in PowerShell 5.0 enables you to control the depth of recursion. You use both the `-Recurse` and the `-Depth` parameter to limit the recursion.
 
 ```yaml
 Type: UInt32
@@ -194,6 +209,7 @@ Accept wildcard characters: False
 ```
 
 ### -Directory
+
 Gets directories (folders).
 
 To get only directories, use the `-Directory` parameter and omit the `-File` parameter. To exclude directories, use the `-File` parameter and omit the `-Directory` parameter, or use the `-Attributes` parameter.
@@ -213,6 +229,7 @@ Accept wildcard characters: False
 ```
 
 ### -Exclude
+
 Omits the specified items.
 The value of this parameter qualifies the `-Path` parameter.
 Enter a path element or pattern, such as "*.txt".
@@ -231,6 +248,7 @@ Accept wildcard characters: True
 ```
 
 ### -File
+
 Gets files.
 
 To get only files, use the `-File` parameter and omit the Directory parameter. To exclude files, use the `-Directory` parameter and omit the `-File` parameter, or use the `-Attributes` parameter.
@@ -250,6 +268,7 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
+
 Specifies a filter in the provider's format or language.
 The value of this parameter qualifies the `-Path` parameter.
 The syntax of the filter, including the use of wildcards, depends on the provider.
@@ -268,6 +287,7 @@ Accept wildcard characters: True
 ```
 
 ### -Force
+
 Allows the cmdlet to get items that cannot otherwise not be accessed by the user, such as hidden or system files.
 Implementation varies among providers.
 
@@ -288,6 +308,7 @@ Accept wildcard characters: False
 ```
 
 ### -Hidden
+
 Gets only hidden files and directories (folders).  By default, `Get-ChildItem` gets only non-hidden items, but you can use the `-Force` parameter to include hidden items in the results.
 
 To get only hidden items, use the `-Hidden` parameter, its "`h`" or "`ah`" aliases, or the Hidden value of the `-Attributes` parameter. To exclude hidden items, omit the `-Hidden` parameter or use the `-Attributes` parameter.
@@ -305,6 +326,7 @@ Accept wildcard characters: False
 ```
 
 ### -Include
+
 Gets only the specified items.
 The value of this parameter qualifies the `-Path` parameter.
 Enter a path element or pattern, such as "*.txt".
@@ -325,6 +347,7 @@ Accept wildcard characters: True
 ```
 
 ### -LiteralPath
+
 Specifies a path to one or more locations.
 Unlike the `-Path` parameter, the value of the `-LiteralPath` parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
@@ -344,6 +367,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Gets only the names of the items in the locations.
 If you pipe the output of this command to another command, only the item names are sent.
 
@@ -360,6 +384,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specifies a path to one or more locations.
 Wildcards are permitted.
 The default location is the current directory (`.`).
@@ -377,6 +402,7 @@ Accept wildcard characters: True
 ```
 
 ### -ReadOnly
+
 Gets only read-only files and directories (folders).
 
 To get only read-only items, use the `-ReadOnly` parameter, its "`ar`" alias, or the ReadOnly value of the `-Attributes` parameter. To exclude read-only items, use the `-Attributes` parameter.
@@ -394,9 +420,8 @@ Accept wildcard characters: False
 ```
 
 ### -Recurse
-Gets the items in the specified locations and in all child items of the locations.
 
-In Windows PowerShell 2.0 and earlier versions of Windows PowerShell, the `-Recurse` parameter works only when the value of the `-Path` parameter is a container that has child items, such as C:\Windows or C:\Windows\*, and not when it is an item does not have child items, such as C:\Windows\*.exe.
+Gets the items in the specified locations and in all child items of the locations.
 
 ```yaml
 Type: SwitchParameter
@@ -411,6 +436,7 @@ Accept wildcard characters: False
 ```
 
 ### -System
+
 Gets only system files and directories (folders).
 
 To get only system files and folders, use the `-System` parameter, its "`as`" alias, or the System value of the `-Attributes` parameter. To exclude system files and folders, use the `-Attributes` parameter.
@@ -428,6 +454,7 @@ Accept wildcard characters: False
 ```
 
 ### -UseTransaction
+
 Includes the command in the active transaction.
 This parameter is valid only when a transaction is in progress.
 For more information, see about_Transactions.
@@ -451,17 +478,21 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## Inputs
 
 ### System.String
+
 You can pipe a string that contains a path to `Get-ChildItem`.
 
 ## Outputs
 
 ### System.Object
+
 The type of object that `Get-ChildItem` returns is determined by the objects in the provider drive path.
 
 ### System.String
+
 If you use the `-Name` parameter, `Get-ChildItem` returns the object names as strings.
 
 ## Notes
+
 You can also refer to `Get-ChildItem` by its built-in aliases, "`ls`", "`dir`", and "`gci`". For more information, see about_Aliases.
 
 `Get-ChildItem` does not get hidden items by default.

--- a/reference/6/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -11,6 +11,7 @@ title:  Get-ChildItem
 # Get-ChildItem
 
 ## Synopsis
+
 Gets the items and child items in one or more specified locations.
 
 ## Syntax
@@ -18,22 +19,20 @@ Gets the items and child items in one or more specified locations.
 ### Items (Default)
 
 ```powershell
-Get-ChildItem [[-Path] <String[]>] [[-Filter] <String>] [-Include <String[]>] [-Exclude <String[]>] [-Recurse]
- [-Force] [-Name] [-UseTransaction]
- [-Attributes <System.Management.Automation.FlagsExpression`1[System.IO.FileAttributes]>] [-Directory] [-File]
- [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]
+Get-ChildItem [[-Path] <String[]>] [[-Filter] <String>] [-Attributes {ReadOnly | Hidden | System | Directory |
+Archive | Device | Normal | Temporary | SparseFile | ReparsePoint | Compressed | Offline | NotContentIndexed |
+Encrypted | IntegrityStream | NoScrubData}] [-Depth <UInt32>] [-Directory] [-Exclude <String[]>] [-File] [-Force]
+[-Hidden] [-Include <String[]>] [-Name] [-ReadOnly] [-Recurse] [-System] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### Literal Items
 
 ```powershell
-Get-ChildItem -LiteralPath <String[]> [[-Filter] <String>] [-Include <String[]>] [-Exclude <String[]>]
- [-Recurse] [-Force] [-Name] [-UseTransaction]
- [-Attributes <System.Management.Automation.FlagsExpression`1[System.IO.FileAttributes]>] [-Directory] [-File]
- [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]
+Get-ChildItem -LiteralPath <String[]> [[-Filter] <String>] [-Attributes {ReadOnly | Hidden | System | Directory | Archive | Device | Normal | Temporary | SparseFile | ReparsePoint | Compressed | Offline | NotContentIndexed | Encrypted | IntegrityStream | NoScrubData}] [-Depth <UInt32>] [-Directory] [-Exclude <String[]>] [-File] [-Force] [-Hidden] [-Include <String[]>] [-Name] [-ReadOnly] [-Recurse] [-System] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## Description
+
 The `Get-ChildItem` cmdlet gets the items in one or more specified locations.
 If the item is a container, it gets the items inside the container, known as child items.
 You can use the `-Recurse` parameter to get items in all child containers and use the `-Depth` parameter to limit the number of levels to recurse.
@@ -43,6 +42,7 @@ A location can be a file system location, such as a directory, or a location exp
 ## Examples
 
 ### Example 1: Get child items in the current directory
+
 ```powershell
 Get-ChildItem
 ```
@@ -55,6 +55,7 @@ The default display lists the mode (attributes), last write time, file size (len
 The valid values for mode are `d` (directory), `a` (archive), `r` (read-only), `h` (hidden), and `s` (system).
 
 ### Example 2: Get all files with the specified file extension in the current directory and subdirectories
+
 ```powershell
 Get-ChildItem -Path *.txt -Recurse -Force
 ```
@@ -68,6 +69,7 @@ Use the `-Include` parameter to specify the .txt file type.
 For example, `Get-ChildItem -Path .\* -Include *.txt -Recurse`
 
 ### Example 3: Get all child items using an inclusion and exclusion
+
 ```powershell
 Get-ChildItem -Path C:\Windows\Logs\* -Include *.txt -Exclude A*
 ```
@@ -77,6 +79,7 @@ It uses the wildcard character (`*`) to indicate the contents of the Logs subdir
 Because the command does not include the `-Recurse` parameter, `Get-ChildItem` does not include the content of directory automatically; you need to specify it.
 
 ### Example 4: Get all registry keys in a specific key
+
 ```powershell
 Get-ChildItem -Path HKLM:\Software
 ```
@@ -84,6 +87,7 @@ Get-ChildItem -Path HKLM:\Software
 This command gets all of the registry keys in the HKEY_LOCAL_MACHINE\SOFTWARE key in the registry of the local computer.
 
 ### Example 5: Get the name of items in the current directory
+
 ```powershell
 Get-ChildItem -Name
 ```
@@ -91,6 +95,7 @@ Get-ChildItem -Name
 This command gets only the names of items in the current directory.
 
 ### Example 6: Get all certificates in a certification drive that have code-signing authority
+
 ```powershell
 Import-Module Microsoft.PowerShell.Security
 Get-ChildItem -Path Cert:\* -Recurse -CodeSigningCert
@@ -110,6 +115,7 @@ This parameter gets only certificates that have code-signing authority.
 For more information about the Certificate provider and the Cert: drive, go to [Certificate Provider](../microsoft.powershell.security/providers/certificate-provider.md) or use the `Update-Help` cmdlet to download the help files for the Microsoft.PowerShell.Security module and then type `Get-Help Certificate`.
 
 ### Example 7: Get all items in the specified directory and its subdirectories that have an inclusion and exclusion
+
 ```powershell
 Get-ChildItem -Path C:\Windows -Include *mouse* -Exclude *.png
 ```
@@ -117,7 +123,8 @@ Get-ChildItem -Path C:\Windows -Include *mouse* -Exclude *.png
 This command gets all of the items in the C:\Windows directory and its subdirectories that have "mouse" in the file name, except for those with a .png file name extension.
 
 ### Example 8: Get all items in the specified directory and its subdirectories limited by the Depth parameter
-```
+
+```powershell
 PS C:\> Get-ChildItem -Path C:\Windows -Depth 2
 ```
 
@@ -126,9 +133,11 @@ This command gets all of the items in the C:\Windows directory and its subdirect
 ## Parameters
 
 ### -Attributes
+
 Gets files and folders with the specified attributes. This parameter supports all attributes and lets you specify complex combinations of attributes.
 
 For example, to get non-system files (not directories) that are encrypted or compressed, type:
+
 ```powershell
 Get-ChildItem -Attributes !Directory+!System+Encrypted, !Directory+!System+Compressed
 ```
@@ -136,13 +145,16 @@ Get-ChildItem -Attributes !Directory+!System+Encrypted, !Directory+!System+Compr
 To find files and folders with commonly used attributes, you can use the `-Attributes` parameter, or the `-Directory`, `-File`, `-Hidden`, `-ReadOnly`, and `-System` switch parameters.
 
 The `-Attributes` parameter supports the following attributes:
+
 - Archive
 - Compressed
 - Device
 - Directory
 - Encrypted
 - Hidden
+- IntegrityStream
 - Normal
+- NoScrubData
 - NotContentIndexed
 - Offline
 - ReadOnly
@@ -153,7 +165,8 @@ The `-Attributes` parameter supports the following attributes:
 
 For a description of these attributes, see the [FileAttributes Enumeration](http://go.microsoft.com/fwlink/?LinkId=201508).
 
-Use the following operators to combine attributes.
+Use the following operators to combine attributes:
+
 - `!`   (NOT)
 - `+`   (AND)
 - `,`   (OR)
@@ -161,6 +174,7 @@ Use the following operators to combine attributes.
 No spaces are permitted between an operator and its attribute. However, spaces are permitted before commas.
 
 You can use the following abbreviations for commonly used attributes:
+
 - `D`   (Directory)
 - `H`   (Hidden)
 - `R`   (Read-only)
@@ -179,6 +193,7 @@ Accept wildcard characters: False
 ```
 
 ### -Depth
+
 This parameter, added in Powershell 5.0 enables you to control the depth of recursion. You use both the `-Recurse` and the `-Depth` parameter to limit the recursion.
 
 ```yaml
@@ -194,6 +209,7 @@ Accept wildcard characters: False
 ```
 
 ### -Directory
+
 Gets directories (folders).
 
 To get only directories, use the `-Directory` parameter and omit the `-File` parameter. To exclude directories, use the `-File` parameter and omit the `-Directory` parameter, or use the `-Attributes` parameter.
@@ -213,6 +229,7 @@ Accept wildcard characters: False
 ```
 
 ### -Exclude
+
 Omits the specified items.
 The value of this parameter qualifies the `-Path` parameter.
 Enter a path element or pattern, such as "*.txt".
@@ -231,6 +248,7 @@ Accept wildcard characters: True
 ```
 
 ### -File
+
 Gets files.
 
 To get only files, use the `-File` parameter and omit the Directory parameter. To exclude files, use the `-Directory` parameter and omit the `-File` parameter, or use the `-Attributes` parameter.
@@ -250,6 +268,7 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
+
 Specifies a filter in the provider's format or language.
 The value of this parameter qualifies the `-Path` parameter.
 The syntax of the filter, including the use of wildcards, depends on the provider.
@@ -268,6 +287,7 @@ Accept wildcard characters: True
 ```
 
 ### -Force
+
 Allows the cmdlet to get items that cannot otherwise not be accessed by the user, such as hidden or system files.
 Implementation varies among providers.
 
@@ -288,6 +308,7 @@ Accept wildcard characters: False
 ```
 
 ### -Hidden
+
 Gets only hidden files and directories (folders).  By default, `Get-ChildItem` gets only non-hidden items, but you can use the `-Force` parameter to include hidden items in the results.
 
 To get only hidden items, use the `-Hidden` parameter, its "`h`" or "`ah`" aliases, or the Hidden value of the `-Attributes` parameter. To exclude hidden items, omit the `-Hidden` parameter or use the `-Attributes` parameter.
@@ -305,6 +326,7 @@ Accept wildcard characters: False
 ```
 
 ### -Include
+
 Gets only the specified items.
 The value of this parameter qualifies the `-Path` parameter.
 Enter a path element or pattern, such as "*.txt".
@@ -325,6 +347,7 @@ Accept wildcard characters: True
 ```
 
 ### -LiteralPath
+
 Specifies a path to one or more locations.
 Unlike the `-Path` parameter, the value of the `-LiteralPath` parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
@@ -344,6 +367,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Gets only the names of the items in the locations.
 If you pipe the output of this command to another command, only the item names are sent.
 
@@ -360,6 +384,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specifies a path to one or more locations.
 Wildcards are permitted.
 The default location is the current directory (`.`).
@@ -377,6 +402,7 @@ Accept wildcard characters: True
 ```
 
 ### -ReadOnly
+
 Gets only read-only files and directories (folders).
 
 To get only read-only items, use the `-ReadOnly` parameter, its "`ar`" alias, or the ReadOnly value of the `-Attributes` parameter. To exclude read-only items, use the `-Attributes` parameter.
@@ -394,9 +420,8 @@ Accept wildcard characters: False
 ```
 
 ### -Recurse
-Gets the items in the specified locations and in all child items of the locations.
 
-In Windows PowerShell 2.0 and earlier versions of Windows PowerShell, the `-Recurse` parameter works only when the value of the `-Path` parameter is a container that has child items, such as C:\Windows or C:\Windows\*, and not when it is an item does not have child items, such as C:\Windows\*.exe.
+Gets the items in the specified locations and in all child items of the locations.
 
 ```yaml
 Type: SwitchParameter
@@ -411,6 +436,7 @@ Accept wildcard characters: False
 ```
 
 ### -System
+
 Gets only system files and directories (folders).
 
 To get only system files and folders, use the `-System` parameter, its "`as`" alias, or the System value of the `-Attributes` parameter. To exclude system files and folders, use the `-Attributes` parameter.
@@ -428,6 +454,7 @@ Accept wildcard characters: False
 ```
 
 ### -UseTransaction
+
 Includes the command in the active transaction.
 This parameter is valid only when a transaction is in progress.
 For more information, see about_Transactions.
@@ -451,17 +478,21 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## Inputs
 
 ### System.String
+
 You can pipe a string that contains a path to `Get-ChildItem`.
 
 ## Outputs
 
 ### System.Object
+
 The type of object that `Get-ChildItem` returns is determined by the objects in the provider drive path.
 
 ### System.String
+
 If you use the `-Name` parameter, `Get-ChildItem` returns the object names as strings.
 
 ## Notes
+
 You can also refer to `Get-ChildItem` by its built-in aliases, "`ls`", "`dir`", and "`gci`". For more information, see about_Aliases.
 
 `Get-ChildItem` does not get hidden items by default.


### PR DESCRIPTION
Fix a syntax block for `Get-ChildItem` and added valid attribute values.
Add the blank lines.
Add 2 missing attributes to the list of valid values for the **Attributes** parameter.
Fix some minor typos.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work