### PR TITLE
Remove reference to .NET Framework

### DIFF
--- a/reference/docs-conceptual/PowerShell-Scripting.md
+++ b/reference/docs-conceptual/PowerShell-Scripting.md
@@ -5,7 +5,7 @@ title:  PowerShell Scripting
 ---
 # PowerShell
 
-PowerShell is a task-based command-line shell and scripting language built on the .NET Framework.
+PowerShell is a task-based command-line shell and scripting language built on .NET.
 PowerShell helps system administrators and power-users can rapidly automate tasks that manage
 operating systems (Linux, macOS, and Windows) and processes.
 


### PR DESCRIPTION
.NET Framework was used for Windows PowerShell. .NET Core was used for PowerShell Core.

I've removed the reference to "Framework" and left it at .NET.

Possible consideration: hyper link to https://www.microsoft.com/net