### PR TITLE
C35472: Adding a space to well create bold content

### DIFF
--- a/wmf/5.0/dsc_statestatus.md
+++ b/wmf/5.0/dsc_statestatus.md
@@ -25,8 +25,8 @@ The table below illustrates the resultant state and status related properties un
 
 | Scenario                        | LCMState             | Status     | Reboot Requested | ResourcesInDesiredState   | ResourcesNotInDesiredState |
 |---------------------------------|----------------------|------------|---------------|------------------------------|--------------------------------|
-| S**^**                          | Idle                 | Success    | $false        | S                            | $null                          |
-| F**^**                          | PendingConfiguration | Failure    | $false        | $null                        | F                              |
+| S **^**                          | Idle                 | Success    | $false        | S                            | $null                          |
+| F **^**                          | PendingConfiguration | Failure    | $false        | $null                        | F                              |
 | S,F                             | PendingConfiguration | Failure    | $false        | S                            | F                              |
 | F,S                             | PendingConfiguration | Failure    | $false        | S                            | F                              |
 | S<sub>1</sub>, F, S<sub>2</sub> | PendingConfiguration | Failure    | $false        | S<sub>1</sub>, S<sub>2</sub> | F                              |

--- a/wmf/5.0/dsc_statestatus.md
+++ b/wmf/5.0/dsc_statestatus.md
@@ -25,8 +25,8 @@ The table below illustrates the resultant state and status related properties un
 
 | Scenario                        | LCMState             | Status     | Reboot Requested | ResourcesInDesiredState   | ResourcesNotInDesiredState |
 |---------------------------------|----------------------|------------|---------------|------------------------------|--------------------------------|
-| S **^**                          | Idle                 | Success    | $false        | S                            | $null                          |
-| F **^**                          | PendingConfiguration | Failure    | $false        | $null                        | F                              |
+| S<sub>i</sub>                   | Idle                 | Success    | $false        | S                            | $null                          |
+| F<sub>i</sub>                   | PendingConfiguration | Failure    | $false        | $null                        | F                              |
 | S,F                             | PendingConfiguration | Failure    | $false        | S                            | F                              |
 | F,S                             | PendingConfiguration | Failure    | $false        | S                            | F                              |
 | S<sub>1</sub>, F, S<sub>2</sub> | PendingConfiguration | Failure    | $false        | S<sub>1</sub>, S<sub>2</sub> | F                              |


### PR DESCRIPTION
Hello, @sdwheeler,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: There are visible asterisks that maybe are intended for bold style.

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.