### PR TITLE
fixed broken info box header

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -1,8 +1,10 @@
+---
 ms.date:  06/09/2017
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Language_Keywords
+---
 
 # About Language Keywords
 


### PR DESCRIPTION
This information was displaying on docs.microsoft.com. I believe it needs to be surrounded by the three hyphens to work properly.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
