### PR TITLE
Unify comma setting over all platforms

### DIFF
--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Linux.md
@@ -324,7 +324,7 @@ sudo apt-get remove powershell
 
 ### Installation via Package Repository (preferred) - CentOS 7
 
-PowerShell Core for Linux is published to official Microsoft repositories for easy installation (and updates).
+PowerShell Core, for Linux, is published to official Microsoft repositories for easy installation (and updates).
 
 ```sh
 # Register the Microsoft RedHat repository
@@ -370,7 +370,7 @@ sudo yum remove powershell
 
 ### Installation via Package Repository (preferred) - Red Hat Enterprise Linux (RHEL) 7
 
-PowerShell Core for Linux is published to official Microsoft repositories for easy installation (and updates).
+PowerShell Core, for Linux, is published to official Microsoft repositories for easy installation (and updates).
 
 ```sh
 # Register the Microsoft RedHat repository
@@ -432,7 +432,7 @@ solution when installing the PowerShell package.
 
 ### Installation via Package Repository (preferred) - OpenSUSE 42.3
 
-PowerShell Core for Linux is published to official Microsoft repositories for easy installation (and updates).
+PowerShell Core, for Linux, is published to official Microsoft repositories for easy installation (and updates).
 
 ```sh
 # Register the Microsoft signature key
@@ -481,7 +481,7 @@ sudo zypper remove powershell
 
 ### Installation via Package Repository (preferred) - Fedora 27, Fedora 28
 
-PowerShell Core for Linux is published to official Microsoft repositories for easy installation (and updates).
+PowerShell Core, for Linux, is published to official Microsoft repositories for easy installation (and updates).
 
 ```sh
 # Register the Microsoft signature key


### PR DESCRIPTION
Added missing commas to the guides for 'CentOS 7', 'Red Hat Enterprise Linux (RHEL) 7', 'OpenSUSE 42.3' and 'Fedora', so they are consistent over the whole document.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
All versions point to the same file so it should fix it for all.