### PR TITLE
Added code tag around pipeline operator

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -80,7 +80,7 @@ order:
 |`-and -or -xor`           |[about_Logical_Operators](about_logical_operators.md)|
 |`.` (dot-source)          |[about_Scopes](about_Scopes.md)|
 |`&` (call)                |[about_Operators](about_Operators.md)|
-|&#124; (pipeline operator)|[about_Operators](about_Operators.md)|
+|<code>&#124;</code> (pipeline operator)|[about_Operators](about_Operators.md)|
 |`> >> 2> 2>> 2>&1`        |[about_Redirection](about_Redirection.md)|
 |`= += -= *= /= %=`        |[about_Assignment_Operators](about_Assignment_Operators.md)|
 


### PR DESCRIPTION
I assume the backticks are missing because they'll output the character entity code instead of the character, and that a simple `|` won't do because it'll mess up the table. Someone who can test what the markdown formatter outputs should try this out.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
