### PR TITLE
Fix for #2528 Update parameters for the Add-Type cmdlet

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Add-Type.md
@@ -12,70 +12,59 @@ title:  Add-Type
 
 ## SYNOPSIS
 
-Adds a Microsoft .NET Framework type (a class) to a Windows PowerShell session.
+Adds a Microsoft .NET Core type (a class) to a PowerShell session.
 
 ## SYNTAX
 
 ### FromSource (Default)
 
 ```
-Add-Type [-CodeDomProvider <CodeDomProvider>] [-CompilerParameters <CompilerParameters>]
- [-TypeDefinition] <String> [-Language <Language>] [-ReferencedAssemblies <String[]>]
- [-OutputAssembly <String>] [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings]
- [<CommonParameters>]
+Add-Type [-TypeDefinition] <string> [-Language <Language>] [-ReferencedAssemblies <string[]>] [-OutputAssembly <string>] [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings] [-CompilerOptions <string[]>] [<CommonParameters>]
 ```
 
 ### FromMember
 
 ```
-Add-Type [-CodeDomProvider <CodeDomProvider>] [-CompilerParameters <CompilerParameters>] [-Name] <String>
- [-MemberDefinition] <String[]> [-Namespace <String>] [-UsingNamespace <String[]>] [-Language <Language>]
- [-ReferencedAssemblies <String[]>] [-OutputAssembly <String>] [-OutputType <OutputAssemblyType>] [-PassThru]
- [-IgnoreWarnings] [<CommonParameters>]
-```
-
-### FromLiteralPath
-
-```
-Add-Type [-CompilerParameters <CompilerParameters>] -LiteralPath <String[]> [-ReferencedAssemblies <String[]>]
- [-OutputAssembly <String>] [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings]
- [<CommonParameters>]
+Add-Type [-Name] <string> [-MemberDefinition] <string[]> [-Namespace <string>] [-UsingNamespace <string[]>] [-Language <Language>] [-ReferencedAssemblies <string[]>] [-OutputAssembly <string>] [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings] [-CompilerOptions <string[]>] [<CommonParameters>]
 ```
 
 ### FromPath
 
 ```
-Add-Type [-CompilerParameters <CompilerParameters>] [-Path] <String[]> [-ReferencedAssemblies <String[]>]
- [-OutputAssembly <String>] [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings]
- [<CommonParameters>]
+Add-Type [-Path] <string[]> [-ReferencedAssemblies <string[]>] [-OutputAssembly <string>] [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings] [-CompilerOptions <string[]>] [<CommonParameters>]
+```
+
+### FromLiteralPath
+
+```
+Add-Type -LiteralPath <string[]> [-ReferencedAssemblies <string[]>] [-OutputAssembly <string>] [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings] [-CompilerOptions <string[]>] [<CommonParameters>]
 ```
 
 ### FromAssemblyName
 
 ```
-Add-Type -AssemblyName <String[]> [-PassThru] [-IgnoreWarnings] [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] [<CommonParameters>]
+Add-Type -AssemblyName <string[]> [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The **Add-Type** cmdlet lets you define a Microsoft .NET Framework class in your Windows PowerShell session.
-You can then instantiate objects (by using the New-Object cmdlet) and use the objects, just as you would use any .NET Framework object.
-If you add an **Add-Type** command to your Windows PowerShell profile, the class is available in all Windows PowerShell sessions.
+The `Add-Type` cmdlet lets you define a Microsoft .NET Core class in your PowerShell session.
+You can then instantiate objects (by using the New-Object cmdlet) and use the objects, just as you would use any .NET Core object.
+If you add an `Add-Type` command to your PowerShell profile, the class is available in all PowerShell sessions.
 
 You can specify the type by specifying an existing assembly or source code files, or you can specify the source code inline or saved in a variable.
-You can even specify only a method and **Add-Type** will define and generate the class.
-You can use this feature to make Platform Invoke (P/Invoke) calls to unmanaged functions in Windows PowerShell.
-If you specify source code, **Add-Type** compiles the specified source code and generates an in-memory assembly that contains the new .NET Framework types.
+You can even specify only a method and `Add-Type` will define and generate the class.
+You can use this feature to make Platform Invoke (P/Invoke) calls to unmanaged functions in PowerShell.
+If you specify source code, `Add-Type` compiles the specified source code and generates an in-memory assembly that contains the new .NET Core types.
 
-You can use the parameters of **Add-Type** to specify an alternate language and compiler (C# is the default), compiler options, assembly dependencies, the class namespace, the names of the type, and the resulting assembly.
+You can use the parameters of `Add-Type` to specify an alternate language and compiler (C# is the default), compiler options, assembly dependencies, the class namespace, the names of the type, and the resulting assembly.
 
 ## EXAMPLES
 
 ### Example 1: Add a .NET type to a session
 
-```
-PS C:\> $Source = @"
+```powershell
+PS> $Source = @"
 public class BasicTest
 {
   public static int Add(int a, int b)
@@ -89,121 +78,117 @@ public class BasicTest
 }
 "@
 
-PS C:\> Add-Type -TypeDefinition $Source
-PS C:\> [BasicTest]::Add(4, 3)
-PS C:\> $BasicTestObject = New-Object BasicTest
-PS C:\> $BasicTestObject.Multiply(5, 2)
+PS> Add-Type -TypeDefinition $Source
+PS> [BasicTest]::Add(4, 3)
+PS> $BasicTestObject = New-Object BasicTest
+PS> $BasicTestObject.Multiply(5, 2)
 ```
 
 These commands add the BasicTest class to the session by specifying source code that is stored in a variable.
 The type has a static method called Add and a non-static method called Multiply.
 
-The first command stores the source code for the class in the $Source variable.
+The first command stores the source code for the class in the `$Source` variable.
 
-The second command uses the **Add-Type** cmdlet to add the class to the session.
-Because it is using inline source code, the command uses the *TypeDefinition* parameter to specify the code in the $Source variable.
+The second command uses the `Add-Type` cmdlet to add the class to the session.
+Because it is using inline source code, the command uses the **TypeDefinition** parameter to specify the code in the `$Source` variable.
 
 The remaining commands use the new class.
 
 The third command calls the Add static method of the BasicTest class.
 It uses the double-colon characters (::) to specify a static member of the class.
 
-The fourth command uses the **New-Object** cmdlet to instantiate an instance of the BasicTest class.
-It saves the new object in the $BasicTestObject variable.
+The fourth command uses the `New-Object` cmdlet to instantiate an instance of the BasicTest class.
+It saves the new object in the `$BasicTestObject` variable.
 
-The fifth command uses the Multiply method of $BasicTestObject.
+The fifth command uses the Multiply method of `$BasicTestObject`.
 
 ### Example 2: Examine an added type
 
+```powershell
+PS> [BasicTest] | Get-Member
 ```
-PS C:\> [BasicTest] | Get-Member
-PS C:\> [BasicTest] | Get-Member -Static
-PS C:\> $BasicTestObject | Get-Member
-PS C:\> [BasicTest] | Get-Member
-TypeName: System.RuntimeType
+
+```output
+   TypeName: System.RuntimeType
+
 Name                           MemberType Definition
 ----                           ---------- ----------
-Clone                          Method     System.ObjectClone(
-Equals                         Method     System.BooleanEquals
-FindInterfaces                 Method     System.Type[] FindInt... 
-PS C:\> [BasicTest] | Get-Member -Static
-TypeName: BasicTest
-Name            MemberType Definition
-----            ---------- ----------
-Add             Method     static System.Int32 Add(Int32 a, Int32 b)
-Equals          Method     static System.Boolean Equals(Object objA,
-ReferenceEquals Method     static System.Boolean ReferenceEquals(Obj 
-PS C:\> $basicTestObject | Get-Member
-TypeName: BasicTest
-Name        MemberType Definition
-----        ---------- ----------
-Equals      Method     System.Boolean Equals(Object obj)
-GetHashCode Method     System.Int32 GetHashCode()
-GetType     Method     System.Type GetType()
-Multiply    Method     System.Int32 Multiply(Int32 a, Int32 b)
-ToString    Method     System.String ToString()
+AsType                         Method     type AsType()
+Clone                          Method     System.Object I
+Equals                         Method     bool Equals(Sys
+FindInterfaces                 Method     type[] FindInter...
+...
 ```
 
-These commands use the Get-Member cmdlet to examine the objects that the **Add-Type** and New-Object cmdlets created in the previous example.
+```powershell
+PS> [BasicTest] | Get-Member -Static
+```
 
-The first command uses the **Get-Member** cmdlet to get the type and members of the BasicTest class that **Add-Type** added to the session.
-The **Get-Member** command reveals that it is a **System.RuntimeType** object, which is derived from the System.Object class.
+```output
+   TypeName: BasicTest
 
-The second command uses the *Static* parameter of the **Get-Member** cmdlet to get the static properties and methods of the BasicTest class.
+Name            MemberType Definition
+----            ---------- ----------
+Add             Method     static int Add(int a, int b)
+Equals          Method     static bool Equals(System.Obj
+new             Method     BasicTest new()
+ReferenceEquals Method     static bool ReferenceEquals(S
+```
+
+```powershell
+PS> $BasicTestObject | Get-Member
+```
+
+```output
+   TypeName: BasicTest
+
+Name        MemberType Definition
+----        ---------- ----------
+Equals      Method     bool Equals(System.Object obj)
+GetHashCode Method     int GetHashCode()
+GetType     Method     type GetType()
+Multiply    Method     int Multiply(int a, int b)
+ToString    Method     string ToString()
+```
+
+These commands use the `Get-Member` cmdlet to examine the objects that the `Add-Type` and `New-Object` cmdlets created in the previous example.
+
+The first command uses the `Get-Member` cmdlet to get the type and members of the BasicTest class that `Add-Type` added to the session.
+The `Get-Member` command reveals that it is a **System.RuntimeType** object, which is derived from the System.Object class.
+
+The second command uses the **Static** parameter of the `Get-Member` cmdlet to get the static properties and methods of the BasicTest class.
 The output shows that the Add method is included.
 
-The third command uses the Get-Member cmdlet to get the members of the object stored in the $BasicTestObject variable.
-This was the object instance that was created by using the New-Object cmdlet with the $BasicType class.
+The third command uses the `Get-Member` cmdlet to get the members of the object stored in the `$BasicTestObject` variable.
+This was the object instance that was created by using the `New-Object` cmdlet with the BasicTest class.
 
-The output reveals that the value of the $BasicTestObject variable is an instance of the BasicTest class and that it includes a member called Multiply.
+The output reveals that the value of the `$BasicTestObject` variable is an instance of the BasicTest class and that it includes a member called Multiply.
 
 ### Example 3: Add types from an assembly
 
-```
-PS C:\> $AccType = Add-Type -AssemblyName "accessib*" -PassThru
+```powershell
+PS> Set-Location -Path $PSHOME
+PS> $AccType = Add-Type -AssemblyName *jsonschema* -PassThru
 ```
 
-This command adds the classes from the Accessibility assembly to the current session.
+This command adds the classes from the NJsonSchema.dll assembly to the current session.
 The command uses the **AssemblyName** parameter to specify the name of the assembly.
 The wildcard character allows you to get the correct assembly even when you are not sure of the name or its spelling.
 
-The command uses the *PassThru* parameter to generate objects that represent the classes that are added to the session, and it saves the objects in the $AccType variable.
+The command uses the **PassThru** parameter to generate objects that represent the classes that are added to the session, and it saves the objects in the `$AccType` variable.
 
-### Example 4: Add a type from a Visual Basic file
+### Example 4: Call native Windows APIs
 
-```
-PS C:\> Add-Type -Path "c:\ps-test\Hello.vb"
-PS C:\> [VBFromFile]::SayHello(", World")
+This example works only on Windows.
 
-# From Hello.vb
-
-Public Class VBFromFile
-  Public Shared Function SayHello(sourceName As String) As String
-    Dim myValue As String = "Hello"
-    return myValue + sourceName
-  End Function
-End Class
-
-Hello, World
-```
-
-This example uses the **Add-Type** cmdlet to add the VBFromFile class that is defined in the Hello.vb file to the current session.
-The text of the Hello.vb file is shown in the command output.
-
-The first command uses the **Add-Type** cmdlet to add the type defined in the Hello.vb file to the current session.
-The command uses the *Path* parameter to specify the source file.
-
-The second command calls the SayHello function as a static method of the VBFromFile class.
-
-### Example 5: Call native Windows APIs
-
-```
-PS C:\> $Signature = @"
+```powershell
+$Signature = @"
 [DllImport("user32.dll")]public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
 "@
+
 $ShowWindowAsync = Add-Type -MemberDefinition $Signature -Name "Win32ShowWindowAsync" -Namespace Win32Functions -PassThru
 
-# Minimize the Windows PowerShell console
+# Minimize the PowerShell console
 
 $ShowWindowAsync::ShowWindowAsync((Get-Process -Id $pid).MainWindowHandle, 2)
 
@@ -212,84 +197,43 @@ $ShowWindowAsync::ShowWindowAsync((Get-Process -Id $pid).MainWindowHandle, 2)
 $ShowWindowAsync::ShowWindowAsync((Get-Process -Id $Pid).MainWindowHandle, 4)
 ```
 
-The commands in this example demonstrate how to call native Windows APIs in Windows PowerShell.
-**Add-Type** uses the Platform Invoke (P/Invoke) mechanism to call a function in User32.dll from Windows PowerShell.
+The commands in this example demonstrate how to call native Windows APIs in PowerShell.
+`Add-Type` uses the Platform Invoke (P/Invoke) mechanism to call a function in User32.dll from PowerShell.
 
-The first command stores the C# signature of the **ShowWindowAsync** function in the $Signature variable.
+The first command stores the C# signature of the `ShowWindowAsync` function in the `$Signature` variable.
 (For more information, see [ShowWindowAsync function](https://go.microsoft.com/fwlink/?LinkId=143643) in the MSDN library.)
-To ensure that the resulting method will be visible in a Windows PowerShell session, the "public" keyword has been added to the standard signature.
+To ensure that the resulting method will be visible in a PowerShell session, the "public" keyword has been added to the standard signature.
 
-The second command uses the **Add-Type** cmdlet to add the ShowWindowAsync function to the Windows PowerShell session as a static method of a class that **Add-Type** creates.
-The command uses the *MemberDefinition* parameter to specify the method definition saved in the $Signature variable.
+The second command uses the `Add-Type` cmdlet to add the `ShowWindowAsync` function to the PowerShell session as a static method of a class that `Add-Type` creates.
+The command uses the **MemberDefinition** parameter to specify the method definition saved in the `$Signature` variable.
 
-The command uses the *Name* and *Namespace* parameters to specify a name and namespace for the class.
-It uses the *PassThru* parameter to generate an object that represents the types, and it saves the object in the $ShowWindowAsync variable.
+The command uses the **Name** and **Namespace** parameters to specify a name and namespace for the class.
+It uses the **PassThru** parameter to generate an object that represents the types, and it saves the object in the `$ShowWindowAsync` variable.
 
 The third and fourth commands use the new ShowWindowAsync static method.
 The method takes two parameters, the window handle, and an integer specifies how the window is to be shown.
 
-The third command calls ShowWindowAsync.
-It uses the Get-Process cmdlet with the $Pid automatic variable to get the process that is hosting the current Windows PowerShell session.
+The third command calls `ShowWindowAsync`.
+It uses the `Get-Process` cmdlet with the $Pid automatic variable to get the process that is hosting the current PowerShell session.
 Then it uses the **MainWindowHandle** property of the current process and a value of 2, which represents the SW_MINIMIZE value.
 
 To restore the window, the fourth command use a value of 4 for the window position, which represents the SW_RESTORE value.
 (SW_MAXIMIZE is 3.)
-
-### Example 6: Add a method from inline JScript
-
-```
-PS C:\> Add-Type -MemberDefinition $JsMethod -Name "PrintInfo" -Language JScript
-```
-
-This command uses the **Add-Type** cmdlet to add a method from inline JScript code to the Windows PowerShell session.
-It uses the *MemberDefinition* parameter to submit source code stored in the $JsMethod variable.
-It uses the *Name* parameter to specify a name for the class that **Add-Type** creates for the method and the *Language* parameter to specify the JScript language.
-
-### Example 7: Add an F# compiler
-
-```
-PS C:\> Add-Type -Path "FSharp.Compiler.CodeDom.dll"
-PS C:\> $Provider = New-Object Microsoft.FSharp.Compiler.CodeDom.FSharpCodeProvider
-PS C:\> $FSharpCode = @"
-let rec loop n =if n <= 0 then () else beginprint_endline (string_of_int n);loop (n-1)end
-"@
-PS C:\> $FSharpType = Add-Type -TypeDefinition $FSharpCode -CodeDomProvider $Provider -PassThru | where { $_.IsPublic }
-PS C:\> $FSharpType::loop(4)4321
-```
-
-This example shows how to use the **Add-Type** cmdlet to add an F# code compiler to your Windows PowerShell session.
-To run this example in Windows PowerShell, you must have the FSharp.Compiler.CodeDom.dll that is installed with the F# language.
-
-The first command in the example uses the **Add-Type** cmdlet with the *Path* parameter to specify an assembly.
-**Add-Type** gets the types in the assembly.
-
-The second command uses the New-Object cmdlet to create an instance of the F# code provider and saves the result in the $Provider variable.
-
-The third command saves the F# code that defines the Loop method in the $FSharpCode variable.
-
-The fourth command uses the **Add-Type** cmdlet to save the public types defined in $FSharpCode in the $FSharpType variable.
-The *TypeDefinition* parameter specifies the source code that defines the types.
-The *CodeDomProvider* parameter specifies the source code compiler.
-
-The *PassThru* parameter directs **Add-Type** to return a **Runtime** object that represents the types and a pipeline operator (|) sends the **Runtime** object to the Where-Object cmdlet, which returns only the public types.
-The **Where-Object** cmdlet is used because the F# provider generates non-public types to support the resulting public type.
-
-The fifth command calls the Loop method as a static method of the type stored in the $FSharpType variable.
 
 ## PARAMETERS
 
 ### -AssemblyName
 
 Specifies the name of an assembly that includes the types.
-**Add-Type** takes the types from the specified assembly.
+`Add-Type` takes the types from the specified assembly.
 This parameter is required when you are creating types based on an assembly name.
 
 Enter the full or simple name (also known as the "partial name") of an assembly.
 Wildcard characters are permitted in the assembly name.
-If you enter a simple or partial name, **Add-Type** resolves it to the full name, and then uses the full name to load the assembly.
+If you enter a simple or partial name, `Add-Type` resolves it to the full name, and then uses the full name to load the assembly.
 
-This parameter does not accept a path or file name.
-To enter the path to the assembly dynamic-link library (DLL) file, use the *Path* parameter.
+This parameter does not accept a path or a file name.
+To enter the path to the assembly dynamic-link library (DLL) file, use the **Path** parameter.
 
 ```yaml
 Type: String[]
@@ -297,26 +241,6 @@ Parameter Sets: FromAssemblyName
 Aliases: AN
 
 Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -CodeDomProvider
-
-Specifies a code generator or compiler.
-**Add-Type** uses the specified compiler to compile the source code.
-The default is the C# compiler.
-Use this parameter if you are using a language that cannot be specified by using the *Language* parameter.
-The *CodeDomProvider* that you specify must be able to generate assemblies from source code.
-
-```yaml
-Type: CodeDomProvider
-Parameter Sets: FromSource, FromMember
-Aliases: Provider
-
-Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -331,7 +255,7 @@ These options are sent to the compiler without revision.
 This parameter allows you to direct the compiler to generate an executable file, embed resources, or set command-line options, such as the "/unsafe" option.
 This parameter implements the **CompilerParameters** class (System.CodeDom.Compiler.CompilerParameters).
 
-You cannot use the *CompilerParameters* and *ReferencedAssemblies* parameters in the same command.
+You cannot use the **CompilerParameters** and **ReferencedAssemblies** parameters in the same command.
 
 ```yaml
 Type: CompilerParameters
@@ -348,7 +272,7 @@ Accept wildcard characters: False
 ### -IgnoreWarnings
 
 Ignores compiler warnings.
-Use this parameter to prevent **Add-Type** from handling compiler warnings as errors.
+Use this parameter to prevent `Add-Type` from handling compiler warnings as errors.
 
 ```yaml
 Type: SwitchParameter
@@ -365,22 +289,14 @@ Accept wildcard characters: False
 ### -Language
 
 Specifies the language that is used in the source code.
-The **Add-Type** cmdlet uses the value of this parameter to select the appropriate *CodeDomProvider*.
-The acceptable values for this parameter are:
-
-- CSharp
-- CSharpVersion3
-- CSharpVersion2
-- VisualBasic
-- JScript
-
-CSharp is the default value.
+The `Add-Type` cmdlet uses the value of this parameter to select the appropriate *CodeDomProvider*.
+The acceptable value for this parameter is CSharp.
 
 ```yaml
 Type: Language
 Parameter Sets: FromSource, FromMember
 Aliases:
-Accepted values: CSharp, CSharpVersion2, CSharpVersion3, JScript, VisualBasic
+Accepted values: CSharp
 
 Required: False
 Position: Named
@@ -392,10 +308,10 @@ Accept wildcard characters: False
 ### -LiteralPath
 
 Specifies the path to source code files or assembly DLL files that contain the types.
-Unlike *Path*, the value of the *LiteralPath* parameter is used exactly as it is typed.
+Unlike **Path**, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String[]
@@ -412,9 +328,9 @@ Accept wildcard characters: False
 ### -MemberDefinition
 
 Specifies new properties or methods for the class.
-**Add-Type** generates the template code that is required to support the properties or methods.
+`Add-Type` generates the template code that is required to support the properties or methods.
 
-You can use this feature to make Platform Invoke (P/Invoke) calls to unmanaged functions in Windows PowerShell.
+On Windows, you can use this feature to make Platform Invoke (P/Invoke) calls to unmanaged functions in PowerShell.
 For more information, see the examples.
 
 ```yaml
@@ -436,7 +352,7 @@ This parameter is required when generating a type from a member definition.
 
 The type name and namespace must be unique within a session.
 You cannot unload a type or change it.
-If you need to change the code for a type, you must change the name or start a new Windows PowerShell session.
+If you need to change the code for a type, you must change the name or start a new PowerShell session.
 Otherwise, the command fails.
 
 ```yaml
@@ -456,7 +372,7 @@ Accept wildcard characters: False
 Specifies a namespace for the type.
 
 If this parameter is not included in the command, the type is created in the **Microsoft.PowerShell.Commands.AddType.AutoGeneratedTypes** namespace.
-If the parameter is included in the command with an empty string value or a value of $Null, the type is generated in the global namespace.
+If the parameter is included in the command with an empty string value or a value of `$Null`, the type is generated in the global namespace.
 
 ```yaml
 Type: String
@@ -475,7 +391,7 @@ Accept wildcard characters: False
 Generates a DLL file for the assembly with the specified name in the location.
 Enter a path (optional) and file name.
 Wildcard characters are permitted.
-By default, **Add-Type** generates the assembly only in memory.
+By default, `Add-Type` generates the assembly only in memory.
 
 ```yaml
 Type: String
@@ -538,11 +454,11 @@ Accept wildcard characters: False
 
 Specifies the path to source code files or assembly DLL files that contain the types.
 
-If you submit source code files, **Add-Type** compiles the code in the files and creates an in-memory assembly of the types.
-The file name extension specified in the value of Path determines the compiler that **Add-Type** uses.
+If you submit source code files, `Add-Type` compiles the code in the files and creates an in-memory assembly of the types.
+The file name extension specified in the value of **Path** determines the compiler that `Add-Type` uses.
 
-If you submit an assembly file, **Add-Type** takes the types from the assembly.
-To specify an in-memory assembly or the global assembly cache, use the *AssemblyName* parameter.
+If you submit an assembly file, `Add-Type` takes the types from the assembly.
+To specify an in-memory assembly or the global assembly cache, use the **AssemblyName** parameter.
 
 ```yaml
 Type: String[]
@@ -559,10 +475,10 @@ Accept wildcard characters: False
 ### -ReferencedAssemblies
 
 Specifies the assemblies upon which the type depends.
-By default, **Add-Type** references System.dll and System.Management.Automation.dll.
+By default, `Add-Type` references System.dll and System.Management.Automation.dll.
 The assemblies that you specify by using this parameter are referenced in addition to the default assemblies.
 
-You cannot use the *CompilerParameters* and *ReferencedAssemblies* parameters in the same command.
+You cannot use the **CompilerParameters** and **ReferencedAssemblies** parameters in the same command.
 
 ```yaml
 Type: String[]
@@ -603,9 +519,9 @@ Accept wildcard characters: False
 Specifies other namespaces that are required for the class.
 This is much like the Using keyword in C#.
 
-By default, **Add-Type** references the **System** namespace.
-When the *MemberDefinition* parameter is used, **Add-Type** also references the **System.Runtime.InteropServices** namespace by default.
-The namespaces that you add by using the *UsingNamespace* parameter are referenced in addition to the default namespaces.
+By default, `Add-Type` references the **System** namespace.
+When the **MemberDefinition** parameter is used, `Add-Type` also references the **System.Runtime.InteropServices** namespace by default.
+The namespaces that you add by using the **UsingNamespace** parameter are referenced in addition to the default namespaces.
 
 ```yaml
 Type: String[]
@@ -627,21 +543,21 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### None
 
-You cannot pipe objects to **Add-Type**.
+You cannot pipe objects to `Add-Type`.
 
 ## OUTPUTS
 
 ### None or System.Type
 
-When you use the *PassThru* parameter, **Add-Type** returns a **System.Type** object that represents the new type.
+When you use the **PassThru** parameter, `Add-Type` returns a **System.Type** object that represents the new type.
 Otherwise, this cmdlet does not generate any output.
 
 ## NOTES
 
-* The types that you add exist only in the current session. To use the types in all sessions, add them to your Windows PowerShell profile. For more information about the profile, see about_Profiles (http://go.microsoft.com/fwlink/?LinkID=113729).
-* Type names (and namespaces) must be unique within a session. You cannot unload a type or change it. If you need to change the code for a type, you must change the name or start a new Windows PowerShell session. Otherwise, the command fails.
-* The CodeDomProvider class for some languages, such as IronPython and J#, does not generate output. As a result, types written in these languages cannot be used with **Add-Type**.
-* This cmdlet is based on the **CodeDomProvider** class. For more information about this class, see the Microsoft .NET Framework SDK.
+- The types that you add exist only in the current session. To use the types in all sessions, add them to your PowerShell profile. For more information about the profile, see about_Profiles (http://go.microsoft.com/fwlink/?LinkID=113729).
+- Type names (and namespaces) must be unique within a session. You cannot unload a type or change it. If you need to change the code for a type, you must change the name or start a new PowerShell session. Otherwise, the command fails.
+- The CodeDomProvider class for some languages, such as IronPython and J#, does not generate output. As a result, types written in these languages cannot be used with `Add-Type`.
+- This cmdlet is based on the **CodeDomProvider** class. For more information about this class, see the Microsoft .NET Framework SDK.
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Add-Type.md
@@ -63,7 +63,7 @@ If you add an `Add-Type` command to your PowerShell profile, the class is availa
 
 You can specify the type by specifying an existing assembly or source code files, or you can specify the source code inline or saved in a variable.
 You can even specify only a method and `Add-Type` will define and generate the class.
-On windows, you can use this feature to make Platform Invoke (P/Invoke) calls to unmanaged functions in PowerShell.
+On Windows, you can use this feature to make Platform Invoke (P/Invoke) calls to unmanaged functions in PowerShell.
 If you specify source code, `Add-Type` compiles the specified source code and generates an in-memory assembly that contains the new .NET Core types.
 
 You can use the parameters of `Add-Type` to specify an alternate language and compiler (C# is the default), compiler options, assembly dependencies, the class namespace, the names of the type, and the resulting assembly.

--- a/reference/6/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Add-Type.md
@@ -19,42 +19,51 @@ Adds a Microsoft .NET Core type (a class) to a PowerShell session.
 ### FromSource (Default)
 
 ```
-Add-Type [-TypeDefinition] <string> [-Language <Language>] [-ReferencedAssemblies <string[]>] [-OutputAssembly <string>] [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings] [-CompilerOptions <string[]>] [<CommonParameters>]
+Add-Type [-TypeDefinition] <String> [-Language <Language>] [-ReferencedAssemblies <String[]>]
+ [-OutputAssembly <String>] [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings]
+ [-CompilerOptions <String[]>] [<CommonParameters>]
 ```
 
 ### FromMember
 
 ```
-Add-Type [-Name] <string> [-MemberDefinition] <string[]> [-Namespace <string>] [-UsingNamespace <string[]>] [-Language <Language>] [-ReferencedAssemblies <string[]>] [-OutputAssembly <string>] [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings] [-CompilerOptions <string[]>] [<CommonParameters>]
+Add-Type [-Name] <String> [-MemberDefinition] <String[]> [-Namespace <String>] [-UsingNamespace <String[]>]
+ [-Language <Language>] [-ReferencedAssemblies <String[]>] [-OutputAssembly <String>]
+ [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings] [-CompilerOptions <String[]>]
+ [<CommonParameters>]
 ```
 
 ### FromPath
 
 ```
-Add-Type [-Path] <string[]> [-ReferencedAssemblies <string[]>] [-OutputAssembly <string>] [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings] [-CompilerOptions <string[]>] [<CommonParameters>]
+Add-Type [-Path] <String[]> [-ReferencedAssemblies <String[]>] [-OutputAssembly <String>]
+ [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings] [-CompilerOptions <String[]>]
+ [<CommonParameters>]
 ```
 
 ### FromLiteralPath
 
 ```
-Add-Type -LiteralPath <string[]> [-ReferencedAssemblies <string[]>] [-OutputAssembly <string>] [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings] [-CompilerOptions <string[]>] [<CommonParameters>]
+Add-Type -LiteralPath <String[]> [-ReferencedAssemblies <String[]>] [-OutputAssembly <String>]
+ [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings] [-CompilerOptions <String[]>]
+ [<CommonParameters>]
 ```
 
 ### FromAssemblyName
 
 ```
-Add-Type -AssemblyName <string[]> [-PassThru] [<CommonParameters>]
+Add-Type -AssemblyName <String[]> [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 The `Add-Type` cmdlet lets you define a Microsoft .NET Core class in your PowerShell session.
-You can then instantiate objects (by using the New-Object cmdlet) and use the objects, just as you would use any .NET Core object.
+You can then instantiate objects (by using the `New-Object` cmdlet) and use the objects, just as you would use any .NET Core object.
 If you add an `Add-Type` command to your PowerShell profile, the class is available in all PowerShell sessions.
 
 You can specify the type by specifying an existing assembly or source code files, or you can specify the source code inline or saved in a variable.
 You can even specify only a method and `Add-Type` will define and generate the class.
-You can use this feature to make Platform Invoke (P/Invoke) calls to unmanaged functions in PowerShell.
+On windows, you can use this feature to make Platform Invoke (P/Invoke) calls to unmanaged functions in PowerShell.
 If you specify source code, `Add-Type` compiles the specified source code and generates an in-memory assembly that contains the new .NET Core types.
 
 You can use the parameters of `Add-Type` to specify an alternate language and compiler (C# is the default), compiler options, assembly dependencies, the class namespace, the names of the type, and the resulting assembly.
@@ -214,7 +223,7 @@ The third and fourth commands use the new ShowWindowAsync static method.
 The method takes two parameters, the window handle, and an integer specifies how the window is to be shown.
 
 The third command calls `ShowWindowAsync`.
-It uses the `Get-Process` cmdlet with the $Pid automatic variable to get the process that is hosting the current PowerShell session.
+It uses the `Get-Process` cmdlet with the $PID automatic variable to get the process that is hosting the current PowerShell session.
 Then it uses the **MainWindowHandle** property of the current process and a value of 2, which represents the SW_MINIMIZE value.
 
 To restore the window, the fourth command use a value of 4 for the window position, which represents the SW_RESTORE value.
@@ -247,20 +256,19 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -CompilerParameters
+### -CompilerOptions
 
 Specifies the options for the source code compiler.
 These options are sent to the compiler without revision.
 
 This parameter allows you to direct the compiler to generate an executable file, embed resources, or set command-line options, such as the "/unsafe" option.
-This parameter implements the **CompilerParameters** class (System.CodeDom.Compiler.CompilerParameters).
 
-You cannot use the **CompilerParameters** and **ReferencedAssemblies** parameters in the same command.
+You cannot use the **CompilerOptions** and **ReferencedAssemblies** parameters in the same command.
 
 ```yaml
-Type: CompilerParameters
-Parameter Sets: FromSource, FromMember, FromLiteralPath, FromPath
-Aliases: CP
+Type: String[]
+Parameter Sets: FromSource, FromMember, FromPath, FromLiteralPath
+Aliases:
 
 Required: False
 Position: Named
@@ -289,7 +297,6 @@ Accept wildcard characters: False
 ### -Language
 
 Specifies the language that is used in the source code.
-The `Add-Type` cmdlet uses the value of this parameter to select the appropriate *CodeDomProvider*.
 The acceptable value for this parameter is CSharp.
 
 ```yaml
@@ -478,7 +485,7 @@ Specifies the assemblies upon which the type depends.
 By default, `Add-Type` references System.dll and System.Management.Automation.dll.
 The assemblies that you specify by using this parameter are referenced in addition to the default assemblies.
 
-You cannot use the **CompilerParameters** and **ReferencedAssemblies** parameters in the same command.
+You cannot use the **CompilerOptions** and **ReferencedAssemblies** parameters in the same command.
 
 ```yaml
 Type: String[]
@@ -556,8 +563,6 @@ Otherwise, this cmdlet does not generate any output.
 
 - The types that you add exist only in the current session. To use the types in all sessions, add them to your PowerShell profile. For more information about the profile, see about_Profiles (http://go.microsoft.com/fwlink/?LinkID=113729).
 - Type names (and namespaces) must be unique within a session. You cannot unload a type or change it. If you need to change the code for a type, you must change the name or start a new PowerShell session. Otherwise, the command fails.
-- The CodeDomProvider class for some languages, such as IronPython and J#, does not generate output. As a result, types written in these languages cannot be used with `Add-Type`.
-- This cmdlet is based on the **CodeDomProvider** class. For more information about this class, see the Microsoft .NET Framework SDK.
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Utility/Add-Type.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Add-Type.md
@@ -11,11 +11,13 @@ title:  Add-Type
 # Add-Type
 
 ## SYNOPSIS
+
 Adds a Microsoft .NET Framework type (a class) to a Windows PowerShell session.
 
 ## SYNTAX
 
 ### FromSource (Default)
+
 ```
 Add-Type [-CodeDomProvider <CodeDomProvider>] [-CompilerParameters <CompilerParameters>]
  [-TypeDefinition] <String> [-Language <Language>] [-ReferencedAssemblies <String[]>]
@@ -24,6 +26,7 @@ Add-Type [-CodeDomProvider <CodeDomProvider>] [-CompilerParameters <CompilerPara
 ```
 
 ### FromMember
+
 ```
 Add-Type [-CodeDomProvider <CodeDomProvider>] [-CompilerParameters <CompilerParameters>] [-Name] <String>
  [-MemberDefinition] <String[]> [-Namespace <String>] [-UsingNamespace <String[]>] [-Language <Language>]
@@ -32,6 +35,7 @@ Add-Type [-CodeDomProvider <CodeDomProvider>] [-CompilerParameters <CompilerPara
 ```
 
 ### FromLiteralPath
+
 ```
 Add-Type [-CompilerParameters <CompilerParameters>] -LiteralPath <String[]> [-ReferencedAssemblies <String[]>]
  [-OutputAssembly <String>] [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings]
@@ -39,6 +43,7 @@ Add-Type [-CompilerParameters <CompilerParameters>] -LiteralPath <String[]> [-Re
 ```
 
 ### FromPath
+
 ```
 Add-Type [-CompilerParameters <CompilerParameters>] [-Path] <String[]> [-ReferencedAssemblies <String[]>]
  [-OutputAssembly <String>] [-OutputType <OutputAssemblyType>] [-PassThru] [-IgnoreWarnings]
@@ -46,12 +51,14 @@ Add-Type [-CompilerParameters <CompilerParameters>] [-Path] <String[]> [-Referen
 ```
 
 ### FromAssemblyName
+
 ```
 Add-Type -AssemblyName <String[]> [-PassThru] [-IgnoreWarnings] [-InformationAction <ActionPreference>]
  [-InformationVariable <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 The **Add-Type** cmdlet lets you define a Microsoft .NET Framework class in your Windows PowerShell session.
 You can then instantiate objects (by using the New-Object cmdlet) and use the objects, just as you would use any .NET Framework object.
 If you add an **Add-Type** command to your Windows PowerShell profile, the class is available in all Windows PowerShell sessions.
@@ -66,6 +73,7 @@ You can use the parameters of **Add-Type** to specify an alternate language and 
 ## EXAMPLES
 
 ### Example 1: Add a .NET type to a session
+
 ```
 PS C:\> $Source = @"
 public class BasicTest
@@ -106,6 +114,7 @@ It saves the new object in the $BasicTestObject variable.
 The fifth command uses the Multiply method of $BasicTestObject.
 
 ### Example 2: Examine an added type
+
 ```
 PS C:\> [BasicTest] | Get-Member
 PS C:\> [BasicTest] | Get-Member -Static
@@ -149,6 +158,7 @@ This was the object instance that was created by using the New-Object cmdlet wit
 The output reveals that the value of the $BasicTestObject variable is an instance of the BasicTest class and that it includes a member called Multiply.
 
 ### Example 3: Add types from an assembly
+
 ```
 PS C:\> $AccType = Add-Type -AssemblyName "accessib*" -PassThru
 ```
@@ -160,6 +170,7 @@ The wildcard character allows you to get the correct assembly even when you are 
 The command uses the *PassThru* parameter to generate objects that represent the classes that are added to the session, and it saves the objects in the $AccType variable.
 
 ### Example 4: Add a type from a Visual Basic file
+
 ```
 PS C:\> Add-Type -Path "c:\ps-test\Hello.vb"
 PS C:\> [VBFromFile]::SayHello(", World")
@@ -185,6 +196,7 @@ The command uses the *Path* parameter to specify the source file.
 The second command calls the SayHello function as a static method of the VBFromFile class.
 
 ### Example 5: Call native Windows APIs
+
 ```
 PS C:\> $Signature = @"
 [DllImport("user32.dll")]public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
@@ -224,6 +236,7 @@ To restore the window, the fourth command use a value of 4 for the window positi
 (SW_MAXIMIZE is 3.)
 
 ### Example 6: Add a method from inline JScript
+
 ```
 PS C:\> Add-Type -MemberDefinition $JsMethod -Name "PrintInfo" -Language JScript
 ```
@@ -233,6 +246,7 @@ It uses the *MemberDefinition* parameter to submit source code stored in the $Js
 It uses the *Name* parameter to specify a name for the class that **Add-Type** creates for the method and the *Language* parameter to specify the JScript language.
 
 ### Example 7: Add an F# compiler
+
 ```
 PS C:\> Add-Type -Path "FSharp.Compiler.CodeDom.dll"
 PS C:\> $Provider = New-Object Microsoft.FSharp.Compiler.CodeDom.FSharpCodeProvider
@@ -265,6 +279,7 @@ The fifth command calls the Loop method as a static method of the type stored in
 ## PARAMETERS
 
 ### -AssemblyName
+
 Specifies the name of an assembly that includes the types.
 **Add-Type** takes the types from the specified assembly.
 This parameter is required when you are creating types based on an assembly name.
@@ -289,6 +304,7 @@ Accept wildcard characters: False
 ```
 
 ### -CodeDomProvider
+
 Specifies a code generator or compiler.
 **Add-Type** uses the specified compiler to compile the source code.
 The default is the C# compiler.
@@ -308,6 +324,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompilerParameters
+
 Specifies the options for the source code compiler.
 These options are sent to the compiler without revision.
 
@@ -329,6 +346,7 @@ Accept wildcard characters: False
 ```
 
 ### -IgnoreWarnings
+
 Ignores compiler warnings.
 Use this parameter to prevent **Add-Type** from handling compiler warnings as errors.
 
@@ -345,6 +363,7 @@ Accept wildcard characters: False
 ```
 
 ### -Language
+
 Specifies the language that is used in the source code.
 The **Add-Type** cmdlet uses the value of this parameter to select the appropriate *CodeDomProvider*.
 The acceptable values for this parameter are:
@@ -371,6 +390,7 @@ Accept wildcard characters: False
 ```
 
 ### -LiteralPath
+
 Specifies the path to source code files or assembly DLL files that contain the types.
 Unlike *Path*, the value of the *LiteralPath* parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
@@ -390,6 +410,7 @@ Accept wildcard characters: False
 ```
 
 ### -MemberDefinition
+
 Specifies new properties or methods for the class.
 **Add-Type** generates the template code that is required to support the properties or methods.
 
@@ -409,6 +430,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Specifies the name of the class to create.
 This parameter is required when generating a type from a member definition.
 
@@ -430,6 +452,7 @@ Accept wildcard characters: False
 ```
 
 ### -Namespace
+
 Specifies a namespace for the type.
 
 If this parameter is not included in the command, the type is created in the **Microsoft.PowerShell.Commands.AddType.AutoGeneratedTypes** namespace.
@@ -448,6 +471,7 @@ Accept wildcard characters: False
 ```
 
 ### -OutputAssembly
+
 Generates a DLL file for the assembly with the specified name in the location.
 Enter a path (optional) and file name.
 Wildcard characters are permitted.
@@ -466,6 +490,7 @@ Accept wildcard characters: False
 ```
 
 ### -OutputType
+
 Specifies the output type of the output assembly.
 The acceptable values for this parameter are:
 
@@ -493,6 +518,7 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns a **System.Runtime** object that represents the types that were added.
 By default, this cmdlet does not generate any output.
 
@@ -509,6 +535,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specifies the path to source code files or assembly DLL files that contain the types.
 
 If you submit source code files, **Add-Type** compiles the code in the files and creates an in-memory assembly of the types.
@@ -530,6 +557,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReferencedAssemblies
+
 Specifies the assemblies upon which the type depends.
 By default, **Add-Type** references System.dll and System.Management.Automation.dll.
 The assemblies that you specify by using this parameter are referenced in addition to the default assemblies.
@@ -549,6 +577,7 @@ Accept wildcard characters: False
 ```
 
 ### -TypeDefinition
+
 Specifies the source code that contains the type definitions.
 Enter the source code in a string or here-string, or enter a variable that contains the source code.
 For more information about here-strings, see about_Quoting_Rules (http://go.microsoft.com/fwlink/?LinkID=113253).
@@ -570,6 +599,7 @@ Accept wildcard characters: False
 ```
 
 ### -UsingNamespace
+
 Specifies other namespaces that are required for the class.
 This is much like the Using keyword in C#.
 
@@ -590,20 +620,24 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None
+
 You cannot pipe objects to **Add-Type**.
 
 ## OUTPUTS
 
 ### None or System.Type
+
 When you use the *PassThru* parameter, **Add-Type** returns a **System.Type** object that represents the new type.
 Otherwise, this cmdlet does not generate any output.
 
 ## NOTES
+
 * The types that you add exist only in the current session. To use the types in all sessions, add them to your Windows PowerShell profile. For more information about the profile, see about_Profiles (http://go.microsoft.com/fwlink/?LinkID=113729).
 * Type names (and namespaces) must be unique within a session. You cannot unload a type or change it. If you need to change the code for a type, you must change the name or start a new Windows PowerShell session. Otherwise, the command fails.
 * The CodeDomProvider class for some languages, such as IronPython and J#, does not generate output. As a result, types written in these languages cannot be used with **Add-Type**.


### PR DESCRIPTION
Fix for #2528.

Fix the syntax block.
Remove the CodeDomProvider parameter.
Remove the CompilerParameters parameter.
Add the CompilerOptions parameter.
Change "Windows PowerShell" to "PowerShell" and ".NET Framework" to ".NET Core".
Change prompts to "PS>".
Remove examples that are irrelevant.
Fix other examples.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work