### PR TITLE
typo: Double word "that"

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -111,7 +111,7 @@ remote access.
 
 To enable remoting on client versions of Windows with public networks, use the
 SkipNetworkProfileCheck parameter of the Enable-PSRemoting cmdlet. It creates
-a firewall rule that that allows remote access only from computers in the same
+a firewall rule that allows remote access only from computers in the same
 local subnet.
 
 To remove the local subnet restriction on public networks and allow remote

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -112,7 +112,7 @@ remote access.
 
 To enable remoting on client versions of Windows with public networks, use the
 SkipNetworkProfileCheck parameter of the Enable-PSRemoting cmdlet. It creates
-a firewall rule that that allows remote access only from computers in the same
+a firewall rule that allows remote access only from computers in the same
 local subnet.
 
 To remove the local subnet restriction on public networks and allow remote

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -112,7 +112,7 @@ remote access.
 
 To enable remoting on client versions of Windows with public networks, use the
 SkipNetworkProfileCheck parameter of the Enable-PSRemoting cmdlet. It creates
-a firewall rule that that allows remote access only from computers in the same
+a firewall rule that allows remote access only from computers in the same
 local subnet.
 
 To remove the local subnet restriction on public networks and allow remote

--- a/reference/5.0/Microsoft.PowerShell.Core/Wait-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Wait-Job.md
@@ -105,7 +105,7 @@ It also shows how to use the **Wait-Job** cmdlet to wait for remote jobs to fini
 
 The first command creates a **PSSession** on each of the computers listed in the Machines.txt file and stores the **PSSession** objects in the $s variable.
 The command uses the Get-Content cmdlet to get the contents of the file.
-The **Get-Content** command is enclosed in parentheses to make sure that that it runs before the New-PSSession command.
+The **Get-Content** command is enclosed in parentheses to make sure that it runs before the New-PSSession command.
 
 The second command stores a **Get-EventLog** command string, in quotation marks, in the $c variable.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -112,7 +112,7 @@ remote access.
 
 To enable remoting on client versions of Windows with public networks, use the
 SkipNetworkProfileCheck parameter of the Enable-PSRemoting cmdlet. It creates
-a firewall rule that that allows remote access only from computers in the same
+a firewall rule that allows remote access only from computers in the same
 local subnet.
 
 To remove the local subnet restriction on public networks and allow remote

--- a/reference/5.1/Microsoft.PowerShell.Core/Wait-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Wait-Job.md
@@ -105,7 +105,7 @@ It also shows how to use the **Wait-Job** cmdlet to wait for remote jobs to fini
 
 The first command creates a **PSSession** on each of the computers listed in the Machines.txt file and stores the **PSSession** objects in the $s variable.
 The command uses the Get-Content cmdlet to get the contents of the file.
-The **Get-Content** command is enclosed in parentheses to make sure that that it runs before the New-PSSession command.
+The **Get-Content** command is enclosed in parentheses to make sure that it runs before the New-PSSession command.
 
 The second command stores a **Get-EventLog** command string, in quotation marks, in the $c variable.
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -199,7 +199,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoClobber
-Indicates that that the cmdlet does not overwrite the contents of an existing file.
+Indicates that the cmdlet does not overwrite the contents of an existing file.
 By default, if a file exists in the specified path, **Export-Clixml** overwrites the file without warning.
 
 ```yaml

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -112,7 +112,7 @@ remote access.
 
 To enable remoting on client versions of Windows with public networks, use the
 SkipNetworkProfileCheck parameter of the Enable-PSRemoting cmdlet. It creates
-a firewall rule that that allows remote access only from computers in the same
+a firewall rule that allows remote access only from computers in the same
 local subnet.
 
 To remove the local subnet restriction on public networks and allow remote

--- a/reference/6/Microsoft.PowerShell.Core/Wait-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Wait-Job.md
@@ -105,7 +105,7 @@ It also shows how to use the **Wait-Job** cmdlet to wait for remote jobs to fini
 
 The first command creates a **PSSession** on each of the computers listed in the Machines.txt file and stores the **PSSession** objects in the $s variable.
 The command uses the Get-Content cmdlet to get the contents of the file.
-The **Get-Content** command is enclosed in parentheses to make sure that that it runs before the New-PSSession command.
+The **Get-Content** command is enclosed in parentheses to make sure that it runs before the New-PSSession command.
 
 The second command stores a **Get-EventLog** command string, in quotation marks, in the $c variable.
 

--- a/reference/6/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -168,7 +168,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoClobber
-Indicates that that the cmdlet does not overwrite the contents of an existing file.
+Indicates that the cmdlet does not overwrite the contents of an existing file.
 By default, if a file exists in the specified path, **Export-Clixml** overwrites the file without warning.
 
 ```yaml


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
