### PR TITLE
corrected arithmetic operator precedence

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -23,7 +23,8 @@ order is the order in which PowerShell evaluates the operators when
 multiple operators appear in the same expression.
 
 When operators have equal precedence, PowerShell evaluates them from
-left to right. The exceptions are the assignment operators, the cast
+left to right as they appear within the expression.
+The exceptions are the assignment operators, the cast
 operators, and the negation operators (!, -not, -bnot), which are evaluated
 from right to left.
 
@@ -41,7 +42,7 @@ the topic, type `get-help <topic-name>`.
 
 |OPERATOR                |REFERENCE|
 |------------------------|---------|
-|`$()  @()`              |[about_Operators](#index-operator)|
+|`$() @() ()`            |[about_Operators](about_Operators.md)|
 |`.` (dereference)       |[about_Operators](about_Operators.md)|
 |`::` (static)           |[about_Operators](about_Operators.md)|
 |`[0]` (index operator)  |[about_Operators](about_Operators.md)|
@@ -54,7 +55,9 @@ the topic, type `get-help <topic-name>`.
 |`! -bNot`               |[about_Comparison_Operators](about_Comparison_Operators.md)|
 |`..` (range operator)   |[about_Operators](about_Operators.md)|
 |`-f` (format operator)  |[about_Operators](about_Operators.md)|
-|`* / % + -`             |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`-` (unary/negative)    |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`* / %`                 |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`+ -`                   |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
 
 The following group of operators have equal precedence. Their case-sensitive
 and explicitly case-insensitive variants have the same precedence.


### PR DESCRIPTION
also fixed a broken about link, and added bare parens which appear to be missing. Fixes #3260

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
