### PR TITLE
Fix TimeToLive (MaxHops) parameter description.

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Test-Connection.md
+++ b/reference/6/Microsoft.PowerShell.Management/Test-Connection.md
@@ -321,16 +321,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -TimeToLive
-Specifies the maximum times a packet can be forwarded. For every hop in gateways, routers etc. 
-the TimeToLive value is decreased by one and at zero the packet is discarded.
+### -MaxHops
+Specifies the maximum times a packet can be forwarded. For every hop in gateways, routers etc.
+the specified value, known as *Time To Live*, is decreased by one and at zero the packet is discarded.
 The default value (in Windows) is 128.
-The alias of the *TimeToLive* parameter is *TTL*.
+The aliases of the *MaxHops* parameter are *TTL*, *TimeToLive*, *Hops*.
 
 ```yaml
 Type: Int32
 Parameter Sets: (All)
-Aliases: TTL
+Aliases: TTL, TimeToLive, Hops
 
 Required: False
 Position: Named


### PR DESCRIPTION
Fix #2956 

Change description for **MaxHops** (previously **TimeToLive**) parameter of `Test-Connection` cmdlet in **PowerShell Core 6.1**.
Add info about new aliases. PR: PowerShell/PowerShell#7850

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
