### PR TITLE
Update Set-PSReadlineOption.md in 6.1

### DIFF
--- a/reference/6/PSReadLine/Set-PSReadlineOption.md
+++ b/reference/6/PSReadLine/Set-PSReadlineOption.md
@@ -18,24 +18,30 @@ Customizes the behavior of command line editing in PSReadline.
 ### OptionsSet
 
 ```
-Set-PSReadlineOption [-EditMode <EditMode>] [-ContinuationPrompt <String>]
- [-ContinuationPromptForegroundColor <ConsoleColor>] [-ContinuationPromptBackgroundColor <ConsoleColor>]
- [-EmphasisForegroundColor <ConsoleColor>] [-EmphasisBackgroundColor <ConsoleColor>]
- [-ErrorForegroundColor <ConsoleColor>] [-ErrorBackgroundColor <ConsoleColor>] [-HistoryNoDuplicates]
- [-AddToHistoryHandler <System.Func`2[System.String,System.Boolean]>]
- [-CommandValidationHandler <System.Action`1[System.Management.Automation.Language.CommandAst]>]
- [-HistorySearchCursorMovesToEnd] [-MaximumHistoryCount <Int32>] [-MaximumKillRingCount <Int32>]
- [-ResetTokenColors] [-ShowToolTips] [-ExtraPromptLineCount <Int32>] [-DingTone <Int32>]
- [-DingDuration <Int32>] [-BellStyle <BellStyle>] [-CompletionQueryItems <Int32>] [-WordDelimiters <String>]
- [-HistorySearchCaseSensitive] [-HistorySaveStyle <HistorySaveStyle>] [-HistorySavePath <String>]
- [-ViModeIndicator <ViModeStyle>] [<CommonParameters>]
-```
-
-### ColorSet
-
-```
-Set-PSReadlineOption [-TokenKind] <TokenClassification> [[-ForegroundColor] <ConsoleColor>]
- [[-BackgroundColor] <ConsoleColor>] [<CommonParameters>]
+Set-PSReadLineOption
+ [-EditMode <EditMode>]
+ [-HistorySavePath <String>]
+ [-HistorySaveStyle <HistorySaveStyle>]
+ [-HistoryNoDuplicates]
+ [-HistorySearchCaseSensitive]
+ [-PromptText <string>]
+ [-ExtraPromptLineCount <Int32>]
+ [-Colors <Hashtable>]
+ [-AddToHistoryHandler <Func[String, Boolean]>]
+ [-CommandValidationHandler <Action[CommandAst]>]
+ [-ContinuationPrompt <String>]
+ [-HistorySearchCursorMovesToEnd]
+ [-MaximumHistoryCount <Int32>]
+ [-MaximumKillRingCount <Int32>]
+ [-ShowToolTips]
+ [-DingTone <Int32>]
+ [-DingDuration <Int32>]
+ [-BellStyle <BellStyle>]
+ [-CompletionQueryItems <Int32>]
+ [-WordDelimiters <string>]
+ [-AnsiEscapeTimeout <int>]
+ [-ViModeIndicator <ViModeStyle>]
+ [-ViModeChangeHandler <ScriptBlock>]
 ```
 
 ## DESCRIPTION
@@ -62,447 +68,171 @@ This cmdlet instructs PSReadline to respond to errors and other conditions that 
 
 ## PARAMETERS
 
-### -AddToHistoryHandler
+### -EditMode
 
-Specifies a **ScriptBlock** that controls which commands get added to PSReadline history.
+Specifies the command line editing mode.
+This will reset any key bindings set by Set-PSReadLineKeyHandler.
+
+Valid values are:
+
+-- Windows: Key bindings emulate PowerShell/cmd with some bindings emulating Visual Studio.
+
+-- Emacs: Key bindings emulate Bash or Emacs.
+
+-- Vi: Key bindings emulate Vi.
 
 ```yaml
-Type: System.Func`2[System.String,System.Boolean]
-Parameter Sets: OptionsSet
+Type: EditMode
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
+Default value: Windows
+Accept pipeline input: false
 Accept wildcard characters: False
 ```
 
-### -BackgroundColor
+### -PromptText
 
-Specifies the background color for the token kind that is specified by the *TokenKind* parameter.
+When there is a parse error, PSReadLine changes a part of the prompt red.
+PSReadLine analyzes your prompt function to determine how it can change just the color of part of your prompt,
+but this analysis cannot be 100% reliable.
 
-The acceptable values for this parameter are:
+Use this option if PSReadLine is changing your prompt in surprising ways,
+be sure to include any trailing whitespace.
 
-- Black
-- DarkBlue
-- DarkGreen
-- DarkCyan
-- DarkRed
-- DarkMagenta
-- DarkYellow
-- Gray
-- DarkGray
-- Blue
-- Green
-- Cyan
-- Red
-- Magenta
-- Yellow
-- White
+For example, if my prompt function looked like:
+
+    function prompt { Write-Host -NoNewLine -ForegroundColor Yellow "$pwd"; return "# " }
+
+Then set:
+
+    Set-PSReadLineOption -PromptText "# "
+
 
 ```yaml
-Type: ConsoleColor
-Parameter Sets: ColorSet
-Aliases:
-Accepted values: Black, DarkBlue, DarkGreen, DarkCyan, DarkRed, DarkMagenta, DarkYellow, Gray, DarkGray, Blue, Green, Cyan, Red, Magenta, Yellow, White
-
-Required: False
-Position: 2
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -BellStyle
-
-Specifies how PSReadLine responds to various error conditions or user prompts.
-If you do not specify this parameter, the default response is Audible.
-The acceptable values for this parameter are:
-
-- None.
-No feedback.
-- Visual.
-Text flashes briefly.
-- Audible.
-A short beep.
-
-```yaml
-Type: BellStyle
-Parameter Sets: OptionsSet
-Aliases:
-Accepted values: None, Visual, Audible
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -CommandValidationHandler
-
-Specifies a **ScriptBlock** that is called from **ValidateAndAcceptLine**.
-If an exception is thrown, validation fails and the error is reported.
-Before throwing an exception, the validation handler can place the cursor at the point of the error to make it easier to fix.
-A validation handler can also change the command line, such as to correct common typographical errors.
-
-```yaml
-Type: System.Action`1[System.Management.Automation.Language.CommandAst]
-Parameter Sets: OptionsSet
+Type: String
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -CompletionQueryItems
-
-Specifies the maximum number of completion items that are shown without prompting.
-If the number of items to show is greater than this value, PSReadline prompts you to specify yes or no (y/n) before it displays the completion items.
-The default maximum number is 100.
-
-```yaml
-Type: Int32
-Parameter Sets: OptionsSet
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
+Default value: >
+Accept pipeline input: false
 Accept wildcard characters: False
 ```
 
 ### -ContinuationPrompt
 
-Specifies the string displayed at the start of the second and subsequent lines when multi-line input is being entered.
-The default value is '\>\>\>'.
+Specifies the string displayed at the beginning of the second and subsequent lines when multi-line input is being entered.
+Defaults to '\>\> '.
 The empty string is valid.
 
 ```yaml
 Type: String
-Parameter Sets: OptionsSet
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ContinuationPromptBackgroundColor
-
-Specifies the background color of the continuation prompt.
-
-The acceptable values for this parameter are: the same values as for the *BackgroundColor* parameter.
-
-```yaml
-Type: ConsoleColor
-Parameter Sets: OptionsSet
-Aliases:
-Accepted values: Black, DarkBlue, DarkGreen, DarkCyan, DarkRed, DarkMagenta, DarkYellow, Gray, DarkGray, Blue, Green, Cyan, Red, Magenta, Yellow, White
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ContinuationPromptForegroundColor
-
-Specifies the foreground color of the continuation prompt.
-
-The acceptable values for this parameter are: the same values as for *BackgroundColor*.
-
-```yaml
-Type: ConsoleColor
-Parameter Sets: OptionsSet
-Aliases:
-Accepted values: Black, DarkBlue, DarkGreen, DarkCyan, DarkRed, DarkMagenta, DarkYellow, Gray, DarkGray, Blue, Green, Cyan, Red, Magenta, Yellow, White
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DingDuration
-
-Specifies the duration of the beep, in milliseconds (ms), if the *BellStyle* parameter has a value of Audible.
-If you do not specify this parameter, and *BellStyle* is set to Audible, the default duration is 50 ms.
-
-```yaml
-Type: Int32
-Parameter Sets: OptionsSet
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DingTone
-
-Specifies the tone of the beep, in hertz (Hz), if the *BellStyle* parameter is set to Audible.
-The acceptable values for this parameter are: integers in the range 37 to 32767 Hz.
-If you do not specify this parameter, and *Bellstyle* is Audible, the default tone is 1221 Hz.
-
-```yaml
-Type: Int32
-Parameter Sets: OptionsSet
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -EditMode
-
-Specifies the command line editing mode.
-The *EditMode* parameter resets any key bindings that you have set by running Set-PSReadlineKeyHandler.
-
-```yaml
-Type: EditMode
-Parameter Sets: OptionsSet
-Aliases:
-Accepted values: Windows, Emacs, Vi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -EmphasisBackgroundColor
-
-Specifies the background color that is used for emphasis, such as to highlight search text.
-
-The acceptable values for this parameter are: the same values as for *BackgroundColor*.
-
-```yaml
-Type: ConsoleColor
-Parameter Sets: OptionsSet
-Aliases:
-Accepted values: Black, DarkBlue, DarkGreen, DarkCyan, DarkRed, DarkMagenta, DarkYellow, Gray, DarkGray, Blue, Green, Cyan, Red, Magenta, Yellow, White
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -EmphasisForegroundColor
-
-Specifies the foreground color that is used for emphasis, such as to highlight search text.
-
-The acceptable values for this parameter are: the same values as for *BackgroundColor*.
-
-```yaml
-Type: ConsoleColor
-Parameter Sets: OptionsSet
-Aliases:
-Accepted values: Black, DarkBlue, DarkGreen, DarkCyan, DarkRed, DarkMagenta, DarkYellow, Gray, DarkGray, Blue, Green, Cyan, Red, Magenta, Yellow, White
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ErrorBackgroundColor
-
-Specifies the background color that is used for errors.
-
-The acceptable values for this parameter are: the same values as for *BackgroundColor*.
-
-```yaml
-Type: ConsoleColor
-Parameter Sets: OptionsSet
-Aliases:
-Accepted values: Black, DarkBlue, DarkGreen, DarkCyan, DarkRed, DarkMagenta, DarkYellow, Gray, DarkGray, Blue, Green, Cyan, Red, Magenta, Yellow, White
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ErrorForegroundColor
-
-Specifies the foreground color that is used for errors.
-
-The acceptable values for this parameter are: the same values as for *BackgroundColor*.
-
-```yaml
-Type: ConsoleColor
-Parameter Sets: OptionsSet
-Aliases:
-Accepted values: Black, DarkBlue, DarkGreen, DarkCyan, DarkRed, DarkMagenta, DarkYellow, Gray, DarkGray, Blue, Green, Cyan, Red, Magenta, Yellow, White
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ExtraPromptLineCount
-
-Specifies the number of extra lines.
-Specify a value for this parameter if your prompt spans more than one line, and you want extra lines to be available when PSReadline displays the prompt after showing some output, such as when PSReadline returns a list of completions.
-
-```yaml
-Type: Int32
-Parameter Sets: OptionsSet
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ForegroundColor
-
-Specifies the foreground color for the token kind that is specified by the *TokenKind* parameter.
-
-The acceptable values for this parameter are: the same values as for *BackgroundColor*.
-
-```yaml
-Type: ConsoleColor
-Parameter Sets: ColorSet
-Aliases:
-Accepted values: Black, DarkBlue, DarkGreen, DarkCyan, DarkRed, DarkMagenta, DarkYellow, Gray, DarkGray, Blue, Green, Cyan, Red, Magenta, Yellow, White
-
-Required: False
-Position: 1
-Default value: None
-Accept pipeline input: False
+Default value: >>
+Accept pipeline input: false
 Accept wildcard characters: False
 ```
 
 ### -HistoryNoDuplicates
 
-Specifies that duplicate commands not added to PSReadline history.
+Repeated commands will usually be added to history to preserve ordering during recall,
+but typically you don't want to see the same command multiple times when recalling or searching the history.
+
+This option controls the recall behavior - duplicates will are still added to the history file,
+but if this option is set, only the most recent invocation will appear when recalling commands.
+
 
 ```yaml
-Type: SwitchParameter
-Parameter Sets: OptionsSet
+Type: switch
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
+Default value:
+Accept pipeline input: false
 Accept wildcard characters: False
 ```
 
-### -HistorySavePath
+### -AddToHistoryHandler
 
-Specifies a path of the history file.
-If you do not add this parameter, the default path is ~\AppData\Roaming\PSReadline\$($host.Name)_history.txt.
+Specifies a ScriptBlock that can be used to control which commands get added to PSReadLine history.
+
+The ScriptBlock is passed the command line.
+If the ScriptBlock returns `$true`, the command line is added to history, otherwise it is not.
 
 ```yaml
-Type: String
-Parameter Sets: OptionsSet
+Type: Func[String, Boolean]
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
+Default value:
+Accept pipeline input: false
 Accept wildcard characters: False
 ```
 
-### -HistorySaveStyle
+### -CommandValidationHandler
 
-Specifies how PSReadLine saves history.
-To avoid unexpected behavior with command history, if you do not want to use the default value, SaveIncrementally, then set this option before you run the first command line in a session.
+Specifies a ScriptBlock that is called from ValidateAndAcceptLine.
+If an exception is thrown, validation fails and the error is reported.
 
-```yaml
-Type: HistorySaveStyle
-Parameter Sets: OptionsSet
-Aliases:
-Accepted values: SaveIncrementally, SaveAtExit, SaveNothing
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -HistorySearchCaseSensitive
-
-Indicates that the searching history is case sensitive in functions such as ReverseSearchHistory or HistorySearchBackward.
+`ValidateAndAcceptLine` is used to avoid cluttering your history with commands that can't work, e.g. specifying parameters that do not exist.
 
 ```yaml
-Type: SwitchParameter
-Parameter Sets: OptionsSet
+Type: Action[CommandAst]
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
+Default value:
+Accept pipeline input: false
 Accept wildcard characters: False
 ```
 
 ### -HistorySearchCursorMovesToEnd
 
-Indicates that the cursor moves to the end of commands that you load from history by using a search.
-You can search the command history by typing one or more of the characters at the start of the command, and then pressing the up or down arrows, or any other keys that you have mapped to cycling through the command history.
-If you do not specify this parameter, the cursor remains at the position it was when you pressed the up or down arrows.
+When using `HistorySearchBackward` and `HistorySearchForward`, the default behavior leaves the cursor at the end of the search string if any.
 
-To turn off this option, you can run either of the following commands:
-
-`Set-PSReadlineOption -HistorySearchCursorMovesToEnd:$False`
-
-`(Get-PSReadlineOption).HistorySearchCursorMovesToEnd = $False`
+To move the cursor to end of the line just like when there is no search string, set this option to `$true`.
 
 ```yaml
-Type: SwitchParameter
-Parameter Sets: OptionsSet
+Type: switch
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
+Default value:
+Accept pipeline input: false
 Accept wildcard characters: False
 ```
 
 ### -MaximumHistoryCount
 
-Specifies the maximum number of commands to save in PSReadline history.
-PSReadline history not the same thing as Windows PowerShell history.
+Specifies the maximum number of commands to save in PSReadLine history.
+
+Note that PSReadLine history is separate from PowerShell history.
 
 ```yaml
 Type: Int32
-Parameter Sets: OptionsSet
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
+Default value: 1024
+Accept pipeline input: false
 Accept wildcard characters: False
 ```
 
@@ -512,110 +242,322 @@ Specifies the maximum number of items stored in the kill ring.
 
 ```yaml
 Type: Int32
-Parameter Sets: OptionsSet
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ResetTokenColors
-
-Indicates that this cmdlet restores token colors to default settings.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: OptionsSet
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
+Default value: 10
+Accept pipeline input: false
 Accept wildcard characters: False
 ```
 
 ### -ShowToolTips
 
-Indicates that when you are displaying possible completions tooltips are shown in the list of completions.
+When displaying possible completions, show tooltips in the list of completions.
+
+This option was not enabled by default in earliers versions of PSReadLine, but is enabled by default now.
+To disable, set this option to `$false`.
 
 ```yaml
-Type: SwitchParameter
-Parameter Sets: OptionsSet
+Type: switch
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
+Default value: true
+Accept pipeline input: false
 Accept wildcard characters: False
 ```
 
-### -TokenKind
+### -ExtraPromptLineCount
 
-Specifies the kind of token when you are setting token coloring options with the *ForegroundColor* and *BackgroundColor* parameters.
-The acceptable values for this parameter are:
+Use this option if your prompt spans more than one line.
 
-- None
-- Comment
-- Keyword
-- String
-- Operator
-- Variable
-- Command
-- Parameter
-- Type
-- Number
-- Member
+This option is needed less than in previous version of PSReadLine, but is useful when the `InvokePrompt` function is used.
 
 ```yaml
-Type: TokenClassification
-Parameter Sets: ColorSet
+Type: Int32
+Parameter Sets: (All)
 Aliases:
-Accepted values: None, Comment, Keyword, String, Operator, Variable, Command, Parameter, Type, Number, Member
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ViModeIndicator
-
-{{Fill ViModeIndicator Description}}
-
-```yaml
-Type: ViModeStyle
-Parameter Sets: OptionsSet
-Aliases:
-Accepted values: None, Prompt, Cursor
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
+Default value: 0
+Accept pipeline input: false
+Accept wildcard characters: False
+```
+
+### -Colors
+
+The Colors parameter is used to specify various colors used by PSReadLine.
+
+The argument is a Hashtable where the keys specify which element and the values specify the color.
+
+Colors can be either a value from ConsoleColor, e.g. [ConsoleColor]::Red, or a valid escape sequence.
+Valid escape sequences depend on your terminal, e.g. "$([char]0x1b)[91m" (Windows PowerShell) or
+"`e[91m" (PowerShell 6.0) specifies Red in most terminals.
+You can specify other escape sequences as well, including but not limited to:
+
+-- 256 color
+-- 24 bit color
+-- Foreground, background, or both
+-- Inverse, bold
+
+The valid keys include:
+
+-- ContinuationPrompt: The color of the continuation prompt.
+
+-- Emphasis: The emphasis color, e.g. the matching text when searching history.
+
+-- Error: The error color, e.g. in the prompt.
+
+-- Selection: The color to highlight the menu selection or selected text.
+
+-- Default: The default token color.
+
+-- Comment: The comment token color.
+
+-- Keyword: The keyword token color.
+
+-- String: The string token color.
+
+-- Operator: The operator token color.
+
+-- Variable: The variable token color.
+
+-- Command: The command token color.
+
+-- Parameter: The parameter token color.
+
+-- Type: The type token color.
+
+-- Number: The number token color.
+
+-- Member: The member name token color.
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value:
+Accept pipeline input: false
+Accept wildcard characters: False
+```
+
+### -DingTone
+
+When BellStyle is set to Audible, specifies the tone of the beep.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 1221
+Accept pipeline input: false
+Accept wildcard characters: False
+```
+
+### -DingDuration
+
+When BellStyle is set to Audible, specifies the duration of the beep.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 50ms
+Accept pipeline input: false
+Accept wildcard characters: False
+```
+
+### -BellStyle
+
+Specifies how PSReadLine should respond to various error and ambiguous conditions.
+
+Valid values are:
+
+-- Audible: a short beep
+
+-- Visible: a brief flash is performed
+
+-- None: no feedback
+
+```yaml
+Type: BellStyle
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Audible
+Accept pipeline input: false
+Accept wildcard characters: False
+```
+
+### -CompletionQueryItems
+
+Specifies the maximum number of completion items that will be shown without prompting.
+
+If the number of items to show is greater than this value, PSReadLine will prompt y/n before displaying the completion items.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 100
+Accept pipeline input: false
 Accept wildcard characters: False
 ```
 
 ### -WordDelimiters
 
 Specifies the characters that delimit words for functions like ForwardWord or KillWord.
-The default value is the following list of characters: \>;:,.\[\]{}()/\|^&*-=+
 
 ```yaml
-Type: String
-Parameter Sets: OptionsSet
+Type: string
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
+Default value: ;:,.[]{}()/\|^&*-=+
+Accept pipeline input: false
 Accept wildcard characters: False
+```
+
+### -HistorySearchCaseSensitive
+
+Specifies the searching history is case sensitive in functions like ReverseSearchHistory or HistorySearchBackward.
+
+```yaml
+Type: switch
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value:
+Accept pipeline input: false
+Accept wildcard characters: False
+```
+
+### -HistorySaveStyle
+
+Specifies how PSReadLine should save history.
+
+Valid values are:
+
+-- SaveIncrementally: save history after each command is executed - and share across multiple instances of PowerShell
+
+-- SaveAtExit: append history file when PowerShell exits
+
+-- SaveNothing: don't use a history file
+
+```yaml
+Type: HistorySaveStyle
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: SaveIncrementally
+Accept pipeline input: false
+Accept wildcard characters: False
+```
+
+### -HistorySavePath
+
+Specifies the path to the file where history is saved.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: A file named $($host.Name)_history.txt in $env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine on Windows and $env:XDG_DATA_HOME/powershell/PSReadLine or $env:HOME/.local/share/powershell/PSReadLine on non-Windows platforms
+Accept pipeline input: false
+Accept wildcard characters: False
+```
+
+### -AnsiEscapeTimeout
+
+This option is specific to Windows when input is redirected, e.g. when running under `tmux` or `screen`.
+
+With redirected input on Windows, many keys are sent as a sequence of characters starting with the Escape character,
+so it is, in general, impossible to distinguish between a single Escape followed by other key presses.
+
+The assumption is the terminal sends the characters quickly, faster than a user types, so PSReadLine waits for this timeout before concluding it won't see an escape sequence.
+
+You can experiment with this timeout if you see issues or random unexpected characters when you type.
+
+```yaml
+Type: int
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 100
+Accept pipeline input: false
+Accept wildcard characters: False
+```
+
+### -ViModeIndicator
+
+This option sets the visual indication for the current mode in Vi mode - either insert mode or command mode.
+
+Valid values are:
+
+-- None - there is no indication
+
+-- Prompt - the prompt changes color
+
+-- Cursor - the cursor changes size
+
+-- Script - user-specified text is printed
+
+```yaml
+Type: ViModeStyle
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value:
+Accept pipeline input: false
+Accept wildcard characters: False
+```
+
+### -ViModeChangeHandler
+
+When the `ViModeIndicator` is set to `Script`, the script block provided will be invoked every time the mode changes. The script block is provided one argument of type `ViMode`. Example usage is shown in Example 3 in this document.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value:
+Accept pipeline input: false
+Accept wildcard characters: false
 ```
 
 ### CommonParameters


### PR DESCRIPTION
Fixes #2639 by updating Set-PSReadlineOption's documented parameters in 6.1 to match PSReadline version 2.0.0, which is currently in use.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.1 document
- [ ] Impacts 6.0 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
