### PR TITLE
Replace Windows PowerShell with PowerShell - the PowerShellGet module

### DIFF
--- a/reference/6/PowerShellGet/Find-DscResource.md
+++ b/reference/6/PowerShellGet/Find-DscResource.md
@@ -175,7 +175,7 @@ This parameter supports wildcard characters.
 If you do not specify wildcard characters, only resources that exactly match the specified names are returned.
 If no matches are found, and you have not used any wildcard characters, the command returns an error.
 If you use wildcard characters, but do not find matching results, no error is returned.
-This follows standard wildcard character matching behavior for Windows PowerShell.
+This follows standard wildcard character matching behavior for PowerShell.
 
 ```yaml
 Type: String[]

--- a/reference/6/PowerShellGet/Find-Module.md
+++ b/reference/6/PowerShellGet/Find-Module.md
@@ -141,7 +141,7 @@ Accept wildcard characters: False
 
 ### -DscResource
 Specifies the name, or part of the name, of modules that contain DSC resources.
-Per Windows PowerShell conventions, performs an OR search when you provide multiple arguments.
+Per PowerShell conventions, performs an OR search when you provide multiple arguments.
 
 ```yaml
 Type: String[]
@@ -187,7 +187,7 @@ Accept wildcard characters: False
 ```
 
 ### -Includes
-Returns only those modules that include specific kinds of Windows PowerShell functionality.
+Returns only those modules that include specific kinds of PowerShell functionality.
 For example, you might only want to find modules that include DSCResource.
 The acceptable values for this parameter are:
 

--- a/reference/6/PowerShellGet/Get-InstalledModule.md
+++ b/reference/6/PowerShellGet/Get-InstalledModule.md
@@ -21,7 +21,7 @@ Get-InstalledModule [[-Name] <String[]>] [-MinimumVersion <Version>] [-RequiredV
 ```
 
 ## DESCRIPTION
-The **Get-InstalledModule** cmdlet gets Windows PowerShell modules that are installed on a computer.
+The **Get-InstalledModule** cmdlet gets PowerShell modules that are installed on a computer.
 
 ## EXAMPLES
 

--- a/reference/6/PowerShellGet/Install-Module.md
+++ b/reference/6/PowerShellGet/Install-Module.md
@@ -120,7 +120,7 @@ You cannot add this parameter if you are attempting to install multiple modules.
 The *MinimumVersion* and the *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
 
 If you are installing multiple modules in a single command, and a specified minimum version for a module is not available for installation, the **Install-Module** command silently continues without installing the unavailable module.
-For example, if you try to install the ContosoServer module with a minimum version of 2.0, but the latest version of the ContosoServer module is 1.5, the **Install-Module** command does not install the ContosoServer module; it goes to install the next specified module, and Windows PowerShell display errors when the command is finished.
+For example, if you try to install the ContosoServer module with a minimum version of 2.0, but the latest version of the ContosoServer module is 1.5, the **Install-Module** command does not install the ContosoServer module; it goes to install the next specified module, and PowerShell display errors when the command is finished.
 
 ```yaml
 Type: Version
@@ -352,7 +352,7 @@ If the version of the installed module is greater than the value of the *Minimum
   To install multiple modules, specify an array of the module names, separated by commas.
 You cannot add *MinimumVersion* or *RequiredVersion* if you specify multiple module names.
 
-  By default, modules are installed to the Program Files folder, to prevent confusion when you are installing Windows PowerShell Desired State Configuration (DSC) resources.You can pipe multiple **PSGetItemInfo** objects to **Install-Module**; this is another way of specifying multiple modules to install in a single command.
+  By default, modules are installed to the Program Files folder, to prevent confusion when you are installing PowerShell Desired State Configuration (DSC) resources.You can pipe multiple **PSGetItemInfo** objects to **Install-Module**; this is another way of specifying multiple modules to install in a single command.
 
   To help prevent running modules that contain malicious code, installed modules are not automatically imported by installation.
 As a security best practice, evaluate module code before running any cmdlets or functions in a module for the first time.

--- a/reference/6/PowerShellGet/New-ScriptFileInfo.md
+++ b/reference/6/PowerShellGet/New-ScriptFileInfo.md
@@ -371,7 +371,7 @@ Accept wildcard characters: False
 
 ### -RequiredModules
 Specifies modules that must be in the global session state.
-If the required modules are not in the global session state, Windows PowerShell imports them.
+If the required modules are not in the global session state, PowerShell imports them.
 
 ```yaml
 Type: Object[]

--- a/reference/6/PowerShellGet/Publish-Script.md
+++ b/reference/6/PowerShellGet/Publish-Script.md
@@ -109,7 +109,7 @@ Specifies a path to one or more locations.
 Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as entered.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose them in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String

--- a/reference/6/PowerShellGet/Save-Module.md
+++ b/reference/6/PowerShellGet/Save-Module.md
@@ -119,7 +119,7 @@ Specifies a path to one or more locations.
 Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as entered.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose them in single quotation marks.
-Windows PowerShell does not interpret any characters that are enclosed in single quotation marks as escape sequences.
+PowerShell does not interpret any characters that are enclosed in single quotation marks as escape sequences.
 
 ```yaml
 Type: String

--- a/reference/6/PowerShellGet/Save-Script.md
+++ b/reference/6/PowerShellGet/Save-Script.md
@@ -83,7 +83,7 @@ Specifies a path to one or more locations.
 Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as entered.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose them in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String

--- a/reference/6/PowerShellGet/Test-ScriptFileInfo.md
+++ b/reference/6/PowerShellGet/Test-ScriptFileInfo.md
@@ -92,7 +92,7 @@ Specifies a path to one or more locations.
 Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is entered.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose them in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String

--- a/reference/6/PowerShellGet/Update-Module.md
+++ b/reference/6/PowerShellGet/Update-Module.md
@@ -22,7 +22,7 @@ Update-Module [[-Name] <String[]>] [-RequiredVersion <Version>] [-MaximumVersion
 ```
 
 ## DESCRIPTION
-The **Update-Module** cmdlet installs a newer version of a Windows PowerShell module that was installed from the online gallery by running Install-Module on the local computer.
+The **Update-Module** cmdlet installs a newer version of a PowerShell module that was installed from the online gallery by running Install-Module on the local computer.
 
 By default, the newest version of the specified module available in online gallery is installed, unless you specify a required version.
 You can update an existing, installed module by specifying the name of the module; **Update-Module** searches $env:PSModulePath for the module that you want to update.

--- a/reference/6/PowerShellGet/Update-ModuleManifest.md
+++ b/reference/6/PowerShellGet/Update-ModuleManifest.md
@@ -236,7 +236,7 @@ Accept wildcard characters: False
 ### -FormatsToProcess
 Specifies the formatting files (.ps1xml) that run when the module is imported.
 
-When you import a module, Windows PowerShell runs the `Update-FormatData` cmdlet with the specified files.
+When you import a module, PowerShell runs the `Update-FormatData` cmdlet with the specified files.
 Because formatting files are not scoped, they affect all session states in the session.
 
 ```yaml
@@ -450,7 +450,7 @@ Accept wildcard characters: False
 ```
 
 ### -PowerShellHostName
-Specifies the name of the Windows PowerShell host program that the module requires.
+Specifies the name of the PowerShell host program that the module requires.
 Enter the name of the host program, such as Windows PowerShell ISE Host or ConsoleHost.
 Wildcards are not permitted.
 
@@ -469,7 +469,7 @@ Accept wildcard characters: False
 ```
 
 ### -PowerShellHostVersion
-Specifies the minimum version of the Windows PowerShell host program that works with the module.
+Specifies the minimum version of the PowerShell host program that works with the module.
 Enter a version number, such as 1.1.
 
 ```yaml
@@ -485,7 +485,7 @@ Accept wildcard characters: False
 ```
 
 ### -PowerShellVersion
-Specifies the minimum version of Windows PowerShell that will work with this module.
+Specifies the minimum version of PowerShell that will work with this module.
 For example, you can specify 3.0, 4.0, or 5.0 as the value of this parameter.
 
 ```yaml
@@ -572,7 +572,7 @@ Accept wildcard characters: False
 ### -RequiredAssemblies
 Specifies the assembly (.dll) files that the module requires.
 Enter the assembly file names.
-Windows PowerShell loads the specified assemblies before updating types or formats, importing nested modules, or importing the module file that is specified in the value of the **RootModule** key.
+PowerShell loads the specified assemblies before updating types or formats, importing nested modules, or importing the module file that is specified in the value of the **RootModule** key.
 
 Use this parameter to specify all of the assemblies that the module requires, including assemblies that must be loaded to update any formatting or type files that are listed in the **FormatsToProcess** or **TypesToProcess** keys, even if those assemblies are also listed as binary modules in the **NestedModules** key.
 
@@ -590,7 +590,7 @@ Accept wildcard characters: False
 
 ### -RequiredModules
 Specifies modules that must be in the global session state.
-If the required modules are not in the global session state, Windows PowerShell imports them.
+If the required modules are not in the global session state, PowerShell imports them.
 If the required modules are not available, the `Import-Module` command fails.
 
 ```yaml
@@ -665,7 +665,7 @@ Accept wildcard characters: False
 ### -TypesToProcess
 Specifies the type files (.ps1xml) that run when the module is imported.
 
-When you import the module, Windows PowerShell runs the `Update-TypeData` cmdlet with the specified files.
+When you import the module, PowerShell runs the `Update-TypeData` cmdlet with the specified files.
 Because type files are not scoped, they affect all session states in the session.
 
 ```yaml

--- a/reference/6/PowerShellGet/Update-ScriptFileInfo.md
+++ b/reference/6/PowerShellGet/Update-ScriptFileInfo.md
@@ -234,7 +234,7 @@ Specifies a path to one or more locations.
 Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is entered.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose them in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -313,7 +313,7 @@ Accept wildcard characters: False
 
 ### -RequiredModules
 Specifies modules that must be in the global session state.
-If the required modules are not in the global session state, Windows PowerShell imports them.
+If the required modules are not in the global session state, PowerShell imports them.
 
 ```yaml
 Type: Object[]


### PR DESCRIPTION
It's a partial fix of #2747 - for the PowerShellGet module only.

This is the second try - the previous one #2776 was reverted.

Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [x] This PR partially fixes the issue, and issue #2747 tracks the remaining work