### PR TITLE
Add "Potential confusion with comparison operators" section

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -137,7 +137,7 @@ PS> 7, 8, 9 -gt 8
 9
 ```
 
-Note: Not to be confused with `>`, the greater-than operator in many other programming languages. See: [Powershell redirection operators](/reference/3.0/Microsoft.PowerShell.Core/About/about_Redirection.md#potential-confusion-with-comparison-operators).  
+Note: Not to be confused with `>`, the greater-than operator in many other programming languages. See: [Powershell redirection operators](about_Redirection.md#potential-confusion-with-comparison-operators).  
 
 #### -ge
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -137,6 +137,8 @@ PS> 7, 8, 9 -gt 8
 9
 ```
 
+Note: Not to be confused with `>`, the greater-than operator in many other programming languages. See: [Powershell redirection operators](/reference/3.0/Microsoft.PowerShell.Core/About/about_Redirection.md#potential-confusion-with-comparison-operators).  
+
 #### -ge
 
 Description: Greater-than or equal to.

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -127,7 +127,7 @@ with its `Encoding` parameter.
 
 ### Potential confusion with comparison operators 
 
-The `>` operator is not to be confused with the [Greater-than](/reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md#-gt) comparison operator (often denoted as `>` in other programming languages). 
+The `>` operator is not to be confused with the [Greater-than](about_Comparison_Operators.md#-gt) comparison operator (often denoted as `>` in other programming languages). 
 
 Depending on the objects being compared, the output using `>` can appear to be correct (because 36 is not greater than 42).
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -125,6 +125,44 @@ If the file has a different encoding, the output might not be formatted
 correctly. To redirect content to non-Unicode files, use the `Out-File` cmdlet
 with its `Encoding` parameter.
 
+### Potential confusion with comparison operators 
+
+The `>` operator is not to be confused with the [Greater-than](/reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md#-gt) comparison operator (often denoted as `>` in other programming languages). 
+
+Depending on the objects being compared, the output using `>` can appear to be correct (because 36 is not greater than 42).
+
+```powershell
+PS> if (36 > 42) { "true" } else { "false" }
+false
+```
+
+However, a check of the local filesystem can see that a file called `42` was written, with the contents `36`. 
+
+```powershell
+PS> dir
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+------          1/02/20  10:10 am              3 42
+
+PS> cat 42
+36
+```
+
+Attempting to use the reverse comparison `<` (less than), yields a system error: 
+
+```powershell
+PS> if (36 < 42) { "true" } else { "false" }
+At line:1 char:8
++ if (36 < 42) { "true" } else { "false" }
++        ~
+The '<' operator is reserved for future use.
++ CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
++ FullyQualifiedErrorId : RedirectionNotSupported
+```
+
+If numeric comparison is the required operation, `-lt` and `-gt` should be used. See: [`-gt` Comparison Operator](reference/3.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md#-gt)
+
 ## See also
 
 [Out-File](../../microsoft.powershell.utility/Out-File.md)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -138,6 +138,8 @@ PS> 7, 8, 9 -gt 8
 9
 ```
 
+Note: Not to be confused with `>`, the greater-than operator in many other programming languages. See: [Powershell redirection operators](about_Redirection.md#potential-confusion-with-comparison-operators).  
+
 #### -ge
 
 Description: Greater-than or equal to.

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -125,6 +125,44 @@ If the file has a different encoding, the output might not be formatted
 correctly. To redirect content to non-Unicode files, use the `Out-File` cmdlet
 with its `Encoding` parameter.
 
+### Potential confusion with comparison operators
+
+The `>` operator is not to be confused with the [Greater-than](about_Comparison_Operators.md#-gt) comparison operator (often denoted as `>` in other programming languages).
+
+Depending on the objects being compared, the output using `>` can appear to be correct (because 36 is not greater than 42).
+
+```powershell
+PS> if (36 > 42) { "true" } else { "false" }
+false
+```
+
+However, a check of the local filesystem can see that a file called `42` was written, with the contents `36`.
+
+```powershell
+PS> dir
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+------          1/02/20  10:10 am              3 42
+
+PS> cat 42
+36
+```
+
+Attempting to use the reverse comparison `<` (less than), yields a system error:
+
+```powershell
+PS> if (36 < 42) { "true" } else { "false" }
+At line:1 char:8
++ if (36 < 42) { "true" } else { "false" }
++        ~
+The '<' operator is reserved for future use.
++ CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
++ FullyQualifiedErrorId : RedirectionNotSupported
+```
+
+If numeric comparison is the required operation, `-lt` and `-gt` should be used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt)
+
 ## See also
 
 [Out-File](../../microsoft.powershell.utility/Out-File.md)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -138,6 +138,8 @@ PS> 7, 8, 9 -gt 8
 9
 ```
 
+Note: Not to be confused with `>`, the greater-than operator in many other programming languages. See: [Powershell redirection operators](about_Redirection.md#potential-confusion-with-comparison-operators).  
+
 #### -ge
 
 Description: Greater-than or equal to.

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -138,6 +138,45 @@ If the file has a different encoding, the output might not be formatted
 correctly. To redirect content to non-Unicode files, use the `Out-File` cmdlet
 with its `Encoding` parameter.
 
+### Potential confusion with comparison operators
+
+The `>` operator is not to be confused with the [Greater-than](about_Comparison_Operators.md#-gt) comparison operator (often denoted as `>` in other programming languages).
+
+Depending on the objects being compared, the output using `>` can appear to be correct (because 36 is not greater than 42).
+
+```powershell
+PS> if (36 > 42) { "true" } else { "false" }
+false
+```
+
+However, a check of the local filesystem can see that a file called `42` was written, with the contents `36`.
+
+```powershell
+PS> dir
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+------          1/02/20  10:10 am              3 42
+
+PS> cat 42
+36
+```
+
+Attempting to use the reverse comparison `<` (less than), yields a system error:
+
+```powershell
+PS> if (36 < 42) { "true" } else { "false" }
+At line:1 char:8
++ if (36 < 42) { "true" } else { "false" }
++        ~
+The '<' operator is reserved for future use.
++ CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
++ FullyQualifiedErrorId : RedirectionNotSupported
+```
+
+If numeric comparison is the required operation, `-lt` and `-gt` should be used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt)
+
+
 ## See also
 
 [Out-File](../../microsoft.powershell.utility/Out-File.md)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -138,6 +138,8 @@ PS> 7, 8, 9 -gt 8
 9
 ```
 
+Note: Not to be confused with `>`, the greater-than operator in many other programming languages. See: [Powershell redirection operators](about_Redirection.md#potential-confusion-with-comparison-operators).  
+
 #### -ge
 
 Description: Greater-than or equal to.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -138,6 +138,44 @@ If the file has a different encoding, the output might not be formatted
 correctly. To redirect content to non-Unicode files, use the `Out-File` cmdlet
 with its `Encoding` parameter.
 
+### Potential confusion with comparison operators
+
+The `>` operator is not to be confused with the [Greater-than](about_Comparison_Operators.md#-gt) comparison operator (often denoted as `>` in other programming languages).
+
+Depending on the objects being compared, the output using `>` can appear to be correct (because 36 is not greater than 42).
+
+```powershell
+PS> if (36 > 42) { "true" } else { "false" }
+false
+```
+
+However, a check of the local filesystem can see that a file called `42` was written, with the contents `36`.
+
+```powershell
+PS> dir
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+------          1/02/20  10:10 am              3 42
+
+PS> cat 42
+36
+```
+
+Attempting to use the reverse comparison `<` (less than), yields a system error:
+
+```powershell
+PS> if (36 < 42) { "true" } else { "false" }
+At line:1 char:8
++ if (36 < 42) { "true" } else { "false" }
++        ~
+The '<' operator is reserved for future use.
++ CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
++ FullyQualifiedErrorId : RedirectionNotSupported
+```
+
+If numeric comparison is the required operation, `-lt` and `-gt` should be used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt)
+
 ## See also
 
 [Out-File](../../microsoft.powershell.utility/Out-File.md)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Comparison_Operators.md
@@ -138,6 +138,8 @@ PS> 7, 8, 9 -gt 8
 9
 ```
 
+Note: Not to be confused with `>`, the greater-than operator in many other programming languages. See: [Powershell redirection operators](about_Redirection.md#potential-confusion-with-comparison-operators).  
+
 #### -ge
 
 Description: Greater-than or equal to.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Redirection.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Redirection.md
@@ -138,6 +138,44 @@ If the file has a different encoding, the output might not be formatted
 correctly. To redirect content to non-Unicode files, use the `Out-File` cmdlet
 with its `Encoding` parameter.
 
+### Potential confusion with comparison operators
+
+The `>` operator is not to be confused with the [Greater-than](about_Comparison_Operators.md#-gt) comparison operator (often denoted as `>` in other programming languages).
+
+Depending on the objects being compared, the output using `>` can appear to be correct (because 36 is not greater than 42).
+
+```powershell
+PS> if (36 > 42) { "true" } else { "false" }
+false
+```
+
+However, a check of the local filesystem can see that a file called `42` was written, with the contents `36`.
+
+```powershell
+PS> dir
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+------          1/02/20  10:10 am              3 42
+
+PS> cat 42
+36
+```
+
+Attempting to use the reverse comparison `<` (less than), yields a system error:
+
+```powershell
+PS> if (36 < 42) { "true" } else { "false" }
+At line:1 char:8
++ if (36 < 42) { "true" } else { "false" }
++        ~
+The '<' operator is reserved for future use.
++ CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
++ FullyQualifiedErrorId : RedirectionNotSupported
+```
+
+If numeric comparison is the required operation, `-lt` and `-gt` should be used. See: [`-gt` Comparison Operator](about_Comparison_Operators.md#-gt)
+
 ## See also
 
 [Out-File](../../microsoft.powershell.utility/Out-File.md)


### PR DESCRIPTION
Adds a section to both `about_Redirection` noting the potential confusion between `-gt` and `>`. 

Added link in `-gt` to reference this note. 

---

Based on original research based on an issue I encountered when attempting numeric comparison and not understanding the language. Since working out the source and work-around, I thought adding a note to the documentation may help someone else avoid this bug. 

(Sorry about any line ending issues, happy to rebase/squash this commit, however the contribution guidelines require)



Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

