### PR TITLE
Update Write-Information.md

### DIFF
--- a/reference/6/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Write-Information.md
@@ -177,9 +177,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### System.Object
 
-`Write-Information` does not accept piped input.
+`Write-Information` accepts piped objects to pass to the information stream.
 
 ## OUTPUTS
 


### PR DESCRIPTION
Corrected the INPUTS to properly show that this cmdlet accepts System.Object objects as pipeline input to the -MessageData parameter.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [X ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [X ] The documented feature was introduced in version 6 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
