### PR TITLE
Revert "Replace Windows PowerShell with PowerShell"

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Disconnected_Sessions.md
@@ -21,7 +21,7 @@ continue to run while the session is disconnected.
 
 The Disconnected Sessions feature is available only when the computer at the
 remote end of a connection is running Windows PowerShell 3.0 or a later
-version of Windows PowerShell and using the WSMan transport.
+version of Windows PowerShell.
 
 The Disconnected Sessions feature allows you to close the session in which a
 PSSession was created, and even close Windows PowerShell, and shut down the

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Session_Configurations.md
@@ -195,9 +195,7 @@ supported versions of Windows, you must change the security descriptors of the
 session configurations to allow remote access.
 
 To enable remote access to the session configurations on the computer, use the
-Enable-PSRemoting cmdlet. This cmdlet creates two session configurations:
-- with the name defined as: "PowerShell." + "current PowerShell version"
-- with name "PowerShell.6", untied to any specific PowerShell version.
+Enable-PSRemoting cmdlet.
 
 Also, by default, only members of the Administrators group on the computer
 have Execute permission to the default session configurations, but you can

--- a/reference/6/Microsoft.PowerShell.Core/About/about_pwsh.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_pwsh.md
@@ -31,7 +31,6 @@ pwsh[.exe]
 [-NoProfile]
 [-OutputFormat {Text | XML}]
 [-WindowStyle <style>]
-[-WorkingDirectory <DirectoryPath>]
 [-File <FilePath> [<Args>]]
 [-Command { - | <script-block> [-args <arg-array>]
 | <string> [<CommandParameters>] } ]
@@ -108,13 +107,6 @@ Determines how output from PowerShell is formatted. Valid values are "Text"
 Sets the window style for the session. Valid values are Normal, Minimized,
 Maximized and Hidden.
 
-#### -WorkingDirectory <DirectoryPath>
-
-Sets the initial working directory when starting PowerShell.  Any valid
-PowerShell file path is supported.
-
-To start PowerShell in your home directory, use: pwsh -WorkingDirectory ~
-
 #### -Command
 
 Executes the specified commands (and any parameters) as though they were typed
@@ -154,9 +146,8 @@ pwsh -Version
 # Example using a script block
 pwsh -Command {Get-Command -Name Get-Item}
 
-# Examples using a string
+# Example using a string
 pwsh -Command "Get-Command -Name Get-Item"
-pwsh -Command "& {Get-Command -Name Get-Command}"
 
 # Example using a command as the last parameter
 pwsh -Command Get-Command -Name Get-Item

--- a/reference/6/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -45,8 +45,6 @@ The **Disconnect-PSSession** cmdlet disconnects a Windows PowerShell session (**
 As a result, the **PSSession** is in a disconnected state.
 You can connect to the disconnected **PSSession** from the current session or from another session on the local computer or a different computer.
 
-Note that this capability only works with PSSessions using the WSMan transport.
-
 The **Disconnect-PSSession** cmdlet disconnects only open **PSSessions** that are connected to the current session.
 **Disconnect-PSSession** cannot disconnect broken or closed **PSSession** objects, or interactive **PSSession** objects started by using the Enter-PSSession cmdlet, and it cannot disconnect **PSSession** objects that are connected to other sessions.
 

--- a/reference/6/Microsoft.PowerShell.Core/Enter-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/Enter-PSSession.md
@@ -68,8 +68,7 @@ Enter-PSSession -ContainerId <String> [-ConfigurationName <String>] [-RunAsAdmin
 
 ### HostName
 ```
-Enter-PSSession [-HostName] <string> [-Port <int>] [-UserName <string>] [-KeyFilePath <string>] [-SSHTransport]
- [-Subsystem <String>] [<CommonParameters>]
+Enter-PSSession [-HostName] <string> [-Port <int>] [-UserName <string>] [-KeyFilePath <string>] [-SSHTransport] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -155,14 +154,14 @@ You can also use the **Exit** keyword to end the interactive session.
 
 ### Example 6: Start an interactive session using SSH
 ```
-PS C:\> Enter-PSSession -HostName UserA@LinuxServer01
+PS C:\> Enter-PSSession -HostName LinuxServer01 -UserName UserA
 ```
 
 This example shows how to start an interactive session using Secure Shell (SSH). If SSH is configured on the remote computer to prompt for passwords then you will get a password prompt.  Otherwise you will have to use SSH key based user authentication.
 
 ### Example 7: Start an interactive session using SSH and specify the Port and user authentication key
 ```
-PS C:\> Enter-PSSession -HostName UserA@LinuxServer02:22 -KeyFilePath c:\<path>\userAKey_rsa
+PS C:\> Enter-PSSession -HostName LinuxServer02 -UserName UserA -Port 22 -KeyFilePath c:\<path>\userAKey_rsa
 ```
 
 This example shows how to start an interactive session using SSH. It uses the *Port* parameter to specify the port to use and the *KeyFilePath* parameter to specify an RSA key used to authenticate the user on the remote computer.
@@ -305,9 +304,6 @@ Specifies the session configuration that is used for the interactive session.
 Enter a configuration name or the fully qualified resource URI for a session configuration.
 If you specify only the configuration name, the following schema URI is prepended: http://schemas.microsoft.com/powershell.
 
-When used with SSH, this specifies the subsystem to use on the target as defined in sshd_config.
-The default value for SSH is the `powershell` subsystem.
-
 The session configuration for a session is located on the remote computer.
 If the specified session configuration does not exist on the remote computer, the command fails.
 
@@ -423,10 +419,6 @@ Accept wildcard characters: False
 ### -HostName
 Specifies a computer name for a Secure Shell (SSH) based connection.
 This is similar to the *ComputerName* parameter except that the connection to the remote computer is made using SSH rather than Windows WinRM.
-This parameter supports specifying the user name and/or port as part of the host name parameter value using
-the form `user@hostname:port`.
-The user name and/or port specified as part of the host name takes precedence over the `-UserName` and `-Port` parameters, if specified.
-This allows passing multiple computer names to this parameter where some have specific user names and/or ports, while others use the user name and/or port from the `-UserName` and `-Port` parameters.
 
 This parameter was introduced in PowerShell 6.0.
 
@@ -626,27 +618,6 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Subsystem
-Specifies the SSH subsystem used for the new **PSSession**.
-
-This specifies the subsystem to use on the target as defined in sshd_config.
-The subsystem starts a specific version of PowerShell with predefined parameters.
-If the specified subsystem does not exist on the remote computer, the command fails.
-
-If this parameter is not used, the default is the 'powershell' subsystem.
-
-```yaml
-Type: String
-Parameter Sets: HostName
-Aliases:
-
-Required: False
-Position: Named
-Default value: powershell
-Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
+++ b/reference/6/Microsoft.PowerShell.Core/Invoke-Command.md
@@ -116,9 +116,9 @@ Invoke-Command [-ConfigurationName <String>] [-ThrottleLimit <Int32>] [-AsJob] [
 
 ### HostName
 ```
-Invoke-Command [-Subsystem <String>] -ScriptBlock <scriptblock> -HostName <string[]> [-Port <int>]
- [-AsJob] [-HideComputerName] [-UserName <string>] [-KeyFilePath <string>] [-SSHTransport] [-RemoteDebug]
- [-InputObject <psobject>] [-ArgumentList <Object[]>] [<CommonParameters>]
+Invoke-Command -ScriptBlock <scriptblock> -HostName <string[]> [-Port <int>] [-AsJob]
+[-HideComputerName] [-UserName <string>] [-KeyFilePath <string>] [-SSHTransport] [-RemoteDebug]
+[-InputObject <psobject>] [-ArgumentList <Object[]>] [<CommonParameters>]
 ```
 
 ### FilePathHostName
@@ -491,21 +491,21 @@ To get the results of commands and scripts that run in disconnected sessions, us
 
 ### Example 17: Run a command on a remote computer using SSH
 ```
-PS C:\> Invoke-Command -HostName UserA@LinuxServer01 -ScriptBlock { Get-MailBox * }
+PS C:\> Invoke-Command -HostName LinuxServer01 -UserName UserA -ScriptBlock { Get-MailBox * }
 ```
 
 This example shows how to run a command on a remote computer using Secure Shell (SSH). If SSH is configured on the remote computer to prompt for passwords then you will get a password prompt. Otherwise you will have to use SSH key based user authentication.
 
 ### Example 18: Run a command on a remote computer using SSH and specify a user authentication key
 ```
-PS C:\> Invoke-Command -HostName UserA@LinuxServer01 -ScriptBlock { Get-MailBox * } -KeyFilePath c:\<path>\userAKey_rsa
+PS C:\> Invoke-Command -HostName LinuxServer01 -UserName UserA -ScriptBlock { Get-MailBox * } -KeyFilePath c:\<path>\userAKey_rsa
 ```
 
 This example shows how to run a command on a remote computer using SSH and specifying a key file for user authentication. You will not get a password prompt unless the key authentication fails and the remote computer is configured to allow basic password authentication.
 
 ### Example 19: Run a script file on multiple remote computers using SSH as a job
 ```
-PS C:\> $sshConnections = @{ HostName="WinServer1"; UserName="domain\userA"; KeyFilePath="c:\users\UserA\id_rsa" }, @{ HostName="UserB@LinuxServer5"; KeyFilePath="c:\UserB\<path>\id_rsa }
+PS C:\> $sshConnections = @{ HostName="WinServer1"; UserName="domain\userA"; KeyFilePath="c:\users\UserA\id_rsa" }, @{ HostName="LinuxServer5"; UserName="UserB"; KeyFilePath="c:\UserB\<path>\id_rsa }
 PS C:\> $results = Invoke-Command -FilePath c:\Scripts\CollectEvents.ps1 -SSHConnection $sshConnections
 ```
 
@@ -702,9 +702,6 @@ Specifies the session configuration that is used for the new **PSSession**.
 
 Enter a configuration name or the fully qualified resource URI for a session configuration.
 If you specify only the configuration name, the following schema URI is prepended: http://schemas.microsoft.com/PowerShell.
-
-When used with SSH, this specifies the subsystem to use on the target as defined in sshd_config.
-The default value for SSH is the `powershell` subsystem.
 
 The session configuration for a session is located on the remote computer.
 If the specified session configuration does not exist on the remote computer, the command fails.
@@ -1171,10 +1168,6 @@ Accept wildcard characters: False
 
 ### -HostName
 Specifies an array of computer names for a Secure Shell (SSH) based connection. This is similar to the ComputerName parameter except that the connection to the remote computer is made using SSH rather than Windows WinRM.
-This parameter supports specifying the user name and/or port as part of the host name parameter value using
-the form `user@hostname:port`.
-The user name and/or port specified as part of the host name takes precedence over the `-UserName` and `-Port` parameters, if specified.
-This allows passing multiple computer names to this parameter where some have specific user names and/or ports, while others use the user name and/or port from the `-UserName` and `-Port` parameters.
 
 This parameter was introduced in PowerShell 6.0.
 
@@ -1228,27 +1221,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Subsystem
-Specifies the SSH subsystem used for the new **PSSession**.
-
-This specifies the subsystem to use on the target as defined in sshd_config.
-The subsystem starts a specific version of PowerShell with predefined parameters.
-If the specified subsystem does not exist on the remote computer, the command fails.
-
-If this parameter is not used, the default is the 'powershell' subsystem.
-
-```yaml
-Type: String
-Parameter Sets: HostName
-Aliases:
-
-Required: False
-Position: Named
-Default value: powershell
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
 ### -UserName
 Specifies the user name for the account used to run a command on the remote computer. User authentication method will depend on how Secure Shell (SSH) is configured on the remote computer.
 
@@ -1273,10 +1245,9 @@ Accept wildcard characters: False
 ```
 
 ### -SSHConnection
-This parameter takes an array of hashtables where each hashtable contains one or more connection parameters needed to establish a Secure Shell (SSH) connection (HostName, Port, UserName, KeyFilePath, Subsystem).
+This parameter takes an array of hashtables where each hashtable contains one or more connection parameters needed to establish a Secure Shell (SSH) connection (HostName, Port, UserName, KeyFilePath).
 
 The hashtable connection parameters are the same as defined for the HostName parameter set.
-Note that the order of the keys in the hashtable result in user name and port being used for the connection where the last one specified is used.  For example, if you use `@{UserName="first";HostName="second@host"}`, then the user name `second` will be used.  However, if you use `@{HostName="second@host:22";Port=23}`, then port 23 will be used.
 
 The SSHConnection parameter is useful for creating multiple sessions where each session requires different connection information.
 

--- a/reference/6/Microsoft.PowerShell.Core/New-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/New-PSSession.md
@@ -215,21 +215,21 @@ The value of the SessionOption parameter is the **SessionOption** object in the 
 
 ### Example 12: Create a session using SSH
 ```
-PS C:\> New-PSSession -HostName UserA@LinuxServer01
+PS C:\> New-PSSession -HostName LinuxServer01 -UserName UserA
 ```
 
 This example shows how to create a new **PSSession** using Secure Shell (SSH). If SSH is configured on the remote computer to prompt for passwords then you will get a password prompt. Otherwise you will have to use SSH key based user authentication.
 
 ### Example 13: Create a session using SSH and specify the port and user authentication key
 ```
-PS C:\> New-PSSession -HostName UserA@LinuxServer01:22 -KeyFilePath c:\<path>\userAKey_rsa
+PS C:\> New-PSSession -HostName LinuxServer01 -UserName UserA -Port 22 -KeyFilePath c:\<path>\userAKey_rsa
 ```
 
 This example shows how to create a **PSSession** using Secure Shell (SSH). It uses the *Port* parameter to specify the port to use and the *KeyFilePath* parameter to specify an RSA key used to identify and authenticate the user on the remote computer.
 
 ### Example 14: Create multiple sessions using SSH
 ```
-PS C:\> $sshConnections = @{ HostName="WinServer1"; UserName="domain\userA"; KeyFilePath="c:\users\UserA\id_rsa" }, @{ HostName="UserB@LinuxServer5"; KeyFilePath="c:\UserB\<path>\id_rsa }
+PS C:\> $sshConnections = @{ HostName="WinServer1"; UserName="domain\userA"; KeyFilePath="c:\users\UserA\id_rsa" }, @{ HostName="LinuxServer5"; UserName="UserB"; KeyFilePath="c:\UserB\<path>\id_rsa }
 PS C:\> New-PSSession -SSHConnection $sshConnections
 ```
 
@@ -371,9 +371,6 @@ Specifies the session configuration that is used for the new **PSSession**.
 
 Enter a configuration name or the fully qualified resource URI for a session configuration.
 If you specify only the configuration name, the following schema URI is prepended: http://schemas.microsoft.com/PowerShell.
-
-When used with SSH, this specifies the subsystem to use on the target as defined in sshd_config.
-The default value for SSH is the `powershell` subsystem.
 
 The session configuration for a session is located on the remote computer.
 If the specified session configuration does not exist on the remote computer, the command fails.

--- a/reference/6/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/6/Microsoft.PowerShell.Core/Save-Help.md
@@ -189,7 +189,7 @@ Do not specify a file name or file name extension.
 ```yaml
 Type: String[]
 Parameter Sets: Path
-Aliases: Path
+Aliases:
 
 Required: True
 Position: 0

--- a/reference/6/Microsoft.PowerShell.Core/Update-Help.md
+++ b/reference/6/Microsoft.PowerShell.Core/Update-Help.md
@@ -365,7 +365,7 @@ For more information, see about_Group_Policy_Settings (http://go.microsoft.com/f
 ```yaml
 Type: String[]
 Parameter Sets: Path
-Aliases: Path
+Aliases:
 
 Required: False
 Position: 1

--- a/reference/6/Microsoft.PowerShell.Core/Where-Object.md
+++ b/reference/6/Microsoft.PowerShell.Core/Where-Object.md
@@ -21,11 +21,6 @@ Selects objects from a collection based on their property values.
 Where-Object [-InputObject <PSObject>] [-Property] <String> [[-Value] <Object>] [-EQ] [<CommonParameters>]
 ```
 
-### NotSet
-```
-Where-Object [-Property] <string> -Not [-InputObject <psobject>] [<CommonParameters>]
-```
-
 ### ScriptBlockSet
 
 ```
@@ -921,25 +916,6 @@ This parameter was introduced in Windows PowerShell 3.0.
 Type: SwitchParameter
 Parameter Sets: NotEqualSet
 Aliases: INE
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Not
-Indicates that this cmdlet gets objects if the property does not exist or has a value of null or false.
-
-For example: `Get-Service | where -Not "DependentServices"`
-
-This parameter was introduced in Windows PowerShell 6.1.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: Not
-Aliases: 
 
 Required: True
 Position: Named

--- a/reference/6/Microsoft.PowerShell.Management/New-Service.md
+++ b/reference/6/Microsoft.PowerShell.Management/New-Service.md
@@ -67,7 +67,7 @@ This parameter is required.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: Path
+Aliases:
 
 Required: True
 Position: 2

--- a/reference/6/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/6/Microsoft.PowerShell.Management/Start-Process.md
@@ -167,7 +167,7 @@ If you specify only a file name, use the *WorkingDirectory* parameter to specify
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: PSPath, Path
+Aliases: PSPath
 
 Required: True
 Position: 1

--- a/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Invoke-RestMethod.md
@@ -13,7 +13,7 @@ title:  Invoke-RestMethod
 ## Synopsis
 Sends an HTTP or HTTPS request to a RESTful web service.
 
-## SYNTAX
+## Syntax
 
 ### StandardMethod (Default)
 ```
@@ -24,9 +24,8 @@ Invoke-RestMethod [-Method <WebRequestMethod>] [-FollowRelLink] [-MaximumFollowR
  [-Certificate <X509Certificate>] [-SkipCertificateCheck] [-SslProtocol <WebSslProtocol>]
  [-Token <SecureString>] [-UserAgent <String>] [-DisableKeepAlive] [-TimeoutSec <Int32>]
  [-Headers <IDictionary>] [-MaximumRedirection <Int32>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
- [-ProxyUseDefaultCredentials] [-Body <Object>] [-Form <IDictionary>] [-ContentType <String>]
- [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>] [-PassThru] [-Resume]
- [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
+ [-ProxyUseDefaultCredentials] [-Body <Object>] [-ContentType <String>] [-TransferEncoding <String>]
+ [-InFile <String>] [-OutFile <String>] [-PassThru] [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
 ```
 
 ### StandardMethodNoProxy
@@ -37,9 +36,9 @@ Invoke-RestMethod [-Method <WebRequestMethod>] [-FollowRelLink] [-MaximumFollowR
  [-Credential <PSCredential>] [-UseDefaultCredentials] [-CertificateThumbprint <String>]
  [-Certificate <X509Certificate>] [-SkipCertificateCheck] [-SslProtocol <WebSslProtocol>]
  [-Token <SecureString>] [-UserAgent <String>] [-DisableKeepAlive] [-TimeoutSec <Int32>]
- [-Headers <IDictionary>] [-MaximumRedirection <Int32>] [-NoProxy] [-Body <Object>] [-Form <IDictionary>]
- [-ContentType <String>] [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>] [-PassThru]
- [-Resume] [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
+ [-Headers <IDictionary>] [-MaximumRedirection <Int32>] [-NoProxy] [-Body <Object>] [-ContentType <String>]
+ [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>] [-PassThru]
+ [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
 ```
 
 ### CustomMethod
@@ -51,9 +50,8 @@ Invoke-RestMethod -CustomMethod <String> [-FollowRelLink] [-MaximumFollowRelLink
  [-Certificate <X509Certificate>] [-SkipCertificateCheck] [-SslProtocol <WebSslProtocol>]
  [-Token <SecureString>] [-UserAgent <String>] [-DisableKeepAlive] [-TimeoutSec <Int32>]
  [-Headers <IDictionary>] [-MaximumRedirection <Int32>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>]
- [-ProxyUseDefaultCredentials] [-Body <Object>] [-Form <IDictionary>] [-ContentType <String>]
- [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>] [-PassThru] [-Resume]
- [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
+ [-ProxyUseDefaultCredentials] [-Body <Object>] [-ContentType <String>] [-TransferEncoding <String>]
+ [-InFile <String>] [-OutFile <String>] [-PassThru] [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
 ```
 
 ### CustomMethodNoProxy
@@ -64,9 +62,9 @@ Invoke-RestMethod -CustomMethod <String> [-FollowRelLink] [-MaximumFollowRelLink
  [-Credential <PSCredential>] [-UseDefaultCredentials] [-CertificateThumbprint <String>]
  [-Certificate <X509Certificate>] [-SkipCertificateCheck] [-SslProtocol <WebSslProtocol>]
  [-Token <SecureString>] [-UserAgent <String>] [-DisableKeepAlive] [-TimeoutSec <Int32>]
- [-Headers <IDictionary>] [-MaximumRedirection <Int32>] [-NoProxy] [-Body <Object>] [-Form <IDictionary>]
- [-ContentType <String>] [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>] [-PassThru]
- [-Resume] [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
+ [-Headers <IDictionary>] [-MaximumRedirection <Int32>] [-NoProxy] [-Body <Object>] [-ContentType <String>]
+ [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>] [-PassThru]
+ [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
 ```
 
 ## Description
@@ -136,40 +134,6 @@ Invoke-RestMethod $url -FollowRelLink -MaximumFollowRelLink 2
 
 Some REST APIs support pagination via Relation Links per [RFC5988](https://tools.ietf.org/html/rfc5988#page-6). Instead of parsing the header to get the URL for the next page, you can have the cmdlet do this for you. This example returns the first two pages of issues from the PowerShell GitHub repository
 
-### Example 4: Simplified Multipart/Form-Data Submission
-```powershell
-$Uri = 'https://api.contoso.com/v2/profile'
-$Form = @{
-    firstName  = 'John'
-    lastName   = 'Doe'
-    email      = 'john.doe@contoso.com'
-    avatar     = Get-Item -Path 'c:\Pictures\jdoe.png'
-    birthday   = '1980-10-15'
-    hobbies    = 'Hiking','Fishing','Jogging'
-}
-$Result = Invoke-RestMethod -Uri $Uri -Method Post -Form $Form
-```
-
-Some APIs require `multipart/form-data` submissions to upload files and mixed content.
-This example demonstrates updating a user profile.
-The profile form requires these fields:
-`firstName`, `lastName`, `email`, `avatar`, `birthday`, and `hobbies`.
-The API is expecting an image for the user profile pic to be supplied in the `avatar` field.
-The API will also accept multiple `hobbies` entries to be submitted in the same form.
-
-When creating the `$Form` HashTable, the key names are used as form field names.
-By default, the values of the HashTable will be converted to strings.
-If a `System.IO.FileInfo` value is present, the file contents will be submitted.
-If a collection such as arrays or lists are present,
-the form field will be submitted will be submitted multiple times.
-
-By using `Get-Item` on the `avatar` key, the `FileInfo` object will be set as the value.
-The result is that the image data for `jdoe.png` will be submitted.
-
-By supplying a list to the `hobbies` key,
-the `hobbies` field will be present in the submissions
-once for each list item.
-
 ## Parameters
 
 ### -AllowUnencryptedAuthentication
@@ -177,7 +141,6 @@ Allows sending of credentials and secrets over unencrypted connections. By defau
 
 > **Warning**: Using this parameter is not secure and is not recommended. It is provided only for compatibility with legacy systems that cannot provide encrypted connections. Use at your own risk.
 
-This feature was added in PowerShell 6.0.0.
 
 ```yaml
 Type: SwitchParameter
@@ -203,7 +166,6 @@ Available Authentication Options:
 
 Supplying **-Authentication** will override any `Authorization` headers supplied to **-Headers** or included in **-WebSession**.
 
-This feature was added in PowerShell 6.0.0.
 
 ```yaml
 Type: WebAuthenticationType
@@ -230,7 +192,7 @@ For other request types (such as POST), the body is set as the value of the requ
 
 When the body is a form, or it is the output of another `Invoke-WebRequest` call, PowerShell sets the request content to the form fields.
 
-The **-Body** parameter may also accept a `System.Net.Http.MultipartFormDataContent` object. This will facilitate `multipart/form-data` requests. When a `MultipartFormDataContent` object is supplied for **-Body**, any Content related headers supplied to the **-ContentType**, **-Headers**, or **-WebSession** parameters will be overridden by the Content headers of the `MultipartFormDataContent` object. This feature was added in PowerShell 6.0.0.
+The **-Body** parameter may also accept a `System.Net.Http.MultipartFormDataContent` object. This will facilitate `multipart/form-data` requests. When a `MultipartFormDataContent` object is supplied for **-Body**, any Content related headers supplied to the **-ContentType**, **-Headers**, or **-WebSession** parameters will be overridden by the Content headers of the `MultipartFormDataContent` object.
 
 ```yaml
 Type: Object
@@ -250,6 +212,8 @@ Enter a variable that contains a certificate or a command or expression that get
 
 To find a certificate, use `Get-PfxCertificate` or use the `Get-ChildItem` cmdlet in the Certificate (`Cert:`) drive.
 If the certificate is not valid or does not have sufficient authority, the command fails.
+
+> **Note**: This feature may not work on OS platforms where `libcurl` is configured with a TLS provider other than OpenSSL.
 
 ```yaml
 Type: X509Certificate
@@ -338,8 +302,6 @@ Invoke-WebRequest -uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'
 
 This makes a `TEST` HTTP request to the API.
 
-This feature was added in PowerShell 6.0.0.
-
 ```yaml
 Type: String
 Parameter Sets: StandardMethod, CustomMethod
@@ -374,66 +336,10 @@ Indicates the cmdlet should follow relation links.
 
 To set how many times to follow relation links, use the **-MaximumFollowRelLink** parameter.
 
-This feature was added in PowerShell 6.0.0.
-
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Form
-Converts a dictionary to a `multipart/form-data` submission.
-`-Form` may not be used with `-Body`.
-If `-ContentType` will be ignored.
-
-The keys of the dictionary will be used as the form field names.
-By default, form values will be converted to string values.
-
-If the value is a `System.IO.FileInfo` object,
-then the binary file contents will be submitted.
-The name of the file will be submitted as the `filename`.
-The MIME will be set as `application/octet-stream`.
-`Get-Item` can be used to simplify supplying the `System.IO.FileInfo` object.
-
-```powershell
-$Form = @{
-    resume = Get-Item 'c:\Users\jdoe\Documents\John Doe.pdf'
-}
-```
-
-If the value is a collection type,
-such Arrays or Lists,
-the for field will be submitted multiple times.
-The values of the the list will be treated as strings by default.
-If the value is a `System.IO.FileInfo` object,
-then the binary file contents will be submitted.
-Nested collections are not supported.
-
-```powershell
-$Form = @{
-    tags     = 'Vacation', 'Italy', '2017'
-    pictures = Get-ChildItem 'c:\Users\jdoe\Pictures\2017-Italy\'
-}
-```
-
-In the above example the `tags` field will be supplied 3 times in the form,
-once for each of `Vacation`, `Italy`, and `2017`.
-The `pictures` field will also be submitted once for each file in the `2017-Italy` folder.
-The binary contents of the files in that folder will be submitted as the values.
-
-This feature was added in PowerShell 6.1.0.
-
-```yaml
-Type: IDictionary
-Parameter Sets: (All)
-Aliases: 
 
 Required: False
 Position: Named
@@ -603,8 +509,6 @@ Indicates the cmdlet should preserve the `Authorization` header, when present, a
 
 By default, the cmdlet strips the `Authorization` header before redirecting. Specifying this parameter disables this logic for cases where the header needs to be sent to the redirection location.
 
-This feature was added in PowerShell 6.0.0.
-
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
@@ -620,8 +524,6 @@ Accept wildcard characters: False
 ### -Proxy
 Uses a proxy server for the request, rather than connecting directly to the Internet resource.
 Enter the URI of a network proxy server.
-
-This feature was added in PowerShell 6.0.0.
 
 ```yaml
 Type: Uri
@@ -677,7 +579,6 @@ Accept wildcard characters: False
 ### -ResponseHeadersVariable
 Creates a Response Headers Dictionary and saves it in the value of the specified variable. The the keys of the dictionary will contain the field names of the Response Header returned by the web server and the values will be the respective field values.
 
-This feature was added in PowerShell 6.0.0.
 
 ```yaml
 Type: String
@@ -690,46 +591,6 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 
-```
-
-### -Resume
-Performs a best effort attempt to resume downloading a partial file.
-`-Resume` requires `-OutFile`.
-
-`-Resume` only operates on the size of the local file and remote file
-and performs no other validation that the local file and the remote file are the same.
-
-If the local file size is smaller than the remote file size,
-then the cmdlet will attempt to resume downloading the file
-and append the remaining bytes to the end of the file.
-
-If the local file size is the same as the remote file size,
-then no action is taken and the cmdlet assumes the download already complete.
-
-If the local file size is larger than the remote file size,
-then the local file will be overwritten and the entire remote file will be completely re-downloaded.
-This behavior is the same as using `-OutFile` without `-Resume`.
-
-If the remote server does not support download resuming,
-then the local file will be overwritten and the entire remote file will be completely re-downloaded.
-This behavior is the same as using `-OutFile` without `-Resume`.
-
-If the local file does not exist,
-then the local file will be created and the entire remote file will be completely downloaded.
-This behavior is the same as using `-OutFile` without `-Resume`.
-
-This feature was added in PowerShell 6.1.0.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: 
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
 ```
 
 ### -SessionVariable
@@ -767,7 +628,6 @@ Skips certificate validation checks. This includes all validations such as expir
 
 > **Warning**: Using this parameter is not secure and is not recommended. This switch is only intended to be used against known hosts using a self-signed certificate for testing purposes. Use at your own risk.
 
-This feature was added in PowerShell 6.0.0.
 
 ```yaml
 Type: SwitchParameter
@@ -786,9 +646,7 @@ Indicates the cmdlet should add headers to the request without validation.
 
 This switch should be used for sites that require header values that do not conform to standards. Specifying this switch disables validation to allow the value to be passed unchecked.  When specified, all headers are added without validation.
 
-This will disable validation for values passed to the **-ContentType**, **-Headers** and **-UserAgent** parameters.
-
-This feature was added in PowerShell 6.0.0.
+This will disable validation for values passed to both the **-Headers** and **-UserAgent** parameters.
 
 ```yaml
 Type: SwitchParameter
@@ -807,9 +665,7 @@ Sets the SSL/TLS protocols that are permissible for the web request. By default 
 
 **-SslProtocol** uses the `WebSslProtocol` Flag Enum. It is possible to supply more than one protocol using flag notation or combining multiple `WebSslProtocol` options with `-bor`, however supplying multiple protocols is not supported on all platforms.
 
-> **Note**: On non-Windows platforms it may not be possible to supply `'Tls, Tls12'` as an option.
-
-This feature was added in PowerShell 6.0.0.
+> **Note**: This feature may not work on OS platforms where `libcurl` is configured with a TLS provider other than OpenSSL.
 
 ```yaml
 Type: WebSslProtocol
@@ -852,8 +708,6 @@ The OAuth or Bearer token to include in the request. **-Token** is required by c
 ```powershell
 Invoke-RestMethod -Uri $uri -Authentication OAuth -Token (Read-Host -AsSecureString)
 ```
-
-This feature was added in PowerShell 6.0.0.
 
 ```yaml
 Type: SecureString
@@ -1011,6 +865,8 @@ The output of the cmdlet depends upon the format of the content that is retrieve
 If the request returns JSON strings, `Invoke-RestMethod` returns a PSObject that represents the strings.
 
 ## Notes
+
+Some features may not be available on all platforms.
 
 ## Related Links
 

--- a/reference/6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Invoke-WebRequest.md
@@ -23,8 +23,8 @@ Invoke-WebRequest [-UseBasicParsing] [-Uri] <Uri> [-WebSession <WebRequestSessio
  [-SkipCertificateCheck] [-SslProtocol <WebSslProtocol>] [-Token <SecureString>] [-UserAgent <String>]
  [-DisableKeepAlive] [-TimeoutSec <Int32>] [-Headers <IDictionary>] [-MaximumRedirection <Int32>]
  [-Method <WebRequestMethod>] [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-ProxyUseDefaultCredentials]
- [-Body <Object>] [-Form <IDictionary>] [-ContentType <String>] [-TransferEncoding <String>] [-InFile <String>]
- [-OutFile <String>] [-PassThru] [-Resume] [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
+ [-Body <Object>] [-ContentType <String>] [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>]
+ [-PassThru] [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
 ```
 
 ### StandardMethodNoProxy
@@ -34,9 +34,8 @@ Invoke-WebRequest [-UseBasicParsing] [-Uri] <Uri> [-WebSession <WebRequestSessio
  [-UseDefaultCredentials] [-CertificateThumbprint <String>] [-Certificate <X509Certificate>]
  [-SkipCertificateCheck] [-SslProtocol <WebSslProtocol>] [-Token <SecureString>] [-UserAgent <String>]
  [-DisableKeepAlive] [-TimeoutSec <Int32>] [-Headers <IDictionary>] [-MaximumRedirection <Int32>]
- [-Method <WebRequestMethod>] [-NoProxy] [-Body <Object>] [-Form <IDictionary>] [-ContentType <String>]
- [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>] [-PassThru] [-Resume]
- [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
+ [-Method <WebRequestMethod>] [-NoProxy] [-Body <Object>] [-ContentType <String>] [-TransferEncoding <String>]
+ [-InFile <String>] [-OutFile <String>] [-PassThru] [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
 ```
 
 ### CustomMethod
@@ -47,8 +46,8 @@ Invoke-WebRequest [-UseBasicParsing] [-Uri] <Uri> [-WebSession <WebRequestSessio
  [-SkipCertificateCheck] [-SslProtocol <WebSslProtocol>] [-Token <SecureString>] [-UserAgent <String>]
  [-DisableKeepAlive] [-TimeoutSec <Int32>] [-Headers <IDictionary>] [-MaximumRedirection <Int32>]
  -CustomMethod <String> [-Proxy <Uri>] [-ProxyCredential <PSCredential>] [-ProxyUseDefaultCredentials]
- [-Body <Object>] [-Form <IDictionary>] [-ContentType <String>] [-TransferEncoding <String>] [-InFile <String>]
- [-OutFile <String>] [-PassThru] [-Resume] [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
+ [-Body <Object>] [-ContentType <String>] [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>]
+ [-PassThru] [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
 ```
 
 ### CustomMethodNoProxy
@@ -58,9 +57,8 @@ Invoke-WebRequest [-UseBasicParsing] [-Uri] <Uri> [-WebSession <WebRequestSessio
  [-UseDefaultCredentials] [-CertificateThumbprint <String>] [-Certificate <X509Certificate>]
  [-SkipCertificateCheck] [-SslProtocol <WebSslProtocol>] [-Token <SecureString>] [-UserAgent <String>]
  [-DisableKeepAlive] [-TimeoutSec <Int32>] [-Headers <IDictionary>] [-MaximumRedirection <Int32>]
- -CustomMethod <String> [-NoProxy] [-Body <Object>] [-Form <IDictionary>] [-ContentType <String>]
- [-TransferEncoding <String>] [-InFile <String>] [-OutFile <String>] [-PassThru] [-Resume]
- [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
+ -CustomMethod <String> [-NoProxy] [-Body <Object>] [-ContentType <String>] [-TransferEncoding <String>]
+ [-InFile <String>] [-OutFile <String>] [-PassThru] [-PreserveAuthorizationOnRedirect] [-SkipHeaderValidation]
 ```
 
 ## DESCRIPTION
@@ -151,40 +149,6 @@ $Response = Invoke-WebRequest -Body $MultipartContent -Method 'POST' -Uri 'https
 
 This example uses the `Invoke-WebRequest` cmdlet upload a file as a `multipart/form-data` submission. The file `c:\document.txt` will be submitted as the form field `document` with the `Content-Type` of `text/plain`.
 
-### Example 5: Simplified Multipart/Form-Data Submission
-```powershell
-$Uri = 'https://api.contoso.com/v2/profile'
-$Form = @{
-    firstName  = 'John'
-    lastName   = 'Doe'
-    email      = 'john.doe@contoso.com'
-    avatar     = Get-Item -Path 'c:\Pictures\jdoe.png'
-    birthday   = '1980-10-15'
-    hobbies    = 'Hiking','Fishing','Jogging'
-}
-$Result = Invoke-RestMethod -Uri $Uri -Method Post -Form $Form
-```
-
-Some APIs require `multipart/form-data` submissions to upload files and mixed content.
-This example demonstrates updating a user profile.
-The profile form requires these fields:
-`firstName`, `lastName`, `email`, `avatar`, `birthday`, and `hobbies`.
-The API is expecting an image for the user profile pic to be supplied in the `avatar` field.
-The API will also accept multiple `hobbies` entries to be submitted in the same form.
-
-When creating the `$Form` HashTable, the key names are used as form field names.
-By default, the values of the HashTable will be converted to strings.
-If a `System.IO.FileInfo` value is present, the file contents will be submitted.
-If a collection such as arrays or lists are present,
-the form field will be submitted will be submitted multiple times.
-
-By using `Get-Item` on the `avatar` key, the `FileInfo` object will be set as the value.
-The result is that the image data for `jdoe.png` will be submitted.
-
-By supplying a list to the `hobbies` key,
-the `hobbies` field will be present in the submissions
-once for each list item.
-
 ## PARAMETERS
 
 ### -AllowUnencryptedAuthentication
@@ -192,7 +156,6 @@ Allows sending of credentials and secrets over unencrypted connections. By defau
 
 > **Warning**: Using this parameter is not secure and is not recommended. It is provided only for compatibility with legacy systems that cannot provide encrypted connections. Use at your own risk.
 
-This feature was added in PowerShell 6.0.0.
 
 ```yaml
 Type: SwitchParameter
@@ -218,7 +181,6 @@ Available Authentication Options:
 
 Supplying **-Authentication** will override any `Authorization` headers supplied to **-Headers** or included in **-WebSession**.
 
-This feature was added in PowerShell 6.0.0.
 
 ```yaml
 Type: WebAuthenticationType
@@ -243,7 +205,7 @@ The **-Body** parameter can be used to specify a list of query parameters or spe
 When the input is a GET request and the body is an `IDictionary` (typically, a hash table), the body is added to the URI as query parameters.
 For other request types (such as POST), the body is set as the value of the request body in the standard name=value format.
 
-The **-Body** parameter may also accept a `System.Net.Http.MultipartFormDataContent` object. This will facilitate `multipart/form-data` requests. When a `MultipartFormDataContent` object is supplied for **-Body**, any Content related headers supplied to the **-ContentType**, **-Headers**, or **-WebSession** parameters will be overridden by the Content headers of the `MultipartFormDataContent` object. This feature was added in PowerShell 6.0.0.
+The **-Body** parameter may also accept a `System.Net.Http.MultipartFormDataContent` object. This will facilitate `multipart/form-data` requests. When a `MultipartFormDataContent` object is supplied for **-Body**, any Content related headers supplied to the **-ContentType**, **-Headers**, or **-WebSession** parameters will be overridden by the Content headers of the `MultipartFormDataContent` object.
 
 ```yaml
 Type: Object
@@ -263,6 +225,8 @@ Enter a variable that contains a certificate or a command or expression that get
 
 To find a certificate, use `Get-PfxCertificate` or use the `Get-ChildItem` cmdlet in the Certificate (`Cert:`) drive.
 If the certificate is not valid or does not have sufficient authority, the command fails.
+
+> **Note**: This feature may not work on OS platforms where `libcurl` is configured with a TLS provider other than OpenSSL.
 
 ```yaml
 Type: X509Certificate
@@ -351,8 +315,6 @@ Invoke-WebRequest -uri 'https://api.contoso.com/widget/' -CustomMethod 'TEST'
 
 This makes a `TEST` HTTP request to the API.
 
-This feature was added in PowerShell 6.0.0.
-
 ```yaml
 Type: String
 Parameter Sets: CustomMethod, CustomMethodNoProxy
@@ -374,60 +336,6 @@ By default, **KeepAlive** is True.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Form
-Converts a dictionary to a `multipart/form-data` submission.
-`-Form` may not be used with `-Body`.
-If `-ContentType` will be ignored.
-
-The keys of the dictionary will be used as the form field names.
-By default, form values will be converted to string values.
-
-If the value is a `System.IO.FileInfo` object,
-then the binary file contents will be submitted.
-The name of the file will be submitted as the `filename`.
-The MIME will be set as `application/octet-stream`.
-`Get-Item` can be used to simplify supplying the `System.IO.FileInfo` object.
-
-```powershell
-$Form = @{
-    resume = Get-Item 'c:\Users\jdoe\Documents\John Doe.pdf'
-}
-```
-
-If the value is a collection type,
-such Arrays or Lists,
-the for field will be submitted multiple times.
-The values of the the list will be treated as strings by default.
-If the value is a `System.IO.FileInfo` object,
-then the binary file contents will be submitted.
-Nested collections are not supported.
-
-```powershell
-$Form = @{
-    tags     = 'Vacation', 'Italy', '2017'
-    pictures = Get-ChildItem 'c:\Users\jdoe\Pictures\2017-Italy\'
-}
-```
-
-In the above example the `tags` field will be supplied 3 times in the form,
-once for each of `Vacation`, `Italy`, and `2017`.
-The `pictures` field will also be submitted once for each file in the `2017-Italy` folder.
-The binary contents of the files in that folder will be submitted as the values.
-
-This feature was added in PowerShell 6.1.0.
-
-```yaml
-Type: IDictionary
-Parameter Sets: (All)
-Aliases: 
 
 Required: False
 Position: Named
@@ -528,8 +436,6 @@ Indicates that the cmdlet will not use a proxy to reach the destination.
 
 When you need to bypass the proxy configured in the environment, use this switch.
 
-This feature was added in PowerShell 6.0.0.
-
 ```yaml
 Type: SwitchParameter
 Parameter Sets: StandardMethodNoProxy, CustomMethodNoProxy
@@ -582,8 +488,6 @@ Accept wildcard characters: False
 Indicates the cmdlet should preserve the `Authorization` header, when present, across redirections.
 
 By default, the cmdlet strips the `Authorization` header before redirecting. Specifying this parameter disables this logic for cases where the header needs to be sent to the redirection location.
-
-This feature was added in PowerShell 6.0.0.
 
 ```yaml
 Type: SwitchParameter
@@ -652,46 +556,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Resume
-Performs a best effort attempt to resume downloading a partial file.
-`-Resume` requires `-OutFile`.
-
-`-Resume` only operates on the size of the local file and remote file
-and performs no other validation that the local file and the remote file are the same.
-
-If the local file size is smaller than the remote file size,
-then the cmdlet will attempt to resume downloading the file
-and append the remaining bytes to the end of the file.
-
-If the local file size is the same as the remote file size,
-then no action is taken and the cmdlet assumes the download already complete.
-
-If the local file size is larger than the remote file size,
-then the local file will be overwritten and the entire remote file will be completely re-downloaded.
-This behavior is the same as using `-OutFile` without `-Resume`.
-
-If the remote server does not support download resuming,
-then the local file will be overwritten and the entire remote file will be completely re-downloaded.
-This behavior is the same as using `-OutFile` without `-Resume`.
-
-If the local file does not exist,
-then the local file will be created and the entire remote file will be completely downloaded.
-This behavior is the same as using `-OutFile` without `-Resume`.
-
-This feature was added in PowerShell 6.1.0.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: 
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -SessionVariable
 Specifies a variable for which this cmdlet creates a web request session and saves it in the value.
 Enter a variable name without the dollar sign (`$`) symbol.
@@ -727,8 +591,6 @@ Skips certificate validation checks. This includes all validations such as expir
 
 > **Warning**: Using this parameter is not secure and is not recommended. This switch is only intended to be used against known hosts using a self-signed certificate for testing purposes. Use at your own risk.
 
-This feature was added in PowerShell 6.0.0.
-
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
@@ -746,9 +608,7 @@ Indicates the cmdlet should add headers to the request without validation.
 
 This switch should be used for sites that require header values that do not conform to standards. Specifying this switch disables validation to allow the value to be passed unchecked.  When specified, all headers are added without validation.
 
-This will disable validation for values passed to the **-ContentType**, **-Headers** and **-UserAgent** parameters.
-
-This feature was added in PowerShell 6.0.0.
+This will disable validation for values passed to both the **-Headers** and **-UserAgent** parameters.
 
 ```yaml
 Type: SwitchParameter
@@ -767,9 +627,7 @@ Sets the SSL/TLS protocols that are permissible for the web request. By default 
 
 **-SslProtocol** uses the `WebSslProtocol` Flag Enum. It is possible to supply more than one protocol using flag notation or combining multiple `WebSslProtocol` options with `-bor`, however supplying multiple protocols is not supported on all platforms.
 
-> **Note**: On non-Windows platforms it may not be possible to supply `'Tls, Tls12'` as an option.
-
-This feature was added in PowerShell 6.0.0.
+> **Note**: This feature may not work on OS platforms where `libcurl` is configured with a TLS provider other than OpenSSL.
 
 ```yaml
 Type: WebSslProtocol
@@ -812,8 +670,6 @@ The OAuth or Bearer token to include in the request. **-Token** is required by c
 ```powershell
 Invoke-WebRequest -Uri $uri -Authentication OAuth -Token (Read-Host -AsSecureString)
 ```
-
-This feature was added in PowerShell 6.0.0.
 
 ```yaml
 Type: SecureString
@@ -968,6 +824,8 @@ You can pipe the body of a web request to `Invoke-WebRequest`.
 ### Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject
 
 ## NOTES
+
+Some features may not be available on all platforms.
 
 Beginning with PowerShell 6.0.0 `Invoke-WebRequest` supports basic parsing only.
 

--- a/reference/6/Microsoft.PowerShell.Utility/Measure-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Measure-Object.md
@@ -93,20 +93,6 @@ This example demonstrates how the **Measure-Object** can measure Boolean values.
 In this case, it uses the PSIsContainer Boolean property to measure the incidence of folders (vs.
 files) in the current directory.
 
-### Example 7: Measure all the values
-```
-PS C:\> 1..5 | Measure-Object -AllStats
-Count             : 5
-Average           : 3
-Sum               : 15
-Maximum           : 5
-Minimum           : 1
-StandardDeviation : 1.58113883008419
-Property          :
-```
-
-This example demonstrates how the **Measure-Object** can measure all the statistics together.
-
 ## PARAMETERS
 
 ### -Average
@@ -237,21 +223,6 @@ Accept wildcard characters: False
 
 ### -Sum
 Indicates that the cmdlet displays the sum of the values of the specified properties.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: GenericMeasure
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -AllStats
-Indicates that the cmdlet displays all the statitics of the specified properties.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/6/Microsoft.PowerShell.Utility/Set-TraceSource.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Set-TraceSource.md
@@ -81,7 +81,7 @@ If you use this parameter to start the trace, use the *RemoveFileListener* param
 ```yaml
 Type: String
 Parameter Sets: optionsSet
-Aliases: PSPath, Path
+Aliases: PSPath
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.PowerShell.Utility/Tee-Object.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Tee-Object.md
@@ -106,7 +106,7 @@ Specifies a file that this cmdlet saves the object to Wildcard characters are pe
 ```yaml
 Type: String
 Parameter Sets: File
-Aliases: Path
+Aliases:
 
 Required: True
 Position: 0

--- a/reference/6/Microsoft.PowerShell.Utility/Trace-Command.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Trace-Command.md
@@ -139,7 +139,7 @@ This parameter also selects the file trace listener.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: PSPath, Path
+Aliases: PSPath
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.WSMan.Management/Invoke-WSManAction.md
+++ b/reference/6/Microsoft.WSMan.Management/Invoke-WSManAction.md
@@ -279,7 +279,7 @@ The file, Input.xml, contains the following content:
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: Path
+Aliases:
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.WSMan.Management/New-WSManInstance.md
+++ b/reference/6/Microsoft.WSMan.Management/New-WSManInstance.md
@@ -201,7 +201,7 @@ You specify the management resource by using the *ResourceURI* parameter and the
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: Path
+Aliases:
 
 Required: False
 Position: Named

--- a/reference/6/Microsoft.WSMan.Management/Set-WSManInstance.md
+++ b/reference/6/Microsoft.WSMan.Management/Set-WSManInstance.md
@@ -282,7 +282,7 @@ You specify the management resource by using the *ResourceURI* parameter and the
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases: Path
+Aliases:
 
 Required: False
 Position: Named

--- a/reference/6/PowerShellGet/Find-DscResource.md
+++ b/reference/6/PowerShellGet/Find-DscResource.md
@@ -175,7 +175,7 @@ This parameter supports wildcard characters.
 If you do not specify wildcard characters, only resources that exactly match the specified names are returned.
 If no matches are found, and you have not used any wildcard characters, the command returns an error.
 If you use wildcard characters, but do not find matching results, no error is returned.
-This follows standard wildcard character matching behavior for PowerShell.
+This follows standard wildcard character matching behavior for Windows PowerShell.
 
 ```yaml
 Type: String[]

--- a/reference/6/PowerShellGet/Find-Module.md
+++ b/reference/6/PowerShellGet/Find-Module.md
@@ -141,7 +141,7 @@ Accept wildcard characters: False
 
 ### -DscResource
 Specifies the name, or part of the name, of modules that contain DSC resources.
-Per PowerShell conventions, performs an OR search when you provide multiple arguments.
+Per Windows PowerShell conventions, performs an OR search when you provide multiple arguments.
 
 ```yaml
 Type: String[]
@@ -187,7 +187,7 @@ Accept wildcard characters: False
 ```
 
 ### -Includes
-Returns only those modules that include specific kinds of PowerShell functionality.
+Returns only those modules that include specific kinds of Windows PowerShell functionality.
 For example, you might only want to find modules that include DSCResource.
 The acceptable values for this parameter are:
 

--- a/reference/6/PowerShellGet/Get-InstalledModule.md
+++ b/reference/6/PowerShellGet/Get-InstalledModule.md
@@ -21,7 +21,7 @@ Get-InstalledModule [[-Name] <String[]>] [-MinimumVersion <Version>] [-RequiredV
 ```
 
 ## DESCRIPTION
-The **Get-InstalledModule** cmdlet gets PowerShell modules that are installed on a computer.
+The **Get-InstalledModule** cmdlet gets Windows PowerShell modules that are installed on a computer.
 
 ## EXAMPLES
 

--- a/reference/6/PowerShellGet/Install-Module.md
+++ b/reference/6/PowerShellGet/Install-Module.md
@@ -120,7 +120,7 @@ You cannot add this parameter if you are attempting to install multiple modules.
 The *MinimumVersion* and the *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
 
 If you are installing multiple modules in a single command, and a specified minimum version for a module is not available for installation, the **Install-Module** command silently continues without installing the unavailable module.
-For example, if you try to install the ContosoServer module with a minimum version of 2.0, but the latest version of the ContosoServer module is 1.5, the **Install-Module** command does not install the ContosoServer module; it goes to install the next specified module, and PowerShell display errors when the command is finished.
+For example, if you try to install the ContosoServer module with a minimum version of 2.0, but the latest version of the ContosoServer module is 1.5, the **Install-Module** command does not install the ContosoServer module; it goes to install the next specified module, and Windows PowerShell display errors when the command is finished.
 
 ```yaml
 Type: Version
@@ -352,7 +352,7 @@ If the version of the installed module is greater than the value of the *Minimum
   To install multiple modules, specify an array of the module names, separated by commas.
 You cannot add *MinimumVersion* or *RequiredVersion* if you specify multiple module names.
 
-  By default, modules are installed to the Program Files folder, to prevent confusion when you are installing PowerShell Desired State Configuration (DSC) resources.You can pipe multiple **PSGetItemInfo** objects to **Install-Module**; this is another way of specifying multiple modules to install in a single command.
+  By default, modules are installed to the Program Files folder, to prevent confusion when you are installing Windows PowerShell Desired State Configuration (DSC) resources.You can pipe multiple **PSGetItemInfo** objects to **Install-Module**; this is another way of specifying multiple modules to install in a single command.
 
   To help prevent running modules that contain malicious code, installed modules are not automatically imported by installation.
 As a security best practice, evaluate module code before running any cmdlets or functions in a module for the first time.

--- a/reference/6/PowerShellGet/New-ScriptFileInfo.md
+++ b/reference/6/PowerShellGet/New-ScriptFileInfo.md
@@ -371,7 +371,7 @@ Accept wildcard characters: False
 
 ### -RequiredModules
 Specifies modules that must be in the global session state.
-If the required modules are not in the global session state, PowerShell imports them.
+If the required modules are not in the global session state, Windows PowerShell imports them.
 
 ```yaml
 Type: Object[]

--- a/reference/6/PowerShellGet/Publish-Script.md
+++ b/reference/6/PowerShellGet/Publish-Script.md
@@ -109,7 +109,7 @@ Specifies a path to one or more locations.
 Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as entered.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose them in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String

--- a/reference/6/PowerShellGet/Save-Module.md
+++ b/reference/6/PowerShellGet/Save-Module.md
@@ -119,7 +119,7 @@ Specifies a path to one or more locations.
 Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as entered.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose them in single quotation marks.
-PowerShell does not interpret any characters that are enclosed in single quotation marks as escape sequences.
+Windows PowerShell does not interpret any characters that are enclosed in single quotation marks as escape sequences.
 
 ```yaml
 Type: String

--- a/reference/6/PowerShellGet/Save-Script.md
+++ b/reference/6/PowerShellGet/Save-Script.md
@@ -83,7 +83,7 @@ Specifies a path to one or more locations.
 Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as entered.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose them in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String

--- a/reference/6/PowerShellGet/Test-ScriptFileInfo.md
+++ b/reference/6/PowerShellGet/Test-ScriptFileInfo.md
@@ -92,7 +92,7 @@ Specifies a path to one or more locations.
 Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is entered.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose them in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String

--- a/reference/6/PowerShellGet/Update-Module.md
+++ b/reference/6/PowerShellGet/Update-Module.md
@@ -22,7 +22,7 @@ Update-Module [[-Name] <String[]>] [-RequiredVersion <Version>] [-MaximumVersion
 ```
 
 ## DESCRIPTION
-The **Update-Module** cmdlet installs a newer version of a PowerShell module that was installed from the online gallery by running Install-Module on the local computer.
+The **Update-Module** cmdlet installs a newer version of a Windows PowerShell module that was installed from the online gallery by running Install-Module on the local computer.
 
 By default, the newest version of the specified module available in online gallery is installed, unless you specify a required version.
 You can update an existing, installed module by specifying the name of the module; **Update-Module** searches $env:PSModulePath for the module that you want to update.

--- a/reference/6/PowerShellGet/Update-ModuleManifest.md
+++ b/reference/6/PowerShellGet/Update-ModuleManifest.md
@@ -236,7 +236,7 @@ Accept wildcard characters: False
 ### -FormatsToProcess
 Specifies the formatting files (.ps1xml) that run when the module is imported.
 
-When you import a module, PowerShell runs the `Update-FormatData` cmdlet with the specified files.
+When you import a module, Windows PowerShell runs the `Update-FormatData` cmdlet with the specified files.
 Because formatting files are not scoped, they affect all session states in the session.
 
 ```yaml
@@ -450,7 +450,7 @@ Accept wildcard characters: False
 ```
 
 ### -PowerShellHostName
-Specifies the name of the PowerShell host program that the module requires.
+Specifies the name of the Windows PowerShell host program that the module requires.
 Enter the name of the host program, such as Windows PowerShell ISE Host or ConsoleHost.
 Wildcards are not permitted.
 
@@ -469,7 +469,7 @@ Accept wildcard characters: False
 ```
 
 ### -PowerShellHostVersion
-Specifies the minimum version of the PowerShell host program that works with the module.
+Specifies the minimum version of the Windows PowerShell host program that works with the module.
 Enter a version number, such as 1.1.
 
 ```yaml
@@ -485,7 +485,7 @@ Accept wildcard characters: False
 ```
 
 ### -PowerShellVersion
-Specifies the minimum version of PowerShell that will work with this module.
+Specifies the minimum version of Windows PowerShell that will work with this module.
 For example, you can specify 3.0, 4.0, or 5.0 as the value of this parameter.
 
 ```yaml
@@ -572,7 +572,7 @@ Accept wildcard characters: False
 ### -RequiredAssemblies
 Specifies the assembly (.dll) files that the module requires.
 Enter the assembly file names.
-PowerShell loads the specified assemblies before updating types or formats, importing nested modules, or importing the module file that is specified in the value of the **RootModule** key.
+Windows PowerShell loads the specified assemblies before updating types or formats, importing nested modules, or importing the module file that is specified in the value of the **RootModule** key.
 
 Use this parameter to specify all of the assemblies that the module requires, including assemblies that must be loaded to update any formatting or type files that are listed in the **FormatsToProcess** or **TypesToProcess** keys, even if those assemblies are also listed as binary modules in the **NestedModules** key.
 
@@ -590,7 +590,7 @@ Accept wildcard characters: False
 
 ### -RequiredModules
 Specifies modules that must be in the global session state.
-If the required modules are not in the global session state, PowerShell imports them.
+If the required modules are not in the global session state, Windows PowerShell imports them.
 If the required modules are not available, the `Import-Module` command fails.
 
 ```yaml
@@ -665,7 +665,7 @@ Accept wildcard characters: False
 ### -TypesToProcess
 Specifies the type files (.ps1xml) that run when the module is imported.
 
-When you import the module, PowerShell runs the `Update-TypeData` cmdlet with the specified files.
+When you import the module, Windows PowerShell runs the `Update-TypeData` cmdlet with the specified files.
 Because type files are not scoped, they affect all session states in the session.
 
 ```yaml

--- a/reference/6/PowerShellGet/Update-ScriptFileInfo.md
+++ b/reference/6/PowerShellGet/Update-ScriptFileInfo.md
@@ -234,7 +234,7 @@ Specifies a path to one or more locations.
 Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is entered.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose them in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -313,7 +313,7 @@ Accept wildcard characters: False
 
 ### -RequiredModules
 Specifies modules that must be in the global session state.
-If the required modules are not in the global session state, PowerShell imports them.
+If the required modules are not in the global session state, Windows PowerShell imports them.
 
 ```yaml
 Type: Object[]

--- a/reference/docs-conceptual/core-powershell/SSH-Remoting-in-PowerShell-Core.md
+++ b/reference/docs-conceptual/core-powershell/SSH-Remoting-in-PowerShell-Core.md
@@ -184,15 +184,6 @@ and optionally key based authentication.
    sudo launchctl start com.openssh.sshd
    ```
 
-## Authentication
-
-PowerShell remoting over SSH relies on the authentication exchange between the SSH client and SSH service and does not implement any authentication schemes itself.
-This means that any configured authentication schemes including multi-factor authentication is handled by SSH and independent of PowerShell.
-For example, you can configure the SSH service to require public key authentication as well as a one-time password for added security.
-Configuration of multi-factor authentication is outside the scope of this documentation.
-Refer to documentation for SSH on how to correctly configure multi-factor authentication and validate it works outside of PowerShell
-before attempting to use it with PowerShell remoting.
-
 ## PowerShell Remoting Example
 
 The easiest way to test remoting is to just try it on a single machine. Here I will create a remote

--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Linux.md
@@ -50,11 +50,11 @@ PowerShell Core, for Linux, is published to package repositories for easy instal
 This is the preferred method.
 
 ```sh
-# Download the Microsoft repository GPG keys
-wget -q https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb
+# Import the public repository GPG keys
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 
-# Register the Microsoft repository GPG keys
-sudo dpkg -i packages-microsoft-prod.deb
+# Register the Microsoft Ubuntu repository
+curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
 
 # Update the list of products
 sudo apt-get update
@@ -101,11 +101,11 @@ PowerShell Core, for Linux, is published to package repositories for easy instal
 This is the preferred method.
 
 ```sh
-# Download the Microsoft repository GPG keys
-wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
+# Import the public repository GPG keys
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 
-# Register the Microsoft repository GPG keys
-sudo dpkg -i packages-microsoft-prod.deb
+# Register the Microsoft Ubuntu repository
+sudo curl -o /etc/apt/sources.list.d/microsoft.list https://packages.microsoft.com/config/ubuntu/16.04/prod.list
 
 # Update the list of products
 sudo apt-get update
@@ -155,11 +155,11 @@ PowerShell Core, for Linux, is published to package repositories for easy instal
 This is the preferred method.
 
 ```sh
-# Download the Microsoft repository GPG keys
-wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
+# Import the public repository GPG keys
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 
-# Register the Microsoft repository GPG keys
-sudo dpkg -i packages-microsoft-prod.deb
+# Register the Microsoft Ubuntu repository
+sudo curl -o /etc/apt/sources.list.d/microsoft.list https://packages.microsoft.com/config/ubuntu/18.04/prod.list
 
 # Update the list of products
 sudo apt-get update

--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
@@ -11,7 +11,6 @@ From a terminal window, type `brew` to run Homebrew.  If the `brew` command is n
 
 > [!NOTE]
 > If you installed Homebrew in the past, it's always a good idea to run 'brew update-reset' && 'brew update'.
-
 ```sh
 brew update-reset
 brew update
@@ -38,7 +37,7 @@ Finally, verify that your install is working properly:
 pwsh
 ```
 
-To exit PowerShell, and return to bash, use the 'exit' command.
+To exit PowerShell, and return to bash, use the 'exit' command. 
 ```sh
 exit
 ```
@@ -98,48 +97,6 @@ brew cask upgrade powershell-preview
 > The commands above can be called from within a PowerShell (pwsh) host,
 > but then the PowerShell shell must be exited and restarted to complete the upgrade
 > and refresh the values shown in $PSVersionTable.
-
-### Installation of latest preview release via Homebrew on macOS 10.12 or higher
-
-[Homebrew][brew] is the preferred package manager for macOS.
-If the `brew` command is not found, you need to install Homebrew following [their instructions][brew].
-
-Once you've installed Homebrew, installing PowerShell is easy.
-First, install [Homebrew-Cask][cask], so you can install more packages and install [Cask-Versions][cask-version] which lets you install alternative versions of packages:
-
-```sh
-brew tap caskroom/cask
-brew tap caskroom/versions
-```
-
-Now, you can install PowerShell:
-
-```sh
-brew cask install powershell-preview
-```
-
-Finally, verify that your install is working properly:
-
-```sh
-pwsh-preview
-```
-
-When new versions of PowerShell are released,
-simply update Homebrew's formulae and upgrade PowerShell:
-
-```sh
-brew update
-brew cask upgrade powershell-preview
-```
-
-> [!NOTE]
-> The commands above can be called from within a PowerShell (pwsh) host,
-> but then the PowerShell shell must be exited and restarted to complete the upgrade.
-> and refresh the values shown in $PSVersionTable.
-
-[brew]: http://brew.sh/
-[cask]: https://caskroom.github.io/
-[cask-versions]: https://github.com/Homebrew/homebrew-cask-versions
 
 ### Installation via Direct Download
 

--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-60.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-60.md
@@ -378,8 +378,9 @@ For a complete list of fixes and changes, check out our [changelog][] on GitHub.
   - the OS platform (`$PSVersionTable.OSDescription`)
   - the exact version of PowerShell (`$PSVersionTable.GitCommitId`)
 
-If you want to opt-out of this telemetry, simply create `POWERSHELL_TELEMETRY_OPTOUT` environment variable with one of the following values: `true`, `1` or `yes`.
-Creating the variable bypasses all telemetry even before the first run of PowerShell.
+If you want to opt-out of this telemetry, simply delete `$PSHome\DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY`
+or create `POWERSHELL_TELEMETRY_OPTOUT` environment variable with one of the following values: `true`, `1` or `yes`.
+Deleting this file or creating the variable bypasses all telemetry even before the first run of PowerShell.
 We also plan on exposing this telemetry data and the insights we glean from the telemetry in the [community dashboard][community-dashboard].
 You can find out more about how we use this data in this [blog post][telemetry-blog].
 


### PR DESCRIPTION
Reverts PowerShell/PowerShell-Docs#2776

I changed the target to staging because the file changes were appropriate to v6. However, this pulled in changes meant for 6.1. We don't want to publish those v6.1 changes yet. 

@it-praktyk Can you resubmit your changes to the staging branch?