### PR TITLE
Fix metadata formatting

### DIFF
--- a/reference/docs-conceptual/core-powershell/SSH-Remoting-in-PowerShell-Core.md
+++ b/reference/docs-conceptual/core-powershell/SSH-Remoting-in-PowerShell-Core.md
@@ -1,4 +1,3 @@
-
 ---
 title: PowerShell Remoting Over SSH
 description: Remoting in PowerShell Core using SSH


### PR DESCRIPTION
The newline at the start of the file was causing the metadata to show as content in the docs

<img width="816" alt="screen shot 2018-08-21 at 13 51 16" src="https://user-images.githubusercontent.com/1709517/44399938-ab4dd300-a549-11e8-98dd-fc675b0d393a.png">

Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document