### PR TITLE
Fix formatting for Set-Location in PS3.0-5.1

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Set-Location.md
@@ -9,72 +9,95 @@ title:  Set-Location
 ---
 
 # Set-Location
+
 ## SYNOPSIS
+
 Sets the current working location to a specified location.
+
 ## SYNTAX
 
 ### Path (Default)
+
 ```
 Set-Location [[-Path] <String>] [-PassThru] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### LiteralPath
+
 ```
 Set-Location -LiteralPath <String> [-PassThru] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### Stack
+
 ```
 Set-Location [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Set-Location cmdlet sets the working location to a specified location.
+
+The `Set-Location` cmdlet sets the working location to a specified location.
 That location could be a directory, a sub-directory, a registry location, or any provider path.
 
-You can also use the StackName parameter of the Set-Location cmdlet to make a named location stack the current location stack.
+You can also use the **StackName** parameter of the `Set-Location` cmdlet to make a named location stack the current location stack.
 For more information about location stacks, see the Notes.
+
 ## EXAMPLES
 
 ### Example 1
+
+```powershell
+PS C:\> Set-Location HKLM:
 ```
-PS C:\> set-location HKLM:
+
+```output
 PS HKLM:\>
 ```
 
 This command sets the current location to the root of the HKLM: drive.
-### Example 2
-```
-PS C:\> set-location env: -passthru
 
+### Example 2
+
+```powershell
+PS C:\> Set-Location Env: -PassThru
+```
+
+```output
 Path
 ----
 Env:\
+
 PS Env:\>
 ```
 
 This command sets the current location to the root of the Env: drive.
-It uses the Passthru parameter to direct Windows PowerShell to return a PathInfo (System.Management.Automation.PathInfo) object that represents the Env: location.
+It uses the **Passthru** parameter to direct Windows PowerShell to return a PathInfo (System.Management.Automation.PathInfo) object that represents the Env: location.
+
 ### Example 3
-```
-PS C:\> set-location C:
+
+```powershell
+PS C:\> Set-Location C:
 ```
 
-This command sets the current location C: drive in the file system provider.
+This command sets the current location C: drive in the FileSystem provider.
+
 ### Example 4
-```
-PS C:\> set-location -stackName WSManPaths
+
+```powershell
+PS C:\> Set-Location -StackName WSManPaths
 ```
 
 This command makes the WSManPaths location stack the current location stack.
 
-The location cmdlets use the current location stack unless a different location stack is specified in the command.
+The `*-Location` cmdlets use the current location stack unless a different location stack is specified in the command.
 For information about location stacks, see the Notes.
+
 ## PARAMETERS
 
 ### -LiteralPath
+
 Specifies a path to the location.
-The value of the LiteralPath parameter is used exactly as it is typed.
+The value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
@@ -92,6 +115,7 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns a System.Management.Automation.PathInfo object that represents the location.
 By default, this cmdlet does not generate any output.
 
@@ -108,6 +132,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 This parameter is used to specify the path to a new working location.
 
 ```yaml
@@ -123,11 +148,12 @@ Accept wildcard characters: False
 ```
 
 ### -StackName
+
 Makes the specified location stack the current location stack.
 Enter a location stack name.
-To indicate the unnamed default location stack, type "$null" or an empty string ("").
+To indicate the unnamed default location stack, type `$null` or an empty string ("").
 
-The Location cmdlets act on the current stack unless you use the StackName parameter to specify a different stack.
+The `*-Location` cmdlets act on the current stack unless you use the **StackName** parameter to specify a different stack.
 
 ```yaml
 Type: String
@@ -142,6 +168,7 @@ Accept wildcard characters: False
 ```
 
 ### -UseTransaction
+
 Includes the command in the active transaction.
 This parameter can only be used when a transaction is in progress.
 For more information, see about_Transactions.
@@ -159,45 +186,51 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains a path (but not a literal path) to Set-Location.
+
+You can pipe a string that contains a path (but not a literal path) to `Set-Location`.
+
 ## OUTPUTS
 
 ### None, System.Management.Automation.PathInfo, System.Management.Automation.PathInfoStack
-When you use the PassThru parameter, Set-Location generates a System.Management.Automation.PathInfo object that represents the location.
+
+When you use the **PassThru** parameter, `Set-Location` generates a System.Management.Automation.PathInfo object that represents the location.
 Otherwise, this cmdlet does not generate any output.
+
 ## NOTES
-* The Set-Location cmdlet is designed to work with the data exposed by any provider. To list the providers available in your session, type "Get-PSProvider". For more information, see about_Providers.
+
+* The `Set-Location` cmdlet is designed to work with the data exposed by any provider. To list the providers available in your session, type `Get-PSProvider`. For more information, see about_Providers.
 
   A "stack" is a last-in, first-out list in which only the most recently added item is accessible.
 You add items to a stack in the order that you use them, and then retrieve them for use in the reverse order.
 Windows PowerShell lets you store provider locations in location stacks.
 Windows PowerShell creates an unnamed default location stack and you can create multiple named location stacks.
 If you do not specify a stack name, Windows PowerShell uses the current location stack.
-By default, the unnamed default location is the current location stack, but you can use the Set-Location cmdlet to change the current location stack.
+By default, the unnamed default location is the current location stack, but you can use the `Set-Location` cmdlet to change the current location stack.
 
-  To manage location stacks, use the Windows PowerShell Location cmdlets, as follows.
+  To manage location stacks, use the Windows PowerShell `*-Location` cmdlets, as follows:
 
-  - To add a location to a location stack, use the Push-Location cmdlet.
+  * To add a location to a location stack, use the `Push-Location` cmdlet.
 
-  - To get a location from a location stack, use the Pop-Location cmdlet.
+  * To get a location from a location stack, use the `Pop-Location` cmdlet.
 
-  - To display the locations in the current location stack, use the Stack parameter of the Get-Location cmdlet.
-To display the locations in a named location stack, use the StackName parameter of the Get-Location cmdlet.
+  * To display the locations in the current location stack, use the **Stack** parameter of the `Get-Location` cmdlet.
+To display the locations in a named location stack, use the **StackName** parameter of the `Get-Location` cmdlet.
 
-  - To create a new location stack, use the StackName parameter of the Push-Location cmdlet.
-If you specify a stack that does not exist, Push-Location creates the stack.
+  * To create a new location stack, use the **StackName** parameter of the `Push-Location` cmdlet.
+If you specify a stack that does not exist, `Push-Location` creates the stack.
 
-  - To make a location stack the current location stack, use the StackName parameter of the Set-Location cmdlet.
+  * To make a location stack the current location stack, use the **StackName** parameter of the `Set-Location` cmdlet.
 
   The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you cannot no longer use Push-Location or Pop-Location cmdlets add or get items from the default stack or use Get-Location command to display the locations in the unnamed stack.
-To make the unnamed stack the current stack, use the StackName parameter of the Set-Location cmdlet with a value of $null or an empty string ("").
+If you make a named location stack the current location stack, you cannot no longer use `Push-Location` or `Pop-Location` cmdlets add or get items from the default stack or use `Get-Location` command to display the locations in the unnamed stack.
+To make the unnamed stack the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of `$null` or an empty string ("").
 
-*
 ## RELATED LINKS
 
 [Get-Location](Get-Location.md)

--- a/reference/4.0/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Set-Location.md
@@ -11,77 +11,93 @@ title:  Set-Location
 # Set-Location
 
 ## SYNOPSIS
+
 Sets the current working location to a specified location.
 
 ## SYNTAX
 
 ### Path (Default)
+
 ```
 Set-Location [[-Path] <String>] [-PassThru] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### LiteralPath
+
 ```
 Set-Location -LiteralPath <String> [-PassThru] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### Stack
+
 ```
 Set-Location [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Set-Location cmdlet sets the working location to a specified location.
+
+The `Set-Location` cmdlet sets the working location to a specified location.
 That location could be a directory, a sub-directory, a registry location, or any provider path.
 
-You can also use the StackName parameter of the Set-Location cmdlet to make a named location stack the current location stack.
+You can also use the **StackName** parameter of the `Set-Location` cmdlet to make a named location stack the current location stack.
 For more information about location stacks, see the Notes.
 
 ## EXAMPLES
 
 ### Example 1
+
+```powershell
+PS C:\> Set-Location HKLM:
 ```
-PS C:\> set-location HKLM:
+
+```output
 PS HKLM:\>
 ```
 
 This command sets the current location to the root of the HKLM: drive.
 
 ### Example 2
-```
-PS C:\> set-location env: -passthru
 
+```powershell
+PS C:\> Set-Location Env: -PassThru
+```
+
+```output
 Path
 ----
 Env:\
+
 PS Env:\>
 ```
 
 This command sets the current location to the root of the Env: drive.
-It uses the Passthru parameter to direct Windows PowerShell to return a PathInfo (System.Management.Automation.PathInfo) object that represents the Env: location.
+It uses the **Passthru** parameter to direct Windows PowerShell to return a PathInfo (System.Management.Automation.PathInfo) object that represents the Env: location.
 
 ### Example 3
-```
-PS C:\> set-location C:
+
+```powershell
+PS C:\> Set-Location C:
 ```
 
 This command sets the current location C: drive in the file system provider.
 
 ### Example 4
+
 ```
-PS C:\> set-location -stackName WSManPaths
+PS C:\> Set-Location -StackName WSManPaths
 ```
 
 This command makes the WSManPaths location stack the current location stack.
 
-The location cmdlets use the current location stack unless a different location stack is specified in the command.
+The `*-Location` cmdlets use the current location stack unless a different location stack is specified in the command.
 For information about location stacks, see the Notes.
 
 ## PARAMETERS
 
 ### -LiteralPath
+
 Specifies a path to the location.
-The value of the LiteralPath parameter is used exactly as it is typed.
+The value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcards.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
@@ -99,6 +115,7 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns a System.Management.Automation.PathInfo object that represents the location.
 By default, this cmdlet does not generate any output.
 
@@ -115,6 +132,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 This parameter is used to specify the path to a new working location.
 
 ```yaml
@@ -130,11 +148,12 @@ Accept wildcard characters: False
 ```
 
 ### -StackName
+
 Makes the specified location stack the current location stack.
 Enter a location stack name.
-To indicate the unnamed default location stack, type "$null" or an empty string ("").
+To indicate the unnamed default location stack, type `$null` or an empty string ("").
 
-The Location cmdlets act on the current stack unless you use the StackName parameter to specify a different stack.
+The `*-Location` cmdlets act on the current stack unless you use the **StackName** parameter to specify a different stack.
 
 ```yaml
 Type: String
@@ -149,6 +168,7 @@ Accept wildcard characters: False
 ```
 
 ### -UseTransaction
+
 Includes the command in the active transaction.
 This parameter can only be used when a transaction is in progress.
 For more information, see about_Transactions.
@@ -166,48 +186,50 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains a path (but not a literal path) to Set-Location.
+
+You can pipe a string that contains a path (but not a literal path) to `Set-Location`.
 
 ## OUTPUTS
 
 ### None, System.Management.Automation.PathInfo, System.Management.Automation.PathInfoStack
-When you use the PassThru parameter, Set-Location generates a System.Management.Automation.PathInfo object that represents the location.
+
+When you use the **PassThru** parameter, `Set-Location` generates a System.Management.Automation.PathInfo object that represents the location.
 Otherwise, this cmdlet does not generate any output.
 
 ## NOTES
-* The Set-Location cmdlet is designed to work with the data exposed by any provider. To list the providers available in your session, type "Get-PSProvider". For more information, see about_Providers.
+
+* The `Set-Location` cmdlet is designed to work with the data exposed by any provider. To list the providers available in your session, type `Get-PSProvider`. For more information, see about_Providers.
 
   A "stack" is a last-in, first-out list in which only the most recently added item is accessible.
 You add items to a stack in the order that you use them, and then retrieve them for use in the reverse order.
 Windows PowerShell lets you store provider locations in location stacks.
 Windows PowerShell creates an unnamed default location stack and you can create multiple named location stacks.
 If you do not specify a stack name, Windows PowerShell uses the current location stack.
-By default, the unnamed default location is the current location stack, but you can use the Set-Location cmdlet to change the current location stack.
+By default, the unnamed default location is the current location stack, but you can use the `Set-Location` cmdlet to change the current location stack.
 
-  To manage location stacks, use the Windows PowerShell Location cmdlets, as follows.
+  To manage location stacks, use the Windows PowerShell `*-Location` cmdlets, as follows:
 
-  - To add a location to a location stack, use the Push-Location cmdlet.
+  * To add a location to a location stack, use the `Push-Location` cmdlet.
 
-  - To get a location from a location stack, use the Pop-Location cmdlet.
+  * To get a location from a location stack, use the `Pop-Location` cmdlet.
 
-  - To display the locations in the current location stack, use the Stack parameter of the Get-Location cmdlet.
-To display the locations in a named location stack, use the StackName parameter of the Get-Location cmdlet.
+  * To display the locations in the current location stack, use the **Stack** parameter of the `Get-Location` cmdlet.
+To display the locations in a named location stack, use the **StackName** parameter of the `Get-Location` cmdlet.
 
-  - To create a new location stack, use the StackName parameter of the Push-Location cmdlet.
-If you specify a stack that does not exist, Push-Location creates the stack.
+  * To create a new location stack, use the **StackName** parameter of the `Push-Location` cmdlet.
+If you specify a stack that does not exist, `Push-Location` creates the stack.
 
-  - To make a location stack the current location stack, use the StackName parameter of the Set-Location cmdlet.
+  * To make a location stack the current location stack, use the **StackName** parameter of the `Set-Location` cmdlet.
 
   The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you cannot no longer use Push-Location or Pop-Location cmdlets add or get items from the default stack or use Get-Location command to display the locations in the unnamed stack.
-To make the unnamed stack the current stack, use the StackName parameter of the Set-Location cmdlet with a value of $null or an empty string ("").
-
-*
+If you make a named location stack the current location stack, you cannot no longer use `Push-Location` or `Pop-Location` cmdlets add or get items from the default stack or use `Get-Location` command to display the locations in the unnamed stack.
+To make the unnamed stack the current stack, use the **StackName** parameter of the `Set-Location` cmdlet with a value of `$null` or an empty string ("").
 
 ## RELATED LINKS
 

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-Location.md
@@ -11,77 +11,93 @@ title:  Set-Location
 # Set-Location
 
 ## SYNOPSIS
+
 Sets the current working location to a specified location.
 
 ## SYNTAX
 
 ### Path (Default)
+
 ```
 Set-Location [[-Path] <String>] [-PassThru] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### LiteralPath
+
 ```
 Set-Location -LiteralPath <String> [-PassThru] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### Stack
+
 ```
 Set-Location [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Set-Location** cmdlet sets the working location to a specified location.
+
+The `Set-Location` cmdlet sets the working location to a specified location.
 That location could be a directory, a sub-directory, a registry location, or any provider path.
 
-You can also use the *StackName* parameter of to make a named location stack the current location stack.
+You can also use the **StackName** parameter of to make a named location stack the current location stack.
 For more information about location stacks, see the Notes.
 
 ## EXAMPLES
 
 ### Example 1: Set the current location
-```
+
+```powershell
 PS C:\> Set-Location -Path "HKLM:"
+```
+
+```output
 PS HKLM:\>
 ```
 
 This command sets the current location to the root of the HKLM: drive.
 
 ### Example 2: Set the current location and display that location
-```
-PS C:\> Set-Location -Path "Env:" -PassThru
 
+```powershell
+PS C:\> Set-Location -Path "Env:" -PassThru
+```
+
+```output
 Path
 ----
 Env:\
+
 PS Env:\>
 ```
 
 This command sets the current location to the root of the Env: drive.
-It uses the *PassThru* parameter to direct Windows PowerShell to return a **PathInfo** object that represents the Env: location.
+It uses the **PassThru** parameter to direct Windows PowerShell to return a **PathInfo** object that represents the Env: location.
 
 ### Example 3: Set location to the C: drive
-```
+
+```powershell
 PS C:\> Set-Location C:
 ```
 
 This command sets the current location C: drive in the file system provider.
 
 ### Example 4: Set the current location to a named stack
-```
+
+```powershell
 PS C:\> Set-Location -StackName "WSManPaths"
 ```
 
 This command makes the WSManPaths location stack the current location stack.
 
-The location cmdlets use the current location stack unless a different location stack is specified in the command.
+The `*-Location` cmdlets use the current location stack unless a different location stack is specified in the command.
 For information about location stacks, see the Notes.
 
 ## PARAMETERS
 
 ### -LiteralPath
+
 Specifies a path of the location.
-The value of the *LiteralPath* parameter is used exactly as it is typed.
+The value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcard characters.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
@@ -99,6 +115,7 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns a **System.Management.Automation.PathInfo** object that represents the location.
 By default, this cmdlet does not generate any output.
 
@@ -115,6 +132,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specify the path of a new working location.
 
 ```yaml
@@ -130,11 +148,12 @@ Accept wildcard characters: False
 ```
 
 ### -StackName
+
 Specifies the location stack name that this cmdlet makes the current location stack.
 Enter a location stack name.
-To indicate the unnamed default location stack, type $Null" or an empty string ("").
+To indicate the unnamed default location stack, type `$null` or an empty string ("").
 
-The **Location** cmdlets act on the current stack unless you use the *StackName* parameter to specify a different stack.
+The `*-Location` cmdlets act on the current stack unless you use the **StackName** parameter to specify a different stack.
 
 ```yaml
 Type: String
@@ -149,6 +168,7 @@ Accept wildcard characters: False
 ```
 
 ### -UseTransaction
+
 Includes the command in the active transaction.
 This parameter is valid only when a transaction is in progress.
 For more information, see about_Transactions.
@@ -166,21 +186,25 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
+
 You can pipe a string that contains a path, but not a literal path, to this cmdlet.
 
 ## OUTPUTS
 
 ### None, System.Management.Automation.PathInfo, System.Management.Automation.PathInfoStack
-This cmdlet generates a **System.Management.Automation.PathInfo** object that represents the location, if you specify the *PassThru* parameter.
+
+This cmdlet generates a **System.Management.Automation.PathInfo** object that represents the location, if you specify the **PassThru** parameter.
 Otherwise, this cmdlet does not generate any output.
 
 ## NOTES
-* The **Set-Location** cmdlet is designed to work with the data exposed by any provider. To list the providers available in your session, type `Get-PSProvider`. For more information, see about_Providers.
+
+* The `Set-Location` cmdlet is designed to work with the data exposed by any provider. To list the providers available in your session, type `Get-PSProvider`. For more information, see about_Providers.
 
   A stack is a last-in, first-out list in which only the most recently added item can be accessed.
 You add items to a stack in the order that you use them, and then retrieve them for use in the reverse order.
@@ -188,23 +212,25 @@ Windows PowerShell lets you store provider locations in location stacks.
 Windows PowerShell creates an unnamed default location stack.
 You can create multiple named location stacks.
 If you do not specify a stack name, Windows PowerShell uses the current location stack.
-By default, the unnamed default location is the current location stack, but you can use the **Set-Location** cmdlet to change the current location stack.
+By default, the unnamed default location is the current location stack, but you can use the `Set-Location` cmdlet to change the current location stack.
 
-  To manage location stacks, use the Windows PowerShell Location cmdlets, as follows:
+  To manage location stacks, use the Windows PowerShell `*-Location` cmdlets, as follows:
 
-- To add a location to a location stack, use the Push-Location cmdlet.
-- To get a location from a location stack, use the Pop-Location cmdlet.
-- To display the locations in the current location stack, use the *Stack* parameter of the Get-Location cmdlet.
-To display the locations in a named location stack, use the *StackName* parameter of **Get-Location**.
-- To create a new location stack, use the *StackName* parameter of **Push-Location**.
-If you specify a stack that does not exist, **Push-Location** creates the stack.
-- To make a location stack the current location stack, use the *StackName* parameter of **Set-Location**.
+* To add a location to a location stack, use the `Push-Location` cmdlet.
+
+* To get a location from a location stack, use the `Pop-Location` cmdlet.
+
+* To display the locations in the current location stack, use the **Stack** parameter of the `Get-Location` cmdlet.
+To display the locations in a named location stack, use the **StackName** parameter of `Get-Location`.
+
+* To create a new location stack, use the **StackName** parameter of `Push-Location`.
+If you specify a stack that does not exist, `Push-Location` creates the stack.
+
+* To make a location stack the current location stack, use the **StackName** parameter of `Set-Location`.
 
   The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you cannot no longer use **Push-Location** or **Pop-Location** cmdlets add or get items from the default stack or use **Get-Location** to display the locations in the unnamed stack.
-To make the unnamed stack the current stack, use the *StackName* parameter of **Set-Location** with a value of $Null or an empty string ("").
-
-*
+If you make a named location stack the current location stack, you cannot no longer use `Push-Location` or `Pop-Location` cmdlets add or get items from the default stack or use `Get-Location` to display the locations in the unnamed stack.
+To make the unnamed stack the current stack, use the **StackName** parameter of `Set-Location` with a value of `$null` or an empty string ("").
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Location.md
@@ -11,77 +11,93 @@ title:  Set-Location
 # Set-Location
 
 ## SYNOPSIS
+
 Sets the current working location to a specified location.
 
 ## SYNTAX
 
 ### Path (Default)
+
 ```
 Set-Location [[-Path] <String>] [-PassThru] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### LiteralPath
+
 ```
 Set-Location -LiteralPath <String> [-PassThru] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### Stack
+
 ```
 Set-Location [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Set-Location** cmdlet sets the working location to a specified location.
+
+The `Set-Location` cmdlet sets the working location to a specified location.
 That location could be a directory, a sub-directory, a registry location, or any provider path.
 
-You can also use the *StackName* parameter of to make a named location stack the current location stack.
+You can also use the **StackName** parameter of to make a named location stack the current location stack.
 For more information about location stacks, see the Notes.
 
 ## EXAMPLES
 
 ### Example 1: Set the current location
-```
+
+```powershell
 PS C:\> Set-Location -Path "HKLM:"
+```
+
+```output
 PS HKLM:\>
 ```
 
 This command sets the current location to the root of the HKLM: drive.
 
 ### Example 2: Set the current location and display that location
-```
-PS C:\> Set-Location -Path "Env:" -PassThru
 
+```powershell
+PS C:\> Set-Location -Path "Env:" -PassThru
+```
+
+```output
 Path
 ----
 Env:\
+
 PS Env:\>
 ```
 
 This command sets the current location to the root of the Env: drive.
-It uses the *PassThru* parameter to direct Windows PowerShell to return a **PathInfo** object that represents the Env: location.
+It uses the **PassThru** parameter to direct Windows PowerShell to return a **PathInfo** object that represents the Env: location.
 
 ### Example 3: Set location to the C: drive
-```
+
+```powershell
 PS C:\> Set-Location C:
 ```
 
 This command sets the current location C: drive in the file system provider.
 
 ### Example 4: Set the current location to a named stack
-```
+
+```powershell
 PS C:\> Set-Location -StackName "WSManPaths"
 ```
 
 This command makes the WSManPaths location stack the current location stack.
 
-The location cmdlets use the current location stack unless a different location stack is specified in the command.
+The `*-Location` cmdlets use the current location stack unless a different location stack is specified in the command.
 For information about location stacks, see the Notes.
 
 ## PARAMETERS
 
 ### -LiteralPath
+
 Specifies a path of the location.
-The value of the *LiteralPath* parameter is used exactly as it is typed.
+The value of the **LiteralPath** parameter is used exactly as it is typed.
 No characters are interpreted as wildcard characters.
 If the path includes escape characters, enclose it in single quotation marks.
 Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
@@ -99,6 +115,7 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns a **System.Management.Automation.PathInfo** object that represents the location.
 By default, this cmdlet does not generate any output.
 
@@ -115,6 +132,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specify the path of a new working location.
 
 ```yaml
@@ -130,11 +148,12 @@ Accept wildcard characters: False
 ```
 
 ### -StackName
+
 Specifies the location stack name that this cmdlet makes the current location stack.
 Enter a location stack name.
-To indicate the unnamed default location stack, type $Null" or an empty string ("").
+To indicate the unnamed default location stack, type `$null` or an empty string ("").
 
-The **Location** cmdlets act on the current stack unless you use the *StackName* parameter to specify a different stack.
+The `*-Location` cmdlets act on the current stack unless you use the **StackName** parameter to specify a different stack.
 
 ```yaml
 Type: String
@@ -149,6 +168,7 @@ Accept wildcard characters: False
 ```
 
 ### -UseTransaction
+
 Includes the command in the active transaction.
 This parameter is valid only when a transaction is in progress.
 For more information, see about_Transactions.
@@ -166,21 +186,25 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
+
 You can pipe a string that contains a path, but not a literal path, to this cmdlet.
 
 ## OUTPUTS
 
 ### None, System.Management.Automation.PathInfo, System.Management.Automation.PathInfoStack
-This cmdlet generates a **System.Management.Automation.PathInfo** object that represents the location, if you specify the *PassThru* parameter.
+
+This cmdlet generates a **System.Management.Automation.PathInfo** object that represents the location, if you specify the **PassThru** parameter.
 Otherwise, this cmdlet does not generate any output.
 
 ## NOTES
-* The **Set-Location** cmdlet is designed to work with the data exposed by any provider. To list the providers available in your session, type `Get-PSProvider`. For more information, see about_Providers.
+
+* The `Set-Location` cmdlet is designed to work with the data exposed by any provider. To list the providers available in your session, type `Get-PSProvider`. For more information, see about_Providers.
 
   A stack is a last-in, first-out list in which only the most recently added item can be accessed.
 You add items to a stack in the order that you use them, and then retrieve them for use in the reverse order.
@@ -188,23 +212,25 @@ Windows PowerShell lets you store provider locations in location stacks.
 Windows PowerShell creates an unnamed default location stack.
 You can create multiple named location stacks.
 If you do not specify a stack name, Windows PowerShell uses the current location stack.
-By default, the unnamed default location is the current location stack, but you can use the **Set-Location** cmdlet to change the current location stack.
+By default, the unnamed default location is the current location stack, but you can use the `Set-Location` cmdlet to change the current location stack.
 
-  To manage location stacks, use the Windows PowerShell Location cmdlets, as follows:
+  To manage location stacks, use the Windows PowerShell `*-Location` cmdlets, as follows:
 
-- To add a location to a location stack, use the Push-Location cmdlet.
-- To get a location from a location stack, use the Pop-Location cmdlet.
-- To display the locations in the current location stack, use the *Stack* parameter of the Get-Location cmdlet.
-To display the locations in a named location stack, use the *StackName* parameter of **Get-Location**.
-- To create a new location stack, use the *StackName* parameter of **Push-Location**.
-If you specify a stack that does not exist, **Push-Location** creates the stack.
-- To make a location stack the current location stack, use the *StackName* parameter of **Set-Location**.
+* To add a location to a location stack, use the `Push-Location` cmdlet.
+
+* To get a location from a location stack, use the `Pop-Location` cmdlet.
+
+* To display the locations in the current location stack, use the **Stack** parameter of the `Get-Location` cmdlet.
+To display the locations in a named location stack, use the **StackName** parameter of `Get-Location`.
+
+* To create a new location stack, use the **StackName** parameter of `Push-Location`.
+If you specify a stack that does not exist, `Push-Location` creates the stack.
+
+* To make a location stack the current location stack, use the **StackName** parameter of `Set-Location`.
 
   The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you cannot no longer use **Push-Location** or **Pop-Location** cmdlets add or get items from the default stack or use **Get-Location** to display the locations in the unnamed stack.
-To make the unnamed stack the current stack, use the *StackName* parameter of **Set-Location** with a value of $Null or an empty string ("").
-
-*
+If you make a named location stack the current location stack, you cannot no longer use `Push-Location` or `Pop-Location` cmdlets add or get items from the default stack or use `Get-Location` to display the locations in the unnamed stack.
+To make the unnamed stack the current stack, use the **StackName** parameter of `Set-Location` with a value of `$null` or an empty string ("").
 
 ## RELATED LINKS
 


### PR DESCRIPTION
Make formatting consistent for all PowerShell versions.

Add blank lines.
Fix code and output blocks.
Format the cmdlet and parameter names.
Fix typos.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work