### PR TITLE
Fix a typo in using-vscode.md

### DIFF
--- a/reference/docs-conceptual/core-powershell/vscode/using-vscode.md
+++ b/reference/docs-conceptual/core-powershell/vscode/using-vscode.md
@@ -33,7 +33,7 @@ For traditional Windows PowerShell workloads, see [Installing Windows PowerShell
   > [!IMPORTANT]
   > On macOS, you must install OpenSSL for the PowerShell extension to work correctly.
   > The easiest way to accomplish this is to install [Homebrew](http://brew.sh/) and then run `brew install openssl`.
-  > VS Code can now load the the PowerShell extension successfully.
+  > VS Code can now load the PowerShell extension successfully.
 
 - **Windows**: follow the installation instructions on the [Running VS Code on Windows](https://code.visualstudio.com/docs/setup/windows) page
 


### PR DESCRIPTION
Replace "the the" with "the".

