### PR TITLE
C33477: adding indentation to cdeblock to avoid broken contenet

### DIFF
--- a/reference/docs-conceptual/core-powershell/web-access/authorization-rules-and-security-features-of-windows-powershell-web-access.md
+++ b/reference/docs-conceptual/core-powershell/web-access/authorization-rules-and-security-features-of-windows-powershell-web-access.md
@@ -242,7 +242,7 @@ or session configurations).
    ```
    Get-PswaAuthorizationRule `
       -RuleName <rule-name> | Remove-PswaAuthorizationRule
-  ```
+   ```
 
 > [!NOTE]
 > You are not prompted to confirm whether you want to delete the specified authorization rule; the


### PR DESCRIPTION
Hello, @sdwheeler ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
"Missing space before \`\`\` , this current state is breaking en-us page"
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance. 