### PR TITLE
Add link to Format.ps1xml schema reference

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -399,4 +399,4 @@ signature. For more information, see [about_Signing](about_Signing.md).
 
 [Get-TraceSource](../../Microsoft.PowerShell.Utility/Get-TraceSource.md)
 
-[Format Schema XML Reference](../../../../developer/format/format-schema-xml-reference.md)
+[Format Schema XML Reference](/powershell/developer/format/format-schema-xml-reference)

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -398,3 +398,5 @@ signature. For more information, see [about_Signing](about_Signing.md).
 [Trace-Command](../../Microsoft.PowerShell.Utility/Trace-Command.md)
 
 [Get-TraceSource](../../Microsoft.PowerShell.Utility/Get-TraceSource.md)
+
+[Format Schema XML Reference](../../../../developer/format/format-schema-xml-reference.md)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -400,4 +400,4 @@ signature. For more information, see [about_Signing](about_Signing.md).
 
 [Get-TraceSource](../../Microsoft.PowerShell.Utility/Get-TraceSource.md)
 
-[Format Schema XML Reference](../../../../developer/format/format-schema-xml-reference.md)
+[Format Schema XML Reference](/powershell/developer/format/format-schema-xml-reference)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -399,3 +399,5 @@ signature. For more information, see [about_Signing](about_Signing.md).
 [Trace-Command](../../Microsoft.PowerShell.Utility/Trace-Command.md)
 
 [Get-TraceSource](../../Microsoft.PowerShell.Utility/Get-TraceSource.md)
+
+[Format Schema XML Reference](../../../../developer/format/format-schema-xml-reference.md)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -400,4 +400,4 @@ signature. For more information, see [about_Signing](about_Signing.md).
 
 [Get-TraceSource](../../Microsoft.PowerShell.Utility/Get-TraceSource.md)
 
-[Format Schema XML Reference](../../../../developer/format/format-schema-xml-reference.md)
+[Format Schema XML Reference](/powershell/developer/format/format-schema-xml-reference)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -399,3 +399,5 @@ signature. For more information, see [about_Signing](about_Signing.md).
 [Trace-Command](../../Microsoft.PowerShell.Utility/Trace-Command.md)
 
 [Get-TraceSource](../../Microsoft.PowerShell.Utility/Get-TraceSource.md)
+
+[Format Schema XML Reference](../../../../developer/format/format-schema-xml-reference.md)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -400,4 +400,4 @@ signature. For more information, see [about_Signing](about_Signing.md).
 
 [Get-TraceSource](../../Microsoft.PowerShell.Utility/Get-TraceSource.md)
 
-[Format Schema XML Reference](../../../../developer/format/format-schema-xml-reference.md)
+[Format Schema XML Reference](/powershell/developer/format/format-schema-xml-reference)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -399,3 +399,5 @@ signature. For more information, see [about_Signing](about_Signing.md).
 [Trace-Command](../../Microsoft.PowerShell.Utility/Trace-Command.md)
 
 [Get-TraceSource](../../Microsoft.PowerShell.Utility/Get-TraceSource.md)
+
+[Format Schema XML Reference](../../../../developer/format/format-schema-xml-reference.md)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -400,4 +400,4 @@ signature. For more information, see [about_Signing](about_Signing.md).
 
 [Get-TraceSource](../../Microsoft.PowerShell.Utility/Get-TraceSource.md)
 
-[Format Schema XML Reference](../../../../developer/format/format-schema-xml-reference.md)
+[Format Schema XML Reference](/powershell/developer/format/format-schema-xml-reference)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Format.ps1xml.md
@@ -399,3 +399,5 @@ signature. For more information, see [about_Signing](about_Signing.md).
 [Trace-Command](../../Microsoft.PowerShell.Utility/Trace-Command.md)
 
 [Get-TraceSource](../../Microsoft.PowerShell.Utility/Get-TraceSource.md)
+
+[Format Schema XML Reference](../../../../developer/format/format-schema-xml-reference.md)


### PR DESCRIPTION
I've always found myself looking up the schema reference for specifics, but it is very hard to find. This should help with that.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->