### PR TITLE
Fix PSCustomObject Count/Length properties and ForEach/Where methods description.

### DIFF
--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-61.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-61.md
@@ -330,46 +330,41 @@ By popular demand, `Update-Help` no longer needs to be run as an administrator.
 ### New methods/properties on `PSCustomObject`
 
 Thanks to [@iSazonov](https://github.com/iSazonov), we've added new methods and properties to `PSCustomObject`.
-`PSCustomObject` now includes a `Count`/`Length` property that gives the number of items.
-
-Both of these examples return `2` as the number of `PSCustomObjects` in the collection.
+`PSCustomObject` now includes a `Count`/`Length` property like other objects.
 
 ```powershell
-@(
-[pscustomobject]@{foo = '1'},
-[pscustomobject]@{bar = '2' }).Length
+[pscustomobject]@{foo = '1'}.Length
+```
+
+```Output
+1
 ```
 
 ```powershell
-@(
-[pscustomobject]@{foo = '1'},
-[pscustomobject]@{bar = '2' }).Count
+[pscustomobject]@{foo = '1'}.Count
+```
+
+```Output
+1
 ```
 
 This work also includes `ForEach` and `Where` methods that allow you
 to operate and filter on `PSCustomObject` items:
 
 ```powershell
-@(
->> [pscustomobject]@{foo = 1},
->> [pscustomobject]@{foo = 2 }).ForEach({$_.foo+1})
+[pscustomobject]@{foo = 1}.ForEach({$_.foo + 1})
 ```
 
 ```Output
 2
-3
 ```
 
 ```powershell
-@(
->> [pscustomobject]@{foo = 1},
->> [pscustomobject]@{foo = 2 }).Where({$_.foo -gt 1})
+[pscustomobject]@{foo = 1}.Where({$_.foo -gt 0}).foo
 ```
 
 ```Output
-foo
----
-  2
+1
 ```
 
 ### `Where-Object -Not`


### PR DESCRIPTION
The **Count/Length** properties and **ForEach/Where** methods was actually added to a **singleton** PSCustomObject.

But examples show applying these methods/properties to **arrays** of PSCustomObject, which existed for quite some time.



<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
