### PR TITLE
Remove duplicated lines

### DIFF
--- a/developer/cmdlet/strongly-encouraged-development-guidelines.md
+++ b/developer/cmdlet/strongly-encouraged-development-guidelines.md
@@ -107,7 +107,6 @@ Frequently, users must perform the same operation against multiple arguments. Fo
 #### Support the PassThru Parameter
 
 By default, many cmdlets that modify the system, such as the [Stop-Process](/powershell/module/Microsoft.PowerShell.Management/Stop-Process) cmdlet, act as "sinks" for objects and do not return a result. These cmdlet should implement the `PassThru` parameter to force the cmdlet to return an object. When the `PassThru` parameter is specified, the cmdlet returns an object by using a call to the [System.Management.Automation.Cmdlet.Writeobject*](/dotnet/api/System.Management.Automation.Cmdlet.WriteObject) method. For example, the following command stops the Calc process and passes the resultant process to the pipeline.
-By default, many cmdlets that modify the system, such as the [Stop-Process](/powershell/module/Microsoft.PowerShell.Management/Stop-Process) cmdlet, act as "sinks" for objects and do not return a result. These cmdlet should implement the `PassThru` parameter to force the cmdlet to return an object. When the `PassThru` parameter is specified, the cmdlet returns an object by using a call to the [System.Management.Automation.Cmdlet.Writeobject*](/dotnet/api/System.Management.Automation.Cmdlet.WriteObject) method. For example, the following command stops the Calc process and passes the resultant process to the pipeline.
 
 ```powershell
 Stop-Process calc -passthru


### PR DESCRIPTION
Looks like a copy paste error in `#### Support the PassThru Parameter` section. Just deleting the duplicated line

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work