### PR TITLE
Add cSpell.json

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -1,0 +1,5 @@
+{
+	"dictionaries": [
+		"powershell"
+	]
+}


### PR DESCRIPTION
The cSpell.json is a setting file for the [streetsidesoftware.code-spell-checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) extension that was added by #3221. The setting can suppress some warnings about "cmdlet", "dynamicparam", etc.
