### PR TITLE
Replace Windows PowerShell with PowerShell - the Microsoft.PowerShell.Host module

### DIFF
--- a/reference/6/Microsoft.PowerShell.Host/Microsoft.PowerShell.Host.md
+++ b/reference/6/Microsoft.PowerShell.Host/Microsoft.PowerShell.Host.md
@@ -12,11 +12,11 @@ Module Name:  Microsoft.PowerShell.Host
 
 # Microsoft.PowerShell.Host Module
 ## Description
-This section contains the help topics for the cmdlets that are installed with the Windows PowerShell Microsoft.PowerShell.Host module. The Host module contains cmdlets that manage data from host programs.
+This section contains the help topics for the cmdlets that are installed with the PowerShell Microsoft.PowerShell.Host module. The Host module contains cmdlets that manage data from host programs.
 
 ## Microsoft.PowerShell.Host Cmdlets
 ### [Start-Transcript](Start-Transcript.md)
-Creates a record of all or part of a Windows PowerShell session to a text file.
+Creates a record of all or part of a PowerShell session to a text file.
 
 
 ### [Stop-Transcript](Stop-Transcript.md)

--- a/reference/6/Microsoft.PowerShell.Host/Start-Transcript.md
+++ b/reference/6/Microsoft.PowerShell.Host/Start-Transcript.md
@@ -11,7 +11,7 @@ title:  Start-Transcript
 # Start-Transcript
 
 ## SYNOPSIS
-Creates a record of all or part of a Windows PowerShell session to a text file.
+Creates a record of all or part of a PowerShell session to a text file.
 
 ## SYNTAX
 
@@ -34,7 +34,7 @@ Start-Transcript [-OutputDirectory <String>] [-Append] [-Force] [-NoClobber] [-I
 ```
 
 ## DESCRIPTION
-The `Start-Transcript` cmdlet creates a record of all or part of a Windows PowerShell session to a text file.
+The `Start-Transcript` cmdlet creates a record of all or part of a PowerShell session to a text file.
 The transcript includes all command that the user types and all output that appears on the console.
 
 Starting in Windows PowerShell 5.0, `Start-Transcript` includes the host name in the generated file name of all transcripts.
@@ -129,7 +129,7 @@ Accept wildcard characters: False
 
 ### -OutputDirectory
 Specifies a specific path and folder in which to save a transcript.
-Windows PowerShell automatically assigns the transcript name.
+PowerShell automatically assigns the transcript name.
 
 ```yaml
 Type: String
@@ -170,7 +170,7 @@ Specifies a location to the transcript file.
 Unlike the **Path** parameter, the value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks inform Windows PowerShell not to interpret any characters as escape sequences.
+Single quotation marks inform PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String


### PR DESCRIPTION
It's a partial fix of #2747 - for the Microsoft.PowerShell.Host module only.

Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [x] This PR partially fixes the issue, and issue #2747 tracks the remaining work