### PR TITLE
Updated the parameters

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/5.0/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -119,7 +119,7 @@ Accepted values: Optimal, NoCompression, Fastest
 
 Required: False
 Position: Named
-Default value: None
+Default value: Optimal
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -167,7 +167,7 @@ Aliases:
 
 Required: True
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -220,7 +220,7 @@ Aliases:
 
 Required: True
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/5.1/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/5.1/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -123,7 +123,7 @@ Accepted values: Optimal, NoCompression, Fastest
 
 Required: False
 Position: Named
-Default value: None
+Default value: Optimal
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -171,7 +171,7 @@ Aliases:
 
 Required: True
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -224,7 +224,7 @@ Aliases:
 
 Required: True
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/reference/6/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/6/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -115,10 +115,11 @@ If this parameter is not specified, the command uses the default value, Optimal.
 Type: String
 Parameter Sets: (All)
 Aliases:
+Accepted values: Optimal, NoCompression, Fastest
 
 Required: False
 Position: Named
-Default value: None
+Default value: Optimal
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -135,7 +136,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -172,7 +173,7 @@ Parameter Sets: Path, PathWithUpdate, PathWithForce
 Aliases:
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
@@ -189,7 +190,7 @@ Aliases:
 
 Required: True
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -235,7 +236,7 @@ Aliases:
 
 Required: True
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
Fixing issue #2670 parameters with values based on [Microsoft.PowerShell.Archive.psm1](https://github.com/PowerShell/Microsoft.PowerShell.Archive/blob/master/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1) parameters.

#### PowerShell 5.0 - Minor Fixes
- Updated the `-CompressionLevel` default value from `None` to `Optimal`
- Updated the `-Update` default value from `None` to `False`
- Updated the `-Force` default value from `None` to `False`

#### PowerShell 5.1 - Minor Fixes
- Updated the `-CompressionLevel` default value from `None` to `Optimal`
- Updated the `-Update` default value from `None` to `False`
- Updated the `-Force` default value from `None` to `False`

#### PowerShell 6 - Minor Fixes
- Updated the `-CompressionLevel` default value from `None` to `Optimal`
- Updated the `-Update` default value from `None` to `False`
- Updated the `-Force` default value from `None` to `False`
- Added `Accepted values: Optimal, NoCompression, Fastest` to `-CompressionLevel`
- Updated the `-DestinationPath` position from `2` to `1`
- Updated the `-Path` position from `1` to `0`
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (5.0, 5.1, 6.x) of PowerShell
- [x] This issue only shows up in version (5.0, 5.1, 6) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
