### PR TITLE
Changed a few broken links.

### DIFF
--- a/developer/windows-powershell-reference.md
+++ b/developer/windows-powershell-reference.md
@@ -25,9 +25,7 @@ The Windows PowerShell Software Development Kit (SDK) is written for command dev
 
 In addition to the Windows PowerShell SDK, the following resources provide more information.
 
-[Getting Started with Windows PowerShell](https://github.com/PowerShell/PowerShell-Docs/blob/staging/reference/docs-conceptual/getting-started/Getting-Started-with-Windows-PowerShell.md)
-
-[Getting Started with Windows PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/getting-started/getting-started-with-windows-powershell)
+[Getting Started with Windows PowerShell](/powershell/scripting/getting-started/getting-started-with-windows-powershell)
 Provides an introduction to Windows PowerShell: the language, the cmdlets, the providers, and the use of objects.
 
 [Writing a Windows PowerShell Module](./module/writing-a-windows-powershell-module.md)
@@ -39,7 +37,7 @@ Provides information and code examples for program managers who are designing cm
 [Windows PowerShell Team Blog](https://blogs.msdn.microsoft.com/PowerShell/)
 The best resource for learning from and collaborating with other Windows PowerShell users. Read the Windows PowerShell Team blog, and then join the Windows PowerShell User Forum (microsoft.public.windows.powershell). Use Windows Live Search to find other Windows PowerShell blogs and resources. Then, as you develop your expertise, freely contribute your ideas.
 
-[Windows PowerShell TechNet Library](https://github.com/PowerShell/PowerShell-Docs/blob/staging/reference/docs-conceptual/PowerShell-Scripting.md)
+[PowerShell module browser](/powershell/module/)
 Provides the latest versions of the command-line Help topics.
 
 ## Class Libraries

--- a/developer/windows-powershell-reference.md
+++ b/developer/windows-powershell-reference.md
@@ -25,9 +25,9 @@ The Windows PowerShell Software Development Kit (SDK) is written for command dev
 
 In addition to the Windows PowerShell SDK, the following resources provide more information.
 
-[Getting Started with Windows PowerShell](/powershell/scripting/getting-started/getting-started-with-windows-powershell)
+[Getting Started with Windows PowerShell](../reference/docs-conceptual/getting-started/Getting-Started-with-Windows-PowerShell.md)
 
-[Getting Started with Windows PowerShell](https://msdn.microsoft.com/en-us/mt707506?redirectUrl=https://msdn.microsoft.com/powershell/scripting/getting-started/getting-started-with-windows-powershell)
+[Getting Started with Windows PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/getting-started/getting-started-with-windows-powershell)
 Provides an introduction to Windows PowerShell: the language, the cmdlets, the providers, and the use of objects.
 
 [Writing a Windows PowerShell Module](./module/writing-a-windows-powershell-module.md)
@@ -39,7 +39,7 @@ Provides information and code examples for program managers who are designing cm
 [Windows PowerShell Team Blog](https://blogs.msdn.microsoft.com/PowerShell/)
 The best resource for learning from and collaborating with other Windows PowerShell users. Read the Windows PowerShell Team blog, and then join the Windows PowerShell User Forum (microsoft.public.windows.powershell). Use Windows Live Search to find other Windows PowerShell blogs and resources. Then, as you develop your expertise, freely contribute your ideas.
 
-[Windows PowerShell TechNet Library](/powershell/scripting/powershell-scripting)
+[Windows PowerShell TechNet Library](../reference/docs-conceptual/PowerShell-Scripting.md)
 Provides the latest versions of the command-line Help topics.
 
 ## Class Libraries

--- a/developer/windows-powershell-reference.md
+++ b/developer/windows-powershell-reference.md
@@ -25,7 +25,7 @@ The Windows PowerShell Software Development Kit (SDK) is written for command dev
 
 In addition to the Windows PowerShell SDK, the following resources provide more information.
 
-[Getting Started with Windows PowerShell](../reference/docs-conceptual/getting-started/Getting-Started-with-Windows-PowerShell.md)
+[Getting Started with Windows PowerShell](https://github.com/PowerShell/PowerShell-Docs/blob/staging/reference/docs-conceptual/getting-started/Getting-Started-with-Windows-PowerShell.md)
 
 [Getting Started with Windows PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/getting-started/getting-started-with-windows-powershell)
 Provides an introduction to Windows PowerShell: the language, the cmdlets, the providers, and the use of objects.
@@ -39,7 +39,7 @@ Provides information and code examples for program managers who are designing cm
 [Windows PowerShell Team Blog](https://blogs.msdn.microsoft.com/PowerShell/)
 The best resource for learning from and collaborating with other Windows PowerShell users. Read the Windows PowerShell Team blog, and then join the Windows PowerShell User Forum (microsoft.public.windows.powershell). Use Windows Live Search to find other Windows PowerShell blogs and resources. Then, as you develop your expertise, freely contribute your ideas.
 
-[Windows PowerShell TechNet Library](../reference/docs-conceptual/PowerShell-Scripting.md)
+[Windows PowerShell TechNet Library](https://github.com/PowerShell/PowerShell-Docs/blob/staging/reference/docs-conceptual/PowerShell-Scripting.md)
 Provides the latest versions of the command-line Help topics.
 
 ## Class Libraries


### PR DESCRIPTION
"Getting Started with Windows PowerShell" and "Windows PowerShell TechNet Library" had broken links to an older structure. The msdn link took a few seconds to redirect, so I linked directly to the article.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->