### PR TITLE
Fix typo: cmldet -> cmdlet

### DIFF
--- a/developer/provider/windows-powershell-provider-overview.md
+++ b/developer/provider/windows-powershell-provider-overview.md
@@ -26,7 +26,7 @@ There are several types of providers, each of which provides a different level o
 
 ## Provider cmdlets
 
-Providers can implement methods that correspond to cmdlets, creating custom behaviors for those cmdlets when used in a drive for that provider. Depending on the type of provider, different sets of cmdlets are available. For a complete list of the cmldets available for customization in providers, see [Provider cmdlets](./provider-cmdlets.md).
+Providers can implement methods that correspond to cmdlets, creating custom behaviors for those cmdlets when used in a drive for that provider. Depending on the type of provider, different sets of cmdlets are available. For a complete list of the cmdlets available for customization in providers, see [Provider cmdlets](./provider-cmdlets.md).
 
 ## Provider paths
 

--- a/dsc/troubleshooting.md
+++ b/dsc/troubleshooting.md
@@ -381,7 +381,7 @@ SRV1   OPERATIONAL  6/24/2016 10:51:54 AM Operation Consistency Check or Pull co
 ```
 
 Pass the **GUID** assigned to a specific DSC operation (as returned by the `Get-xDscOperation`
-cmldet) to get the event details for that DSC operation:
+cmdlet) to get the event details for that DSC operation:
 
 ```powershell
 PS C:\DiagnosticsTest> Trace-xDscOperation -JobID 9e0bfb6b-3a3a-11e6-9165-00155d390509

--- a/reference/3.0/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Import-Module.md
@@ -972,7 +972,7 @@ You can pipe a module name, module object, or assembly object to `Import-Module`
 ### None, System.Management.Automation.PSModuleInfo, or System.Management.Automation.PSCustomObject
 
 By default, **Import-Module** does not generate any output.
-If you specify the *PassThru* parameter, the cmldet generates a **System.Management.Automation.PSModuleInfo** object that represents the module.
+If you specify the *PassThru* parameter, the cmdlet generates a **System.Management.Automation.PSModuleInfo** object that represents the module.
 If you specify the *AsCustomObject* parameter, it generates a **PSCustomObject** object.
 
 ## NOTES

--- a/reference/4.0/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Import-Module.md
@@ -944,7 +944,7 @@ You can pipe a module name, module object, or assembly object to `Import-Module`
 ### None, System.Management.Automation.PSModuleInfo, or System.Management.Automation.PSCustomObject
 
 By default, **Import-Module** does not generate any output.
-If you specify the *PassThru* parameter, the cmldet generates a **System.Management.Automation.PSModuleInfo** object that represents the module.
+If you specify the *PassThru* parameter, the cmdlet generates a **System.Management.Automation.PSModuleInfo** object that represents the module.
 If you specify the *AsCustomObject* parameter, it generates a **PSCustomObject** object.
 
 ## NOTES

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-Job.md
@@ -588,7 +588,7 @@ You cannot pipe input to this cmdlet.
 ## OUTPUTS
 
 ### System.Management.Automation.RemotingJob
-This cmldet returns objects that represent the jobs in the session.
+This cmdlet returns objects that represent the jobs in the session.
 
 ## NOTES
 * The **PSJobTypeName** property of jobs indicates the job type of the job. The property value is determined by the job type author. The following list shows common job types.

--- a/reference/5.0/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Import-Module.md
@@ -975,7 +975,7 @@ You can pipe a module name, module object, or assembly object to `Import-Module`
 ### None, System.Management.Automation.PSModuleInfo, or System.Management.Automation.PSCustomObject
 
 By default, **Import-Module** does not generate any output.
-If you specify the *PassThru* parameter, the cmldet generates a **System.Management.Automation.PSModuleInfo** object that represents the module.
+If you specify the *PassThru* parameter, the cmdlet generates a **System.Management.Automation.PSModuleInfo** object that represents the module.
 If you specify the *AsCustomObject* parameter, it generates a **PSCustomObject** object.
 
 ## NOTES

--- a/reference/5.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -936,7 +936,7 @@ You cannot pipe input to this cmdlet.
 ## OUTPUTS
 
 ### None or System.String
-This cmldet does not generate any output by default.
+This cmdlet does not generate any output by default.
 However, if you use the *PassThru* parameter, it generates a **System.String** object that represents the module manifest.
 
 ## NOTES

--- a/reference/5.0/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -711,16 +711,16 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.Management.Automation.Runspaces.PSSession
-You can pipe session objects, such as those returned by the Get-PSSession cmdlet, to this cmldet.
+You can pipe session objects, such as those returned by the Get-PSSession cmdlet, to this cmdlet.
 
 ### System.Int32
-You can pipe session IDs to this cmldet.
+You can pipe session IDs to this cmdlet.
 
 ### System.Guid
-You can pipe the instance IDs of sessions this cmldet.
+You can pipe the instance IDs of sessions this cmdlet.
 
 ### System.String
-You can pipe session names to this cmldet.
+You can pipe session names to this cmdlet.
 
 ## OUTPUTS
 

--- a/reference/5.0/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Save-Help.md
@@ -49,7 +49,7 @@ Without parameters, a **Save-Help** command downloads the newest help for all mo
 This action skips modules that do not support Updatable Help without warning.
 
 The **Save-Help** cmdlet checks the version of any help files in the destination folder.
-If newer help files are available, this cmldet downloads the newest help files from the Internet, and then saves them in the folder.
+If newer help files are available, this cmdlet downloads the newest help files from the Internet, and then saves them in the folder.
 The **Save-Help** cmdlet works just like the Update-Help cmdlet, except that it saves the downloaded cabinet (.cab) files, instead of extracting the help files from the cabinet files and installing them on the computer.
 
 The saved help for each module consists of one help information (HelpInfo XML) file and one cabinet (.cab) file for the help files each UI culture.

--- a/reference/5.0/Microsoft.PowerShell.Management/Show-ControlPanelItem.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Show-ControlPanelItem.md
@@ -51,7 +51,7 @@ PS C:\> Show-ControlPanelItem -Name "AutoPlay"
 
 This command shows the AutoPlay item.
 
-### Example 2: Pipe a control panel item to this cmldet
+### Example 2: Pipe a control panel item to this cmdlet
 ```
 PS C:\> Get-ControlPanelItem -Name "Windows Firewall" | Show-ControlPanelItem
 ```

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-Job.md
@@ -589,7 +589,7 @@ You cannot pipe input to this cmdlet.
 ## OUTPUTS
 
 ### System.Management.Automation.RemotingJob
-This cmldet returns objects that represent the jobs in the session.
+This cmdlet returns objects that represent the jobs in the session.
 
 ## NOTES
 * The **PSJobTypeName** property of jobs indicates the job type of the job. The property value is determined by the job type author. The following list shows common job types.

--- a/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
@@ -993,7 +993,7 @@ You can pipe a module name, module object, or assembly object to `Import-Module`
 ### None, System.Management.Automation.PSModuleInfo, or System.Management.Automation.PSCustomObject
 
 By default, **Import-Module** does not generate any output.
-If you specify the *PassThru* parameter, the cmldet generates a **System.Management.Automation.PSModuleInfo** object that represents the module.
+If you specify the *PassThru* parameter, the cmdlet generates a **System.Management.Automation.PSModuleInfo** object that represents the module.
 If you specify the *AsCustomObject* parameter, it generates a **PSCustomObject** object.
 
 ## NOTES

--- a/reference/5.1/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -956,7 +956,7 @@ You cannot pipe input to this cmdlet.
 ## OUTPUTS
 
 ### None or System.String
-This cmldet does not generate any output by default.
+This cmdlet does not generate any output by default.
 However, if you use the *PassThru* parameter, it generates a **System.String** object that represents the module manifest.
 
 ## NOTES

--- a/reference/5.1/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -712,16 +712,16 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.Management.Automation.Runspaces.PSSession
-You can pipe session objects, such as those returned by the Get-PSSession cmdlet, to this cmldet.
+You can pipe session objects, such as those returned by the Get-PSSession cmdlet, to this cmdlet.
 
 ### System.Int32
-You can pipe session IDs to this cmldet.
+You can pipe session IDs to this cmdlet.
 
 ### System.Guid
-You can pipe the instance IDs of sessions this cmldet.
+You can pipe the instance IDs of sessions this cmdlet.
 
 ### System.String
-You can pipe session names to this cmldet.
+You can pipe session names to this cmdlet.
 
 ## OUTPUTS
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Save-Help.md
@@ -50,7 +50,7 @@ Without parameters, a **Save-Help** command downloads the newest help for all mo
 This action skips modules that do not support Updatable Help without warning.
 
 The **Save-Help** cmdlet checks the version of any help files in the destination folder.
-If newer help files are available, this cmldet downloads the newest help files from the Internet, and then saves them in the folder.
+If newer help files are available, this cmdlet downloads the newest help files from the Internet, and then saves them in the folder.
 The **Save-Help** cmdlet works just like the Update-Help cmdlet, except that it saves the downloaded cabinet (.cab) files, instead of extracting the help files from the cabinet files and installing them on the computer.
 
 The saved help for each module consists of one help information (HelpInfo XML) file and one cabinet (.cab) file for the help files each UI culture.

--- a/reference/5.1/Microsoft.PowerShell.Management/Show-ControlPanelItem.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Show-ControlPanelItem.md
@@ -52,7 +52,7 @@ PS C:\> Show-ControlPanelItem -Name "AutoPlay"
 
 This command shows the AutoPlay item.
 
-### Example 2: Pipe a control panel item to this cmldet
+### Example 2: Pipe a control panel item to this cmdlet
 ```
 PS C:\> Get-ControlPanelItem -Name "Windows Firewall" | Show-ControlPanelItem
 ```

--- a/reference/6/Microsoft.PowerShell.Core/Get-Job.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Job.md
@@ -589,7 +589,7 @@ You cannot pipe input to this cmdlet.
 ## OUTPUTS
 
 ### System.Management.Automation.RemotingJob
-This cmldet returns objects that represent the jobs in the session.
+This cmdlet returns objects that represent the jobs in the session.
 
 ## NOTES
 * The **PSJobTypeName** property of jobs indicates the job type of the job. The property value is determined by the job type author. The following list shows common job types.

--- a/reference/6/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Import-Module.md
@@ -948,14 +948,14 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.String, System.Management.Automation.PSModuleInfo, System.Reflection.Assembly
-You can pipe a module name, module object, or assembly object to this cmldet.
+You can pipe a module name, module object, or assembly object to this cmdlet.
 
 ## OUTPUTS
 
 ### None, System.Management.Automation.PSModuleInfo, or System.Management.Automation.PSCustomObject
 This cmdlet returns a **PSModuleInfo** or **PSCustomObject**.
 By default, **Import-Module** does not generate any output.
-If you specify the *PassThru* parameter, the cmldet generates a **System.Management.Automation.PSModuleInfo** object that represents the module.
+If you specify the *PassThru* parameter, the cmdlet generates a **System.Management.Automation.PSModuleInfo** object that represents the module.
 If you specify the *AsCustomObject* parameter, it generates a **PSCustomObject** object.
 
 ## NOTES

--- a/reference/6/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/6/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -951,7 +951,7 @@ You cannot pipe input to this cmdlet.
 ## OUTPUTS
 
 ### None or System.String
-This cmldet does not generate any output by default.
+This cmdlet does not generate any output by default.
 However, if you use the *PassThru* parameter, it generates a **System.String** object that represents the module manifest.
 
 ## NOTES

--- a/reference/6/Microsoft.PowerShell.Core/Receive-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/Receive-PSSession.md
@@ -712,16 +712,16 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## INPUTS
 
 ### System.Management.Automation.Runspaces.PSSession
-You can pipe session objects, such as those returned by the Get-PSSession cmdlet, to this cmldet.
+You can pipe session objects, such as those returned by the Get-PSSession cmdlet, to this cmdlet.
 
 ### System.Int32
-You can pipe session IDs to this cmldet.
+You can pipe session IDs to this cmdlet.
 
 ### System.Guid
-You can pipe the instance IDs of sessions this cmldet.
+You can pipe the instance IDs of sessions this cmdlet.
 
 ### System.String
-You can pipe session names to this cmldet.
+You can pipe session names to this cmdlet.
 
 ## OUTPUTS
 

--- a/reference/6/Microsoft.PowerShell.Core/Save-Help.md
+++ b/reference/6/Microsoft.PowerShell.Core/Save-Help.md
@@ -50,7 +50,7 @@ Without parameters, a **Save-Help** command downloads the newest help for all mo
 This action skips modules that do not support Updatable Help without warning.
 
 The **Save-Help** cmdlet checks the version of any help files in the destination folder.
-If newer help files are available, this cmldet downloads the newest help files from the Internet, and then saves them in the folder.
+If newer help files are available, this cmdlet downloads the newest help files from the Internet, and then saves them in the folder.
 The **Save-Help** cmdlet works just like the Update-Help cmdlet, except that it saves the downloaded cabinet (.cab) files, instead of extracting the help files from the cabinet files and installing them on the computer.
 
 The saved help for each module consists of one help information (HelpInfo XML) file and one cabinet (.cab) file for the help files each UI culture.


### PR DESCRIPTION
Hi, I'm the typo police. :cop:

Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
