### PR TITLE
corrected mention of PSDirect to apply to containers when trying pwsh first

### DIFF
--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-61.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-61.md
@@ -208,13 +208,13 @@ and [`Invoke-RestMethod`](/powershell/module/microsoft.powershell.utility/invoke
 
 ## Remoting improvements
 
-### PowerShell Direct tries to use PowerShell Core first
+### PowerShell Direct for Containers tries to use PowerShell Core first
 
 [PowerShell Direct](/virtualization/hyper-v-on-windows/user-guide/powershell-direct)
-is a feature of PowerShell and Hyper-V that allows you to connect to a Hyper-V VM
+is a feature of PowerShell and Hyper-V that allows you to connect to a Hyper-V VM or Container
 without network connectivity or other remote management services.
 
-In the past, PowerShell Direct connected using the inbox Windows PowerShell instance on the VM.
+In the past, PowerShell Direct connected using the inbox Windows PowerShell instance on the Container.
 Now, PowerShell Direct first attempts to connect using any available `pwsh.exe` on the `PATH` environment variable.
 If `pwsh.exe` isn't available, PowerShell Direct falls back to use `powershell.exe`.
 


### PR DESCRIPTION
Per https://github.com/PowerShell/PowerShell/issues/7919, looking at the code, the change in PSCore6.1 is only in the Container path and not the VM path.  So the change in 6.1 is that we try starting pwsh.exe first then fallback to powershell.exe.  For VMs, there is no change and it tries the default microsoft.powershell endpoint which, by default, goes to Windows PowerShell (although it can be changed by the user).

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [X] The documented feature was introduced in version (6.1) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
