### PR TITLE
Revised powershell.exe -Command parameter

### DIFF
--- a/reference/docs-conceptual/core-powershell/console/PowerShell.exe-Command-Line-Help.md
+++ b/reference/docs-conceptual/core-powershell/console/PowerShell.exe-Command-Line-Help.md
@@ -98,22 +98,38 @@ Sets the window style for the session. Valid values are Normal, Minimized, Maxim
 
 ### -Command
 
-Executes the specified commands (with any parameters) as though they were typed at the PowerShell command prompt. After execution, PowerShell exits unless the `-NoExit` parameter is specified.
-Any text after `-Command` is sent as a single command line to PowerShell. This is different from how `-File` handles parameters sent to a script.
+Executes the specified commands (with any parameters) as though they were typed at the PowerShell command prompt.
+After execution, PowerShell exits unless the **NoExit** parameter is specified.
+Any text after `-Command` is sent as a single command line to PowerShell.
+This is different from how `-File` handles parameters sent to a script.
 
-The value of Command can be "-", a string. or a script block. If the value of Command is "-", the command text is read from standard input.
+The value of `-Command` can be "-", a string, or a script block.
+The results of the command are returned to the parent shell as deserialized XML objects, not live objects.
 
-Script blocks must be enclosed in braces ({}). You can specify a script block only when running PowerShell.exe in PowerShell. The results of the script are returned to the parent shell as deserialized XML objects, not live objects.
+If the value of `-Command` is "-", the command text is read from standard input.
 
-If the value of Command is a string, **Command** must be the last parameter in the command, because any characters typed after the command are interpreted as the command arguments.
+When the value of `-Command` is a string, **Command** _must_ be the last parameter specified
+because any characters typed after the command are interpreted as the command arguments.
 
-To write a string that runs a PowerShell command, use the format:
+The **Command** parameter only accepts a script block for execution when it can recognize the value passed to `-Command` as a ScriptBlock type.
+This is _only_ possible when running PowerShell.exe from another PowerShell host.
+The ScriptBlock type may be contained in an existing variable, returned from an expression,
+or parsed by the PowerShell host as a literal script block enclosed in curly braces `{}`,
+before being passed to PowerShell.exe.
 
-```powershell
+In cmd.exe, there is no such thing as a script block (or ScriptBlock type),
+so the value passed to **Command** will _always_ be a string.
+You can write a script block inside the string,
+but instead of being executed it will behave exactly as though you typed it at a typical PowerShell prompt,
+printing the contents of the script block back out to you.
+
+A string passed to `-Command` will still be executed as PowerShell,
+so the script block curly braces are often not required in the first place when running from cmd.exe.
+To execute an inline script block defined inside a string, the [call operator](/powershell/module/microsoft.powershell.core/about/about_operators#call-operator-) `&` can be used:
+
+```console
 "& {<command>}"
 ```
-
-The quotation marks indicate a string and the invoke operator (&) causes the command to be executed.
 
 ### -Help, -?, /?
 


### PR DESCRIPTION
Tried to stick to the style guide as it pertains to backticks, bold, semantic linefeeds, and URLs.

Moved some sections around to be more of a logical flow; first introducing the concept, then elaborating on inputs and outputs, and finally detailing each acceptable input type for `-Command`.

I wanted to clarify exactly why script blocks only work in powershell.exe, and I think this does a good job of explaining why types are important, and why attempting to write a script block when running from cmd.exe usually gets it spat back out at you.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
--------------------------——
- [x] Impacts docs-conceptual
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document
