### PR TITLE
Fix DynamicParam sample function

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -650,11 +650,11 @@ of the parameter, such as `Mandatory`, `Position`, or `ValueFromPipeline` or its
 parameter set.
 
 The following example shows a sample function with standard parameters named
-`Name` and `Path`, and an optional dynamic parameter named `DP1`.The `DP1`
-parameter is in the `PSet1` parameter set and has a type of `Int32`. The `DP1`
-parameter is available in the Sample function only when the value of the `Path`
-parameter contains "HKLM:", indicating that it is being used in the
-HKEY_LOCAL_MACHINE registry drive.
+**Name** and **Path**, and an optional dynamic parameter named **DP1**.
+The **DP1** parameter is in the PSet1 parameter set and has a type of `Int32`.
+The **DP1** parameter is available in the `Get-Sample` function
+only when the value of the **Path** parameter starts with "HKLM:",
+indicating that it is being used in the HKEY_LOCAL_MACHINE registry drive.
 
 ```powershell
 function Get-Sample {
@@ -663,23 +663,23 @@ function Get-Sample {
 
   DynamicParam
   {
-    if ($path -match ".HKLM.:")
+    if ($Path.StartsWith("HKLM:"))
     {
       $attributes = New-Object -Type `
         System.Management.Automation.ParameterAttribute
-      $attributes.ParameterSetName = "__AllParameterSets"
+      $attributes.ParameterSetName = "PSet1"
       $attributes.Mandatory = $false
       $attributeCollection = New-Object `
         -Type System.Collections.ObjectModel.Collection[System.Attribute]
       $attributeCollection.Add($attributes)
 
       $dynParam1 = New-Object -Type `
-        System.Management.Automation.RuntimeDefinedParameter("dp1", [Int32],
+        System.Management.Automation.RuntimeDefinedParameter("DP1", [Int32],
           $attributeCollection)
 
       $paramDictionary = New-Object `
         -Type System.Management.Automation.RuntimeDefinedParameterDictionary
-      $paramDictionary.Add("dp1", $dynParam1)
+      $paramDictionary.Add("DP1", $dynParam1)
       return $paramDictionary
     }
   }

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -650,11 +650,11 @@ of the parameter, such as `Mandatory`, `Position`, or `ValueFromPipeline` or its
 parameter set.
 
 The following example shows a sample function with standard parameters named
-`Name` and `Path`, and an optional dynamic parameter named `DP1`.The `DP1`
-parameter is in the `PSet1` parameter set and has a type of `Int32`. The `DP1`
-parameter is available in the Sample function only when the value of the `Path`
-parameter contains "HKLM:", indicating that it is being used in the
-HKEY_LOCAL_MACHINE registry drive.
+**Name** and **Path**, and an optional dynamic parameter named **DP1**.
+The **DP1** parameter is in the PSet1 parameter set and has a type of `Int32`.
+The **DP1** parameter is available in the `Get-Sample` function
+only when the value of the **Path** parameter starts with "HKLM:",
+indicating that it is being used in the HKEY_LOCAL_MACHINE registry drive.
 
 ```powershell
 function Get-Sample {
@@ -663,23 +663,23 @@ function Get-Sample {
 
   DynamicParam
   {
-    if ($path -match ".HKLM.:")
+    if ($Path.StartsWith("HKLM:"))
     {
       $attributes = New-Object -Type `
         System.Management.Automation.ParameterAttribute
-      $attributes.ParameterSetName = "__AllParameterSets"
+      $attributes.ParameterSetName = "PSet1"
       $attributes.Mandatory = $false
       $attributeCollection = New-Object `
         -Type System.Collections.ObjectModel.Collection[System.Attribute]
       $attributeCollection.Add($attributes)
 
       $dynParam1 = New-Object -Type `
-        System.Management.Automation.RuntimeDefinedParameter("dp1", [Int32],
+        System.Management.Automation.RuntimeDefinedParameter("DP1", [Int32],
           $attributeCollection)
 
       $paramDictionary = New-Object `
         -Type System.Management.Automation.RuntimeDefinedParameterDictionary
-      $paramDictionary.Add("dp1", $dynParam1)
+      $paramDictionary.Add("DP1", $dynParam1)
       return $paramDictionary
     }
   }

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -650,11 +650,11 @@ of the parameter, such as `Mandatory`, `Position`, or `ValueFromPipeline` or its
 parameter set.
 
 The following example shows a sample function with standard parameters named
-`Name` and `Path`, and an optional dynamic parameter named `DP1`.The `DP1`
-parameter is in the `PSet1` parameter set and has a type of `Int32`. The `DP1`
-parameter is available in the Sample function only when the value of the `Path`
-parameter contains "HKLM:", indicating that it is being used in the
-HKEY_LOCAL_MACHINE registry drive.
+**Name** and **Path**, and an optional dynamic parameter named **DP1**.
+The **DP1** parameter is in the PSet1 parameter set and has a type of `Int32`.
+The **DP1** parameter is available in the `Get-Sample` function
+only when the value of the **Path** parameter starts with "HKLM:",
+indicating that it is being used in the HKEY_LOCAL_MACHINE registry drive.
 
 ```powershell
 function Get-Sample {
@@ -663,23 +663,23 @@ function Get-Sample {
 
   DynamicParam
   {
-    if ($path -match ".HKLM.:")
+    if ($Path.StartsWith("HKLM:"))
     {
       $attributes = New-Object -Type `
         System.Management.Automation.ParameterAttribute
-      $attributes.ParameterSetName = "__AllParameterSets"
+      $attributes.ParameterSetName = "PSet1"
       $attributes.Mandatory = $false
       $attributeCollection = New-Object `
         -Type System.Collections.ObjectModel.Collection[System.Attribute]
       $attributeCollection.Add($attributes)
 
       $dynParam1 = New-Object -Type `
-        System.Management.Automation.RuntimeDefinedParameter("dp1", [Int32],
+        System.Management.Automation.RuntimeDefinedParameter("DP1", [Int32],
           $attributeCollection)
 
       $paramDictionary = New-Object `
         -Type System.Management.Automation.RuntimeDefinedParameterDictionary
-      $paramDictionary.Add("dp1", $dynParam1)
+      $paramDictionary.Add("DP1", $dynParam1)
       return $paramDictionary
     }
   }

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -688,11 +688,11 @@ of the parameter, such as `Mandatory`, `Position`, or `ValueFromPipeline` or its
 parameter set.
 
 The following example shows a sample function with standard parameters named
-`Name` and `Path`, and an optional dynamic parameter named `DP1`.The `DP1`
-parameter is in the `PSet1` parameter set and has a type of `Int32`. The `DP1`
-parameter is available in the Sample function only when the value of the `Path`
-parameter contains "HKLM:", indicating that it is being used in the
-HKEY_LOCAL_MACHINE registry drive.
+**Name** and **Path**, and an optional dynamic parameter named **DP1**.
+The **DP1** parameter is in the PSet1 parameter set and has a type of `Int32`.
+The **DP1** parameter is available in the `Get-Sample` function
+only when the value of the **Path** parameter starts with "HKLM:",
+indicating that it is being used in the HKEY_LOCAL_MACHINE registry drive.
 
 ```powershell
 function Get-Sample {
@@ -701,23 +701,23 @@ function Get-Sample {
 
   DynamicParam
   {
-    if ($path -match ".HKLM.:")
+    if ($Path.StartsWith("HKLM:"))
     {
       $attributes = New-Object -Type `
         System.Management.Automation.ParameterAttribute
-      $attributes.ParameterSetName = "__AllParameterSets"
+      $attributes.ParameterSetName = "PSet1"
       $attributes.Mandatory = $false
       $attributeCollection = New-Object `
         -Type System.Collections.ObjectModel.Collection[System.Attribute]
       $attributeCollection.Add($attributes)
 
       $dynParam1 = New-Object -Type `
-        System.Management.Automation.RuntimeDefinedParameter("dp1", [Int32],
+        System.Management.Automation.RuntimeDefinedParameter("DP1", [Int32],
           $attributeCollection)
 
       $paramDictionary = New-Object `
         -Type System.Management.Automation.RuntimeDefinedParameterDictionary
-      $paramDictionary.Add("dp1", $dynParam1)
+      $paramDictionary.Add("DP1", $dynParam1)
       return $paramDictionary
     }
   }

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced_Parameters.md
@@ -688,11 +688,11 @@ of the parameter, such as `Mandatory`, `Position`, or `ValueFromPipeline` or its
 parameter set.
 
 The following example shows a sample function with standard parameters named
-`Name` and `Path`, and an optional dynamic parameter named `DP1`.The `DP1`
-parameter is in the `PSet1` parameter set and has a type of `Int32`. The `DP1`
-parameter is available in the Sample function only when the value of the `Path`
-parameter contains "HKLM:", indicating that it is being used in the
-HKEY_LOCAL_MACHINE registry drive.
+**Name** and **Path**, and an optional dynamic parameter named **DP1**.
+The **DP1** parameter is in the PSet1 parameter set and has a type of `Int32`.
+The **DP1** parameter is available in the `Get-Sample` function
+only when the value of the **Path** parameter starts with "HKLM:",
+indicating that it is being used in the HKEY_LOCAL_MACHINE registry drive.
 
 ```powershell
 function Get-Sample {
@@ -701,23 +701,23 @@ function Get-Sample {
 
   DynamicParam
   {
-    if ($path -match ".HKLM.:")
+    if ($Path.StartsWith("HKLM:"))
     {
       $attributes = New-Object -Type `
         System.Management.Automation.ParameterAttribute
-      $attributes.ParameterSetName = "__AllParameterSets"
+      $attributes.ParameterSetName = "PSet1"
       $attributes.Mandatory = $false
       $attributeCollection = New-Object `
         -Type System.Collections.ObjectModel.Collection[System.Attribute]
       $attributeCollection.Add($attributes)
 
       $dynParam1 = New-Object -Type `
-        System.Management.Automation.RuntimeDefinedParameter("dp1", [Int32],
+        System.Management.Automation.RuntimeDefinedParameter("DP1", [Int32],
           $attributeCollection)
 
       $paramDictionary = New-Object `
         -Type System.Management.Automation.RuntimeDefinedParameterDictionary
-      $paramDictionary.Add("dp1", $dynParam1)
+      $paramDictionary.Add("DP1", $dynParam1)
       return $paramDictionary
     }
   }


### PR DESCRIPTION
Fixed the following issues:
* `if ($path -match ".HKLM.:")` does not indicate the HKEY_LOCAL_MACHINE registry drive
* The **DP1** parameter is not in the "PSet1" parameter set but the "__AllParameterSets"

Also fixed some minor formatting issues.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
