### PR TITLE
Fix typo ("Enoding" -> "Encoding")

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Get-Content.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-Content.md
@@ -420,7 +420,7 @@ Encoding is a dynamic parameter that the FileSystem provider adds to the `Get-Co
 When reading from and writing to binary files, use a value of Byte for the Encoding dynamic parameter and a value of 0 for the ReadCount parameter.  A ReadCount value of 0 reads the entire file in a single read operation and converts it into a single object (PSObject).  The default ReadCount value, 1, reads one byte in each read operation and converts each byte into a separate object, which causes errors when you use the `Set-Content` cmdlet to write the bytes to a file. For more information, see the examples.
 
 > [!NOTE]
-> Beginning in PowerShell 6.0, **Byte** is no longer a valid option for the `-Enoding` parameter. You can use the `-AsByteStream` parameter to indicate that the content should be read and output as a byte stream.
+> Beginning in PowerShell 6.0, **Byte** is no longer a valid option for the `-Encoding` parameter. You can use the `-AsByteStream` parameter to indicate that the content should be read and output as a byte stream.
 
 ```yaml
 Type: FileSystemCmdletProviderEncoding


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version 6 of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
