### PR TITLE
Fixed out of date redirect link to be relative

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Write-Error.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Write-Error.md
@@ -49,7 +49,7 @@ Non-terminating errors write an error to the error stream, but they do not stop 
 If a non-terminating error is declared on one item in a collection of input items, the command continues to process the other items in the collection.
 
 To declare a terminating error, use the **Throw** keyword.
-For more information, see about_Throw (http://go.microsoft.com/fwlink/?LinkID=145153).
+For more information, see [about_Throw](../Microsoft.PowerShell.Core/About/about_Throw.md).
 
 ## EXAMPLES
 


### PR DESCRIPTION
about_Throw should be a relative link within the docs repo. Existing fwlink was for an old version.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
