### PR TITLE
Added Remove-Alias.md for PowerShell 6

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Remove-Alias.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Remove-Alias.md
@@ -1,0 +1,140 @@
+---
+ms.date:  17/10/2018
+schema: 2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+online version: 
+external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
+title:  Remove-Alias
+---
+
+# Remove-Alias
+
+## SYNOPSIS
+
+Remove aliases for the current session.
+
+## SYNTAX
+
+```
+Remove-Alias [-Name] <String[]> [-Scope <String>] [-Force] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The **Remove-Alias** cmdlet removes an alias in the current PowerShell session.
+You must use **Remove-Alias** with **-Force** to remove any aliases with **Constant** or **Read-Only** option.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> Remove-Alias -Name del
+```
+
+This command removes an alias named del that represent the Remove-Item cmdlet.
+
+### Example 2
+
+```powershell
+PS C:\> Get-Alias | Where-Object { $_.Options -ne "Constant" } | Remove-Alias -Force
+```
+
+This command get all aliases except for alias with Constant option and removes them in the current PowerShell session.
+
+## PARAMETERS
+
+### -Force
+
+Indicates that the cmdlet removes an alias even if it is read-only.
+Even using the *Force* parameter, the cmdlet cannot remove a constant.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+
+Specifies the name of the alias to be removed.
+The parameter name (*Name*) is optional.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Scope
+
+Gets only the variables in the specified scope.
+The acceptable values for this parameter are:
+
+- Global
+- Local
+- Script
+- A number relative to the current scope (0 through the number of scopes, where 0 is the current scope and 1 is its parent)
+
+Local is the default.
+For more information, see about_Scopes.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String[]
+
+You can pipe an alias object to **Remove-Alias**.
+
+## OUTPUTS
+
+### None
+
+This cmdlet does not return any output.
+
+## NOTES
+
+- Changes affect only the current scope, such as a session. To delete an alias from all sessions, add a **Remove-Alias** command to your PowerShell profile.
+
+For more information, see about_Aliases.
+
+## RELATED LINKS
+
+[Export-Alias](Export-Alias.md)
+
+[Get-Alias](Get-Alias.md)
+
+[Import-Alias](Import-Alias.md)
+
+[New-Alias](New-Alias.md)
+
+[Set-Alias](Set-Alias.md)

--- a/reference/6/Microsoft.PowerShell.Utility/Remove-Alias.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Remove-Alias.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  17/10/2018
+ms.date:  10/17/2018
 schema: 2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -12,7 +12,7 @@ title:  Remove-Alias
 
 ## SYNOPSIS
 
-Remove aliases for the current session.
+Remove an alias from the current session.
 
 ## SYNTAX
 
@@ -22,33 +22,34 @@ Remove-Alias [-Name] <String[]> [-Scope <String>] [-Force] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The **Remove-Alias** cmdlet removes an alias in the current PowerShell session.
-You must use **Remove-Alias** with **-Force** to remove any aliases with **Constant** or **Read-Only** option.
+The `Remove-Alias` cmdlet removes an alias from the current PowerShell session.
+You must use the **-Force** parameter to remove any aliases with the **Read-Only** option.
 
 ## EXAMPLES
 
-### Example 1
+### Example 1 - Remove an alias
+
+This command removes an alias named `del` that represents the Remove-Item cmdlet.
 
 ```powershell
-PS C:\> Remove-Alias -Name del
+Remove-Alias -Name del
 ```
 
-This command removes an alias named del that represent the Remove-Item cmdlet.
 
-### Example 2
+### Example 2 - Remove all non-Constant aliases
+
+This command get all aliases except for alias with Constant option and removes them from the current PowerShell session.
 
 ```powershell
-PS C:\> Get-Alias | Where-Object { $_.Options -ne "Constant" } | Remove-Alias -Force
+Get-Alias | Where-Object { $_.Options -ne "Constant" } | Remove-Alias -Force
 ```
-
-This command get all aliases except for alias with Constant option and removes them in the current PowerShell session.
 
 ## PARAMETERS
 
 ### -Force
 
 Indicates that the cmdlet removes an alias even if it is read-only.
-Even using the *Force* parameter, the cmdlet cannot remove a constant.
+Even using the **Force** parameter, the cmdlet cannot remove a constant alias.
 
 ```yaml
 Type: SwitchParameter
@@ -65,7 +66,6 @@ Accept wildcard characters: False
 ### -Name
 
 Specifies the name of the alias to be removed.
-The parameter name (*Name*) is optional.
 
 ```yaml
 Type: String[]
@@ -81,7 +81,7 @@ Accept wildcard characters: False
 
 ### -Scope
 
-Gets only the variables in the specified scope.
+Affects only the aliases in the specified scope.
 The acceptable values for this parameter are:
 
 - Global
@@ -89,8 +89,8 @@ The acceptable values for this parameter are:
 - Script
 - A number relative to the current scope (0 through the number of scopes, where 0 is the current scope and 1 is its parent)
 
-Local is the default.
-For more information, see about_Scopes.
+Local is the default scope.
+For more information, see [about_Scopes](../microsoft.powershell.core/about/about_scopes.md).
 
 ```yaml
 Type: String
@@ -123,9 +123,9 @@ This cmdlet does not return any output.
 
 ## NOTES
 
-- Changes affect only the current scope, such as a session. To delete an alias from all sessions, add a **Remove-Alias** command to your PowerShell profile.
+Changes affect only the current scope. To remove an alias from all sessions, add a **Remove-Alias** command to your PowerShell profile.
 
-For more information, see about_Aliases.
+For more information, see [about_Aliases](../microsoft.powershell.core/about/about_aliases.md).
 
 ## RELATED LINKS
 


### PR DESCRIPTION
Addressing Docs needed for 'Add Remove-Alias Command' #3073

- New Remove-Alias draft doc

----
Hi @joeyaiello, @sdwheeler or @TravisEz13,

Anyone able to update or provide me the `online version: <URL>` in the markdown metadata for this new `Remove-Alias.md` doc? Or if you can do it on your end, that will be great.
 
----

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version (6) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [x] This PR partially fixes the issue, and issue #3073 tracks the remaining work
