### PR TITLE
Add CMS cmdlets help topics to PS60 docs

### DIFF
--- a/reference/6/Microsoft.PowerShell.Security/Get-CmsMessage.md
+++ b/reference/6/Microsoft.PowerShell.Security/Get-CmsMessage.md
@@ -1,0 +1,163 @@
+---
+ms.date:  06/09/2017
+schema:  2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+online version:  http://go.microsoft.com/fwlink/?LinkId=821712
+external help file:  Microsoft.PowerShell.Security.dll-Help.xml
+title:  Get-CmsMessage
+---
+
+# Get-CmsMessage
+
+## SYNOPSIS
+
+Gets content that has been encrypted by using the Cryptographic Message Syntax format.
+
+## SYNTAX
+
+### ByContent
+
+```
+Get-CmsMessage [-Content] <String> [<CommonParameters>]
+```
+
+### ByPath
+
+```
+Get-CmsMessage [-Path] <String> [<CommonParameters>]
+```
+
+### ByLiteralPath
+
+```
+Get-CmsMessage [-LiteralPath] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Get-CmsMessage` cmdlet gets content that has been encrypted using the Cryptographic Message Syntax (CMS) format.
+
+The CMS cmdlets support encryption and decryption of content using the IETF format for cryptographically protecting messages, as documented by [RFC5652](https://tools.ietf.org/html/rfc5652).
+
+The CMS encryption standard uses public key cryptography, where the keys used to encrypt content (the public key) and the keys used to decrypt content (the private key) are separate.
+Your public key can be shared widely, and is not sensitive data.
+If any content is encrypted with this public key, only your private key can decrypt it.
+For more information, see [Public-key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography).
+
+`Get-CmsMessage` gets content that has been encrypted in CMS format.
+It does not decrypt or unprotect content.
+You can run this cmdlet to get content that you have encrypted by running the `Protect-CmsMessage` cmdlet.
+You can specify content that you want to decrypt as a string, or by path to the encrypted content.
+You can pipe the results of `Get-CmsMessage` to `Unprotect-CmsMessage` to decrypt the content, provided that you have information about the document encryption certificate that was used to encrypt the content.
+
+## EXAMPLES
+
+### Example 1: Get encrypted content
+
+```powershell
+$Msg = Get-CmsMessage -Path "C:\Users\Test\Documents\PowerShell\Future_Plans.txt"
+$Msg.Content
+```
+
+```output
+-----BEGIN CMS-----
+MIIBqAYJKoZIhvcNAQcDoIIBmTCCAZUCAQAxggFQMIIBTAIBADA0MCAxHjAcBgNVBAMBFWxlZWhv
+bG1AbGljcm9zb2Z0LmNvbQIQQYHsbcXnjIJCtH+OhGmc1DANBgkqhkiG9w0BAQcwAASCAQAnkFHM
+proJnFy4geFGfyNmxH3yeoPvwEYzdnsoVqqDPAd8D3wao77z7OhJEXwz9GeFLnxD6djKV/tF4PxR
+E27aduKSLbnxfpf/sepZ4fUkuGibnwWFrxGE3B1G26MCenHWjYQiqv+Nq32Gc97qEAERrhLv6S4R
+G+2dJEnesW8A+z9QPo+DwYP5FzD0Td0ExrkswVckpLNR6j17Yaags3ltNXmbdEXekhi6Psf2MLMP
+TSO79lv2L0KeXFGuPOrdzPRwCkV0vNEqTEBeDnZGrjv/5766bM3GW34FXApod9u+VSFpBnqVOCBA
+DVDraA6k+xwBt66cV84AHLkh0kT02SIHMDwGCSqGSIb3DQEHATAdBglghkgBZQMEASoEEJbJaiRl
+KMnBoD1dkb/FzSWAEBaL8xkFwCu0e1AtDj7nSJc=
+-----END CMS-----
+```
+
+This command gets encrypted content located at C:\Users\Test\Documents\PowerShell\Future_Plans.txt.
+
+### Example 2: Pipe encrypted content to Unprotect-CmsMessage
+
+```powershell
+$Msg = Get-CmsMessage -Path "C:\Users\Test\Documents\PowerShell\Future_Plans.txt"
+$Msg | Unprotect-CmsMessage -To "cn=youralias@emailaddress.com"
+```
+
+```output
+Try the new Break All command
+```
+
+This command pipes the results of the `Get-CmsMessage` cmdlet from Example 1 to `Unprotect-CmsMessage`, to decrypt the message and read it in plain text.
+In this case, the value of the **To** parameter is the value of the encrypting certificate's Subject line.
+The decrypted message, "Try the new Break All command," is the result.
+
+## PARAMETERS
+
+### -Content
+
+Specifies an encrypted string, or a variable containing an encrypted string.
+
+```yaml
+Type: String
+Parameter Sets: ByContent
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -LiteralPath
+
+Specifies the path to encrypted content that you want to get.
+Unlike **Path**, the value of **LiteralPath** is used exactly as it is typed.
+No characters are interpreted as wildcard characters.
+If the path includes escape characters, enclose each one in single quotation marks.
+Single quotation marks tell PowerShell not to interpret enclosed characters as escape characters.
+
+```yaml
+Type: String
+Parameter Sets: ByLiteralPath
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+
+Specifies the path to encrypted content that you want to decrypt.
+
+```yaml
+Type: String
+Parameter Sets: ByPath
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md)
+
+[Protect-CmsMessage](Protect-CmsMessage.md)
+
+[Unprotect-CmsMessage](Unprotect-CmsMessage.md)

--- a/reference/6/Microsoft.PowerShell.Security/Protect-CmsMessage.md
+++ b/reference/6/Microsoft.PowerShell.Security/Protect-CmsMessage.md
@@ -1,0 +1,210 @@
+---
+ms.date:  06/09/2017
+schema:  2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+online version:  http://go.microsoft.com/fwlink/?LinkId=821716
+external help file:  Microsoft.PowerShell.Security.dll-Help.xml
+title:  Protect-CmsMessage
+---
+
+# Protect-CmsMessage
+
+## SYNOPSIS
+
+Encrypts content by using the Cryptographic Message Syntax format.
+
+## SYNTAX
+
+### ByContent (Default)
+
+```
+Protect-CmsMessage [-To] <CmsMessageRecipient[]> [-Content] <PSObject> [[-OutFile] <String>]
+ [<CommonParameters>]
+```
+
+### ByPath
+
+```
+Protect-CmsMessage [-To] <CmsMessageRecipient[]> [-Path] <String> [[-OutFile] <String>] [<CommonParameters>]
+```
+
+### ByLiteralPath
+
+```
+Protect-CmsMessage [-To] <CmsMessageRecipient[]> [-LiteralPath] <String> [[-OutFile] <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Protect-CmsMessage` cmdlet encrypts content by using the Cryptographic Message Syntax (CMS) format.
+
+The CMS cmdlets support encryption and decryption of content using the IETF format as documented by [RFC5652](https://tools.ietf.org/html/rfc5652).
+
+The CMS encryption standard uses public key cryptography, where the keys used to encrypt content (the public key) and the keys used to decrypt content (the private key) are separate.
+Your public key can be shared widely, and is not sensitive data.
+If any content is encrypted with this public key, only your private key can decrypt it.
+For more information, see [Public-key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography).
+
+Before you can run the `Protect-CmsMessage` cmdlet, you must have an encryption certificate set up.
+To be recognized in PowerShell, encryption certificates require a unique extended key usage ([EKU](https://msdn.microsoft.com/library/windows/desktop/aa381990)) ID to identify them as data encryption certificates (such as the IDs for Code Signing and Encrypted Mail).
+For an example of a certificate that would work for document encryption, see Example 1 in this topic.
+
+## EXAMPLES
+
+### Example 1: Create a certificate for encrypting content
+
+```powershell
+# Create .INF file for certreq
+
+{[Version]
+Signature = "$Windows NT$"
+
+[Strings]
+szOID_ENHANCED_KEY_USAGE = "2.5.29.37"
+szOID_DOCUMENT_ENCRYPTION = "1.3.6.1.4.1.311.80.1"
+
+[NewRequest]
+Subject = "cn=youralias@emailaddress.com"
+MachineKeySet = false
+KeyLength = 2048
+KeySpec = AT_KEYEXCHANGE
+HashAlgorithm = Sha1
+Exportable = true
+RequestType = Cert
+KeyUsage = "CERT_KEY_ENCIPHERMENT_KEY_USAGE | CERT_DATA_ENCIPHERMENT_KEY_USAGE"
+ValidityPeriod = "Years"
+ValidityPeriodUnits = "1000"
+
+[Extensions]
+%szOID_ENHANCED_KEY_USAGE% = "{text}%szOID_DOCUMENT_ENCRYPTION%"
+} | Out-File -FilePath DocumentEncryption.inf
+
+# After you have created your certificate file, run the following command to add the certificate file to the certificate store. Now you are ready to encrypt and decrypt content.
+certreq -new DocumentEncryption.inf DocumentEncryption.cer
+```
+
+Before you can run the `Protect-CmsMessage` cmdlet, you must create an encryption certificate.
+Using the following text, change the name in the Subject line to your name, email, or other identifier, and save the certificate in a file (such as DocumentEncryption.inf, as shown in this example).
+
+### Example 2: Encrypt a message sent by email
+
+```powershell
+$Protected = "Hello World" | Protect-CmsMessage -To "*youralias@emailaddress.com*"
+```
+
+In the following example, you encrypt a message, "Hello World", by piping it to the `Protect-CmsMessage` cmdlet, and then save the encrypted message in a variable.
+The **To** parameter uses the value of the Subject line in the certificate.
+
+## PARAMETERS
+
+### -Content
+
+Specifies a PSObject that contains content that you want to encrypt.
+For example, you can encrypt the content of an event message, and then use the variable containing the message (`$Event`, in this example) as the value of the **Content** parameter: `$event = Get-WinEvent -ProviderName "PowerShell" -MaxEvents 1`.
+You can also use the `Get-Content` cmdlet to get the contents of a file, such as a Microsoft Word document, and save the content in a variable that you use as the value of the **Content** parameter.
+
+```yaml
+Type: PSObject
+Parameter Sets: ByContent
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -LiteralPath
+
+Specifies the path to content that you want to encrypt.
+Unlike **Path**, the value of **LiteralPath** is used exactly as it is typed.
+No characters are interpreted as wildcards.
+If the path includes escape characters, enclose it in single quotation marks.
+Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+
+```yaml
+Type: String
+Parameter Sets: ByLiteralPath
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutFile
+
+Specifies the path and file name of a file to which you want to send the encrypted content.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+
+Specifies the path to content that you want to encrypt.
+
+```yaml
+Type: String
+Parameter Sets: ByPath
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -To
+
+Specifies one or more CMS message recipients, identified in any of the following formats:
+
+- An actual certificate (as retrieved from the certificate provider).
+- Path to the file containing the certificate.
+- Path to a directory containing the certificate.
+- Thumbprint of the certificate (used to look in the certificate store).
+- Subject name of the certificate (used to look in the certificate store).
+
+```yaml
+Type: CmsMessageRecipient[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md)
+
+[Get-CmsMessage](Get-CmsMessage.md)
+
+[Unprotect-CmsMessage](Unprotect-CmsMessage.md)

--- a/reference/6/Microsoft.PowerShell.Security/Unprotect-CmsMessage.md
+++ b/reference/6/Microsoft.PowerShell.Security/Unprotect-CmsMessage.md
@@ -1,0 +1,207 @@
+---
+ms.date:  06/09/2017
+schema:  2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+online version:  http://go.microsoft.com/fwlink/?LinkId=821720
+external help file:  Microsoft.PowerShell.Security.dll-Help.xml
+title:  Unprotect-CmsMessage
+---
+
+# Unprotect-CmsMessage
+
+## SYNOPSIS
+
+Decrypts content that has been encrypted by using the Cryptographic Message Syntax format.
+
+## SYNTAX
+
+### ByWinEvent (Default)
+
+```
+Unprotect-CmsMessage [-EventLogRecord] <PSObject> [-IncludeContext] [[-To] <CmsMessageRecipient[]>]
+ [<CommonParameters>]
+```
+
+### ByContent
+
+```
+Unprotect-CmsMessage [-Content] <String> [-IncludeContext] [[-To] <CmsMessageRecipient[]>] [<CommonParameters>]
+```
+
+### ByPath
+
+```
+Unprotect-CmsMessage [-Path] <String> [-IncludeContext] [[-To] <CmsMessageRecipient[]>] [<CommonParameters>]
+```
+
+### ByLiteralPath
+
+```
+Unprotect-CmsMessage [-LiteralPath] <String> [-IncludeContext] [[-To] <CmsMessageRecipient[]>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Unprotect-CmsMessage` cmdlet decrypts content that has been encrypted by using the Cryptographic Message Syntax (CMS) format.
+
+The CMS cmdlets support encryption and decryption of content using the IETF standard format for cryptographically protecting messages, as documented by [RFC5652](https://tools.ietf.org/html/rfc5652).
+
+The CMS encryption standard uses public key cryptography, where the keys used to encrypt content (the public key) and the keys used to decrypt content (the private key) are separate.
+Your public key can be shared widely, and is not sensitive data.
+If any content is encrypted with this public key, only your private key can decrypt it.
+For more information, see [Public-key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography).
+
+`Unprotect-CmsMessage` decrypts content that has been encrypted in CMS format.
+You can run this cmdlet to decrypt content that you have encrypted by running the `Protect-CmsMessage` cmdlet.
+You can specify content that you want to decrypt as a string, by the encryption event log record ID number, or by path to the encrypted content.
+The `Unprotect-CmsMessage` cmdlet returns the decrypted content.
+
+## EXAMPLES
+
+### Example 1: Decrypt a message
+
+```powershell
+Unprotect-CmsMessage -LiteralPath "C:\Users\Test\Documents\PowerShell\Future_Plans.txt" -To '0f 8j b1 ab e0 ce 35 1d 67 d2 f2 6f a2 d2 00 cl 22 z9 m9 85'
+```
+
+```output
+Try the new Break All command
+```
+
+In the following example, you decrypt content that is located at the literal path C:\Users\Test\Documents\PowerShell.
+For the value of the required **To** parameter, this example uses the thumbprint of the certificate that was used to perform the encryption.
+The decrypted message, "Try the new Break All command," is the result.
+
+## PARAMETERS
+
+### -Content
+
+Specifies an encrypted string, or a variable containing an encrypted string.
+
+```yaml
+Type: String
+Parameter Sets: ByContent
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -EventLogRecord
+
+Specifies an event log record ID that represents a CMS encryption operation.
+
+```yaml
+Type: PSObject
+Parameter Sets: ByWinEvent
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -IncludeContext
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LiteralPath
+
+Specifies the path to encrypted content that you want to decrypt.
+Unlike **Path**, the value of **LiteralPath** is used exactly as it is typed.
+No characters are interpreted as wildcard characters.
+If the path includes escape characters, enclose it in single quotation marks.
+Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+
+```yaml
+Type: String
+Parameter Sets: ByLiteralPath
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+
+Specifies the path to encrypted content that you want to decrypt.
+
+```yaml
+Type: String
+Parameter Sets: ByPath
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -To
+
+Specifies one or more CMS message recipients, identified in any of the following formats:
+
+- An actual certificate (as retrieved from the certificate provider).
+- Path to the a file containing the certificate.
+- Path to a directory containing the certificate.
+- Thumbprint of the certificate (used to look in the certificate store).
+- Subject name of the certificate (used to look in the certificate store).
+
+```yaml
+Type: CmsMessageRecipient[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Diagnostics.Eventing.Reader.EventLogRecord or System.String
+
+You can pipe an object containing encrypted content to `Unprotect-CmsMessage`.
+
+## OUTPUTS
+
+### System.String
+
+The unencrypted message.
+
+## NOTES
+
+## RELATED LINKS
+
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md)
+
+[Get-CmsMessage](Get-CmsMessage.md)
+
+[Protect-CmsMessage](Protect-CmsMessage.md)


### PR DESCRIPTION
Fix examples.
Remove an example that uses a dynamic parameter that's not ported to PowerShell 6.
Remove a prompt in examples.
Change "Windows PowerShell" to "PowerShell".
Add blank lines.
Fix a formatting of the cmdlet and parameter names.


<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [x] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work