### PR TITLE
Adding Enable/Disable PSRemoting cmdlets to PSCore6 documents

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/Disable-PSRemoting.md
+++ b/reference/6/Microsoft.PowerShell.Core/Disable-PSRemoting.md
@@ -1,0 +1,337 @@
+---
+ms.date:  10/02/2018
+schema:  2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+online version:  http://go.microsoft.com/fwlink/?LinkId=821472
+external help file:  System.Management.Automation.dll-Help.xml
+title:  Disable-PSRemoting
+---
+
+# Disable-PSRemoting
+
+## SYNOPSIS
+Prevents remote users from running commands on the local computer.
+
+## SYNTAX
+
+```
+Disable-PSRemoting [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The **Disable-PSRemoting** cmdlet prevents users on other computers from running commands on the local computer.
+
+**Disable-PSRemoting** blocks remote access to all session configurations on the local computer.
+This prevents remote users from creating temporary or persistent sessions to the local computer.
+**Disable-PSRemoting** does not prevent users of the local computer from creating sessions (**PSSessions**) on the local computer or remote computers.
+
+To re-enable remote access to all session configurations, use the Enable-PSRemoting cmdlet.
+To enable remote access to selected session configurations, use the *AccessMode* parameter of the Set-PSSessionConfiguration cmdlet.
+You can also use the Enable-PSSessionConfiguration and Disable-PSSessionConfiguration cmdlets to enable and disable session configurations for all users.
+For more information about session configurations, see [about_Session_Configurations](About/about_Session_Configurations.md).
+
+In Windows PowerShell 2.0, **Disable-PSRemoting** prevents all users from creating user-managed sessions to the local computer.
+In Windows PowerShell 3.0, **Disable-PSRemoting** prevents users on other computers from creating user-managed sessions on the local computer, but allows users of the local computer to create user-managed loopback sessions.
+
+To run this cmdlet, start PowerShell with the Run as administrator option.
+
+> [!NOTE]
+> This command appears only on PowerShell running on the Windows platform. It is not available on Linux or MacOS versions.
+
+> [!CAUTION]
+> On systems that have both Windows PowerShell 3.0 and the Windows PowerShell 2.0 engine, do not use Windows PowerShell 2.0 to run the **Enable-PSRemoting** and **Disable-PSRemoting** cmdlets.
+> The commands might appear to succeed, but the remoting is not configured correctly.
+> Remote commands, and later attempts to enable and disable remoting, are likely to fail.
+
+## EXAMPLES
+
+### Example 1: Prevent remote access to all session configurations
+```
+PS C:\> Disable-PSRemoting
+```
+
+This command prevents remote access to all session configurations on the computer.
+
+### Example 2: Prevent remote access to all session configurations without confirmation prompt
+```
+PS C:\> Disable-PSRemoting -Force
+```
+
+This command prevents remote access all session configurations on the computer without prompting.
+
+### Example 3: Effects of running this cmdlet
+```
+PS C:\> Disable-PSRemoting -Force
+
+
+[ADMIN] PS C:\> New-PSSession -ComputerName localhost
+
+
+Id Name       ComputerName    State    Configuration         Availability
+-- ----       ------------    -----    -------------         ------------
+1 Session1   Server02...     Opened   Microsoft.PowerShell     Available
+# On Server02 remote computer:
+PS C:\> New-PSSession -ComputerName Server01
+
+[SERVER01] Connecting to remote server failed with the following error
+message : Access is denied. For more information, see the about_Remote_Troubleshooting Help topic.
++ CategoryInfo          : OpenError: (System.Manageme....RemoteRunspace:RemoteRunspace) [], PSRemotingTransportException
++ FullyQualifiedErrorId : PSSessionOpenFailed
+```
+
+This example shows the effect of using the **Disable-PSRemoting** cmdlet.
+To run this command sequence, start PowerShell with the Run as administrator option.
+
+The first command uses the **Disable-PSRemoting** cmdlet to disable all registered session configurations on the Server01 computer.
+
+The second command uses the New-PSSession cmdlet to create a remote session to the local computer (also known as a "loopback").
+The command succeeds.
+
+The third command is run on the Server02 remote computer.
+The command uses the **New-PSSession** cmdlet to create a session to the Server01 remote computer.
+Because remote access is disabled, the command fails.
+
+### Example 4: Effects of running this cmdlet and Enable-PSRemoting
+```
+PS C:\> Disable-PSRemoting -force
+
+[ADMIN] PS C:\> Get-PSSessionConfiguration | Format-Table -Property Name, Permission -Auto
+
+Name                          Permission
+----                          ----------
+microsoft.powershell          NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+microsoft.powershell.workflow NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+microsoft.powershell32        NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+microsoft.ServerManager       NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+WithProfile                   NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+
+
+[ADMIN] PS C:\> Enable-PSRemoting -Force
+WinRM already is set up to receive requests on this machine.
+WinRM already is set up for remote management on this machine.
+
+[ADMIN] PS C:\> Get-PSSessionConfiguration | Format-Table -Property Name, Permission -Auto
+
+Name                          Permission
+----                          ----------
+microsoft.powershell          BUILTIN\Administrators AccessAllowed
+microsoft.powershell.workflow BUILTIN\Administrators AccessAllowed
+microsoft.powershell32        BUILTIN\Administrators AccessAllowed
+microsoft.ServerManager       BUILTIN\Administrators AccessAllowed
+WithProfile                   BUILTIN\Administrators AccessAllowed
+```
+
+This example shows the effect on the session configurations of using the **Disable-PSRemoting** and **Enable-PSRemoting** cmdlets.
+
+The first command uses the **Disable-PSRemoting** cmdlet to disable remote access to all session configurations.
+The *Force* parameter suppresses all user prompts.
+
+The second command uses the Get-PSSessionConfiguration cmdlet to display the session configurations on the computer.
+The command uses a pipeline operator to send the results to a Format-Table command, which displays only the Name and Permission properties of the configurations in a table.
+
+The output shows that only remote users are denied access to the configurations.
+Members of the Administrators group on the local computer are allowed to use the session configurations.
+The output also shows that the command affects all session configurations that includes the user-created WithProfile session configuration.
+
+The third command uses the **Enable-PSRemoting** cmdlet to re-enable remote access to all session configurations on the computer.
+The command uses the *Force* parameter to suppress all user prompts and to restart the WinRM service without prompting.
+
+The fourth command uses the **Get-PSSessionConfiguration** and **Format-Table** cmdlets to display the names and permissions of the session configurations.
+The results show that the AccessDenied security descriptors have been removed from all session configurations.
+
+### Example 5: Prevent remote access to session configurations that have custom security descriptors
+```
+PS C:\> Register-PSSessionConfiguration -Name Test -FilePath .\TestEndpoint.pssc -ShowSecurityDescriptorUI
+
+[ADMIN] PS C:\> Get-PSSessionConfiguration | Format-Table -Property Name, Permission -Wrap
+
+Name                          Permission
+----                          ----------
+microsoft.powershell          BUILTIN\Administrators AccessAllowed
+Test                          NT AUTHORITY\INTERACTIVE AccessAllowed, BUILTIN\Administrators AccessAllowed,
+DOMAIN01\User01 AccessAllowed
+
+[ADMIN] PS C:\> Disable-PSRemoting -Force
+
+
+[ADMIN] PS C:\> Get-PSSessionConfiguration | Format-Table -Property Name, Permission -Wrap
+
+Name                          Permission
+----                          ----------
+microsoft.powershell          NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+Test                          NT AUTHORITY\NETWORK AccessDenied, NTAUTHORITY\INTERACTIVE AccessAllowed,
+BUILTIN\Administrators AccessAllowed, DOMAIN01\User01 AccessAllowed
+
+# Domain01\User01
+
+PS C:\> New-PSSession -ComputerName Server01 -ConfigurationName Test
+[Server01] Connecting to remote server failed with the following error message : Access is denied. For more information, see the about_Rem
+ote_Troubleshooting Help topic.
++ CategoryInfo          : OpenError: (System.Manageme....RemoteRunspace:RemoteRunspace) [], PSRemotingTransportException
++ FullyQualifiedErrorId : PSSessionOpenFailed
+```
+
+This example demonstrates that the **Disable-PSRemoting** cmdlet disables remote access to all session configurations that include session configurations with custom security descriptors.
+
+The first command uses the Register-PSSessionConfiguration cmdlet to create the Test session configuration.
+The command uses the *FilePath* parameter to specify a session configuration file that customizes the session and the *ShowSecurityDescriptorUI* parameter to display a dialog box that sets permissions for the session configuration.
+In the Permissions dialog box, we create custom full-access permissions for the Domain01\User01 user.
+
+The second command uses the **Get-PSSessionConfiguration** and **Format-Table** cmdlets to display the session configurations and their properties.
+The output shows that the Test session configuration allows interactive access and special permissions for the Domain01\User01 user.
+
+The third command uses the **Disable-PSRemoting** cmdlet to disable remote access to all session configurations.
+
+The fourth command uses the **Get-PSSessionConfiguration** and **Format-Table** cmdlets to display the session configurations and their properties.
+The output shows that an AccessDenied security descriptor for all network users is added to all session configurations that includes the Test session configuration.
+Although the other security descriptors are not changed, the "network_deny_all" security descriptor takes precedence.
+
+The fifth command shows that the **Disable-PSRemoting** command prevents even the Domain01\User01 user who has special permissions to the Test session configuration from using the Test session configuration to connect to the computer remotely.
+
+### Example 6: Re-enable remote access to selected session configurations
+```
+PS C:\> Disable-PSRemoting -Force
+
+
+[ADMIN] PS C:\> Get-PSSessionConfiguration | Format-Table -Property Name, Permission -Auto
+
+Name                          Permission
+----                          ----------
+microsoft.powershell          NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+microsoft.powershell.workflow NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+microsoft.powershell32        NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+microsoft.ServerManager       NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+WithProfile                   NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+
+[ADMIN] PS C:\> Set-PSSessionConfiguration -Name Microsoft.ServerManager -AccessMode Remote -Force
+
+[ADMIN] PS C:\> Get-PSSessionConfiguration | Format-Table -Property Name, Permission -Auto
+
+Name                          Permission
+----                          ----------
+microsoft.powershell          NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+microsoft.powershell.workflow NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+microsoft.powershell32        NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+microsoft.ServerManager       BUILTIN\Administrators AccessAllowed
+WithProfile                   NT AUTHORITY\NETWORK AccessDenied, BUILTIN\Administrators AccessAllowed
+```
+
+This example shows how to re-enable remote access only to selected session configurations.
+
+The first command uses the **Disable-PSRemoting** cmdlet to disable remote access to all session configurations.
+
+The second command uses the **Get-PSSessionConfiguration** and **Format-Table** cmdlets to display the session configurations and their properties.
+The output shows that an AccessDenied security descriptor for all network users is added to all session configurations.
+
+The third command uses the **Set-PSSessionConfiguration** cmdlet.
+The command uses the *AccessMode* parameter with a value of Remote to enable remote access to the Microsoft.ServerManager session configuration.
+You can also use the *AccessMode* parameter to enable Local access and to disable session configurations.
+
+The fourth command uses the **Get-PSSessionConfiguration** and **Format-Table** cmdlets to display the session configurations and their properties.
+The output shows that the AccessDenied security descriptor for all network users is removed, thereby restoring remote access to the Microsoft.ServerManager session configuration.
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Forces the command to run without asking for user confirmation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+You cannot pipe input to this cmdlet.
+
+## OUTPUTS
+
+### None
+This cmdlet does not return any object.
+
+## NOTES
+* Disabling the session configurations does not undo all the changes that were made by the **Enable-PSRemoting** or **Enable-PSSessionConfiguration** cmdlets. You might have to undo the following changes manually.
+
+  1.
+Stop and disable the WinRM service.
+
+  2.
+Delete the listener that accepts requests on any IP address.
+
+  3.
+Disable the firewall exceptions for WS-Management communications.
+
+  4.
+Restore the value of the LocalAccountTokenFilterPolicy to 0, which restricts remote access to members of the Administrators group on the computer.
+
+  A session configuration is a group of settings that define the environment for a session.
+Every session that connects to the computer must use one of the session configurations that are registered on the computer.
+By denying remote access to all session configurations, you effectively prevent remote users from establishing sessions that connect to the computer.
+
+  In Windows PowerShell 2.0, **Disable-PSRemoting** adds a Deny_All entry to the security descriptors of all session configurations.
+This setting prevents all users from creating user-managed sessions to the local computer.
+In Windows PowerShell 3.0, **Disable-PSRemoting** adds a Network_Deny_All entry to the security descriptors of all session configurations.
+This setting prevents users on other computers from creating user-managed sessions on the local computer, but allows users of the local computer to create user-managed loopback sessions.
+
+  In Windows PowerShell 2.0, **Disable-PSRemoting** is the equivalent of `Disable-PSSessionConfiguration -Name *`.
+In Windows PowerShell 3.0 and later releases, **Disable-PSRemoting** is the equivalent of `Set-PSSessionConfiguration -Name \<Configuration name\> -AccessMode Local`
+
+  In Windows PowerShell 2.0, **Disable-PSRemoting** is a function.
+Beginning in Windows PowerShell 3.0, it is a cmdlet.
+
+## RELATED LINKS
+
+[Disable-PSSessionConfiguration](Disable-PSSessionConfiguration.md)
+
+[Enable-PSRemoting](Enable-PSRemoting.md)
+
+[Get-PSSessionConfiguration](Get-PSSessionConfiguration.md)
+
+[Register-PSSessionConfiguration](Register-PSSessionConfiguration.md)
+
+[Set-PSSessionConfiguration](Set-PSSessionConfiguration.md)
+
+[Unregister-PSSessionConfiguration](Unregister-PSSessionConfiguration.md)

--- a/reference/6/Microsoft.PowerShell.Core/Enable-PSRemoting.md
+++ b/reference/6/Microsoft.PowerShell.Core/Enable-PSRemoting.md
@@ -1,0 +1,212 @@
+---
+ms.date:  10/02/2018
+schema:  2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+online version:  http://go.microsoft.com/fwlink/?LinkId=821475
+external help file:  System.Management.Automation.dll-Help.xml
+title:  Enable-PSRemoting
+---
+
+# Enable-PSRemoting
+
+## SYNOPSIS
+Configures the computer to receive remote commands.
+
+## SYNTAX
+
+```
+Enable-PSRemoting [-Force] [-SkipNetworkProfileCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The **Enable-PSRemoting** cmdlet configures the computer to receive PowerShell remote commands that are sent by using the WS-Management technology.
+
+By default, on Windows Server® 2012, PowerShell remoting is enabled.
+You can use **Enable-PSRemoting** to enable PowerShell remoting on other supported versions of Windows and to re-enable remoting on Windows Server 2012 if it becomes disabled.
+
+You have to run this command only one time on each computer that will receive commands.
+You do not have to run it on computers that only send commands.
+Because the configuration starts listeners, it is prudent to run it only where it is needed.
+
+Beginning in Windows PowerShell 3.0, the **Enable-PSRemoting** cmdlet can enable PowerShell remoting on client versions of Windows when the computer is on a public network.
+For more information, see the description of the *SkipNetworkProfileCheck* parameter.
+
+The **Enable-PSRemoting** cmdlet performs the following operations:
+
+- Runs the [Set-WSManQuickConfig](http://go.microsoft.com/fwlink/?LinkID=141463) cmdlet, which performs the following tasks:
+ - Starts the WinRM service.
+ - Sets the startup type on the WinRM service to Automatic.
+ - Creates a listener to accept requests on any IP address.
+ - Enables a firewall exception for WS-Management communications.
+ - Registers the Microsoft.PowerShell and Microsoft.PowerShell.Workflow session configurations, if it they are not already registered.
+ - Registers the Microsoft.PowerShell32 session configuration on 64-bit computers, if it is not already registered.
+ - Enables all session configurations.
+ - Changes the security descriptor of all session configurations to allow remote access.
+- Restarts the WinRM service to make the preceding changes effective.
+
+To run this cmdlet, start PowerShell by using the Run as administrator option.
+
+> [!NOTE]
+> This command appears only on PowerShell running on the Windows platform. It is not available on Linux or MacOS versions.
+
+> [!CAUTION]
+> On systems that have both Windows PowerShell 3.0 and Windows PowerShell 2.0, do not use Windows PowerShell 2.0 to run the **Enable-PSRemoting** and Disable-PSRemoting cmdlets.
+> The commands might appear to succeed, but the remoting is not configured correctly.
+> Remote commands and later attempts to enable and disable remoting, are likely to fail.
+
+## EXAMPLES
+
+### Example 1: Configure a computer to receive remote commands
+```
+PS C:\> Enable-PSRemoting
+```
+
+This command configures the computer to receive remote commands.
+
+### Example 2: Configure a computer to receive remote commands without a confirmation prompt
+```
+PS C:\> Enable-PSRemoting -Force
+```
+
+This command configures the computer to receive remote commands.
+It uses the *Force* parameter to suppress the user prompts.
+
+### Example 3: Allow remote access on clients
+```
+PS C:\> Enable-PSRemoting -SkipNetworkProfileCheck -Force
+PS C:\> Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP" -RemoteAddress Any
+```
+
+This example shows how to allow remote access from public networks on client versions of the Windows operating system.
+Before using these commands, analyze the security setting and verify that the computer network will be safe from harm.
+
+The first command enables remoting in PowerShell.
+By default, this creates network rules that allow remote access from private and domain networks.
+The command uses the *SkipNetworkProfileCheck* parameter to allow remote access from public networks in the same local subnet.
+The command specifies the *Force* parameter to suppress confirmation messages.
+
+The *SkipNetworkProfileCheck* parameter does not affect server version of the Windows operating system, which allow remote access from public networks in the same local subnet by default.
+
+The second command eliminates the subnet restriction.
+The command uses the **Set-NetFirewallRule** cmdlet in the **NetSecurity** module to add a firewall rule that allows remote access from public networks from any remote location.
+This includes locations in different subnets.
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Forces the command to run without asking for user confirmation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipNetworkProfileCheck
+Indicates that this cmdlet enables remoting on client versions of the Windows operating system when the computer is on a public network.
+This parameter enables a firewall rule for public networks that allows remote access only from computers in the same local subnet.
+
+This parameter does not affect server versions of the Windows operating system, which, by default, have a local subnet firewall rule for public networks.
+If the local subnet firewall rule is disabled on a server version, **Enable-PSRemoting** re-enables it, regardless of the value of this parameter.
+
+To remove the local subnet restriction and enable remote access from all locations on public networks, use the **Set-NetFirewallRule** cmdlet in the **NetSecurity** module.
+
+This parameter was introduced in Windows PowerShell 3.0.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+You cannot pipe input to this cmdlet.
+
+## OUTPUTS
+
+### System.String
+This cmdlet returns strings that describe its results.
+
+## NOTES
+* In Windows PowerShell 3.0, **Enable-PSRemoting** creates the following firewall exceptions for WS-Management communications.
+
+  On server versions of the Windows operating system, **Enable-PSRemoting** creates firewall rules for private and domain networks that allow remote access, and creates a firewall rule for public networks that allows remote access only from computers in the same local subnet.
+
+  On client versions of the Windows operating system, **Enable-PSRemoting** in Windows PowerShell 3.0 creates firewall rules for private and domain networks that allow unrestricted remote access.
+To create a firewall rule for public networks that allows remote access from the same local subnet, use the *SkipNetworkProfileCheck* parameter.
+
+  On client or server versions of the Windows operating system, to create a firewall rule for public networks that removes the local subnet restriction and allows remote access , use the **Set-NetFirewallRule** cmdlet in the NetSecurity module to run the following command: `Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP-PUBLIC" -RemoteAddress Any`
+
+* In Windows PowerShell 2.0, **Enable-PSRemoting** creates the following firewall exceptions for WS-Management communications.
+
+  On server versions of the Windows operating system, it creates firewall rules for all networks that allow remote access.
+
+  On client versions of the Windows operating system, **Enable-PSRemoting** in Windows PowerShell 2.0 creates a firewall exception only for domain and private network locations.
+To minimize security risks, **Enable-PSRemoting** does not create a firewall rule for public networks on client versions of Windows.
+When the current network location is public, **Enable-PSRemoting** returns the following message: Unable to check the status of the firewall.
+
+* Starting in Windows PowerShell 3.0, **Enable-PSRemoting** enables all session configurations by setting the value of the **Enabled** property of all session configurations (WSMan:\\\<ComputerName\>\Plugin\\\<SessionConfigurationName\>\Enabled) to True ($True).
+* In Windows PowerShell 2.0, **Enable-PSRemoting** removes the Deny_All setting from the security descriptor of session configurations. In Windows PowerShell 3.0, **Enable-PSRemoting** removes the Deny_All and Network_Deny_All settings. This provides remote access to session configurations that were reserved for local use.
+
+## RELATED LINKS
+
+[Disable-PSSessionConfiguration](Disable-PSSessionConfiguration.md)
+
+[Enable-PSSessionConfiguration](Enable-PSSessionConfiguration.md)
+
+[Get-PSSessionConfiguration](Get-PSSessionConfiguration.md)
+
+[Register-PSSessionConfiguration](Register-PSSessionConfiguration.md)
+
+[Set-PSSessionConfiguration](Set-PSSessionConfiguration.md)
+
+[Disable-PSRemoting](Disable-PSRemoting.md)


### PR DESCRIPTION
This change copies the Enable-PSRemoting and Disable-PSRemoting help files from 5.1 to  6 location, because they were missing.
In addition a NOTE was added stating that the cmdlets only apply to Windows platform.
Also, "Windows PowerShell" was changed to "PowerShell", except when specifying specific older Windows PowerShell versions.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
