### PR TITLE
Fixed missing whitespace between words.

### DIFF
--- a/reference/5.1/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Disable-ComputerRestore.md
@@ -115,7 +115,7 @@ You cannot pipe input to this cmdlet.
 This cmdlet does not generate any output.
 
 ## NOTES
-* To run this cmdlet on Windows Vistaand later versions of Windows, open Windows PowerShell with the Run as administrator option.
+* To run this cmdlet on Windows Vista and later versions of Windows, open Windows PowerShell with the Run as administrator option.
 
   To find the file system drives that are eligible for system restore, in System in Control Panel, see the System Protection tab.
 To open this tab in Windows PowerShell, type `SystemPropertiesProtection`.


### PR DESCRIPTION
Line 118 `Windows Vistaand` to `Windows Vista and`

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [x] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
