### PR TITLE
Remove unavailable `-Help` parameter

### DIFF
--- a/reference/docs-conceptual/getting-started/fundamental/Learning-PowerShell-Names.md
+++ b/reference/docs-conceptual/getting-started/fundamental/Learning-PowerShell-Names.md
@@ -126,8 +126,8 @@ Here are some of the general characteristics of the standard parameter names and
 
 ### The Help parameter (?)
 
-When you specify the `-Help` or `-?` parameter on any cmdlet, PowerShell displays help for the
-cmdlet. The cmdlet is not executed.
+When you specify the `-?` parameter on any cmdlet, PowerShell displays help for the cmdlet.
+The cmdlet is not executed.
 
 ### Common parameters
 


### PR DESCRIPTION
The `-Help` parameter on any cmdlet does not work.