### PR TITLE
Add Get-PxfCertificate to PS60 docs

### DIFF
--- a/reference/6/Microsoft.PowerShell.Security/Get-PfxCertificate.md
+++ b/reference/6/Microsoft.PowerShell.Security/Get-PfxCertificate.md
@@ -1,0 +1,128 @@
+---
+ms.date:  06/09/2017
+schema:  2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+online version:  http://go.microsoft.com/fwlink/?LinkId=821715
+external help file:  Microsoft.PowerShell.Security.dll-Help.xml
+title:  Get-PfxCertificate
+---
+
+# Get-PfxCertificate
+
+## SYNOPSIS
+
+Gets information about .pfx certificate files on the computer.
+
+## SYNTAX
+
+### ByPath (Default)
+
+```
+Get-PfxCertificate [-FilePath] <String[]> [<CommonParameters>]
+```
+
+### ByLiteralPath
+
+```
+Get-PfxCertificate -LiteralPath <String[]> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Get-PfxCertificate` cmdlet gets an object representing each specified .pfx certificate file.
+A .pfx file includes both the certificate and a private key.
+
+## EXAMPLES
+
+### Example 1: Get a .pfx certificate
+
+```powershell
+Get-PfxCertificate -FilePath "C:\windows\system32\Test.pfx"
+```
+
+```output
+Password: ******
+Signer Certificate:      David Chew (Self Certificate)
+Time Certificate:
+Time Stamp:
+Path:                    C:\windows\system32\zap.pfx
+```
+
+This command gets information about the Test.pfx certificate file on the system.
+
+### Example 2: Get a .pfx certificate from a remote computer
+
+```powershell
+Invoke-Command -ComputerName "Server01" -ScriptBlock {Get-PfxCertificate -FilePath "C:\Text\TestNoPassword.pfx"} -Authentication CredSSP
+```
+
+This command gets a .pfx certificate file from the Server01 remote computer.
+It uses `Invoke-Command` to run a `Get-PfxCertificate` command remotely.
+
+When the .pfx certificate file is not password-protected, the value of the **Authentication** parameter of `Invoke-Command` must be CredSSP.
+
+## PARAMETERS
+
+### -FilePath
+
+Specifies the full path to the .pfx file of the secured file.
+If you specify a value for this parameter, it is not necessary to type `-FilePath` at the command line.
+
+```yaml
+Type: String[]
+Parameter Sets: ByPath
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -LiteralPath
+
+The full path to the .pfx file of the secured file.
+Unlike **FilePath**, the value of the **LiteralPath** parameter is used exactly as it is typed.
+No characters are interpreted as wildcards.
+If the path includes escape characters, enclose it in single quotation marks.
+Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+
+```yaml
+Type: String[]
+Parameter Sets: ByLiteralPath
+Aliases: PSPath
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+You can pipe a string that contains a file path to `Get-PfxCertificate`.
+
+## OUTPUTS
+
+### System.Security.Cryptography.X509Certificates.X509Certificate2
+
+`Get-PfxCertificate` returns an object for each certificate that it gets.
+
+## NOTES
+
+* When using the `Invoke-Command` cmdlet to run a `Get-PfxCertificate` command remotely, and the .pfx certificate file is not password protected, the value of the **Authentication** parameter of `Invoke-Command` must be CredSSP.
+
+## RELATED LINKS
+
+[Get-AuthenticodeSignature](Get-AuthenticodeSignature.md)
+
+[Set-AuthenticodeSignature](Set-AuthenticodeSignature.md)


### PR DESCRIPTION
Add Get-PxfCertificate to PS60 docs.
Including fixes:
Remove a prompt in examples.
Replace "Windows PowerShell" with "PowerShell".
Add blank lines.
Format cmdlet and parameter names.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [x] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work