### PR TITLE
Update known-issues-ps6.md

### DIFF
--- a/reference/docs-conceptual/whats-new/known-issues-ps6.md
+++ b/reference/docs-conceptual/whats-new/known-issues-ps6.md
@@ -137,11 +137,11 @@ something we will consider post 6.0 as it requires significant design work.
 
 Because PowerShell runs most commands in memory (like Python or Ruby), you can't use sudo directly
 with PowerShell built-ins. (You can, of course, run `powershell` from sudo.) If it is necessary to
-run a PowerShell cmdlet from within PowerShell with sudo, for example, `sudo `Set-Date` 8/18/2016`,
-then you would do `sudo powershell `Set-Date` 8/18/2016`. Likewise, you can't exec a PowerShell
+run a PowerShell cmdlet from within PowerShell with sudo, for example, `sudo Set-Date 8/18/2016`,
+then you would do `sudo powershell Set-Date 8/18/2016`. Likewise, you can't exec a PowerShell
 built-in directly. Instead you would have to do `exec powershell item_to_exec`.
 
-This issue is currently being tracked as part of #3232.
+This issue is currently being tracked as part of [#3232](https://github.com/PowerShell/PowerShell/issues/3232).
 
 ### Missing Cmdlets
 

--- a/reference/docs-conceptual/whats-new/known-issues-ps6.md
+++ b/reference/docs-conceptual/whats-new/known-issues-ps6.md
@@ -136,10 +136,10 @@ something we will consider post 6.0 as it requires significant design work.
 ### `sudo`, `exec`, and PowerShell
 
 Because PowerShell runs most commands in memory (like Python or Ruby), you can't use sudo directly
-with PowerShell built-ins. (You can, of course, run `powershell` from sudo.) If it is necessary to
+with PowerShell built-ins. (You can, of course, run `pwsh` from sudo.) If it is necessary to
 run a PowerShell cmdlet from within PowerShell with sudo, for example, `sudo Set-Date 8/18/2016`,
-then you would do `sudo powershell Set-Date 8/18/2016`. Likewise, you can't exec a PowerShell
-built-in directly. Instead you would have to do `exec powershell item_to_exec`.
+then you would do `sudo pwsh Set-Date 8/18/2016`. Likewise, you can't exec a PowerShell
+built-in directly. Instead you would have to do `exec pwsh item_to_exec`.
 
 This issue is currently being tracked as part of [#3232](https://github.com/PowerShell/PowerShell/issues/3232).
 


### PR DESCRIPTION
Actually I tried `sudo powershell Set-Date 8/18/2016` on google cloud platform(debian 9) and got `sudo: powershell: command not foundSet-Date 8/18/2016`... Is this a wrong example?

Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
