### PR TITLE
Fixes #2150 Add Password and NoPromptForPassword parameters

### DIFF
--- a/reference/6/Microsoft.PowerShell.Security/Get-PfxCertificate.md
+++ b/reference/6/Microsoft.PowerShell.Security/Get-PfxCertificate.md
@@ -19,13 +19,15 @@ Gets information about .pfx certificate files on the computer.
 ### ByPath (Default)
 
 ```
-Get-PfxCertificate [-FilePath] <String[]> [<CommonParameters>]
+Get-PfxCertificate [-FilePath] <String[]> [-Password <SecureString>] [-NoPromptForPassword]
+ [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
-Get-PfxCertificate -LiteralPath <String[]> [<CommonParameters>]
+Get-PfxCertificate -LiteralPath <String[]> [-Password <SecureString>] [-NoPromptForPassword]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -98,6 +100,38 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -NoPromptForPassword
+
+Suppresses prompting for a password.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+
+Specifies a password required to access a .pfx certificate file.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 


### PR DESCRIPTION
Fixes #2150

Add Password and NoPromptForPassword parameters in the Syntax and Parameters sections.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (6.1) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work