### PR TITLE
typo: Double word "specifies"

### DIFF
--- a/reference/3.0/Microsoft.WsMan.Management/provider/new-item-for-plugin.md
+++ b/reference/3.0/Microsoft.WsMan.Management/provider/new-item-for-plugin.md
@@ -112,7 +112,7 @@ New-Item -Plugin <string> -Filename <string> -ResourceURI <Uri> -Capability <str
 |Accept Wildcard Characters?|false|
 
 ### -xmlns <string\>
- A string that specifies specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
+ A string that specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
 
 |||
 |-|-|

--- a/reference/3.0/Microsoft.WsMan.Management/provider/wsman-provider.md
+++ b/reference/3.0/Microsoft.WsMan.Management/provider/wsman-provider.md
@@ -861,7 +861,7 @@ ClientCertificate                     Container
 -   [Set-Item](../../Microsoft.PowerShell.Management/Set-Item.md)
 
 ### xmlns <String\>
- A string that specifies specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
+ A string that specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
 
 #### Cmdlets supported:
 

--- a/reference/4.0/Microsoft.WsMan.Management/provider/new-item-for-plugin.md
+++ b/reference/4.0/Microsoft.WsMan.Management/provider/new-item-for-plugin.md
@@ -112,7 +112,7 @@ New-Item -Plugin <string> -Filename <string> -ResourceURI <Uri> -Capability <str
 |Accept Wildcard Characters?|false|
 
 ### -xmlns <string\>
- A string that specifies specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
+ A string that specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
 
 |||
 |-|-|

--- a/reference/4.0/Microsoft.WsMan.Management/provider/wsman-provider.md
+++ b/reference/4.0/Microsoft.WsMan.Management/provider/wsman-provider.md
@@ -861,7 +861,7 @@ ClientCertificate                     Container
 -   [Set-Item](../../Microsoft.PowerShell.Management/Set-Item.md)
 
 ### xmlns <String\>
- A string that specifies specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
+ A string that specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
 
 #### Cmdlets supported:
 

--- a/reference/5.0/Microsoft.WsMan.Management/providers/new-item-for-plugin.md
+++ b/reference/5.0/Microsoft.WsMan.Management/providers/new-item-for-plugin.md
@@ -113,7 +113,7 @@ New-Item -Plugin <string> -Filename <string> -ResourceURI <Uri> -Capability <str
 |Accept Wildcard Characters?|false|
 
 ### -xmlns <string\>
- A string that specifies specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
+ A string that specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
 
 |||
 |-|-|

--- a/reference/5.0/Microsoft.WsMan.Management/providers/wsman-provider.md
+++ b/reference/5.0/Microsoft.WsMan.Management/providers/wsman-provider.md
@@ -862,7 +862,7 @@ ClientCertificate                     Container
 -   [Set-Item](../../Microsoft.PowerShell.Management/Set-Item.md)
 
 ### xmlns <String\>
- A string that specifies specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
+ A string that specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
 
 #### Cmdlets supported:
 

--- a/reference/5.1/Microsoft.WsMan.Management/Providers/New-Item-for-Plugin.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Providers/New-Item-for-Plugin.md
@@ -113,7 +113,7 @@ New-Item -Plugin <string> -Filename <string> -ResourceURI <Uri> -Capability <str
 |Accept Wildcard Characters?|false|
 
 ### -xmlns <string\>
- A string that specifies specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
+ A string that specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
 
 |||
 |-|-|

--- a/reference/5.1/Microsoft.WsMan.Management/Providers/WSMan-Provider.md
+++ b/reference/5.1/Microsoft.WsMan.Management/Providers/WSMan-Provider.md
@@ -862,7 +862,7 @@ ClientCertificate                     Container
 -   [Set-Item](../../Microsoft.PowerShell.Management/Set-Item.md)
 
 ### xmlns <String\>
- A string that specifies specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
+ A string that specifies a Uniform Resource Name (URN) that uniquely identifies the namespace.
 
 #### Cmdlets supported:
 


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
