### PR TITLE
Documented difference of this cmdlet in Unix v Window

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/6/Microsoft.PowerShell.Management/Start-Process.md
@@ -396,7 +396,7 @@ Otherwise, this cmdlet does not return any output.
 ## NOTES
 * This cmdlet is implemented by using the **Start** method of the **System.Diagnostics.Process** class. For more information about this method, see [Process.Start Method](https://msdn.microsoft.com/library/system.diagnostics.process.start) in the MSDN library.
 
-* When using PowerShell Core on Linux, to open a new process within a new window (similar to the default behavior when using Start-Process in Windows), run the cmdlet with -UseNewEnvironment -Wait.  This is done to prevent the new process from blocking PowerShell's control of keyboard input.
+* When using PowerShell Core on Linux, to open a new process within a new window (similar to the default behavior when using Start-Process in Windows), run the cmdlet with the `-UseNewEnvironment -Wait` parameters.  This is done to prevent the new process from blocking PowerShell's control of keyboard input.
 
 ## RELATED LINKS
 

--- a/reference/6/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/6/Microsoft.PowerShell.Management/Start-Process.md
@@ -396,6 +396,8 @@ Otherwise, this cmdlet does not return any output.
 ## NOTES
 * This cmdlet is implemented by using the **Start** method of the **System.Diagnostics.Process** class. For more information about this method, see [Process.Start Method](https://msdn.microsoft.com/library/system.diagnostics.process.start) in the MSDN library.
 
+* When using PowerShell Core on Linux, to open a new process within a new window (similar to the default behavior when using Start-Process in Windows), run the cmdlet with -UseNewEnvironment -Wait.  This is done to prevent the new process from blocking PowerShell's control of keyboard input.
+
 ## RELATED LINKS
 
 [Debug-Process](Debug-Process.md)


### PR DESCRIPTION
Summarized the information here in the notes for this cmdlet.

https://github.com/PowerShell/PowerShell/issues/4521#issuecomment-324931106

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
