### PR TITLE
Fix a typo in Get-ChildItem.md.

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -292,7 +292,7 @@ Accept wildcard characters: True
 ### -FollowSymlink
 
 By default, the `Get-ChildItem` cmdlet displays symbolic links to directories found during recursion, but does not recurse into them.
-Use the **FolowSymlink** switch to search the directories that those symbolic links target.
+Use the **FollowSymlink** switch to search the directories that those symbolic links target.
 The **FollowSymlink** is a dynamic parameter and it is supported only in the FileSystem provider.
 
 ```yaml


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [x] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work