### PR TITLE
Add .optemp dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ packages.config
 *.orig
 _themes/
 dependentPackages/
-
+.optemp/


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->

Partial build left this in my build dir -- looks like a git ignorable file?

Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
