### PR TITLE
Fix Example 2 in Get-EventSubscriber.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -89,9 +89,9 @@ Id  Name           State      HasMoreData  Location  Command
 3   Timer.Random   NotStarted False                  $random = Get-Random ...
 
 PS> $timer.Enabled = $true
-PS> $subscriber = Get-EventSubcriber -sourceIdentifer Timer.Random
+PS> $subscriber = Get-EventSubscriber -SourceIdentifier Timer.Random
 PS> ($subscriber.action).gettype().fullname
-PSEventJob
+System.Management.Automation.PSEventJob
 
 PS> $subscriber.action | format-list -property *
 
@@ -108,9 +108,9 @@ Id            : 1
 Name          : Timer.Random
 ChildJobs     : {}
 ...
+
 PS> & $subscriber.action.module {$random}
 96
-
 PS> & $subscriber.action.module {$random}
 23
 ```

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -84,9 +84,9 @@ Id  Name           State      HasMoreData  Location  Command
 3   Timer.Random   NotStarted False                  $random = Get-Random ...
 
 PS C:\> $timer.Enabled = $true
-PS C:\> $subscriber = Get-EventSubcriber -sourceIdentifer Timer.Random
+PS C:\> $subscriber = Get-EventSubscriber -SourceIdentifier Timer.Random
 PS C:\> ($subscriber.action).gettype().fullname
-PSEventJob
+System.Management.Automation.PSEventJob
 
 PS C:\> $subscriber.action | format-list -property *
 
@@ -103,9 +103,9 @@ Id            : 1
 Name          : Timer.Random
 ChildJobs     : {}
 ...
+
 PS C:\> & $subscriber.action.module {$random}
 96
-
 PS C:\> & $subscriber.action.module {$random}
 23
 ```

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -74,12 +74,17 @@ The fourth command uses the **Get-EventSubscriber** cmdlet to get the event subs
 PS C:\> $Timer = New-Object Timers.Timer
 PS C:\> $Timer.Interval = 500
 PS C:\> Register-ObjectEvent -InputObject $Timer -EventName Elapsed -SourceIdentifier Timer.Random -Action { $Random = Get-Random -Min 0 -Max 100 }
+
 Id  Name           State      HasMoreData  Location  Command
 --  ----           -----      -----------  --------  -------
-3   Timer.Random   NotStarted False                  $Random = Get-Random ... PS C:\> $Timer.Enabled = $True
-PS C:\> $Subscriber = Get-EventSubcriber -SourceIdentifer Timer.Random
+3   Timer.Random   NotStarted False                  $Random = Get-Random ...
+
+PS C:\> $Timer.Enabled = $True
+PS C:\> $Subscriber = Get-EventSubscriber -SourceIdentifier Timer.Random
 PS C:\> ($Subscriber.action).gettype().fullname
-PSEventJob PS C:\> $Subscriber.action | Format-List -Property *
+System.Management.Automation.PSEventJob
+PS C:\> $Subscriber.action | Format-List -Property *
+
 State         : Running
 Module        : __DynamicModule_6b5cbe82-d634-41d1-ae5e-ad7fe8d57fe0
 StatusMessage :
@@ -92,8 +97,11 @@ InstanceId    : 88944290-133d-4b44-8752-f901bd8012e2
 Id            : 1
 Name          : Timer.Random
 ChildJobs     : {}
-... PS C:\> & $Subscriber.action.module {$Random}
-96 PS C:\> & $Subscriber.action.module {$Random}
+...
+
+PS C:\> & $Subscriber.action.module {$Random}
+96
+PS C:\> & $Subscriber.action.module {$Random}
 23
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -74,12 +74,17 @@ The fourth command uses the **Get-EventSubscriber** cmdlet to get the event subs
 PS C:\> $Timer = New-Object Timers.Timer
 PS C:\> $Timer.Interval = 500
 PS C:\> Register-ObjectEvent -InputObject $Timer -EventName Elapsed -SourceIdentifier Timer.Random -Action { $Random = Get-Random -Min 0 -Max 100 }
+
 Id  Name           State      HasMoreData  Location  Command
 --  ----           -----      -----------  --------  -------
-3   Timer.Random   NotStarted False                  $Random = Get-Random ... PS C:\> $Timer.Enabled = $True
-PS C:\> $Subscriber = Get-EventSubcriber -SourceIdentifer Timer.Random
+3   Timer.Random   NotStarted False                  $Random = Get-Random ...
+
+PS C:\> $Timer.Enabled = $True
+PS C:\> $Subscriber = Get-EventSubscriber -SourceIdentifier Timer.Random
 PS C:\> ($Subscriber.action).gettype().fullname
-PSEventJob PS C:\> $Subscriber.action | Format-List -Property *
+System.Management.Automation.PSEventJob
+PS C:\> $Subscriber.action | Format-List -Property *
+
 State         : Running
 Module        : __DynamicModule_6b5cbe82-d634-41d1-ae5e-ad7fe8d57fe0
 StatusMessage :
@@ -92,8 +97,11 @@ InstanceId    : 88944290-133d-4b44-8752-f901bd8012e2
 Id            : 1
 Name          : Timer.Random
 ChildJobs     : {}
-... PS C:\> & $Subscriber.action.module {$Random}
-96 PS C:\> & $Subscriber.action.module {$Random}
+...
+
+PS C:\> & $Subscriber.action.module {$Random}
+96
+PS C:\> & $Subscriber.action.module {$Random}
 23
 ```
 

--- a/reference/6/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-EventSubscriber.md
@@ -74,12 +74,17 @@ The fourth command uses the **Get-EventSubscriber** cmdlet to get the event subs
 PS C:\> $Timer = New-Object Timers.Timer
 PS C:\> $Timer.Interval = 500
 PS C:\> Register-ObjectEvent -InputObject $Timer -EventName Elapsed -SourceIdentifier Timer.Random -Action { $Random = Get-Random -Min 0 -Max 100 }
+
 Id  Name           State      HasMoreData  Location  Command
 --  ----           -----      -----------  --------  -------
-3   Timer.Random   NotStarted False                  $Random = Get-Random ... PS C:\> $Timer.Enabled = $True
-PS C:\> $Subscriber = Get-EventSubcriber -SourceIdentifer Timer.Random
+3   Timer.Random   NotStarted False                  $Random = Get-Random ...
+
+PS C:\> $Timer.Enabled = $True
+PS C:\> $Subscriber = Get-EventSubscriber -SourceIdentifier Timer.Random
 PS C:\> ($Subscriber.action).gettype().fullname
-PSEventJob PS C:\> $Subscriber.action | Format-List -Property *
+System.Management.Automation.PSEventJob
+PS C:\> $Subscriber.action | Format-List -Property *
+
 State         : Running
 Module        : __DynamicModule_6b5cbe82-d634-41d1-ae5e-ad7fe8d57fe0
 StatusMessage :
@@ -92,8 +97,11 @@ InstanceId    : 88944290-133d-4b44-8752-f901bd8012e2
 Id            : 1
 Name          : Timer.Random
 ChildJobs     : {}
-... PS C:\> & $Subscriber.action.module {$Random}
-96 PS C:\> & $Subscriber.action.module {$Random}
+...
+
+PS C:\> & $Subscriber.action.module {$Random}
+96
+PS C:\> & $Subscriber.action.module {$Random}
 23
 ```
 


### PR DESCRIPTION
The Example 2 does not work. The outputs are not correct.

* Get-EventSubcriber -> Get-EventSub **s** criber
* -SourceIdentifer -> -SourceIdentif **i** er
* PSEventJob -> System.Management.Automation.PSEventJob
* Added line breaks before `PS C:\>`
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
