### PR TITLE
Fixed syntax error in powershell example code

### DIFF
--- a/developer/module/how-to-write-a-powershell-script-module.md
+++ b/developer/module/how-to-write-a-powershell-script-module.md
@@ -34,7 +34,7 @@ You create a script module by saving a valid PowerShell script to a .psm1 file, 
        [int[]] $highlightDay,
        [string[]] $highlightDate = [DateTime]::Today.ToString()
        )
-   {
+
        #actual code for the function goes here see the end of the topic for the complete code sample
    }
    ```


### PR DESCRIPTION
When I pasted this into VS, I noticed that there were 2 `{`. Only 1 is needed.