### PR TITLE
Update Start-Process -Wait description

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Start-Process.md
+++ b/reference/6/Microsoft.PowerShell.Management/Start-Process.md
@@ -328,8 +328,8 @@ Accept wildcard characters: False
 ```
 
 ### -Wait
-Indicates that this cmdlet waits for the specified process to complete before accepting more input.
-This parameter suppresses the command prompt or retains the window until the process finishes.
+Indicates that this cmdlet waits for the specified process and its descendants to complete before accepting more input.
+This parameter suppresses the command prompt or retains the window until the processes finish.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
Mention that `-Wait` waits for the whole process tree, not just the process it ran.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

This behavior appears to have started in powershell version 2.