### PR TITLE
Removing powershell alias' in example code

### DIFF
--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Windows.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Windows.md
@@ -61,14 +61,14 @@ Windows IoT already comes with Windows PowerShell which we will use to deploy Po
 
    ```powershell
    Enter-PSSession $s
-   cd u:\users\administrator\downloads
+   Set-Location u:\users\administrator\downloads
    Expand-Archive .\PowerShell-6.1.0-win-arm32.zip
    ```
 
 4. Setup remoting to PowerShell Core 6
 
    ```powershell
-   cd .\PowerShell-6.1.0-win-arm32
+   Set-Location .\PowerShell-6.1.0-win-arm32
    # Be sure to use the -PowerShellHome parameter otherwise it'll try to create a new
    # endpoint with Windows PowerShell 5.1
    .\Install-PowerShellRemoting.ps1 -PowerShellHome .


### PR DESCRIPTION
It is best practice to avoid using powershell alias in production code as cd is hard to read and folks may not have linux support to understand what change directory  means.

https://blogs.technet.microsoft.com/heyscriptingguy/2013/04/08/using-powershell-aliases-best-practices/ to expand more on it.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
