### PR TITLE
 Replace Windows PowerShell with PowerShell - the Microsoft.PowerShell.Archive module

### DIFF
--- a/reference/6/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/6/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -75,7 +75,7 @@ Compress-Archive -Path C:\Reference\* -CompressionLevel Fastest -DestinationPath
 ```
 
 This command creates a new archive file, Draft.zip, in the C:\Archives folder.
-Note that though the file name extension .zip was not added to the value of the **DestinationPath** parameter, Windows PowerShell appends this to the specified archive file name automatically.
+Note that though the file name extension .zip was not added to the value of the **DestinationPath** parameter, PowerShell appends this to the specified archive file name automatically.
 The new archive file contains every file in the C:\Reference folder, because a wildcard character was used in place of specific file names in the **Path** parameter.
 The specified compression level is Fastest, which might result in a larger output file, but compresses a large number of files faster.
 
@@ -93,7 +93,7 @@ Compress-Archive -Path C:\Reference -DestinationPath C:\Archives\Draft
 ```
 
 This command creates an archive from an entire folder, C:\Reference.
-Note that though the file name extension .zip was not added to the value of the **DestinationPath** parameter, Windows PowerShell appends this to the specified archive file name automatically.
+Note that though the file name extension .zip was not added to the value of the **DestinationPath** parameter, PowerShell appends this to the specified archive file name automatically.
 
 ## PARAMETERS
 
@@ -145,7 +145,7 @@ Accept wildcard characters: False
 Specifies the path or paths to the files that you want to add to the archive zipped file.
 Unlike the **Path** parameter, the value of **LiteralPath** is used exactly as it is typed.
 No characters are interpreted as wildcards.
-If the path includes escape characters, enclose each escape character in single quotation marks, to instruct Windows PowerShell not to interpret any characters as escape sequences.
+If the path includes escape characters, enclose each escape character in single quotation marks, to instruct PowerShell not to interpret any characters as escape sequences.
 To specify multiple paths, and include files in multiple locations in your output zipped file, use commas to separate the paths.
 
 ```yaml

--- a/reference/6/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/6/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -93,7 +93,7 @@ Accept wildcard characters: False
 Specifies the path to an archive file.
 Unlike the **Path** parameter, the value of **LiteralPath** is used exactly as it is typed.
 Wildcard characters are not supported.
-If the path includes escape characters, enclose each escape character in single quotation marks, to instruct Windows PowerShell not to interpret any characters as escape sequences.
+If the path includes escape characters, enclose each escape character in single quotation marks, to instruct PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String

--- a/reference/6/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.md
+++ b/reference/6/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.md
@@ -12,7 +12,7 @@ Module Name:  Microsoft.PowerShell.Archive
 
 # Microsoft.PowerShell.Archive Module
 ## Description
-This section contains the help topics for the cmdlets that are installed with the Windows PowerShell Microsoft.PowerShell.Archive module. The Archive module contains cmdlets that let you create and extract archive or ZIP files.
+This section contains the help topics for the cmdlets that are installed with the PowerShell Microsoft.PowerShell.Archive module. The Archive module contains cmdlets that let you create and extract archive or ZIP files.
 
 ## Microsoft.PowerShell.Archive Cmdlets
 ### [Compress-Archive](Compress-Archive.md)


### PR DESCRIPTION
It's a partial fix of #2747 - for the Microsoft.PowerShell.Archive module only.

Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [x] This PR partially fixes the issue, and issue #2747 tracks the remaining work