### PR TITLE
Update about_CommonParameters.md

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_CommonParameters.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_CommonParameters.md
@@ -429,7 +429,7 @@ Alias: cf
 Prompts you for confirmation before executing the command.
 
 The Confirm parameter overrides the value of the $ConfirmPreference variable
-for the current command. The default value is High. For more information, type
+for the current command. The default value is true. For more information, type
 the following command:
 
 ```powershell


### PR DESCRIPTION
Confirm default value was described to be "High" instead of "True"

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work