### PR TITLE
Minor tweaks

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -200,21 +200,21 @@ Accept wildcard characters: False
 Specifies the authentication level that is used for the WMI connection.
 The acceptable values for this parameter are:
 
-- Call.
+- Call:
 Call-level COM authentication
-- Connect.
+- Connect:
 Connect-level COM authentication
-- Default.
-Windows Authentication
-- None.
+- Default:
+WMI's default settings (Windows authentication); despite its name, this item is not default value of this cmdlet
+- None:
 No COM authentication
-- Packet.
+- Packet:
 Packet-level COM authentication
-- PacketIntegrity.
+- PacketIntegrity:
 Packet Integrity-level COM authentication
-- PacketPrivacy.
+- PacketPrivacy:
 Packet Privacy-level COM authentication
-- Unchanged.
+- Unchanged:
 The authentication level is the same as the previous command
 
 The default value is Packet.
@@ -263,13 +263,13 @@ This parameter is valid only with the *Wait* parameter.
 
 The acceptable values for this parameter are:
 
-- Default.
+- Default:
 Waits for Windows PowerShell to restart.
-- PowerShell.
+- PowerShell:
 Can run commands in a Windows PowerShell remote session on the computer.
-- WMI.
+- WMI:
 Receives a reply to a Win32_ComputerSystem query for the computer.
-- WinRM.
+- WinRM:
 Can establish a remote session to the computer by using WS-Management.
 
 This parameter was introduced in Windows PowerShell 3.0.
@@ -307,13 +307,13 @@ Specifies the impersonation level that this cmdlet uses to call WMI.
 **Restart-Computer** uses WMI.
 The acceptable values for this parameter are:
 
- -- Default.
-Default impersonation.
-- Anonymous.
+- Default:
+Default impersonation. Despite the name, this item is not the default value for this cmdlet.
+- Anonymous:
 Hides the identity of the caller.
-- Identify.
+- Identify:
 Allows objects to query the credentials of the caller.
-- Impersonate.
+- Impersonate:
 Allows objects to use the credentials of the caller.
 
 The default value is Impersonate.
@@ -478,16 +478,10 @@ Otherwise, it does not generate any output.
 
 ## RELATED LINKS
 
-[Add-Computer](Add-Computer.md)
-
-[Checkpoint-Computer](Checkpoint-Computer.md)
-
-[Rename-Computer](Rename-Computer.md)
-
-[Remove-Computer](Remove-Computer.md)
-
-[Restore-Computer](Restore-Computer.md)
-
-[Stop-Computer](Stop-Computer.md)
-
-[Test-Connection](Test-Connection.md)
+* [Add-Computer](Add-Computer.md)
+* [Checkpoint-Computer](Checkpoint-Computer.md)
+* [Rename-Computer](Rename-Computer.md)
+* [Remove-Computer](Remove-Computer.md)
+* [Restore-Computer](Restore-Computer.md)
+* [Stop-Computer](Stop-Computer.md)
+* [Test-Connection](Test-Connection.md)

--- a/reference/5.1/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -463,10 +463,16 @@ In Windows PowerShell 2.0, *AsJob* does not work reliably when you are restartin
 
 ## RELATED LINKS
 
-* [Add-Computer](Add-Computer.md)
-* [Checkpoint-Computer](Checkpoint-Computer.md)
-* [Rename-Computer](Rename-Computer.md)
-* [Remove-Computer](Remove-Computer.md)
-* [Restore-Computer](Restore-Computer.md)
-* [Stop-Computer](Stop-Computer.md)
-* [Test-Connection](Test-Connection.md)
+[Add-Computer](Add-Computer.md)
+
+[Checkpoint-Computer](Checkpoint-Computer.md)
+
+[Rename-Computer](Rename-Computer.md)
+
+[Remove-Computer](Remove-Computer.md)
+
+[Restore-Computer](Restore-Computer.md)
+
+[Stop-Computer](Stop-Computer.md)
+
+[Test-Connection](Test-Connection.md)

--- a/reference/5.1/Microsoft.PowerShell.Management/Restart-Computer.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Restart-Computer.md
@@ -200,22 +200,14 @@ Accept wildcard characters: False
 Specifies the authentication level that is used for the WMI connection.
 The acceptable values for this parameter are:
 
-- Call:
-Call-level COM authentication
-- Connect:
-Connect-level COM authentication
-- Default:
-WMI's default settings (Windows authentication); despite its name, this item is not default value of this cmdlet
-- None:
-No COM authentication
-- Packet:
-Packet-level COM authentication
-- PacketIntegrity:
-Packet Integrity-level COM authentication
-- PacketPrivacy:
-Packet Privacy-level COM authentication
-- Unchanged:
-The authentication level is the same as the previous command
+- Call: Call-level COM authentication
+- Connect: Connect-level COM authentication
+- Default: WMI's default settings (Windows authentication); despite its name, this item is not default value of this cmdlet
+- None: No COM authentication
+- Packet: Packet-level COM authentication
+- PacketIntegrity: Packet Integrity-level COM authentication
+- PacketPrivacy: Packet Privacy-level COM authentication
+- Unchanged: The authentication level is the same as the previous command
 
 The default value is Packet.
 
@@ -263,14 +255,10 @@ This parameter is valid only with the *Wait* parameter.
 
 The acceptable values for this parameter are:
 
-- Default:
-Waits for Windows PowerShell to restart.
-- PowerShell:
-Can run commands in a Windows PowerShell remote session on the computer.
-- WMI:
-Receives a reply to a Win32_ComputerSystem query for the computer.
-- WinRM:
-Can establish a remote session to the computer by using WS-Management.
+- Default: Waits for Windows PowerShell to restart.
+- PowerShell: Can run commands in a Windows PowerShell remote session on the computer.
+- WMI: Receives a reply to a Win32_ComputerSystem query for the computer.
+- WinRM: Can establish a remote session to the computer by using WS-Management.
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -307,14 +295,10 @@ Specifies the impersonation level that this cmdlet uses to call WMI.
 **Restart-Computer** uses WMI.
 The acceptable values for this parameter are:
 
-- Default:
-Default impersonation. Despite the name, this item is not the default value for this cmdlet.
-- Anonymous:
-Hides the identity of the caller.
-- Identify:
-Allows objects to query the credentials of the caller.
-- Impersonate:
-Allows objects to use the credentials of the caller.
+- Default: Default impersonation. Despite the name, this item is not the default value for this cmdlet.
+- Anonymous: Hides the identity of the caller.
+- Identify: Allows objects to query the credentials of the caller.
+- Impersonate: Allows objects to use the credentials of the caller.
 
 The default value is Impersonate.
 
@@ -461,7 +445,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.String
-You can pipe computer names to this cmdlet..
+You can pipe computer names to this cmdlet.
 
 In Windows PowerShell 2.0, the *ComputerName* parameter takes input from the pipeline only by property name.
 In Windows PowerShell 3.0, the *ComputerName* parameter takes input from the pipeline by value.
@@ -473,8 +457,9 @@ This cmdlet returns a job object, if you specify the *AsJob* parameter.
 Otherwise, it does not generate any output.
 
 ## NOTES
-* This cmdlet uses the **Win32Shutdown** method of the WMI **WIN32_OperatingSystem** class.
-* In Windows PowerShell 2.0, *AsJob* does not work reliably when you are restarting/stopping remote computers. In Windows PowerShell 3.0, the implementation is changed to resolve this problem.
+
+This cmdlet uses the **Win32Shutdown** method of the WMI **WIN32_OperatingSystem** class.
+In Windows PowerShell 2.0, *AsJob* does not work reliably when you are restarting/stopping remote computers. In Windows PowerShell 3.0, the implementation is changed to resolve this problem.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
1. In three cases, I specified that although the parameter accepts a "Default" value, this value is not the default value for the cmdlet.
2. Fixed several formatting artifacts. For example, in the Impersonation section, I replaced a " --" (clearly a typo) with a bullet.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
