### PR TITLE
Add comma (see description)

### DIFF
--- a/reference/docs-conceptual/PowerShell-Scripting.md
+++ b/reference/docs-conceptual/PowerShell-Scripting.md
@@ -6,7 +6,7 @@ title:  PowerShell Scripting
 # PowerShell
 
 PowerShell is a task-based command-line shell and scripting language built on .NET.
-PowerShell helps system administrators and power-users can rapidly automate tasks that manage
+PowerShell helps system administrators, and power-users can rapidly automate tasks that manage
 operating systems (Linux, macOS, and Windows) and processes.
 
 PowerShell commands let you manage computers from the command line. PowerShell providers let you

--- a/reference/docs-conceptual/PowerShell-Scripting.md
+++ b/reference/docs-conceptual/PowerShell-Scripting.md
@@ -6,7 +6,7 @@ title:  PowerShell Scripting
 # PowerShell
 
 PowerShell is a task-based command-line shell and scripting language built on .NET.
-PowerShell helps system administrators, and power-users can rapidly automate tasks that manage
+PowerShell helps system administrators and power-users rapidly automate tasks that manage
 operating systems (Linux, macOS, and Windows) and processes.
 
 PowerShell commands let you manage computers from the command line. PowerShell providers let you


### PR DESCRIPTION
Without the added comma, the sentence does not make sense when "administrators and power-shell" are read together.
