### PR TITLE
fixed an old redirect link to an about_ page

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Get-TypeData.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-TypeData.md
@@ -30,7 +30,7 @@ Extended type data adds properties and methods to objects in PowerShell.
 You can use the added properties and methods in the same ways that you would use the properties and methods that are defined in the object type.
 However, when writing scripts, be aware that the added properties and methods might not be present in every PowerShell session.
 
-For more information about Types.ps1xml files, see about_Types.ps1xml (http://go.microsoft.com/fwlink/?LinkID=113274).
+For more information about Types.ps1xml files, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 For more information about dynamic type data that the **Update-TypeData** cmdlet adds, see Update-TypeData.
 
 This cmdlet was introduced in Windows PowerShell 3.0.


### PR DESCRIPTION
redirect was targeting a specific version of the docs instead of being generic

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
