### PR TITLE
Test-Connection TimeToLive description corrected

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/6/Microsoft.PowerShell.Management/Test-Connection.md
@@ -322,9 +322,9 @@ Accept wildcard characters: False
 ```
 
 ### -TimeToLive
-Specifies the maximum time, in seconds, that each echo request packet, or ping, is active.
-Enter an integer between 1 and 255.
-The default value is 80 (seconds).
+Specifies the maximum times a packet can be forwarded. For every hop in gateways, routers etc. 
+the TimeToLive value is decreased by one and at zero the packet is discarded.
+The default value (in Windows) is 128.
 The alias of the *TimeToLive* parameter is *TTL*.
 
 ```yaml


### PR DESCRIPTION
Inconsistent with the source of TestConnectionCommand.cs and in general the Time To Live of packets has this meaning.

Description from source:
https://github.com/PowerShell/PowerShell/blob/master/src/Microsoft.PowerShell.Commands.Management/commands/management/TestConnectionCommand.cs

---Line 85
/// <summary>
        /// The number of times the Ping data packets can be forwarded by routers.
        /// As gateways and routers transmit packets through a network,
        /// they decrement the CurrentMTUSize Time-to-Live (TTL) value found in the packet header.
        /// The default (from Windows) is 128 hops.
/// </summary>
...
---Line 95
[Alias("Ttl")]

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.1 document
- [x] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work