### PR TITLE
Corrected alignment of output in Example 6

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Member.md
@@ -147,14 +147,16 @@ The results show that only process objects (**System.Diagnostics.Process**) and 
 ```
 PS C:\> $A = Get-Member - InputObject @(1)
 PS C:\> $A.Count
-1 PS C:\> $A = Get-Member -InputObject 1,2,3
+1
+PS C:\> $A = Get-Member -InputObject 1,2,3
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
 Count              AliasProperty Count = Length
 Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
-... PS C:\> $A.Count
+...
+PS C:\> $A.Count
 1
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
@@ -147,14 +147,16 @@ The results show that only process objects (**System.Diagnostics.Process**) and 
 ```
 PS C:\> $A = Get-Member - InputObject @(1)
 PS C:\> $A.Count
-1 PS C:\> $A = Get-Member -InputObject 1,2,3
+1
+PS C:\> $A = Get-Member -InputObject 1,2,3
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
 Count              AliasProperty Count = Length
 Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
-... PS C:\> $A.Count
+...
+PS C:\> $A.Count
 1
 ```
 

--- a/reference/6/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Member.md
@@ -147,14 +147,16 @@ The results show that only process objects (**System.Diagnostics.Process**) and 
 ```
 PS C:\> $A = Get-Member - InputObject @(1)
 PS C:\> $A.Count
-1 PS C:\> $A = Get-Member -InputObject 1,2,3
+1
+PS C:\> $A = Get-Member -InputObject 1,2,3
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
 Count              AliasProperty Count = Length
 Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
-... PS C:\> $A.Count
+...
+PS C:\> $A.Count
 1
 ```
 


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work