### PR TITLE
Update macOS installation instructions

### DIFF
--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
@@ -10,6 +10,38 @@ PowerShell Core supports macOS 10.12 and higher.
 All packages are available on our GitHub [releases][] page.
 Once the package is installed, run `pwsh` from a terminal.
 
+### Installation of latest stable release via Homebrew on macOS 10.12 or higher
+
+[Homebrew][brew] is the preferred package manager for macOS.
+If the `brew` command is not found, you need to install Homebrew following [their instructions][brew].
+
+To install PowerShell, run:
+
+```sh
+brew cask install powershell
+```
+
+Finally, verify that your install is working properly:
+
+```sh
+pwsh
+```
+
+When new versions of PowerShell are released,
+simply update Homebrew's formulae and upgrade PowerShell:
+
+```sh
+brew update
+brew cask upgrade powershell
+```
+
+> [!NOTE]
+> The commands above can be called from within a PowerShell (pwsh) host,
+> but then the PowerShell shell must be exited and restarted to complete the upgrade
+> and refresh the values shown in $PSVersionTable.
+
+[brew]: http://brew.sh/
+
 ### Installation of latest preview release via Homebrew on macOS 10.12 or higher
 
 [Homebrew][brew] is the preferred package manager for macOS.
@@ -48,48 +80,6 @@ brew cask upgrade powershell-preview
 > and refresh the values shown in $PSVersionTable.
 
 [brew]: http://brew.sh/
-[cask-versions]: https://github.com/Homebrew/homebrew-cask-versions
-
-### Installation of latest preview release via Homebrew on macOS 10.12 or higher
-
-[Homebrew][brew] is the preferred package manager for macOS.
-If the `brew` command is not found, you need to install Homebrew following [their instructions][brew].
-
-Once you've installed Homebrew, installing PowerShell is easy.
-First, install [Homebrew-Cask][cask], so you can install more packages and install [Cask-Versions][cask-version] which lets you install alternative versions of packages:
-
-```sh
-brew tap caskroom/cask
-brew tap caskroom/versions
-```
-
-Now, you can install PowerShell:
-
-```sh
-brew cask install powershell-preview
-```
-
-Finally, verify that your install is working properly:
-
-```sh
-pwsh-preview
-```
-
-When new versions of PowerShell are released,
-simply update Homebrew's formulae and upgrade PowerShell:
-
-```sh
-brew update
-brew cask upgrade powershell-preview
-```
-
-> [!NOTE]
-> The commands above can be called from within a PowerShell (pwsh) host,
-> but then the PowerShell shell must be exited and restarted to complete the upgrade.
-> and refresh the values shown in $PSVersionTable.
-
-[brew]: http://brew.sh/
-[cask]: https://caskroom.github.io/
 [cask-versions]: https://github.com/Homebrew/homebrew-cask-versions
 
 ### Installation via Direct Download

--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
@@ -16,10 +16,9 @@ Once the package is installed, run `pwsh` from a terminal.
 If the `brew` command is not found, you need to install Homebrew following [their instructions][brew].
 
 Once you've installed Homebrew, installing PowerShell is easy.
-First, install [Homebrew-Cask][cask], so you can install more packages and install [Cask-Versions][cask-versions] which lets you install alternative versions of packages:
+First, install [Cask-Versions][cask-versions] which lets you install alternative versions of packages:
 
 ```sh
-brew tap caskroom/cask
 brew tap caskroom/versions
 ```
 
@@ -49,7 +48,6 @@ brew cask upgrade powershell-preview
 > and refresh the values shown in $PSVersionTable.
 
 [brew]: http://brew.sh/
-[cask]: https://caskroom.github.io/
 [cask-versions]: https://github.com/Homebrew/homebrew-cask-versions
 
 ### Installation of latest preview release via Homebrew on macOS 10.12 or higher

--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-macOS.md
@@ -16,7 +16,7 @@ Once the package is installed, run `pwsh` from a terminal.
 If the `brew` command is not found, you need to install Homebrew following [their instructions][brew].
 
 Once you've installed Homebrew, installing PowerShell is easy.
-First, install [Homebrew-Cask][cask], so you can install more packages and install [Cask-Versions][cask-version] which lets you install alternative versions of packages:
+First, install [Homebrew-Cask][cask], so you can install more packages and install [Cask-Versions][cask-versions] which lets you install alternative versions of packages:
 
 ```sh
 brew tap caskroom/cask
@@ -45,7 +45,7 @@ brew cask upgrade powershell-preview
 
 > [!NOTE]
 > The commands above can be called from within a PowerShell (pwsh) host,
-> but then the PowerShell shell must be exited and restarted to complete the upgrade.
+> but then the PowerShell shell must be exited and restarted to complete the upgrade
 > and refresh the values shown in $PSVersionTable.
 
 [brew]: http://brew.sh/


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [x] Impacts 6.0 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->

This PR applies the following fixes to the **Installing PowerShell Core on macOS** chapter:

- Re-add missing installation instructions for the stable version of PowerShell, which seems to have been inadvertently deleted. ([1](https://github.com/TravisEz13/PowerShell-Docs/commit/8305067e9909b5bbba4fd1bedbf64e8a8ce12ea0) [2](https://github.com/TravisEz13/PowerShell-Docs/commit/941cd96d4d0d0fd6702896648c95f42c6620baca))

- Remove instructions for tapping `homebrew/cask`. Those instructions are no longer necessary because Homebrew-Cask is now part of Homebrew ([3](https://github.com/Homebrew/brew/pull/725) [4](https://github.com/Homebrew/homebrew-cask/pull/23852)) and will be tapped automatically ([5](https://github.com/Homebrew/homebrew-cask/tree/3e8674eb8f7fd4932a9e37e44ad80aad103a485a#lets-try-it)).

- Fix a typo in a Markdown link reference.

- Fix punctuation.

