### PR TITLE
Replace Windows PowerShell with PowerShell - the CimCmdlets

### DIFF
--- a/reference/6/CimCmdlets/Invoke-CimMethod.md
+++ b/reference/6/CimCmdlets/Invoke-CimMethod.md
@@ -296,7 +296,7 @@ Accept wildcard characters: False
 Specifies the namespace for the CIM operation.
 
 The default namespace is root/cimv2. You can use tab completion to browse the list of namespaces,
-because Windows PowerShell gets a list of namespaces from the local WMI server to provide the list
+because PowerShell gets a list of namespaces from the local WMI server to provide the list
 of namespaces.
 
 ```yaml

--- a/reference/6/CimCmdlets/New-CimInstance.md
+++ b/reference/6/CimCmdlets/New-CimInstance.md
@@ -172,7 +172,7 @@ Accept wildcard characters: False
 
 ### -ClientOnly
 Indicates that the instance is only created in PowerShell without going to the CIM server.
-You can use this parameter to create an in-memory CIM instance for use in subsequent Windows PowerShell operations.
+You can use this parameter to create an in-memory CIM instance for use in subsequent PowerShell operations.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
It's a partial fix of #2747 - for the CimCmdlets only.

Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [x] This PR partially fixes the issue, and issue #2747 tracks the remaining work