### PR TITLE
Fixed broken headers and bookmarks from CATS report

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -4,6 +4,7 @@ schema:  2.0.0
 keywords:  powershell,cmdlet
 title:  about_Assignment_Operators
 ---
+
 # About Assignment Operators
 
 ## SHORT DESCRIPTION
@@ -15,7 +16,7 @@ Describes how to use operators to assign values to variables.
 Assignment operators assign one or more values to a variable. They can
 perform numeric operations on the values before the assignment.
 
-Windows PowerShell supports the following assignment operators.
+PowerShell supports the following assignment operators.
 
 |Operator|Description                                                  |
 |--------|-------------------------------------------------------------|
@@ -59,14 +60,14 @@ replace the existing value of the variable, or you can append a new value
 to the existing value.
 
 The basic assignment operator is the equal sign `=` `(ASCII 61)`. For
-example, the following statement assigns the value Windows PowerShell to
+example, the following statement assigns the value PowerShell to
 the $MyShell variable:
 
 ```powershell
-$MyShell = "Windows PowerShell"
+$MyShell = "PowerShell"
 ```
 
-When you assign a value to a variable in Windows PowerShell, the variable
+When you assign a value to a variable in PowerShell, the variable
 is created if it did not already exist. For example, the first of the
 following two assignement statements creates the $a variable and assigns a
 value of 6 to $a. The second assignment statement assigns a value of 12 to
@@ -78,7 +79,7 @@ $a = 6
 $a = 12
 ```
 
-Variables in Windows PowerShell do not have a specific data type unless you
+Variables in PowerShell do not have a specific data type unless you
 cast them. When a variable contains only one object, the variable takes the
 data type of that object. When a variable contains a collection of objects,
 the variable has the System.Object data type. Therefore, you can assign any
@@ -141,7 +142,7 @@ $a = "apple", "orange", "lemon", "grape"
 ```
 
 To assign a hash table to a variable, use the standard hash table notation
-in Windows PowerShell. Type an at sign `@` followed by key/value pairs that
+in PowerShell. Type an at sign `@` followed by key/value pairs that
 are separated by semicolons `;` and enclosed in braces `{ }`. For example,
 to assign a hash table to the $a variable, type:
 
@@ -150,7 +151,7 @@ $a = @{one=1; two=2; three=3}
 ```
 
 To assign hexadecimal values to a variable, precede the value with `0x`.
-Windows PowerShell converts the hexadecimal value (0x10) to a decimal value
+PowerShell converts the hexadecimal value (0x10) to a decimal value
 (in this case, 16) and assigns that value to the $a variable. For example,
 to assign a value of 0x10 to the $a variable, type:
 
@@ -166,7 +167,7 @@ assign a value of 3.1415 to the power of 1,000 to the $a variable, type:
 $a = 3.1415e3
 ```
 
-Windows PowerShell can also convert kilobytes `KB`, megabytes `MB`, and
+PowerShell can also convert kilobytes `KB`, megabytes `MB`, and
 gigabytes `GB` into bytes. For example, to assign a value of 10 kilobytes
 to the $a variable, type:
 
@@ -411,7 +412,7 @@ $a *= 2
 $a = ($a * 2)
 ```
 
-When a variable contains a string value, Windows PowerShell appends the
+When a variable contains a string value, PowerShell appends the
 specified number of strings to the value, as follows:
 
 ```powershell
@@ -498,7 +499,7 @@ $a
 3
 ```
 
-# THE INCREMENT AND DECREMENT OPERATORS
+## THE INCREMENT AND DECREMENT OPERATORS
 
 The increment operator `++` increases the value of a variable by 1. When
 you use the increment operator in a simple statement, no value is returned.
@@ -689,7 +690,7 @@ $a
 file3
 ```
 
-If the first value is an integer, Windows PowerShell treats all operations
+If the first value is an integer, PowerShell treats all operations
 as integer operations and casts new values to integers. This occurs in the
 following example:
 
@@ -753,7 +754,7 @@ In addition, when you precede a variable name with a data type, the type of
 that variable is locked unless you explicitly override the type by
 specifying another data type. If you try to assign a value that is
 incompatible with the existing type, and you do not explicitly override the
-type, Windows PowerShell displays an error, as shown in the following
+type, PowerShell displays an error, as shown in the following
 example:
 
 ```powershell
@@ -774,7 +775,7 @@ At line:1 char:3
 [string]$a = "string"
 ```
 
-In Windows PowerShell, the data types of variables that contain multiple
+In PowerShell, the data types of variables that contain multiple
 items in an array are handled differently from the data types of variables
 that contain a single item. Unless a data type is specifically assigned to
 an array variable, the data type is always `System.Object []`. This data
@@ -788,7 +789,7 @@ array type:
 [string []] $a = "one", "two", "three"
 ```
 
-Windows PowerShell variables can be any .NET Framework data type. In
+PowerShell variables can be any .NET Framework data type. In
 addition, you can assign any fully qualified .NET Framework data type that
 is available in the current process. For example, the following command
 specifies a `System.DateTime` data type:
@@ -805,9 +806,9 @@ following:
 Tuesday, May 31, 2005 12:00:00 AM
 ```
 
-# ASSIGNING MULTIPLE VARIABLES
+## ASSIGNING MULTIPLE VARIABLES
 
-In Windows PowerShell, you can assign values to multiple variables by using
+In PowerShell, you can assign values to multiple variables by using
 a single command. The first element of the assignment value is assigned to
 the first variable, the second element is assigned to the second variable,
 the third element to the third variable, and so on. For example, the
@@ -826,7 +827,7 @@ following command contains three variables and five values:
 $a, $b, $c = 1, 2, 3, 4, 5
 ```
 
-Therefore, Windows PowerShell assigns the value 1 to the $a variable and
+Therefore, PowerShell assigns the value 1 to the $a variable and
 the value 2 to the $b variable. It assigns the values 3, 4, and 5 to the $c
 variable. To assign the values in the $c variable to three other variables,
 use the following format:

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
@@ -4,20 +4,21 @@ schema:  2.0.0
 keywords:  powershell,cmdlet
 title:  about_Command_Syntax
 ---
+
 # About Command Syntax
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
-Describes the syntax diagrams that are used in Windows PowerShell.
+Describes the syntax diagrams that are used in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 The [Get-Help](../../Microsoft.PowerShell.Core/Get-Help.md) and
 [Get-Command](../../Microsoft.PowerShell.Core/Get-Command.md) cmdlets display
 syntax diagrams to help you construct commands correctly. This topic
 explains how to interpret the syntax diagrams.
 
-# SYNTAX DIAGRAMS
+## SYNTAX DIAGRAMS
 
 Each paragraph in a command syntax diagram represents a valid form of the
 command.
@@ -25,7 +26,7 @@ command.
 To construct a command, follow the syntax diagram from left to right. Select
 from among the optional parameters and provide values for the placeholders.
 
-Windows PowerShell uses the following notation for syntax diagrams.
+PowerShell uses the following notation for syntax diagrams.
 
 ```powershell
 <command-name> -<Required Parameter Name> <Required Parameter Value>
@@ -43,7 +44,7 @@ New-Alias [-Name] <string> [-Value] <string> [-Description <string>]
 [-PassThru] [-Scope <string>] [-Confirm] [-WhatIf] [<CommonParameters>]
 ```
 
-The syntax is capitalized for readability, but Windows PowerShell is
+The syntax is capitalized for readability, but PowerShell is
 case-insensitive.
 
 The syntax diagram has the following elements.
@@ -62,8 +63,8 @@ For example, the `Get-Help` command has a **Name** parameter that lets you
 specify the name of the topic for which help is displayed. The topic name is
 the value of the **Name** parameter.
 
-In a Windows PowerShell command, parameter names always begin with a hyphen.
-The hyphen tells Windows PowerShell that the item in the command is a
+In a PowerShell command, parameter names always begin with a hyphen.
+The hyphen tells PowerShell that the item in the command is a
 parameter name.
 
 For example, to use the Name parameter of `New-Alias`, you type the following:
@@ -166,7 +167,7 @@ returns a random number.
 
 In each parameter set, the parameters appear in position order. The order of
 parameters in a command matters only when you omit the optional parameter
-names. When parameter names are omitted, Windows PowerShell assigns values to
+names. When parameter names are omitted, PowerShell assigns values to
 parameters by position and type. For more information about parameter
 position, see `about_Parameters`.
 
@@ -309,7 +310,7 @@ In syntax examples, brackets are also used in naming and casting to .NET
 Framework types. In this context, brackets do not indicate an element is
 optional.
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Parameters](about_Parameters.md)
 - [Get-Command](../../Microsoft.PowerShell.Core/Get-Command.md)

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -5,15 +5,16 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Functions
 ---
+
 # About Functions
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
-Describes how to create and use functions in Windows PowerShell.
+Describes how to create and use functions in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
-A function is a list of Windows PowerShell statements that has a name that you
+A function is a list of PowerShell statements that has a name that you
 assign. When you run a function, you type the function name. The statements in
 the list run as if you had typed them at the command prompt.
 
@@ -63,7 +64,7 @@ A function includes the following items:
 - A scope (optional)
 - A name that you select
 - Any number of named parameters (optional)
-- One or more Windows PowerShell commands enclosed in braces ({})
+- One or more PowerShell commands enclosed in braces ({})
 
 For more information about the Dynamicparam keyword and dynamic parameters in
 functions, see
@@ -78,7 +79,7 @@ have the following format:
 function <function-name> {statements}
 ```
 
-For example, the following function starts Windows PowerShell with the Run as
+For example, the following function starts PowerShell with the Run as
 Administrator option.
 
 ```powershell
@@ -103,21 +104,21 @@ function Get-NewPix
 ```
 
 You can create a toolbox of useful small functions. Add these functions to
-your Windows PowerShell profile, as described in about_Profiles and later in
+your PowerShell profile, as described in about_Profiles and later in
 this topic.
 
 ### Function Names
 
 You can assign any name to a function, but functions that you share with
 others should follow the naming rules that have been established for all
-Windows PowerShell commands.
+PowerShell commands.
 
 Functions names should consist of a verb-noun pair in which the verb
 identifies the action that the function performs and the noun identifies the
 item on which the cmdlet performs its action.
 
 Functions should use the standard verbs that have been approved for all
-Windows PowerShell commands. These verbs help us to keep our command names
+PowerShell commands. These verbs help us to keep our command names
 simple, consistent, and easy for users to understand.
 
 For more information about the standard PowerShell verbs, see
@@ -463,20 +464,20 @@ in functions, and at the command line.
 Functions normally create a scope. The items created in a function, such as
 variables, exist only in the function scope.
 
-For more information about scope in Windows PowerShell, see
+For more information about scope in PowerShell, see
 [about_Scopes](about_Scopes.md).
 
 ### Finding and Managing Functions Using the Function: Drive
 
-All the functions and filters in Windows PowerShell are automatically stored
-in the Function: drive. This drive is exposed by the Windows PowerShell
+All the functions and filters in PowerShell are automatically stored
+in the Function: drive. This drive is exposed by the PowerShell
 Function provider.
 
 When referring to the Function: drive, type a colon after Function, just as
 you would do when referencing the C or D drive of a computer.
 
 The following command displays all the functions in the current session of
-Windows PowerShell:
+PowerShell:
 
 ```powershell
 Get-ChildItem function:
@@ -484,7 +485,7 @@ Get-ChildItem function:
 
 The commands in the function are stored as a script block in the definition
 property of the function. For example, to display the commands in the Help
-function that comes with Windows PowerShell, type:
+function that comes with PowerShell, type:
 
 ```powershell
 (Get-ChildItem function:help).Definition
@@ -495,15 +496,15 @@ for the Function provider. Type `Get-Help Function`.
 
 ### Reusing Functions in New Sessions
 
-When you type a function at the Windows PowerShell command prompt, the
+When you type a function at the PowerShell command prompt, the
 function becomes part of the current session. It is available until the
 session ends.
 
-To use your function in all Windows PowerShell sessions, add the function
-to your Windows PowerShell profile. For more information about profiles,
+To use your function in all PowerShell sessions, add the function
+to your PowerShell profile. For more information about profiles,
 see [about_Profiles](about_Profiles.md).
 
-You can also save your function in a Windows PowerShell script file. Type your
+You can also save your function in a PowerShell script file. Type your
 function in a text file, and then save the file with the .ps1 file name
 extension.
 
@@ -546,7 +547,7 @@ methods:
   information about XML-based help, see [How to Write Cmdlet
   Help](https://go.microsoft.com/fwlink/?LinkID=123415) in the MSDN library.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Automatic_Variables](about_Automatic_Variables.md)
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -5,13 +5,14 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Functions_Advanced
 ---
+
 # About Functions Advanced
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Introduces advanced functions that act similar to cmdlets.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Advanced functions allow you to write functions that can perform operations
 that are similar to the operations you can perform with cmdlets. Advanced
@@ -24,7 +25,7 @@ compiled cmdlet.
 There is a difference between authoring a compiled cmdlet and an advanced
 function. Compiled cmdlets are .NET Framework classes that must be written in
 a .NET Framework language such as C#. In contrast, advanced functions are
-written in the Windows PowerShell script language in the same way that other
+written in the PowerShell script language in the same way that other
 functions or script blocks are written.
 
 Advanced functions use the CmdletBinding attribute to identify them as
@@ -78,7 +79,7 @@ Advanced functions differ from compiled cmdlets in the following ways:
 
 - Advanced functions cannot be used in transactions.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Functions](about_Functions.md)
 
@@ -90,4 +91,4 @@ Advanced functions differ from compiled cmdlets in the following ways:
 
 [about_Functions_OutputTypeAttribute](about_Functions_OutputTypeAttribute.md)
 
-[Windows PowerShell Cmdlets](http://go.microsoft.com/fwlink/?LinkID=135279)
+[PowerShell Cmdlets](http://go.microsoft.com/fwlink/?LinkID=135279)

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -5,30 +5,31 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Job_Details
 ---
+
 # About Job Details
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Provides details about background jobs on local and remote computers.
 
-# DETAILED DESCRIPTION
+## DETAILED DESCRIPTION
 
 This topic explains the concept of a background job and provides technical
-information about how background jobs work in Windows PowerShell.
+information about how background jobs work in PowerShell.
 
 This topic is a supplement to the [about_Jobs](about_Jobs.md) and
 [about_Remote_Jobs](about_Remote_Jobs.md) topics.
 
-# ABOUT BACKGROUND JOBS
+### ABOUT BACKGROUND JOBS
 
 A background job runs a command or expression asynchronously. It might run
 a cmdlet, a function, a script, or any other command-based task. It is
 designed to run commands that take an extended period of time, but you
 can use it to run any command in the background.
 
-When a synchronous command runs, the Windows PowerShell command prompt is
+When a synchronous command runs, the PowerShell command prompt is
 suppressed until the command is complete. But a background job does not
-suppress the Windows PowerShell prompt. A command to start a background job
+suppress the PowerShell prompt. A command to start a background job
 returns a job object. The prompt returns immediately so you can work on
 other tasks while the background job runs.
 
@@ -40,13 +41,13 @@ You can also run commands to stop the job, to wait for the job to be
 completed, and to delete the job.
 
 To make the timing of a background job independent of other commands, each
-background job runs in its own Windows PowerShell environment
+background job runs in its own PowerShell environment
 (a "session"). However, this can be a temporary connection that is created
 only to run the job and is then destroyed, or it can be a persistent
 session (a PSSession) that you can use to run several related jobs or
 commands.
 
-# USING THE JOB CMDLETS
+### USING THE JOB CMDLETS
 
 Use a Start-Job command to start a background job on a local computer.
 Start-Job returns a job object. You can also get objects representing the
@@ -63,7 +64,7 @@ the Remove-Job cmdlet.
 For more information about how the cmdlets work, see the Help topic for
 each cmdlet, and see about_Jobs.
 
-# STARTING BACKGROUND JOBS ON REMOTE COMPUTERS
+### STARTING BACKGROUND JOBS ON REMOTE COMPUTERS
 
 You can create and manage background jobs on a local or remote computer. To
 run a background job remotely, use the AsJob parameter of a cmdlet such as
@@ -73,7 +74,7 @@ session.
 
 For more information about remote background jobs, see about_Remote_Jobs.
 
-# CHILD JOBS
+### CHILD JOBS
 
 Each background job consists of a parent job and one or more child jobs. In
 jobs started by using Start-Job or the AsJob parameter of Invoke-Command,
@@ -218,39 +219,36 @@ ComputerName DateTime
 Server02     Thursday, March 13, 2008 4:16:03 PM
 ```
 
-The child jobs feature of Windows PowerShell background jobs gives you
+The child jobs feature of PowerShell background jobs gives you
 more control over the jobs that you run.
 
-# JOB TYPES
+### JOB TYPES
 
+PowerShell supports different types of jobs for different tasks. Beginning in
+Windows PowerShell 3.0, developers can write "job source adapters" that add
+new job types to PowerShell and include the job source adapters in modules.
+When you import the module, you can use the new job type in your session.
 
-Windows PowerShell supports different types of jobs for different tasks.
-Beginning in Windows PowerShell 3.0, developers can write "job source
-adapters" that add new job types to Windows PowerShell and include the
-job source adapters in modules. When you import the module, you can
-use the new job type in your session.
+For example, the PSScheduledJob module adds scheduled jobs and the PSWorkflow
+module adds workflow jobs.
 
-For example, the PSScheduledJob module adds scheduled jobs and the
-PSWorkflow module adds workflow jobs.
+Custom jobs types might differ significantly from standard Windows PowerShell
+background jobs. For example, scheduled jobs are saved on disk; they do not
+exist only in a particular session. Workflow jobs can be suspended and
+resumed.
 
-Custom jobs types might differ significantly from standard Windows
-PowerShell background jobs. For example, scheduled jobs are saved
-on disk; they do not exist only in a particular session. Workflow
-jobs can be suspended and resumed.
+The cmdlets that you use to manage custom jobs depend on the job type. For
+some, you use the standard job cmdlets, such as Get-Job and Start-Job. Others
+come with specialized cmdlets that manage only a particular type of job. For
+detailed information about custom job types, see the help topics about the job
+type.
 
-The cmdlets that you use to manage custom jobs depend on the job
-type. For some, you use the standard job cmdlets, such as Get-Job
-and Start-Job. Others come with specialized cmdlets that manage
-only a particular type of job. For detailed information about
-custom job types, see the help topics about the job type.
+To find the job type of a job, use the Get-Job cmdlet. Get-Job returns
+different job objects for different types of jobs. The value of the
+PSJobTypeName property of the job objects that Get-Job returns indicates the
+job type.
 
-To find the job type of a job, use the Get-Job cmdlet. Get-Job
-returns different job objects for different types of jobs. The
-value of the PSJobTypeName property of the job objects that
-Get-Job returns indicates the job type.
-
-The following table lists the job types that come with Windows
-PowerShell.
+The following table lists the job types that come with PowerShell.
 
 |Job Type      |Description                                               |
 |--------------|----------------------------------------------------------|
@@ -270,7 +268,7 @@ NOTE: Before using the Get-Job cmdlet to get jobs of a particular type, verify
 that the module that adds the job type is imported into the current session.
 Otherwise, Get-Job does not get jobs of that type.
 
-# EXAMPLE
+## EXAMPLE
 
 The following commands create a local background job, a remote background job,
 a workflow job, and a scheduled job. Then, it uses the Get-Job cmdlet to get
@@ -350,7 +348,7 @@ Id         Name            JobTriggers     Command       Enabled
 1          ScheduledJob    1               Get-Process   True
 ```
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Jobs](about_Jobs.md)
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -5,6 +5,7 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Language_Modes
 ---
+
 # About Language Modes
 
 ## SHORT DESCRIPTION
@@ -60,7 +61,8 @@ In RestrictedLanguage language mode, users may run commands (cmdlets,
 functions, CIM commands, and workflows) but are not permitted to use script
 blocks.
 
-Only the following variables are permitted:
+By default, only the following variables are permitted in RestrictedLanguage
+language mode:
 
 - \$PSCulture
 - \$PSUICulture
@@ -69,6 +71,7 @@ Only the following variables are permitted:
 - \$Null.
 
 Only the following comparison operators are permitted:
+
 - -eq (equal)
 - -gt (greater-than)
 - -lt (less-than)
@@ -197,7 +200,7 @@ the session configuration has a LanguageMode property. You can find the
 language mode by getting the value of the LanguageMode property.
 
 ```powershell
-PS> (Get-PSSessionConfiguration -Name Test).LanguageMode
+PS C:\> (Get-PSSessionConfiguration -Name Test).LanguageMode
 FullLanguage
 ```
 
@@ -214,7 +217,7 @@ state.
 For example:
 
 ```powershell
-PS> $ExecutionContext.SessionState.LanguageMode
+PS C:> $ExecutionContext.SessionState.LanguageMode
 ConstrainedLanguage
 ```
 
@@ -239,14 +242,14 @@ NoLanguage session, PowerShell returns the ScriptsNotAllowed error message.
 - ScriptsNotAllowed: The syntax is not supported by this runspace. This
   might be because it is in no-language mode.
 
-# KEYWORDS
+## KEYWORDS
 
 - about_ConstrainedLanguage
 - about_FullLanguage
 - about_NoLanguage
 - about_RestrictedLanguage
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Session_Configuration_Files](about_Session_Configuration_Files.md)
 - [about_Session_Configurations](about_Session_Configurations.md)

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -5,6 +5,7 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Operator_Precedence
 ---
+
 # About Operator Precedence
 
 ## SHORT DESCRIPTION
@@ -22,7 +23,8 @@ order is the order in which PowerShell evaluates the operators when
 multiple operators appear in the same expression.
 
 When operators have equal precedence, PowerShell evaluates them from
-left to right. The exceptions are the assignment operators, the cast
+left to right as they appear within the expression.
+The exceptions are the assignment operators, the cast
 operators, and the negation operators (!, -not, -bnot), which are evaluated
 from right to left.
 
@@ -40,7 +42,7 @@ the topic, type `get-help <topic-name>`.
 
 |OPERATOR                |REFERENCE|
 |------------------------|---------|
-|`$()  @()`              |[about_Operators](#index-operator)|
+|`$() @() ()`            |[about_Operators](about_Operators.md)|
 |`.` (dereference)       |[about_Operators](about_Operators.md)|
 |`::` (static)           |[about_Operators](about_Operators.md)|
 |`[0]` (index operator)  |[about_Operators](about_Operators.md)|
@@ -53,7 +55,9 @@ the topic, type `get-help <topic-name>`.
 |`! -bNot`               |[about_Comparison_Operators](about_Comparison_Operators.md)|
 |`..` (range operator)   |[about_Operators](about_Operators.md)|
 |`-f` (format operator)  |[about_Operators](about_Operators.md)|
-|`* / % + -`             |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`-` (unary/negative)    |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`* / %`                 |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`+ -`                   |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
 
 The following group of operators have equal precedence. Their case-sensitive
 and explicitly case-insensitive variants have the same precedence.
@@ -79,11 +83,11 @@ order:
 |`-and -or -xor`           |[about_Logical_Operators](about_logical_operators.md)|
 |`.` (dot-source)          |[about_Scopes](about_Scopes.md)|
 |`&` (call)                |[about_Operators](about_Operators.md)|
-|&#124; (pipeline operator)|[about_Operators](about_Operators.md)|
+|<code>&#124;</code> (pipeline operator)|[about_Operators](about_Operators.md)|
 |`> >> 2> 2>> 2>&1`        |[about_Redirection](about_Redirection.md)|
 |`= += -= *= /= %=`        |[about_Assignment_Operators](about_Assignment_Operators.md)|
 
-# EXAMPLES
+## EXAMPLES
 
 The following two commands show the arithmetic operators and the effect of
 using parentheses to force PowerShell to evaluate the enclosed part of

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -5,24 +5,25 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Remote_Requirements
 ---
+
 # About Remote Requirements
 
 ## SHORT DESCRIPTION
 
 Describes the system requirements and configuration requirements for running
-remote commands in Windows PowerShell.
+remote commands in PowerShell.
 
 ## LONG DESCRIPTION
 
 This topic describes the system requirements, user requirements, and resource
 requirements for establishing remote connections and running remote commands
-in Windows PowerShell. It also provides instructions for configuring remote
+in PowerShell. It also provides instructions for configuring remote
 operations.
 
 Note: Many cmdlets (including the Get-Service, Get-Process, Get-WMIObject,
 Get-EventLog, and Get-WinEvent cmdlets) get objects from remote computers by
 using Microsoft .NET Framework methods to retrieve the objects. They do not
-use the Windows PowerShell remoting infrastructure. The requirements in this
+use the PowerShell remoting infrastructure. The requirements in this
 document do not apply to these cmdlets.
 
 To find the cmdlets that have a ComputerName parameter but do not use Windows
@@ -50,7 +51,7 @@ You can create remote sessions between computers running Windows PowerShell
 PowerShell 3.0, such as the ability to disconnect and reconnect to sessions,
 are available only when both computers are running Windows PowerShell 3.0.
 
-To find the version number of an installed version of Windows PowerShell,
+To find the version number of an installed version of PowerShell,
 use the $PSVersionTable automatic variable.
 
 Windows Remote Management (WinRM) 3.0 and Microsoft .NET Framework 4 are
@@ -142,7 +143,7 @@ Administrator privileges are required for the following remoting operations:
 - Viewing and changing WS-Management settings on the local computer. These are
   the settings in the LocalHost node of the WSMAN: drive.
 
-To perform these tasks, you must start Windows PowerShell with the "Run as
+To perform these tasks, you must start PowerShell with the "Run as
 administrator" option even if you are a member of the Administrators group on
 the local computer.
 
@@ -169,28 +170,28 @@ the "Run as administrator" option to start the program.
 ## HOW TO CONFIGURE YOUR COMPUTER FOR REMOTING
 
 Computers running all supported versions of Windows can establish remote
-connections to and run remote commands in Windows PowerShell without any
+connections to and run remote commands in PowerShell without any
 configuration. However, to receive connections, and allow users to create
-local and remote user-managed Windows PowerShell sessions ("PSSessions") and
-run commands on the local computer, you must enable Windows PowerShell
+local and remote user-managed PowerShell sessions ("PSSessions") and
+run commands on the local computer, you must enable PowerShell
 remoting on the computer.
 
 Windows Server 2012 and newer releases of Windows Server are enabled for
-Windows PowerShell remoting by default. If the settings are changed, you can
+PowerShell remoting by default. If the settings are changed, you can
 restore the default settings by running the Enable-PSRemoting cmdlet.
 
 On all other supported versions of Windows, you need to run the
-Enable-PSRemoting cmdlet to enable Windows PowerShell remoting.
+Enable-PSRemoting cmdlet to enable PowerShell remoting.
 
-The remoting features of Windows PowerShell are supported by the WinRM
+The remoting features of PowerShell are supported by the WinRM
 service, which is the Microsoft implementation of the Web Services for
-Management (WS-Management) protocol. When you enable Windows PowerShell
+Management (WS-Management) protocol. When you enable PowerShell
 remoting, you change the default configuration of WS-Management and add system
 configuration that allow users to connect to WS-Management.
 
-To configure Windows PowerShell to receive remote commands:
+To configure PowerShell to receive remote commands:
 
-1. Start Windows PowerShell with the "Run as administrator" option.
+1. Start PowerShell with the "Run as administrator" option.
 2. At the command prompt, type: `Enable-PSRemoting`
 
 To verify that remoting is configured correctly, run a test command such as
@@ -215,16 +216,16 @@ If the command fails, for assistance, see
 
 ## UNDERSTAND POLICIES
 
-When you work remotely, you use two instances of Windows PowerShell, one on
+When you work remotely, you use two instances of PowerShell, one on
 the local computer and one on the remote computer. As a result, your work is
-affected by the Windows policies and the Windows PowerShell policies on the
+affected by the Windows policies and the PowerShell policies on the
 local and remote computers.
 
 In general, before you connect and as you are establishing the connection, the
 policies on the local computer are in effect. When you are using the
 connection, the policies on the remote computer are in effect.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Remote](about_Remote.md)
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -5,19 +5,20 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Remote_Troubleshooting
 ---
+
 # About Remote Troubleshooting
 
 ## SHORT DESCRIPTION
 
-Describes how to troubleshoot remote operations in Windows PowerShell.
+Describes how to troubleshoot remote operations in PowerShell.
 
 ## LONG DESCRIPTION
 
 This section describes some of the problems that you might encounter when
-using the remoting features of Windows PowerShell that are based on
+using the remoting features of PowerShell that are based on
 WS-Management technology and it suggests solutions to these problems.
 
-Before using Windows PowerShell remoting, see about_Remote and
+Before using PowerShell remoting, see about_Remote and
 about_Remote_Requirements for guidance on configuration and basic use Also,
 the Help topics for each of the remoting cmdlets, particularly the parameter
 descriptions, have useful information that is designed to help you avoid
@@ -25,7 +26,7 @@ problems.
 
 NOTE: To view or change settings for the local computer in the WSMan: drive,
 including changes to the session configurations, trusted hosts, ports, or
-listeners, start Windows PowerShell with the "Run as administrator" option.
+listeners, start PowerShell with the "Run as administrator" option.
 
 ## TROUBLESHOOTING PERMISSION AND AUTHENTICATION ISSUES
 
@@ -67,7 +68,7 @@ WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
 
 No configuration is required to enable a computer to send remote
-commands. However, to receive remote commands, Windows PowerShell remoting
+commands. However, to receive remote commands, PowerShell remoting
 must be enabled on the computer. Enabling includes starting the WinRM
 service, setting the startup type for the WinRM service to Automatic,
 creating listeners for HTTP and HTTPS connections, and creating default
@@ -102,7 +103,7 @@ ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
 
-To enable a single computer to receive remote Windows PowerShell commands
+To enable a single computer to receive remote PowerShell commands
 and accept connections, use the Enable-PSRemoting cmdlet.
 
 To enable remoting for multiple computers in an enterprise, you can use the
@@ -199,7 +200,7 @@ the Windows Remote Management service.
 
 ERROR:  ACCESS IS DENIED
 
-Windows PowerShell remoting depends upon the Windows Remote Management
+PowerShell remoting depends upon the Windows Remote Management
 (WinRM) service. The service must be running to support remote commands.
 
 On server versions of Windows, the startup type of the Windows Remote
@@ -219,8 +220,8 @@ Servers.txt file and then sets the startup type of the WinRM service on all
 of the computers to Automatic.
 
 ```powershell
-PS> $servers = Get-Content servers.txt
-PS> Set-Service WinRM -ComputerName $servers -startuptype Automatic
+C:\PS> $servers = Get-Content servers.txt
+C:\PS> Set-Service WinRM -ComputerName $servers -startuptype Automatic
 ```
 
 To see the results use the Get-WMIObject cmdlet with the Win32_Service object.
@@ -338,7 +339,7 @@ To change the policy, use the following command to set the value of the
 LocalAccountTokenFilterPolicy registry entry to 1.
 
 ```powershell
-PS> New-ItemProperty -Name LocalAccountTokenFilterPolicy -Path `
+C:\PS> New-ItemProperty -Name LocalAccountTokenFilterPolicy -Path `
 HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System `
 -PropertyType DWord -Value 1
 ```
@@ -528,9 +529,9 @@ ERROR: The client cannot connect to the destination specified in the
 request. Verify that the service on the destination is running and is
 accepting requests.
 
-Because Windows PowerShell remoting uses the HTTP protocol, it is affected
+Because PowerShell remoting uses the HTTP protocol, it is affected
 by HTTP proxy settings. In enterprises that have proxy servers, users
-cannot access a Windows PowerShell remote computer directly.
+cannot access a PowerShell remote computer directly.
 
 To resolve this problem, use proxy setting options in your remote command.
 The following settings are available:
@@ -554,10 +555,10 @@ For example, the following command creates a session option object with
 proxy session options and then uses the object to create a remote session.
 
 ```powershell
-PS> $SessionOption = New-PSSessionOption -ProxyAccessType IEConfig `
+C:\PS> $SessionOption = New-PSSessionOption -ProxyAccessType IEConfig `
 -ProxyAuthentication Negotiate -ProxyCredential Domain01\User01
 
-PS> New-PSSession -ConnectionURI https://www.fabrikam.com
+C:\PS> New-PSSession -ConnectionURI https://www.fabrikam.com
 ```
 
 For more information about the New-PSSessionOption cmdlet, see
@@ -568,9 +569,9 @@ the option object that New-PSSessionOption creates in the value of the
 $PSSessionOption preference variable. For more information about the
 $PSSessionOption preference variable, see about_Preference_Variables.
 
-To set these options for all remote commands all Windows PowerShell sessions
+To set these options for all remote commands all PowerShell sessions
 on the local computer, add the $PSSessionOption preference variable to your
-Windows PowerShell profile. For more information about Windows PowerShell
+PowerShell profile. For more information about PowerShell
 profiles, see about_Profiles.
 
 ### HOW TO DETECT A 32-BIT SESSION ON A 64-BIT COMPUTER
@@ -628,7 +629,7 @@ process.
 
 For example, the following command starts a process with the RemoteSigned
 execution policy. The execution policy change affects only the current
-process and does not change the Windows PowerShell ExecutionPolicy registry
+process and does not change the PowerShell ExecutionPolicy registry
 setting.
 
 ```powershell
@@ -672,7 +673,7 @@ The following quotas are available in the basic configuration.
   MaximumReceivedObjectSizeMB parameters of the Register-PSSessionConfiguration
   cmdlet.
 
-When quotas conflict with a command, Windows PowerShell generates an error.
+When quotas conflict with a command, PowerShell generates an error.
 
 To resolve the error, change the remote command to comply with the quota.
 Or, determine the source of the quota, and then increase the quota to allow
@@ -700,7 +701,7 @@ the time specified in OperationTimeout.
 
 You can use timeouts to protect the local computer and the remote computer
 from excessive resource use, both accidental and malicious. When timeouts
-are set on both the local and remote computer, Windows PowerShell uses the
+are set on both the local and remote computer, PowerShell uses the
 shortest timeout settings.
 
 The following timeouts are available in the basic configuration.
@@ -730,9 +731,9 @@ create a session option object with an OperationTimeout value of 4 minutes
 (in MS) and then use the session option object to create a remote session.
 
 ```powershell
-PS> $pso = New-PSSessionoption -OperationTimeout 240000
+C:\PS> $pso = New-PSSessionoption -OperationTimeout 240000
 
-PS> New-PSSession -ComputerName Server01 -sessionOption $pso
+C:\PS> New-PSSession -ComputerName Server01 -sessionOption $pso
 ```
 
 For more information about the WS-Management timeouts, see the Help topic for
@@ -744,13 +745,13 @@ New-PSSessionOption.
 ## TROUBLESHOOTING UNRESPONSIVE BEHAVIOR
 
 This section discusses remoting problems that prevent a command from completing
-and prevent or delay the return of the Windows PowerShell prompt.
+and prevent or delay the return of the PowerShell prompt.
 
 ### HOW TO INTERRUPT A COMMAND
 
 Some native Windows programs, such as programs with a user interface, console
 applications that prompt for input, and console applications that use the
-Win32 console API, do not work correctly in the Windows PowerShell remote host.
+Win32 console API, do not work correctly in the PowerShell remote host.
 
 When you use these programs, you might see unexpected behavior, such as no
 output, partial output, or a remote command that does not complete.
@@ -770,14 +771,14 @@ WinRM operations are in progress.
 To resolve this issue, verify that the WinRM service is running and try
 the command again.
 
-1. Start Windows PowerShell with the "Run as administrator" option.
+1. Start PowerShell with the "Run as administrator" option.
 2. Run the following command:
 
    Start-Service WinRM
 
 3. Re-run the command that generated the error.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Remote](about_Remote.md)
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -16,22 +16,22 @@ policies.
 ## LONG DESCRIPTION
 
 The Restricted execution policy does not permit any scripts to run. The
-AllSigned and RemoteSigned execution policies prevent PowerShell from running
-scripts that do not have a digital signature.
+**AllSigned** and **RemoteSigned** execution policies prevent PowerShell from
+running scripts that do not have a digital signature.
 
 This topic explains how to run selected scripts that are not signed, even
-while the execution policy is RemoteSigned, and how to sign scripts for your
-own use.
+while the execution policy is **RemoteSigned**, and how to sign scripts for
+your own use.
 
 For more information about PowerShell execution policies, see
 [about_Execution_Policies](about_Execution_Policies.md).
 
 ## TO PERMIT SIGNED SCRIPTS TO RUN
 
-When you start PowerShell on a computer for the first time, the Restricted
+When you start PowerShell on a computer for the first time, the **Restricted**
 execution policy (the default) is likely to be in effect.
 
-The Restricted policy does not permit any scripts to run.
+The **Restricted** policy does not permit any scripts to run.
 
 To find the effective execution policy on your computer, type:
 
@@ -42,23 +42,22 @@ Get-ExecutionPolicy
 To run unsigned scripts that you write on your local computer and signed
 scripts from other users, start PowerShell with the Run as Administrator
 option and then use the following command to change the execution policy on
-the computer to RemoteSigned:
+the computer to **RemoteSigned**:
 
 ```powershell
 Set-ExecutionPolicy RemoteSigned
 ```
 
-For more information, see the help topic for the Set-ExecutionPolicy cmdlet.
+For more information, see the help topic for the `Set-ExecutionPolicy` cmdlet.
 
 ## RUNNING UNSIGNED SCRIPTS (REMOTESIGNED EXECUTION POLICY)
 
-If your PowerShell execution policy is RemoteSigned, Windows
-PowerShell will not run unsigned scripts that are downloaded from the
-Internet, including unsigned scripts you receive through e-mail and instant
-messaging programs.
+If your PowerShell execution policy is **RemoteSigned**, Windows PowerShell
+will not run unsigned scripts that are downloaded from the Internet, including
+unsigned scripts you receive through e-mail and instant messaging programs.
 
-If you try to run a downloaded script, PowerShell displays the
-following error message:
+If you try to run a downloaded script, PowerShell displays the following error
+message:
 
 ```output
 The file <file-name> cannot be loaded. The file <file-name> is not digitally
@@ -98,9 +97,9 @@ this publisher.
 
 ## METHODS OF SIGNING SCRIPTS
 
-You can sign the scripts that you write and the
-scripts that you obtain from other sources. Before you sign any script,
-examine each command to verify that it is safe to run.
+You can sign the scripts that you write and the scripts that you obtain from
+other sources. Before you sign any script, examine each command to verify that
+it is safe to run.
 
 For best practices about code signing, see
 [Code-Signing Best Practices](/previous-versions/windows/hardware/design/dn653556(v=vs.85)).
@@ -289,7 +288,7 @@ signed while the signing certificate was valid.
 Because most signing certificates are valid for one year only, using a time
 stamp server ensures that users can use your script for many years to come.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Execution_Policies](about_Execution_Policies.md)
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -5,22 +5,23 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Special_Characters
 ---
+
 # About Special Characters
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Describes the special characters that you can use to control how Windows
 PowerShell interprets the next character in a command or parameter.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
-Windows PowerShell supports a set of special character sequences that are used
+PowerShell supports a set of special character sequences that are used
 to represent characters that are not part of the standard character set.
 
-The special characters in Windows PowerShell begin with the backtick
+The special characters in PowerShell begin with the backtick
 character, also known as the grave accent (ASCII 96).
 
-The following special characters are recognized by Windows PowerShell:
+The following special characters are recognized by PowerShell:
 
 ```
 | Character | Description             |
@@ -41,9 +42,9 @@ when used within double quoted (") strings.
 
 ## NULL (`0)
 
-Windows PowerShell recognizes a null special character (`0) and represents it
+PowerShell recognizes a null special character (`0) and represents it
 with a character code of 0. It appears as an empty space in the Windows
-PowerShell output. This allows you to use Windows PowerShell to read and
+PowerShell output. This allows you to use PowerShell to read and
 process text files that use null characters, such as string termination or
 record termination indicators. The null special character is not equivalent to
 the $null variable, which stores a value of NULL.
@@ -119,7 +120,7 @@ Delete everything before this point.
 ## HORIZONTAL TAB (`t)
 
 The horizontal tab character (`t) advances to the next tab stop and continues
-writing at that point. By default, the Windows PowerShell console has a tab
+writing at that point. By default, the PowerShell console has a tab
 stop at every eighth space.
 
 For example, the following command inserts two tabs between each column.
@@ -142,8 +143,8 @@ printed documents only. It does not affect screen output.
 
 ## STOP PARSING  (--%)
 
-The stop-parsing symbol (--%) prevents Windows PowerShell from interpreting
-arguments in program calls as Windows PowerShell commands and expressions.
+The stop-parsing symbol (--%) prevents PowerShell from interpreting
+arguments in program calls as PowerShell commands and expressions.
 
 Place the stop-parsing symbol after the program name and before program
 arguments that might cause errors.
@@ -154,7 +155,7 @@ For example, the following Icacls command uses the stop-parsing symbol.
 icacls X:\VMS --% /grant Dom\HVAdmin:(CI)(OI)F
 ```
 
-Windows PowerShell sends the following command to Icacls.
+PowerShell sends the following command to Icacls.
 
 ```output
 X:\VMS /grant Dom\HVAdmin:(CI)(OI)F
@@ -162,6 +163,6 @@ X:\VMS /grant Dom\HVAdmin:(CI)(OI)F
 
 For more information about the stop-parsing symbol, see [about_Parsing](about_Parsing.md).
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Quoting_Rules](about_Quoting_Rules.md)

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -5,6 +5,7 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Splatting
 ---
+
 # About Splatting
 
 ## SHORT DESCRIPTION
@@ -19,10 +20,10 @@ administrator and the winner of the Advanced Division of the 2012 Scripting
 Games. Revised for Windows PowerShell 3.0.]
 
 Splatting is a method of passing a collection of parameter values to a command
-as unit. Windows PowerShell associates each value in the collection with a
+as unit. PowerShell associates each value in the collection with a
 command parameter. Splatted parameter values are stored in named splatting
 variables, which look like standard variables, but begin with an At symbol (@)
-instead of a dollar sign ($). The At symbol tells Windows PowerShell that you
+instead of a dollar sign ($). The At symbol tells PowerShell that you
 are passing a collection of values, instead of a single value.
 
 Splatting makes your commands shorter and easier to read. You can re-use the
@@ -84,7 +85,7 @@ Copy-Item @HashArguments
 ```
 
 Note: In the first command, the At symbol (@) indicates a hash table, not a
-splatted value. The syntax for hash tables in Windows PowerShell is:
+splatted value. The syntax for hash tables in PowerShell is:
 @{\<name\>=\<value\>; \<name\>=\<value\>; …}*
 
 ## SPLATTING WITH ARRAYS
@@ -280,7 +281,7 @@ FileVersionInfo    : File:             C:\Windows\System32\WindowsPowerShell
                      Language:         English (United States)
 ```
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Arrays](about_Arrays.md)
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -8,20 +8,20 @@ title:  about_Types.ps1xml
 
 # About Types.ps1xml
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Explains how to use Types.ps1xml files to extend the types of objects
-that are used in Windows PowerShell.
+that are used in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Extended type data defines additional properties and methods ("members")
-of object types in Windows PowerShell. There are two techniques for adding
-extended type data to a Windows PowerShell session.
+of object types in PowerShell. There are two techniques for adding
+extended type data to a PowerShell session.
 
 - Types.ps1xml file: An XML file that defines extended type data.
 - `Update-TypeData`: A cmdlet that reloads Types.ps1xml files and defines
-extended data for types in the current session.
+  extended data for types in the current session.
 
 This topic describes Types.ps1xml files. For more information about using the
 `Update-TypeData` cmdlet to add dynamic extended type data to the current
@@ -31,11 +31,11 @@ session see
 ## About Extended Type Data
 
 Extended type data defines additional properties and methods ("members") of
-object types in Windows PowerShell. You can extend any type that is supported
-by Windows PowerShell and use the added properties and methods in the same way
+object types in PowerShell. You can extend any type that is supported
+by PowerShell and use the added properties and methods in the same way
 that you use the properties that are defined on the object types.
 
-For example, Windows PowerShell adds a `DateTime` property to all
+For example, PowerShell adds a `DateTime` property to all
 `System.DateTime` objects, such as the ones that the `Get-Date` cmdlet
 returns.
 
@@ -46,19 +46,19 @@ Sunday, January 29, 2012 9:43:57 AM
 
 You won't find the `DateTime` property in the description of the
 [`System.DateTime` structure](http://msdn.microsoft.com/library/system.datetime.aspx),
-because Windows PowerShell adds the property and it is visible only in Windows
+because PowerShell adds the property and it is visible only in Windows
 PowerShell.
 
-To add the `DateTime` property to all Windows PowerShell sessions, Windows
+To add the `DateTime` property to all PowerShell sessions, Windows
 PowerShell defines the `DateTime` property in the Types.ps1xml file in the
-Windows PowerShell installation directory (`$PSHOME`).
+PowerShell installation directory (`$PSHOME`).
 
-## Adding Extended Type Data to Windows PowerShell.
+## Adding Extended Type Data to PowerShell.
 
-There are three sources of extended type data in Windows PowerShell sessions.
+There are three sources of extended type data in PowerShell sessions.
 
-- The Types.ps1xml files in the Windows PowerShell installation directory
-  are loaded automatically into every Windows PowerShell session.
+- The Types.ps1xml files in the PowerShell installation directory
+  are loaded automatically into every PowerSheall session.
 
 - The Types.ps1xml files that modules export are loaded when the module
   is imported into the current session.
@@ -73,7 +73,8 @@ types.
 ## The TypeData Cmdlets
 
 The following TypeData cmdlets are included in the Microsoft.PowerShell.Utility
-module in Windows PowerShell 3.0 and later versions of Windows PowerShell.
+module in Windows PowerShell 3.0 and later versions of Windows PowerShell
+and PowerShell Core.
 
 - `Get-TypeData`: Gets extended type data in the current session.
 - `Update-TypeData`: Reloads Types.ps1xml files. Adds extended type data to the
@@ -87,9 +88,9 @@ For more information about these cmdlets, see the help topic for each cmdlet.
 The Types.ps1xml files in the `$PSHOME` directory are added automatically to
 every session.
 
-The Types.ps1xml file in the Windows PowerShell installation directory
+The Types.ps1xml file in the PowerShell installation directory
 (`$PSHOME`) is an XML-based text file that lets you add properties and
-methods to the objects that are used in Windows PowerShell. Windows
+methods to the objects that are used in PowerShell. Windows
 PowerShell has built-in Types.ps1xml files that add several elements
 to the .NET Framework types, but you can create additional Types.ps1xml
 files to further extend the types.
@@ -136,7 +137,7 @@ Get        Method        System.Object Get(Int32)
 ```
 
 As a result, you can use either the Count property or the Length property
-of arrays in Windows PowerShell. For example:
+of arrays in PowerShell. For example:
 
 ```powershell
 C:\PS> (1, 2, 3, 4).count
@@ -150,32 +151,32 @@ C:\PS> (1, 2, 3, 4).length
 
 ## Creating New Types.ps1xml Files
 
-The .ps1xml files that are installed with Windows PowerShell are
+The .ps1xml files that are installed with PowerShell are
 digitally signed to prevent tampering because the formatting can include
 script blocks. Therefore, to add a property or method to a .NET Framework
 type, create your own Types.ps1xml files, and then add them to your
-Windows PowerShell session.
+PowerShell session.
 
 To create a new file, start by copying an existing Types.ps1xml file. The
 new file can have any name, but it must have a .ps1xml file name
 extension. You can place the new file in any directory that is accessible
-to Windows PowerShell, but it is useful to place the files in the Windows
+to PowerShell, but it is useful to place the files in the Windows
 PowerShell installation directory (`$PSHOME`) or in a subdirectory of the
 installation directory.
 
 When you have saved the new file, use the `Update-TypeData` cmdlet to add
-the new file to your Windows PowerShell session. If you want your types
+the new file to your PowerShell session. If you want your types
 to take precedence over the types that are defined in the built-in file,
 use the PrependData parameter of the `Update-TypeData` cmdlet.
 `Update-TypeData` affects only the current session. To make the change to
 all future sessions, export the console, or add the `Update-TypeData`
-command to your Windows PowerShell profile.
+command to your PowerShell profile.
 
 ## Types.ps1xml and Add-Member
 
 The Types.ps1xml files add properties and methods to all the instances
 of the objects of the specified .NET Framework type in the affected
-Windows PowerShell session. However, if you need to add properties or
+PowerShell session. However, if you need to add properties or
 methods only to one instance of an object, use the `Add-Member` cmdlet.
 
 For more information, see [Add-Member](../../Microsoft.PowerShell.Utility/Add-Member.md).
@@ -330,7 +331,7 @@ the name of the new method and a pair of `<GetCodeReference>` tags
 that specify the code in which the method is defined.
 
 For example, the Mode property of directories (`System.IO.DirectoryInfo`
-objects) is a code property defined in the Windows PowerShell
+objects) is a code property defined in the PowerShell
 FileSystem provider.
 
 ```xml
@@ -357,7 +358,7 @@ the name of the new property and a pair of `<GetCodeReference>` tags
 that specify the code in which the property is defined.
 
 For example, the `Mode` property of directories (`System.IO.DirectoryInfo`
-objects) is a code property defined in the Windows PowerShell
+objects) is a code property defined in the PowerShell
 FileSystem provider.
 
 ```xml
@@ -387,7 +388,7 @@ create a property (such as `<NoteProperty>` or `<ScriptProperty>`) or a
 method (such as `<Method>` or `<ScriptMethod>`) can be members of the set.
 
 In Types.ps1xml files, the `<MemberSet>` tag is used to define the
-default views of the .NET Framework objects in Windows PowerShell. In
+default views of the .NET Framework objects in PowerShell. In
 this case, the name of the member set (the value within the `<Name>`
 tags) is always "PsStandardMembers", and the names of the properties
 (the value of the `<Name>` tag) are one of the following:
@@ -397,8 +398,8 @@ tags) is always "PsStandardMembers", and the names of the properties
 - `DefaultDisplayPropertySet`: One or more properties of an object.
 
 - `DefaultKeyPropertySet`: One or more key properties of an object.
-A key property identifies instances of property values, such as
-the ID number of items in a session history.
+  A key property identifies instances of property values, such as
+  the ID number of items in a session history.
 
 For example, the following XML defines the default display of services
 (`System.ServiceProcess.ServiceController` objects) that are returned by
@@ -560,7 +561,7 @@ library](http://go.microsoft.com/fwlink/?LinkId=144538).
 
 ## `Update-TypeData`
 
-To load your Types.ps1xml files into a Windows PowerShell session, run
+To load your Types.ps1xml files into a PowerShell session, run
 the `Update-TypeData` cmdlet. If you want the types in your file to take
 precedence over types in the built-in Types.ps1xml file, add the
 PrependData parameter of `Update-TypeData`. `Update-TypeData` affects only
@@ -589,7 +590,7 @@ To protect users of your Types.ps1xml file, you can sign the file using a
 digital signature. For more information, see
 [about_Signing](about_Signing.md).
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Signing](about_Signing.md)
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -389,7 +389,7 @@ the script.
 
 The Online parameter does not work with About topics. To see the about topics
 for PowerShell Core, including help topics about the PowerShell language, see
-[Windows PowerShell Core Module About Topics](http://go.microsoft.com/fwlink/?LinkID=113206).
+[PowerShell Core Module About Topics](http://go.microsoft.com/fwlink/?LinkID=113206).
 
 ## HOW TO MINIMIZE OR PREVENT INTERNET DOWNLOADS
 
@@ -447,7 +447,7 @@ your modules. For more information, see "Supporting Updatable Help" and
 
 Updatable help not available for PowerShell snap-ins or comment-based help.
 
-# REMARKS
+## REMARKS
 
 The Update-Help and Save-Help cmdlets are not supported on Windows
 Preinstallation Environment (Windows PE).

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -16,7 +16,7 @@ Describes how to use operators to assign values to variables.
 Assignment operators assign one or more values to a variable. They can
 perform numeric operations on the values before the assignment.
 
-Windows PowerShell supports the following assignment operators.
+PowerShell supports the following assignment operators.
 
 |Operator|Description                                                  |
 |--------|-------------------------------------------------------------|
@@ -60,14 +60,14 @@ replace the existing value of the variable, or you can append a new value
 to the existing value.
 
 The basic assignment operator is the equal sign `=` `(ASCII 61)`. For
-example, the following statement assigns the value Windows PowerShell to
+example, the following statement assigns the value PowerShell to
 the $MyShell variable:
 
 ```powershell
-$MyShell = "Windows PowerShell"
+$MyShell = "PowerShell"
 ```
 
-When you assign a value to a variable in Windows PowerShell, the variable
+When you assign a value to a variable in PowerShell, the variable
 is created if it did not already exist. For example, the first of the
 following two assignement statements creates the $a variable and assigns a
 value of 6 to $a. The second assignment statement assigns a value of 12 to
@@ -79,7 +79,7 @@ $a = 6
 $a = 12
 ```
 
-Variables in Windows PowerShell do not have a specific data type unless you
+Variables in PowerShell do not have a specific data type unless you
 cast them. When a variable contains only one object, the variable takes the
 data type of that object. When a variable contains a collection of objects,
 the variable has the System.Object data type. Therefore, you can assign any
@@ -142,7 +142,7 @@ $a = "apple", "orange", "lemon", "grape"
 ```
 
 To assign a hash table to a variable, use the standard hash table notation
-in Windows PowerShell. Type an at sign `@` followed by key/value pairs that
+in PowerShell. Type an at sign `@` followed by key/value pairs that
 are separated by semicolons `;` and enclosed in braces `{ }`. For example,
 to assign a hash table to the $a variable, type:
 
@@ -151,7 +151,7 @@ $a = @{one=1; two=2; three=3}
 ```
 
 To assign hexadecimal values to a variable, precede the value with `0x`.
-Windows PowerShell converts the hexadecimal value (0x10) to a decimal value
+PowerShell converts the hexadecimal value (0x10) to a decimal value
 (in this case, 16) and assigns that value to the $a variable. For example,
 to assign a value of 0x10 to the $a variable, type:
 
@@ -167,7 +167,7 @@ assign a value of 3.1415 to the power of 1,000 to the $a variable, type:
 $a = 3.1415e3
 ```
 
-Windows PowerShell can also convert kilobytes `KB`, megabytes `MB`, and
+PowerShell can also convert kilobytes `KB`, megabytes `MB`, and
 gigabytes `GB` into bytes. For example, to assign a value of 10 kilobytes
 to the $a variable, type:
 
@@ -412,7 +412,7 @@ $a *= 2
 $a = ($a * 2)
 ```
 
-When a variable contains a string value, Windows PowerShell appends the
+When a variable contains a string value, PowerShell appends the
 specified number of strings to the value, as follows:
 
 ```powershell
@@ -499,7 +499,7 @@ $a
 3
 ```
 
-# THE INCREMENT AND DECREMENT OPERATORS
+## THE INCREMENT AND DECREMENT OPERATORS
 
 The increment operator `++` increases the value of a variable by 1. When
 you use the increment operator in a simple statement, no value is returned.
@@ -690,7 +690,7 @@ $a
 file3
 ```
 
-If the first value is an integer, Windows PowerShell treats all operations
+If the first value is an integer, PowerShell treats all operations
 as integer operations and casts new values to integers. This occurs in the
 following example:
 
@@ -754,7 +754,7 @@ In addition, when you precede a variable name with a data type, the type of
 that variable is locked unless you explicitly override the type by
 specifying another data type. If you try to assign a value that is
 incompatible with the existing type, and you do not explicitly override the
-type, Windows PowerShell displays an error, as shown in the following
+type, PowerShell displays an error, as shown in the following
 example:
 
 ```powershell
@@ -775,7 +775,7 @@ At line:1 char:3
 [string]$a = "string"
 ```
 
-In Windows PowerShell, the data types of variables that contain multiple
+In PowerShell, the data types of variables that contain multiple
 items in an array are handled differently from the data types of variables
 that contain a single item. Unless a data type is specifically assigned to
 an array variable, the data type is always `System.Object []`. This data
@@ -789,7 +789,7 @@ array type:
 [string []] $a = "one", "two", "three"
 ```
 
-Windows PowerShell variables can be any .NET Framework data type. In
+PowerShell variables can be any .NET Framework data type. In
 addition, you can assign any fully qualified .NET Framework data type that
 is available in the current process. For example, the following command
 specifies a `System.DateTime` data type:
@@ -806,9 +806,9 @@ following:
 Tuesday, May 31, 2005 12:00:00 AM
 ```
 
-# ASSIGNING MULTIPLE VARIABLES
+## ASSIGNING MULTIPLE VARIABLES
 
-In Windows PowerShell, you can assign values to multiple variables by using
+In PowerShell, you can assign values to multiple variables by using
 a single command. The first element of the assignment value is assigned to
 the first variable, the second element is assigned to the second variable,
 the third element to the third variable, and so on. For example, the
@@ -827,7 +827,7 @@ following command contains three variables and five values:
 $a, $b, $c = 1, 2, 3, 4, 5
 ```
 
-Therefore, Windows PowerShell assigns the value 1 to the $a variable and
+Therefore, PowerShell assigns the value 1 to the $a variable and
 the value 2 to the $b variable. It assigns the values 3, 4, and 5 to the $c
 variable. To assign the values in the $c variable to three other variables,
 use the following format:

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
@@ -7,18 +7,18 @@ title:  about_Command_Syntax
 
 # About Command Syntax
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
-Describes the syntax diagrams that are used in Windows PowerShell.
+Describes the syntax diagrams that are used in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 The [Get-Help](../../Microsoft.PowerShell.Core/Get-Help.md) and
 [Get-Command](../../Microsoft.PowerShell.Core/Get-Command.md) cmdlets display
 syntax diagrams to help you construct commands correctly. This topic
 explains how to interpret the syntax diagrams.
 
-# SYNTAX DIAGRAMS
+## SYNTAX DIAGRAMS
 
 Each paragraph in a command syntax diagram represents a valid form of the
 command.
@@ -26,7 +26,7 @@ command.
 To construct a command, follow the syntax diagram from left to right. Select
 from among the optional parameters and provide values for the placeholders.
 
-Windows PowerShell uses the following notation for syntax diagrams.
+PowerShell uses the following notation for syntax diagrams.
 
 ```powershell
 <command-name> -<Required Parameter Name> <Required Parameter Value>
@@ -44,7 +44,7 @@ New-Alias [-Name] <string> [-Value] <string> [-Description <string>]
 [-PassThru] [-Scope <string>] [-Confirm] [-WhatIf] [<CommonParameters>]
 ```
 
-The syntax is capitalized for readability, but Windows PowerShell is
+The syntax is capitalized for readability, but PowerShell is
 case-insensitive.
 
 The syntax diagram has the following elements.
@@ -63,8 +63,8 @@ For example, the `Get-Help` command has a **Name** parameter that lets you
 specify the name of the topic for which help is displayed. The topic name is
 the value of the **Name** parameter.
 
-In a Windows PowerShell command, parameter names always begin with a hyphen.
-The hyphen tells Windows PowerShell that the item in the command is a
+In a PowerShell command, parameter names always begin with a hyphen.
+The hyphen tells PowerShell that the item in the command is a
 parameter name.
 
 For example, to use the Name parameter of `New-Alias`, you type the following:
@@ -167,7 +167,7 @@ returns a random number.
 
 In each parameter set, the parameters appear in position order. The order of
 parameters in a command matters only when you omit the optional parameter
-names. When parameter names are omitted, Windows PowerShell assigns values to
+names. When parameter names are omitted, PowerShell assigns values to
 parameters by position and type. For more information about parameter
 position, see `about_Parameters`.
 
@@ -310,7 +310,7 @@ In syntax examples, brackets are also used in naming and casting to .NET
 Framework types. In this context, brackets do not indicate an element is
 optional.
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Parameters](about_Parameters.md)
 - [Get-Command](../../Microsoft.PowerShell.Core/Get-Command.md)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -8,14 +8,14 @@ title:  about_Data_Sections
 
 # About Data Sections
 
-### Short Description
+## Short Description
 
 Explains Data sections, which isolate text strings and other read-only
 data from script logic.
 
-### Long Description
+## Long Description
 
-Scripts that are designed for Windows PowerShell can have one or more
+Scripts that are designed for PowerShell can have one or more
 Data sections that contain only data. You can include one or more Data
 sections in any script, function, or advanced function. The content of
 the Data section is restricted to a specified subset of the Windows
@@ -26,7 +26,7 @@ both logic and data. It lets you have separate string resource files for
 text, such as error messages and Help strings. It also isolates the code
 logic, which facilitates security and validation tests.
 
-In Windows PowerShell, the Data section is used to support script
+In PowerShell, the Data section is used to support script
 internationalization. You can use Data sections to make it easier to
 isolate, locate, and process strings that will be translated into many
 user interface (UI) languages.
@@ -47,7 +47,7 @@ The Data keyword is required. It is not case-sensitive.
 
 The permitted content is limited to the following elements:
 
-- All Windows PowerShell operators, except `-match`
+- All PowerShell operators, except `-match`
 
 - `If`, `Else`, and `ElseIf` statements
 
@@ -157,7 +157,7 @@ Simple data strings.
 
 ```powershell
 DATA {
-    "Thank you for using my Windows PowerShell Organize.pst script."
+    "Thank you for using my PowerShell Organize.pst script."
     "It is provided free of charge to the community."
     "I appreciate your comments and feedback."
 }
@@ -203,7 +203,7 @@ DATA -supportedCommand Format-XML {
 }
 ```
 
-# See Also
+## See Also
 
 [about_Automatic_Variables](about_Automatic_Variables.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -8,13 +8,13 @@ title:  about_Functions
 
 # About Functions
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
-Describes how to create and use functions in Windows PowerShell.
+Describes how to create and use functions in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
-A function is a list of Windows PowerShell statements that has a name that you
+A function is a list of PowerShell statements that has a name that you
 assign. When you run a function, you type the function name. The statements in
 the list run as if you had typed them at the command prompt.
 
@@ -64,7 +64,7 @@ A function includes the following items:
 - A scope (optional)
 - A name that you select
 - Any number of named parameters (optional)
-- One or more Windows PowerShell commands enclosed in braces ({})
+- One or more PowerShell commands enclosed in braces ({})
 
 For more information about the Dynamicparam keyword and dynamic parameters in
 functions, see
@@ -79,7 +79,7 @@ have the following format:
 function <function-name> {statements}
 ```
 
-For example, the following function starts Windows PowerShell with the Run as
+For example, the following function starts PowerShell with the Run as
 Administrator option.
 
 ```powershell
@@ -99,26 +99,26 @@ function Get-NewPix
 {
   $start = Get-Date -Month 1 -Day 1 -Year 2010
   $allpix = Get-ChildItem -Path $env:UserProfile\*.jpg -Recurse
-  $allpix | where {$_.LastWriteTime -gt $Start}
+  $allpix | Where-Object {$_.LastWriteTime -gt $Start}
 }
 ```
 
 You can create a toolbox of useful small functions. Add these functions to
-your Windows PowerShell profile, as described in about_Profiles and later in
+your PowerShell profile, as described in about_Profiles and later in
 this topic.
 
 ### Function Names
 
 You can assign any name to a function, but functions that you share with
 others should follow the naming rules that have been established for all
-Windows PowerShell commands.
+PowerShell commands.
 
 Functions names should consist of a verb-noun pair in which the verb
 identifies the action that the function performs and the noun identifies the
 item on which the cmdlet performs its action.
 
 Functions should use the standard verbs that have been approved for all
-Windows PowerShell commands. These verbs help us to keep our command names
+PowerShell commands. These verbs help us to keep our command names
 simple, consistent, and easy for users to understand.
 
 For more information about the standard PowerShell verbs, see
@@ -169,7 +169,7 @@ value of the $size parameter, and it excludes directories:
 ```powershell
 function Get-SmallFiles {
   Param($Size)
-  Get-ChildItem $HOME | where {
+  Get-ChildItem $HOME | Where-Object {
     $_.Length -lt $Size -and !$_.PSIsContainer
   }
 }
@@ -198,7 +198,7 @@ Get-SmallFiles example:
 
 ```powershell
 function Get-SmallFiles ($Size = 100) {
-  Get-ChildItem $HOME | where {
+  Get-ChildItem $HOME | Where-Object {
     $_.Length -lt $Size -and !$_.PSIsContainer
   }
 }
@@ -248,7 +248,7 @@ function Get-Extension {
 ```
 
 ```powershell
-C:\PS> Get-Extension myTextFile
+PS> Get-Extension myTextFile
 myTextFile.txt
 ```
 
@@ -272,10 +272,10 @@ When you type the On switch parameter after the function name, the function
 displays "Switch on". Without the switch parameter, it displays "Switch off".
 
 ```powershell
-C:\PS> Switch-Item -on
+PS> Switch-Item -on
 Switch on
 
-C:\PS> Switch-Item
+PS> Switch-Item
 Switch off
 ```
 
@@ -283,10 +283,10 @@ You can also assign a Boolean value to a switch when you run the function, as
 shown in the following example:
 
 ```powershell
-C:\PS> Switch-Item -on:$true
+PS> Switch-Item -on:$true
 Switch on
 
-C:\PS> Switch-Item -on:$false
+PS> Switch-Item -on:$false
 Switch off
 ```
 
@@ -311,7 +311,7 @@ Get-MyCommand function. The parameters and parameter values are passed to the
 command using @Args.
 
 ```powershell
-PS C:> Get-MyCommand -Name Get-ChildItem
+PS> Get-MyCommand -Name Get-ChildItem
 CommandType     Name                ModuleName
 -----------     ----                ----------
 Cmdlet          Get-ChildItem       Microsoft.PowerShell.Management
@@ -360,7 +360,7 @@ To demonstrate this function, enter an list of numbers separated by commas, as
 shown in the following example:
 
 ```powershell
-C:\PS> 1,2,4 | Get-Pipeline
+PS> 1,2,4 | Get-Pipeline
 The value is: 1
 The value is: 2
 The value is: 4
@@ -387,7 +387,7 @@ If this function is run by using the pipeline, it displays the following
 results:
 
 ```powershell
-C:\PS> 1,2,4 | Get-PipelineBeginEnd
+PS> 1,2,4 | Get-PipelineBeginEnd
 Begin: The input is
 End:   The input is 1 2 4
 ```
@@ -412,7 +412,7 @@ at a time. The $input automatic variable is empty when the function reaches
 the End keyword.
 
 ```powershell
-C:\PS> 1,2,4 | Get-PipelineInput
+PS> 1,2,4 | Get-PipelineInput
 Processing:  1
 Processing:  2
 Processing:  4
@@ -436,7 +436,7 @@ either the whole entry or only the message portion of the entry:
 ```powershell
 filter Get-ErrorLog ([switch]$message)
 {
-  if ($message) { out-host -inputobject $_.Message }
+  if ($message) { Out-Host -InputObject $_.Message }
   else { $_ }
 }
 ```
@@ -454,7 +454,7 @@ the global scope in the following example:
 
 ```powershell
 function global:Get-DependentSvs {
-  Get-Service | where {$_.DependentServices}
+  Get-Service | Where-Object {$_.DependentServices}
 }
 ```
 
@@ -464,20 +464,20 @@ in functions, and at the command line.
 Functions normally create a scope. The items created in a function, such as
 variables, exist only in the function scope.
 
-For more information about scope in Windows PowerShell, see
+For more information about scope in PowerShell, see
 [about_Scopes](about_Scopes.md).
 
 ### Finding and Managing Functions Using the Function: Drive
 
-All the functions and filters in Windows PowerShell are automatically stored
-in the Function: drive. This drive is exposed by the Windows PowerShell
+All the functions and filters in PowerShell are automatically stored
+in the Function: drive. This drive is exposed by the PowerShell
 Function provider.
 
 When referring to the Function: drive, type a colon after Function, just as
 you would do when referencing the C or D drive of a computer.
 
 The following command displays all the functions in the current session of
-Windows PowerShell:
+PowerShell:
 
 ```powershell
 Get-ChildItem function:
@@ -485,7 +485,7 @@ Get-ChildItem function:
 
 The commands in the function are stored as a script block in the definition
 property of the function. For example, to display the commands in the Help
-function that comes with Windows PowerShell, type:
+function that comes with PowerShell, type:
 
 ```powershell
 (Get-ChildItem function:help).Definition
@@ -496,15 +496,15 @@ for the Function provider. Type `Get-Help Function`.
 
 ### Reusing Functions in New Sessions
 
-When you type a function at the Windows PowerShell command prompt, the
+When you type a function at the PowerShell command prompt, the
 function becomes part of the current session. It is available until the
 session ends.
 
-To use your function in all Windows PowerShell sessions, add the function
-to your Windows PowerShell profile. For more information about profiles,
+To use your function in all PowerShell sessions, add the function
+to your PowerShell profile. For more information about profiles,
 see [about_Profiles](about_Profiles.md).
 
-You can also save your function in a Windows PowerShell script file. Type your
+You can also save your function in a PowerShell script file. Type your
 function in a text file, and then save the file with the .ps1 file name
 extension.
 
@@ -547,7 +547,7 @@ methods:
   information about XML-based help, see [How to Write Cmdlet
   Help](https://go.microsoft.com/fwlink/?LinkID=123415) in the MSDN library.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Automatic_Variables](about_Automatic_Variables.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -8,11 +8,11 @@ title:  about_Functions_Advanced
 
 # About Functions Advanced
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Introduces advanced functions that act similar to cmdlets.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Advanced functions allow you to write functions that can perform operations
 that are similar to the operations you can perform with cmdlets. Advanced
@@ -25,7 +25,7 @@ compiled cmdlet.
 There is a difference between authoring a compiled cmdlet and an advanced
 function. Compiled cmdlets are .NET Framework classes that must be written in
 a .NET Framework language such as C#. In contrast, advanced functions are
-written in the Windows PowerShell script language in the same way that other
+written in the PowerShell script language in the same way that other
 functions or script blocks are written.
 
 Advanced functions use the CmdletBinding attribute to identify them as
@@ -51,7 +51,7 @@ function Send-Greeting
 
     Process
     {
-        write-host ("Hello " + $Name + "!")
+        Write-Host ("Hello " + $Name + "!")
     }
 }
 ```
@@ -79,7 +79,7 @@ Advanced functions differ from compiled cmdlets in the following ways:
 
 - Advanced functions cannot be used in transactions.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Functions](about_Functions.md)
 
@@ -91,4 +91,4 @@ Advanced functions differ from compiled cmdlets in the following ways:
 
 [about_Functions_OutputTypeAttribute](about_Functions_OutputTypeAttribute.md)
 
-[Windows PowerShell Cmdlets](http://go.microsoft.com/fwlink/?LinkID=135279)
+[PowerShell Cmdlets](http://go.microsoft.com/fwlink/?LinkID=135279)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -8,28 +8,28 @@ title:  about_Job_Details
 
 # About Job Details
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Provides details about background jobs on local and remote computers.
 
-# DETAILED DESCRIPTION
+## DETAILED DESCRIPTION
 
 This topic explains the concept of a background job and provides technical
-information about how background jobs work in Windows PowerShell.
+information about how background jobs work in PowerShell.
 
 This topic is a supplement to the [about_Jobs](about_Jobs.md) and
 [about_Remote_Jobs](about_Remote_Jobs.md) topics.
 
-# ABOUT BACKGROUND JOBS
+### ABOUT BACKGROUND JOBS
 
 A background job runs a command or expression asynchronously. It might run
 a cmdlet, a function, a script, or any other command-based task. It is
 designed to run commands that take an extended period of time, but you
 can use it to run any command in the background.
 
-When a synchronous command runs, the Windows PowerShell command prompt is
+When a synchronous command runs, the PowerShell command prompt is
 suppressed until the command is complete. But a background job does not
-suppress the Windows PowerShell prompt. A command to start a background job
+suppress the PowerShell prompt. A command to start a background job
 returns a job object. The prompt returns immediately so you can work on
 other tasks while the background job runs.
 
@@ -41,13 +41,13 @@ You can also run commands to stop the job, to wait for the job to be
 completed, and to delete the job.
 
 To make the timing of a background job independent of other commands, each
-background job runs in its own Windows PowerShell environment
+background job runs in its own PowerShell environment
 (a "session"). However, this can be a temporary connection that is created
 only to run the job and is then destroyed, or it can be a persistent
 session (a PSSession) that you can use to run several related jobs or
 commands.
 
-# USING THE JOB CMDLETS
+### USING THE JOB CMDLETS
 
 Use a Start-Job command to start a background job on a local computer.
 Start-Job returns a job object. You can also get objects representing the
@@ -64,7 +64,7 @@ the Remove-Job cmdlet.
 For more information about how the cmdlets work, see the Help topic for
 each cmdlet, and see about_Jobs.
 
-# STARTING BACKGROUND JOBS ON REMOTE COMPUTERS
+### STARTING BACKGROUND JOBS ON REMOTE COMPUTERS
 
 You can create and manage background jobs on a local or remote computer. To
 run a background job remotely, use the AsJob parameter of a cmdlet such as
@@ -74,7 +74,7 @@ session.
 
 For more information about remote background jobs, see about_Remote_Jobs.
 
-# CHILD JOBS
+### CHILD JOBS
 
 Each background job consists of a parent job and one or more child jobs. In
 jobs started by using Start-Job or the AsJob parameter of Invoke-Command,
@@ -93,7 +93,7 @@ parameter of the Get-Job cmdlet. The IncludeChildJob parameter is
 introduced in Windows PowerShell 3.0.
 
 ```powershell
-C:\PS> Get-Job -IncludeChildJob
+PS> Get-Job -IncludeChildJob
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -107,7 +107,7 @@ value, use the ChildJobState parameter of the Get-Job cmdlet. The
 ChildJobState parameter is introduced in Windows PowerShell 3.0.
 
 ```powershell
-C:\PS> Get-Job -ChildJobState Failed
+PS> Get-Job -ChildJobState Failed
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -115,11 +115,11 @@ Id Name   PSJobTypeName State      HasMoreData   Location    Command
 3  Job3                 Failed     False         localhost   Get-Process
 ```
 
-To get the child jobs of a job on all versions of Windows PowerShell,
+To get the child jobs of a job on all versions of PowerShell,
 use the ChildJob property of the parent job.
 
 ```powershell
-C:\PS> (Get-Job Job1).ChildJobs
+PS> (Get-Job Job1).ChildJobs
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -131,7 +131,7 @@ You can also use a Get-Job command on the child job, as shown in the
 following command:
 
 ```powershell
-C:\PS> Get-Job Job3
+PS> Get-Job Job3
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -168,7 +168,7 @@ background jobs on the local computer and two remote computers. The command
 saves the job in the \$j variable.
 
 ```powershell
-PS C:> $j = Invoke-Command -ComputerName localhost, Server01, Server02 `
+PS> $j = Invoke-Command -ComputerName localhost, Server01, Server02 `
 -Command {Get-Date} -AsJob
 ```
 
@@ -177,7 +177,7 @@ shows that the command returned a job object with three child jobs, one for
 each computer.
 
 ```powershell
-PS C:> $j | Format-List Name, ChildJobs
+PS> $j | Format-List Name, ChildJobs
 
 Name      : Job3
 ChildJobs : {Job4, Job5, Job6}
@@ -186,7 +186,7 @@ ChildJobs : {Job4, Job5, Job6}
 When you display the parent job, it shows that the job failed.
 
 ```powershell
-C:\PS> $j
+PS> $j
 
 Id Name   PSJobTypeName State      HasMoreData   Location
 -- ----   ------------- -----      -----------   --------
@@ -197,7 +197,7 @@ But when you run a Get-Job command that gets the child jobs, the output
 shows that only one child job failed.
 
 ```powershell
-PS C:> Get-Job -IncludeChildJobs
+PS> Get-Job -IncludeChildJobs
 
 Id  Name   PSJobTypeName State      HasMoreData   Location    Command
 --  ----   ------------- -----      -----------   --------    -------
@@ -212,47 +212,43 @@ the results of the parent job. But you can also get the results of a
 particular child job, as shown in the following command.
 
 ```powershell
-C:\PS> Receive-Job -Name Job6 -Keep | Format-Table ComputerName,
->> DateTime -Auto
-
+PS> Receive-Job -Name Job6 -Keep | Format-Table ComputerName,
+>> DateTime -AutoSize
 ComputerName DateTime
 ------------ --------
 Server02     Thursday, March 13, 2008 4:16:03 PM
 ```
 
-The child jobs feature of Windows PowerShell background jobs gives you
+The child jobs feature of PowerShell background jobs gives you
 more control over the jobs that you run.
 
-# JOB TYPES
+### JOB TYPES
 
+PowerShell supports different types of jobs for different tasks. Beginning in
+Windows PowerShell 3.0, developers can write "job source adapters" that add
+new job types to PowerShell and include the job source adapters in modules.
+When you import the module, you can use the new job type in your session.
 
-Windows PowerShell supports different types of jobs for different tasks.
-Beginning in Windows PowerShell 3.0, developers can write "job source
-adapters" that add new job types to Windows PowerShell and include the
-job source adapters in modules. When you import the module, you can
-use the new job type in your session.
+For example, the PSScheduledJob module adds scheduled jobs and the PSWorkflow
+module adds workflow jobs.
 
-For example, the PSScheduledJob module adds scheduled jobs and the
-PSWorkflow module adds workflow jobs.
+Custom jobs types might differ significantly from standard Windows PowerShell
+background jobs. For example, scheduled jobs are saved on disk; they do not
+exist only in a particular session. Workflow jobs can be suspended and
+resumed.
 
-Custom jobs types might differ significantly from standard Windows
-PowerShell background jobs. For example, scheduled jobs are saved
-on disk; they do not exist only in a particular session. Workflow
-jobs can be suspended and resumed.
+The cmdlets that you use to manage custom jobs depend on the job type. For
+some, you use the standard job cmdlets, such as Get-Job and Start-Job. Others
+come with specialized cmdlets that manage only a particular type of job. For
+detailed information about custom job types, see the help topics about the job
+type.
 
-The cmdlets that you use to manage custom jobs depend on the job
-type. For some, you use the standard job cmdlets, such as Get-Job
-and Start-Job. Others come with specialized cmdlets that manage
-only a particular type of job. For detailed information about
-custom job types, see the help topics about the job type.
+To find the job type of a job, use the Get-Job cmdlet. Get-Job returns
+different job objects for different types of jobs. The value of the
+PSJobTypeName property of the job objects that Get-Job returns indicates the
+job type.
 
-To find the job type of a job, use the Get-Job cmdlet. Get-Job
-returns different job objects for different types of jobs. The
-value of the PSJobTypeName property of the job objects that
-Get-Job returns indicates the job type.
-
-The following table lists the job types that come with Windows
-PowerShell.
+The following table lists the job types that come with PowerShell.
 
 |Job Type      |Description                                               |
 |--------------|----------------------------------------------------------|
@@ -272,7 +268,7 @@ NOTE: Before using the Get-Job cmdlet to get jobs of a particular type, verify
 that the module that adds the job type is imported into the current session.
 Otherwise, Get-Job does not get jobs of that type.
 
-# EXAMPLE
+## EXAMPLE
 
 The following commands create a local background job, a remote background job,
 a workflow job, and a scheduled job. Then, it uses the Get-Job cmdlet to get
@@ -282,7 +278,7 @@ instances of the scheduled job.
 Start a background job on the local computer.
 
 ```powershell
-PS C:> Start-Job -Name LocalData {Get-Process}
+PS> Start-Job -Name LocalData {Get-Process}
 
 Id Name        PSJobTypeName   State   HasMoreData   Location   Command
 -- ----        -------------   -----   -----------   --------   -------
@@ -292,7 +288,7 @@ Id Name        PSJobTypeName   State   HasMoreData   Location   Command
 Start a background job that runs on a remote computer.
 
 ```powershell
-PS C:> Invoke-Command -ComputerName Server01 {Get-Process} `
+PS> Invoke-Command -ComputerName Server01 {Get-Process} `
 -AsJob -JobName RemoteData
 
 Id  Name        PSJobTypeName  State   HasMoreData   Location   Command
@@ -301,8 +297,9 @@ Id  Name        PSJobTypeName  State   HasMoreData   Location   Command
 ```
 
 Create a scheduled job
+
 ```powershell
-PS C:>  Register-ScheduledJob -Name ScheduledJob -ScriptBlock `
+PS>  Register-ScheduledJob -Name ScheduledJob -ScriptBlock `
  {Get-Process} -Trigger (New-JobTrigger -Once -At "3 PM")
 
 Id         Name            JobTriggers     Command       Enabled
@@ -311,14 +308,16 @@ Id         Name            JobTriggers     Command       Enabled
 ```
 
 Create a workflow.
+
 ```powershell
-PS C:> workflow Test-Workflow {Get-Process}
+PS> workflow Test-Workflow {Get-Process}
 ```
 
 Run the workflow as a job.
+
 ```powershell
 
-PS C:> Test-Workflow -AsJob -JobName TestWFJob
+PS> Test-Workflow -AsJob -JobName TestWFJob
 
 Id  Name       PSJobTypeName   State   HasMoreData   Location   Command
 --  ----       -------------   -----   -----------   --------   -------
@@ -329,7 +328,7 @@ Get the jobs. The `Get-Job` command does not get scheduled jobs, but it gets
 instances of the scheduled job that are started.
 
 ```powershell
-PS C:> Get-Job
+PS> Get-Job
 
 Id  Name         PSJobTypeName  State     HasMoreData  Location  Command
 --  ----         -------------  -----     -----------  --------  -------
@@ -342,14 +341,14 @@ Id  Name         PSJobTypeName  State     HasMoreData  Location  Command
 To get scheduled jobs, use the Get-ScheduledJob cmdlet.
 
 ```powershell
-PS C:> Get-ScheduledJob
+PS> Get-ScheduledJob
 
 Id         Name            JobTriggers     Command       Enabled
 --         ----            -----------     -------       -------
 1          ScheduledJob    1               Get-Process   True
 ```
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Jobs](about_Jobs.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -61,7 +61,8 @@ In RestrictedLanguage language mode, users may run commands (cmdlets,
 functions, CIM commands, and workflows) but are not permitted to use script
 blocks.
 
-Only the following variables are permitted:
+By default, only the following variables are permitted in RestrictedLanguage
+language mode:
 
 - \$PSCulture
 - \$PSUICulture
@@ -70,6 +71,7 @@ Only the following variables are permitted:
 - \$Null.
 
 Only the following comparison operators are permitted:
+
 - -eq (equal)
 - -gt (greater-than)
 - -lt (less-than)
@@ -240,14 +242,14 @@ NoLanguage session, PowerShell returns the ScriptsNotAllowed error message.
 - ScriptsNotAllowed: The syntax is not supported by this runspace. This
   might be because it is in no-language mode.
 
-# KEYWORDS
+## KEYWORDS
 
 - about_ConstrainedLanguage
 - about_FullLanguage
 - about_NoLanguage
 - about_RestrictedLanguage
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Session_Configuration_Files](about_Session_Configuration_Files.md)
 - [about_Session_Configurations](about_Session_Configurations.md)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -23,7 +23,8 @@ order is the order in which PowerShell evaluates the operators when
 multiple operators appear in the same expression.
 
 When operators have equal precedence, PowerShell evaluates them from
-left to right. The exceptions are the assignment operators, the cast
+left to right as they appear within the expression.
+The exceptions are the assignment operators, the cast
 operators, and the negation operators (!, -not, -bnot), which are evaluated
 from right to left.
 
@@ -41,7 +42,7 @@ the topic, type `get-help <topic-name>`.
 
 |OPERATOR                |REFERENCE|
 |------------------------|---------|
-|`$()  @()`              |[about_Operators](#index-operator)|
+|`$() @() ()`            |[about_Operators](about_Operators.md)|
 |`.` (dereference)       |[about_Operators](about_Operators.md)|
 |`::` (static)           |[about_Operators](about_Operators.md)|
 |`[0]` (index operator)  |[about_Operators](about_Operators.md)|
@@ -54,7 +55,9 @@ the topic, type `get-help <topic-name>`.
 |`! -bNot`               |[about_Comparison_Operators](about_Comparison_Operators.md)|
 |`..` (range operator)   |[about_Operators](about_Operators.md)|
 |`-f` (format operator)  |[about_Operators](about_Operators.md)|
-|`* / % + -`             |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`-` (unary/negative)    |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`* / %`                 |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`+ -`                   |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
 
 The following group of operators have equal precedence. Their case-sensitive
 and explicitly case-insensitive variants have the same precedence.
@@ -80,21 +83,21 @@ order:
 |`-and -or -xor`           |[about_Logical_Operators](about_logical_operators.md)|
 |`.` (dot-source)          |[about_Scopes](about_Scopes.md)|
 |`&` (call)                |[about_Operators](about_Operators.md)|
-|&#124; (pipeline operator)|[about_Operators](about_Operators.md)|
+|<code>&#124;</code> (pipeline operator)|[about_Operators](about_Operators.md)|
 |`> >> 2> 2>> 2>&1`        |[about_Redirection](about_Redirection.md)|
 |`= += -= *= /= %=`        |[about_Assignment_Operators](about_Assignment_Operators.md)|
 
-# EXAMPLES
+## EXAMPLES
 
 The following two commands show the arithmetic operators and the effect of
 using parentheses to force PowerShell to evaluate the enclosed part of
 the expression first.
 
 ```powershell
-C:\PS> 2 + 3 * 4
+PS> 2 + 3 * 4
 14
 
-C:\PS> (2 + 3) * 4
+PS> (2 + 3) * 4
 20
 ```
 
@@ -102,12 +105,13 @@ The following example gets the read-only text files from the local directory
 and saves them in the `$read_only` variable.
 
 ```powershell
-$read_only = get-childitem *.txt | where-object {$_.isReadOnly}
+$read_only = Get-ChildItem *.txt | Where-Object {$_.isReadOnly}
 ```
+
 It is equivalent to the following example.
 
 ```powershell
-$read_only = ( get-childitem *.txt | where-object {$_.isReadOnly} )
+$read_only = ( Get-ChildItem *.txt | Where-Object {$_.isReadOnly} )
 ```
 
 Because the pipeline operator (|) has a higher precedence than the assignment
@@ -124,7 +128,7 @@ which is the first string. Finally, it casts the selected object as a string.
 In this case, the cast has no effect.
 
 ```powershell
-C:\PS> [string]@('Windows','PowerShell','2.0')[0]
+PS> [string]@('Windows','PowerShell','2.0')[0]
 Windows
 ```
 
@@ -134,7 +138,7 @@ before the index selection. As a result, the entire array is cast as a
 array, which is the first character.
 
 ```powershell
-C:\PS> ([string]@('Windows','PowerShell','2.0'))[0]
+PS> ([string]@('Windows','PowerShell','2.0'))[0]
 W
 ```
 
@@ -143,21 +147,21 @@ precedence than the -and (logical AND) operator, the result of the expression
 is FALSE.
 
 ```powershell
-C:\PS> 2 -gt 4 -and 1
+PS> 2 -gt 4 -and 1
 False
 ```
 
 It is equivalent to the following expression.
 
 ```powershell
-C:\PS> (2 -gt 4) -and 1
+PS> (2 -gt 4) -and 1
 False
 ```
 
 If the -and operator had higher precedence, the answer would be TRUE.
 
 ```powershell
-C:\PS> 2 -gt (4 -and 1)
+PS> 2 -gt (4 -and 1)
 True
 ```
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -11,19 +11,19 @@ title:  about_Remote_Requirements
 ## SHORT DESCRIPTION
 
 Describes the system requirements and configuration requirements for running
-remote commands in Windows PowerShell.
+remote commands in PowerShell.
 
 ## LONG DESCRIPTION
 
 This topic describes the system requirements, user requirements, and resource
 requirements for establishing remote connections and running remote commands
-in Windows PowerShell. It also provides instructions for configuring remote
+in PowerShell. It also provides instructions for configuring remote
 operations.
 
 Note: Many cmdlets (including the Get-Service, Get-Process, Get-WMIObject,
 Get-EventLog, and Get-WinEvent cmdlets) get objects from remote computers by
 using Microsoft .NET Framework methods to retrieve the objects. They do not
-use the Windows PowerShell remoting infrastructure. The requirements in this
+use the PowerShell remoting infrastructure. The requirements in this
 document do not apply to these cmdlets.
 
 To find the cmdlets that have a ComputerName parameter but do not use Windows
@@ -51,7 +51,7 @@ You can create remote sessions between computers running Windows PowerShell
 PowerShell 3.0, such as the ability to disconnect and reconnect to sessions,
 are available only when both computers are running Windows PowerShell 3.0.
 
-To find the version number of an installed version of Windows PowerShell,
+To find the version number of an installed version of PowerShell,
 use the $PSVersionTable automatic variable.
 
 Windows Remote Management (WinRM) 3.0 and Microsoft .NET Framework 4 are
@@ -143,7 +143,7 @@ Administrator privileges are required for the following remoting operations:
 - Viewing and changing WS-Management settings on the local computer. These are
   the settings in the LocalHost node of the WSMAN: drive.
 
-To perform these tasks, you must start Windows PowerShell with the "Run as
+To perform these tasks, you must start PowerShell with the "Run as
 administrator" option even if you are a member of the Administrators group on
 the local computer.
 
@@ -170,28 +170,28 @@ the "Run as administrator" option to start the program.
 ## HOW TO CONFIGURE YOUR COMPUTER FOR REMOTING
 
 Computers running all supported versions of Windows can establish remote
-connections to and run remote commands in Windows PowerShell without any
+connections to and run remote commands in PowerShell without any
 configuration. However, to receive connections, and allow users to create
-local and remote user-managed Windows PowerShell sessions ("PSSessions") and
-run commands on the local computer, you must enable Windows PowerShell
+local and remote user-managed PowerShell sessions ("PSSessions") and
+run commands on the local computer, you must enable PowerShell
 remoting on the computer.
 
 Windows Server 2012 and newer releases of Windows Server are enabled for
-Windows PowerShell remoting by default. If the settings are changed, you can
+PowerShell remoting by default. If the settings are changed, you can
 restore the default settings by running the Enable-PSRemoting cmdlet.
 
 On all other supported versions of Windows, you need to run the
-Enable-PSRemoting cmdlet to enable Windows PowerShell remoting.
+Enable-PSRemoting cmdlet to enable PowerShell remoting.
 
-The remoting features of Windows PowerShell are supported by the WinRM
+The remoting features of PowerShell are supported by the WinRM
 service, which is the Microsoft implementation of the Web Services for
-Management (WS-Management) protocol. When you enable Windows PowerShell
+Management (WS-Management) protocol. When you enable PowerShell
 remoting, you change the default configuration of WS-Management and add system
 configuration that allow users to connect to WS-Management.
 
-To configure Windows PowerShell to receive remote commands:
+To configure PowerShell to receive remote commands:
 
-1. Start Windows PowerShell with the "Run as administrator" option.
+1. Start PowerShell with the "Run as administrator" option.
 2. At the command prompt, type: `Enable-PSRemoting`
 
 To verify that remoting is configured correctly, run a test command such as
@@ -216,16 +216,16 @@ If the command fails, for assistance, see
 
 ## UNDERSTAND POLICIES
 
-When you work remotely, you use two instances of Windows PowerShell, one on
+When you work remotely, you use two instances of PowerShell, one on
 the local computer and one on the remote computer. As a result, your work is
-affected by the Windows policies and the Windows PowerShell policies on the
+affected by the Windows policies and the PowerShell policies on the
 local and remote computers.
 
 In general, before you connect and as you are establishing the connection, the
 policies on the local computer are in effect. When you are using the
 connection, the policies on the remote computer are in effect.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Remote](about_Remote.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -10,15 +10,15 @@ title:  about_Remote_Troubleshooting
 
 ## SHORT DESCRIPTION
 
-Describes how to troubleshoot remote operations in Windows PowerShell.
+Describes how to troubleshoot remote operations in PowerShell.
 
 ## LONG DESCRIPTION
 
 This section describes some of the problems that you might encounter when
-using the remoting features of Windows PowerShell that are based on
+using the remoting features of PowerShell that are based on
 WS-Management technology and it suggests solutions to these problems.
 
-Before using Windows PowerShell remoting, see about_Remote and
+Before using PowerShell remoting, see about_Remote and
 about_Remote_Requirements for guidance on configuration and basic use Also,
 the Help topics for each of the remoting cmdlets, particularly the parameter
 descriptions, have useful information that is designed to help you avoid
@@ -26,7 +26,7 @@ problems.
 
 NOTE: To view or change settings for the local computer in the WSMan: drive,
 including changes to the session configurations, trusted hosts, ports, or
-listeners, start Windows PowerShell with the "Run as administrator" option.
+listeners, start PowerShell with the "Run as administrator" option.
 
 ## TROUBLESHOOTING PERMISSION AND AUTHENTICATION ISSUES
 
@@ -68,7 +68,7 @@ WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
 
 No configuration is required to enable a computer to send remote
-commands. However, to receive remote commands, Windows PowerShell remoting
+commands. However, to receive remote commands, PowerShell remoting
 must be enabled on the computer. Enabling includes starting the WinRM
 service, setting the startup type for the WinRM service to Automatic,
 creating listeners for HTTP and HTTPS connections, and creating default
@@ -103,7 +103,7 @@ ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
 
-To enable a single computer to receive remote Windows PowerShell commands
+To enable a single computer to receive remote PowerShell commands
 and accept connections, use the Enable-PSRemoting cmdlet.
 
 To enable remoting for multiple computers in an enterprise, you can use the
@@ -200,7 +200,7 @@ the Windows Remote Management service.
 
 ERROR:  ACCESS IS DENIED
 
-Windows PowerShell remoting depends upon the Windows Remote Management
+PowerShell remoting depends upon the Windows Remote Management
 (WinRM) service. The service must be running to support remote commands.
 
 On server versions of Windows, the startup type of the Windows Remote
@@ -529,9 +529,9 @@ ERROR: The client cannot connect to the destination specified in the
 request. Verify that the service on the destination is running and is
 accepting requests.
 
-Because Windows PowerShell remoting uses the HTTP protocol, it is affected
+Because PowerShell remoting uses the HTTP protocol, it is affected
 by HTTP proxy settings. In enterprises that have proxy servers, users
-cannot access a Windows PowerShell remote computer directly.
+cannot access a PowerShell remote computer directly.
 
 To resolve this problem, use proxy setting options in your remote command.
 The following settings are available:
@@ -569,9 +569,9 @@ the option object that New-PSSessionOption creates in the value of the
 $PSSessionOption preference variable. For more information about the
 $PSSessionOption preference variable, see about_Preference_Variables.
 
-To set these options for all remote commands all Windows PowerShell sessions
+To set these options for all remote commands all PowerShell sessions
 on the local computer, add the $PSSessionOption preference variable to your
-Windows PowerShell profile. For more information about Windows PowerShell
+PowerShell profile. For more information about PowerShell
 profiles, see about_Profiles.
 
 ### HOW TO DETECT A 32-BIT SESSION ON A 64-BIT COMPUTER
@@ -597,8 +597,8 @@ following command finds the processor architecture of the session in the
 \$s variable.
 
 ```powershell
-$s = New-PSSession -ComputerName Server01 -configurationName CustomShell
-invoke-command -session $s {$env:PROCESSOR_ARCHITECTURE}
+$s = New-PSSession -ComputerName Server01 -ConfigurationName CustomShell
+Invoke-Command -Session $s {$env:PROCESSOR_ARCHITECTURE}
 x86
 ```
 
@@ -629,7 +629,7 @@ process.
 
 For example, the following command starts a process with the RemoteSigned
 execution policy. The execution policy change affects only the current
-process and does not change the Windows PowerShell ExecutionPolicy registry
+process and does not change the PowerShell ExecutionPolicy registry
 setting.
 
 ```powershell
@@ -673,7 +673,7 @@ The following quotas are available in the basic configuration.
   MaximumReceivedObjectSizeMB parameters of the Register-PSSessionConfiguration
   cmdlet.
 
-When quotas conflict with a command, Windows PowerShell generates an error.
+When quotas conflict with a command, PowerShell generates an error.
 
 To resolve the error, change the remote command to comply with the quota.
 Or, determine the source of the quota, and then increase the quota to allow
@@ -701,7 +701,7 @@ the time specified in OperationTimeout.
 
 You can use timeouts to protect the local computer and the remote computer
 from excessive resource use, both accidental and malicious. When timeouts
-are set on both the local and remote computer, Windows PowerShell uses the
+are set on both the local and remote computer, PowerShell uses the
 shortest timeout settings.
 
 The following timeouts are available in the basic configuration.
@@ -745,13 +745,13 @@ New-PSSessionOption.
 ## TROUBLESHOOTING UNRESPONSIVE BEHAVIOR
 
 This section discusses remoting problems that prevent a command from completing
-and prevent or delay the return of the Windows PowerShell prompt.
+and prevent or delay the return of the PowerShell prompt.
 
 ### HOW TO INTERRUPT A COMMAND
 
 Some native Windows programs, such as programs with a user interface, console
 applications that prompt for input, and console applications that use the
-Win32 console API, do not work correctly in the Windows PowerShell remote host.
+Win32 console API, do not work correctly in the PowerShell remote host.
 
 When you use these programs, you might see unexpected behavior, such as no
 output, partial output, or a remote command that does not complete.
@@ -771,14 +771,14 @@ WinRM operations are in progress.
 To resolve this issue, verify that the WinRM service is running and try
 the command again.
 
-1. Start Windows PowerShell with the "Run as administrator" option.
+1. Start PowerShell with the "Run as administrator" option.
 2. Run the following command:
 
    Start-Service WinRM
 
 3. Re-run the command that generated the error.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Remote](about_Remote.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -16,22 +16,22 @@ policies.
 ## LONG DESCRIPTION
 
 The Restricted execution policy does not permit any scripts to run. The
-AllSigned and RemoteSigned execution policies prevent PowerShell from running
-scripts that do not have a digital signature.
+**AllSigned** and **RemoteSigned** execution policies prevent PowerShell from
+running scripts that do not have a digital signature.
 
 This topic explains how to run selected scripts that are not signed, even
-while the execution policy is RemoteSigned, and how to sign scripts for your
-own use.
+while the execution policy is **RemoteSigned**, and how to sign scripts for
+your own use.
 
 For more information about PowerShell execution policies, see
 [about_Execution_Policies](about_Execution_Policies.md).
 
 ## TO PERMIT SIGNED SCRIPTS TO RUN
 
-When you start PowerShell on a computer for the first time, the Restricted
+When you start PowerShell on a computer for the first time, the **Restricted**
 execution policy (the default) is likely to be in effect.
 
-The Restricted policy does not permit any scripts to run.
+The **Restricted** policy does not permit any scripts to run.
 
 To find the effective execution policy on your computer, type:
 
@@ -42,23 +42,22 @@ Get-ExecutionPolicy
 To run unsigned scripts that you write on your local computer and signed
 scripts from other users, start PowerShell with the Run as Administrator
 option and then use the following command to change the execution policy on
-the computer to RemoteSigned:
+the computer to **RemoteSigned**:
 
 ```powershell
 Set-ExecutionPolicy RemoteSigned
 ```
 
-For more information, see the help topic for the Set-ExecutionPolicy cmdlet.
+For more information, see the help topic for the `Set-ExecutionPolicy` cmdlet.
 
 ## RUNNING UNSIGNED SCRIPTS (REMOTESIGNED EXECUTION POLICY)
 
-If your PowerShell execution policy is RemoteSigned, Windows
-PowerShell will not run unsigned scripts that are downloaded from the
-Internet, including unsigned scripts you receive through e-mail and instant
-messaging programs.
+If your PowerShell execution policy is **RemoteSigned**, Windows PowerShell
+will not run unsigned scripts that are downloaded from the Internet, including
+unsigned scripts you receive through e-mail and instant messaging programs.
 
-If you try to run a downloaded script, PowerShell displays the
-following error message:
+If you try to run a downloaded script, PowerShell displays the following error
+message:
 
 ```output
 The file <file-name> cannot be loaded. The file <file-name> is not digitally
@@ -98,9 +97,9 @@ this publisher.
 
 ## METHODS OF SIGNING SCRIPTS
 
-You can sign the scripts that you write and the
-scripts that you obtain from other sources. Before you sign any script,
-examine each command to verify that it is safe to run.
+You can sign the scripts that you write and the scripts that you obtain from
+other sources. Before you sign any script, examine each command to verify that
+it is safe to run.
 
 For best practices about code signing, see
 [Code-Signing Best Practices](/previous-versions/windows/hardware/design/dn653556(v=vs.85)).
@@ -289,7 +288,7 @@ signed while the signing certificate was valid.
 Because most signing certificates are valid for one year only, using a time
 stamp server ensures that users can use your script for many years to come.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Execution_Policies](about_Execution_Policies.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -8,20 +8,20 @@ title:  about_Special_Characters
 
 # About Special Characters
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Describes the special characters that you can use to control how Windows
 PowerShell interprets the next character in a command or parameter.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
-Windows PowerShell supports a set of special character sequences that are used
+PowerShell supports a set of special character sequences that are used
 to represent characters that are not part of the standard character set.
 
-The special characters in Windows PowerShell begin with the backtick
+The special characters in PowerShell begin with the backtick
 character, also known as the grave accent (ASCII 96).
 
-The following special characters are recognized by Windows PowerShell:
+The following special characters are recognized by PowerShell:
 
 ```
 | Character | Description             |
@@ -29,10 +29,12 @@ The following special characters are recognized by Windows PowerShell:
 | `0        | Null                    |
 | `a        | Alert                   |
 | `b        | Backspace               |
+| `e        | Escape                  |
 | `f        | Form feed               |
 | `n        | New line                |
 | `r        | Carriage return         |
 | `t        | Horizontal tab          |
+| `u{x}     | Unicode escape sequence |
 | `v        | Vertical tab            |
 | --%       | Stop parsing            |
 ```
@@ -42,9 +44,9 @@ when used within double quoted (") strings.
 
 ## NULL (`0)
 
-Windows PowerShell recognizes a null special character (`0) and represents it
+PowerShell recognizes a null special character (`0) and represents it
 with a character code of 0. It appears as an empty space in the Windows
-PowerShell output. This allows you to use Windows PowerShell to read and
+PowerShell output. This allows you to use PowerShell to read and
 process text files that use null characters, such as string termination or
 record termination indicators. The null special character is not equivalent to
 the $null variable, which stores a value of NULL.
@@ -120,7 +122,7 @@ Delete everything before this point.
 ## HORIZONTAL TAB (`t)
 
 The horizontal tab character (`t) advances to the next tab stop and continues
-writing at that point. By default, the Windows PowerShell console has a tab
+writing at that point. By default, the PowerShell console has a tab
 stop at every eighth space.
 
 For example, the following command inserts two tabs between each column.
@@ -143,8 +145,8 @@ printed documents only. It does not affect screen output.
 
 ## STOP PARSING  (--%)
 
-The stop-parsing symbol (--%) prevents Windows PowerShell from interpreting
-arguments in program calls as Windows PowerShell commands and expressions.
+The stop-parsing symbol (--%) prevents PowerShell from interpreting
+arguments in program calls as PowerShell commands and expressions.
 
 Place the stop-parsing symbol after the program name and before program
 arguments that might cause errors.
@@ -155,7 +157,7 @@ For example, the following Icacls command uses the stop-parsing symbol.
 icacls X:\VMS --% /grant Dom\HVAdmin:(CI)(OI)F
 ```
 
-Windows PowerShell sends the following command to Icacls.
+PowerShell sends the following command to Icacls.
 
 ```output
 X:\VMS /grant Dom\HVAdmin:(CI)(OI)F
@@ -163,6 +165,6 @@ X:\VMS /grant Dom\HVAdmin:(CI)(OI)F
 
 For more information about the stop-parsing symbol, see [about_Parsing](about_Parsing.md).
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Quoting_Rules](about_Quoting_Rules.md)

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -20,10 +20,10 @@ administrator and the winner of the Advanced Division of the 2012 Scripting
 Games. Revised for Windows PowerShell 3.0.]
 
 Splatting is a method of passing a collection of parameter values to a command
-as unit. Windows PowerShell associates each value in the collection with a
+as unit. PowerShell associates each value in the collection with a
 command parameter. Splatted parameter values are stored in named splatting
 variables, which look like standard variables, but begin with an At symbol (@)
-instead of a dollar sign ($). The At symbol tells Windows PowerShell that you
+instead of a dollar sign ($). The At symbol tells PowerShell that you
 are passing a collection of values, instead of a single value.
 
 Splatting makes your commands shorter and easier to read. You can re-use the
@@ -85,7 +85,7 @@ Copy-Item @HashArguments
 ```
 
 Note: In the first command, the At symbol (@) indicates a hash table, not a
-splatted value. The syntax for hash tables in Windows PowerShell is:
+splatted value. The syntax for hash tables in PowerShell is:
 @{\<name\>=\<value\>; \<name\>=\<value\>; …}*
 
 ## SPLATTING WITH ARRAYS
@@ -281,7 +281,7 @@ FileVersionInfo    : File:             C:\Windows\System32\WindowsPowerShell
                      Language:         English (United States)
 ```
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Arrays](about_Arrays.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -8,20 +8,20 @@ title:  about_Types.ps1xml
 
 # About Types.ps1xml
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Explains how to use Types.ps1xml files to extend the types of objects
-that are used in Windows PowerShell.
+that are used in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Extended type data defines additional properties and methods ("members")
-of object types in Windows PowerShell. There are two techniques for adding
-extended type data to a Windows PowerShell session.
+of object types in PowerShell. There are two techniques for adding
+extended type data to a PowerShell session.
 
 - Types.ps1xml file: An XML file that defines extended type data.
 - `Update-TypeData`: A cmdlet that reloads Types.ps1xml files and defines
-extended data for types in the current session.
+  extended data for types in the current session.
 
 This topic describes Types.ps1xml files. For more information about using the
 `Update-TypeData` cmdlet to add dynamic extended type data to the current
@@ -31,11 +31,11 @@ session see
 ## About Extended Type Data
 
 Extended type data defines additional properties and methods ("members") of
-object types in Windows PowerShell. You can extend any type that is supported
-by Windows PowerShell and use the added properties and methods in the same way
+object types in PowerShell. You can extend any type that is supported
+by PowerShell and use the added properties and methods in the same way
 that you use the properties that are defined on the object types.
 
-For example, Windows PowerShell adds a `DateTime` property to all
+For example, PowerShell adds a `DateTime` property to all
 `System.DateTime` objects, such as the ones that the `Get-Date` cmdlet
 returns.
 
@@ -46,19 +46,19 @@ Sunday, January 29, 2012 9:43:57 AM
 
 You won't find the `DateTime` property in the description of the
 [`System.DateTime` structure](http://msdn.microsoft.com/library/system.datetime.aspx),
-because Windows PowerShell adds the property and it is visible only in Windows
+because PowerShell adds the property and it is visible only in Windows
 PowerShell.
 
-To add the `DateTime` property to all Windows PowerShell sessions, Windows
+To add the `DateTime` property to all PowerShell sessions, Windows
 PowerShell defines the `DateTime` property in the Types.ps1xml file in the
-Windows PowerShell installation directory (`$PSHOME`).
+PowerShell installation directory (`$PSHOME`).
 
-## Adding Extended Type Data to Windows PowerShell.
+## Adding Extended Type Data to PowerShell.
 
-There are three sources of extended type data in Windows PowerShell sessions.
+There are three sources of extended type data in PowerShell sessions.
 
-- The Types.ps1xml files in the Windows PowerShell installation directory
-  are loaded automatically into every Windows PowerShell session.
+- The Types.ps1xml files in the PowerShell installation directory
+  are loaded automatically into every PowerShell session.
 
 - The Types.ps1xml files that modules export are loaded when the module
   is imported into the current session.
@@ -73,7 +73,8 @@ types.
 ## The TypeData Cmdlets
 
 The following TypeData cmdlets are included in the Microsoft.PowerShell.Utility
-module in Windows PowerShell 3.0 and later versions of Windows PowerShell.
+module in Windows PowerShell 3.0 and later versions of Windows PowerShell
+and PowerShell Core.
 
 - `Get-TypeData`: Gets extended type data in the current session.
 - `Update-TypeData`: Reloads Types.ps1xml files. Adds extended type data to the
@@ -87,9 +88,9 @@ For more information about these cmdlets, see the help topic for each cmdlet.
 The Types.ps1xml files in the `$PSHOME` directory are added automatically to
 every session.
 
-The Types.ps1xml file in the Windows PowerShell installation directory
+The Types.ps1xml file in the PowerShell installation directory
 (`$PSHOME`) is an XML-based text file that lets you add properties and
-methods to the objects that are used in Windows PowerShell. Windows
+methods to the objects that are used in PowerShell. Windows
 PowerShell has built-in Types.ps1xml files that add several elements
 to the .NET Framework types, but you can create additional Types.ps1xml
 files to further extend the types.
@@ -136,7 +137,7 @@ Get        Method        System.Object Get(Int32)
 ```
 
 As a result, you can use either the Count property or the Length property
-of arrays in Windows PowerShell. For example:
+of arrays in PowerShell. For example:
 
 ```powershell
 C:\PS> (1, 2, 3, 4).count
@@ -150,32 +151,32 @@ C:\PS> (1, 2, 3, 4).length
 
 ## Creating New Types.ps1xml Files
 
-The .ps1xml files that are installed with Windows PowerShell are
+The .ps1xml files that are installed with PowerShell are
 digitally signed to prevent tampering because the formatting can include
 script blocks. Therefore, to add a property or method to a .NET Framework
 type, create your own Types.ps1xml files, and then add them to your
-Windows PowerShell session.
+PowerShell session.
 
 To create a new file, start by copying an existing Types.ps1xml file. The
 new file can have any name, but it must have a .ps1xml file name
 extension. You can place the new file in any directory that is accessible
-to Windows PowerShell, but it is useful to place the files in the Windows
+to PowerShell, but it is useful to place the files in the Windows
 PowerShell installation directory (`$PSHOME`) or in a subdirectory of the
 installation directory.
 
 When you have saved the new file, use the `Update-TypeData` cmdlet to add
-the new file to your Windows PowerShell session. If you want your types
+the new file to your PowerShell session. If you want your types
 to take precedence over the types that are defined in the built-in file,
 use the PrependData parameter of the `Update-TypeData` cmdlet.
 `Update-TypeData` affects only the current session. To make the change to
 all future sessions, export the console, or add the `Update-TypeData`
-command to your Windows PowerShell profile.
+command to your PowerShell profile.
 
 ## Types.ps1xml and Add-Member
 
 The Types.ps1xml files add properties and methods to all the instances
 of the objects of the specified .NET Framework type in the affected
-Windows PowerShell session. However, if you need to add properties or
+PowerShell session. However, if you need to add properties or
 methods only to one instance of an object, use the `Add-Member` cmdlet.
 
 For more information, see [Add-Member](../../Microsoft.PowerShell.Utility/Add-Member.md).
@@ -330,7 +331,7 @@ the name of the new method and a pair of `<GetCodeReference>` tags
 that specify the code in which the method is defined.
 
 For example, the Mode property of directories (`System.IO.DirectoryInfo`
-objects) is a code property defined in the Windows PowerShell
+objects) is a code property defined in the PowerShell
 FileSystem provider.
 
 ```xml
@@ -357,7 +358,7 @@ the name of the new property and a pair of `<GetCodeReference>` tags
 that specify the code in which the property is defined.
 
 For example, the `Mode` property of directories (`System.IO.DirectoryInfo`
-objects) is a code property defined in the Windows PowerShell
+objects) is a code property defined in the PowerShell
 FileSystem provider.
 
 ```xml
@@ -387,7 +388,7 @@ create a property (such as `<NoteProperty>` or `<ScriptProperty>`) or a
 method (such as `<Method>` or `<ScriptMethod>`) can be members of the set.
 
 In Types.ps1xml files, the `<MemberSet>` tag is used to define the
-default views of the .NET Framework objects in Windows PowerShell. In
+default views of the .NET Framework objects in PowerShell. In
 this case, the name of the member set (the value within the `<Name>`
 tags) is always "PsStandardMembers", and the names of the properties
 (the value of the `<Name>` tag) are one of the following:
@@ -397,8 +398,8 @@ tags) is always "PsStandardMembers", and the names of the properties
 - `DefaultDisplayPropertySet`: One or more properties of an object.
 
 - `DefaultKeyPropertySet`: One or more key properties of an object.
-A key property identifies instances of property values, such as
-the ID number of items in a session history.
+  A key property identifies instances of property values, such as
+  the ID number of items in a session history.
 
 For example, the following XML defines the default display of services
 (`System.ServiceProcess.ServiceController` objects) that are returned by
@@ -560,7 +561,7 @@ library](http://go.microsoft.com/fwlink/?LinkId=144538).
 
 ## `Update-TypeData`
 
-To load your Types.ps1xml files into a Windows PowerShell session, run
+To load your Types.ps1xml files into a PowerShell session, run
 the `Update-TypeData` cmdlet. If you want the types in your file to take
 precedence over types in the built-in Types.ps1xml file, add the
 PrependData parameter of `Update-TypeData`. `Update-TypeData` affects only
@@ -589,7 +590,7 @@ To protect users of your Types.ps1xml file, you can sign the file using a
 digital signature. For more information, see
 [about_Signing](about_Signing.md).
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Signing](about_Signing.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -389,7 +389,7 @@ the script.
 
 The Online parameter does not work with About topics. To see the about topics
 for PowerShell Core, including help topics about the PowerShell language, see
-[Windows PowerShell Core Module About Topics](http://go.microsoft.com/fwlink/?LinkID=113206).
+[PowerShell Core Module About Topics](http://go.microsoft.com/fwlink/?LinkID=113206).
 
 ## HOW TO MINIMIZE OR PREVENT INTERNET DOWNLOADS
 
@@ -447,7 +447,7 @@ your modules. For more information, see "Supporting Updatable Help" and
 
 Updatable help not available for PowerShell snap-ins or comment-based help.
 
-# REMARKS
+## REMARKS
 
 The Update-Help and Save-Help cmdlets are not supported on Windows
 Preinstallation Environment (Windows PE).

--- a/reference/5.0/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/About_Using.md
@@ -8,11 +8,11 @@ title:  about_Using
 
 # About Using
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Allows to indicate which namespaces are used in the session.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 The `using` statement allows to indicate which namespaces are used in the
 session. Making easier to mention classes and members, as it requires less
@@ -35,7 +35,7 @@ using module <module-name>
 **Note**: The `using` statetement, for modules, is intended to surface the
 classes in the module. If the module isn't loaded, the `using` fails.
 
-## Example 1
+## Examples
 
 The following script gets the cryptographic hash for the "Hello World" string.
 
@@ -58,8 +58,6 @@ $hashfromstream = Get-FileHash -InputStream $memorystream `
   -Algorithm $algorithm
 $hashfromstream.Hash.ToString()
 ```
-
-## Example 2
 
 The following script assumes a module named 'CardGames' was loaded
 automatically.

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -16,7 +16,7 @@ Describes how to use operators to assign values to variables.
 Assignment operators assign one or more values to a variable. They can
 perform numeric operations on the values before the assignment.
 
-Windows PowerShell supports the following assignment operators.
+PowerShell supports the following assignment operators.
 
 |Operator|Description                                                  |
 |--------|-------------------------------------------------------------|
@@ -60,14 +60,14 @@ replace the existing value of the variable, or you can append a new value
 to the existing value.
 
 The basic assignment operator is the equal sign `=` `(ASCII 61)`. For
-example, the following statement assigns the value Windows PowerShell to
+example, the following statement assigns the value PowerShell to
 the $MyShell variable:
 
 ```powershell
-$MyShell = "Windows PowerShell"
+$MyShell = "PowerShell"
 ```
 
-When you assign a value to a variable in Windows PowerShell, the variable
+When you assign a value to a variable in PowerShell, the variable
 is created if it did not already exist. For example, the first of the
 following two assignement statements creates the $a variable and assigns a
 value of 6 to $a. The second assignment statement assigns a value of 12 to
@@ -79,7 +79,7 @@ $a = 6
 $a = 12
 ```
 
-Variables in Windows PowerShell do not have a specific data type unless you
+Variables in PowerShell do not have a specific data type unless you
 cast them. When a variable contains only one object, the variable takes the
 data type of that object. When a variable contains a collection of objects,
 the variable has the System.Object data type. Therefore, you can assign any
@@ -142,7 +142,7 @@ $a = "apple", "orange", "lemon", "grape"
 ```
 
 To assign a hash table to a variable, use the standard hash table notation
-in Windows PowerShell. Type an at sign `@` followed by key/value pairs that
+in PowerShell. Type an at sign `@` followed by key/value pairs that
 are separated by semicolons `;` and enclosed in braces `{ }`. For example,
 to assign a hash table to the $a variable, type:
 
@@ -151,7 +151,7 @@ $a = @{one=1; two=2; three=3}
 ```
 
 To assign hexadecimal values to a variable, precede the value with `0x`.
-Windows PowerShell converts the hexadecimal value (0x10) to a decimal value
+PowerShell converts the hexadecimal value (0x10) to a decimal value
 (in this case, 16) and assigns that value to the $a variable. For example,
 to assign a value of 0x10 to the $a variable, type:
 
@@ -167,7 +167,7 @@ assign a value of 3.1415 to the power of 1,000 to the $a variable, type:
 $a = 3.1415e3
 ```
 
-Windows PowerShell can also convert kilobytes `KB`, megabytes `MB`, and
+PowerShell can also convert kilobytes `KB`, megabytes `MB`, and
 gigabytes `GB` into bytes. For example, to assign a value of 10 kilobytes
 to the $a variable, type:
 
@@ -412,7 +412,7 @@ $a *= 2
 $a = ($a * 2)
 ```
 
-When a variable contains a string value, Windows PowerShell appends the
+When a variable contains a string value, PowerShell appends the
 specified number of strings to the value, as follows:
 
 ```powershell
@@ -499,7 +499,7 @@ $a
 3
 ```
 
-# THE INCREMENT AND DECREMENT OPERATORS
+## THE INCREMENT AND DECREMENT OPERATORS
 
 The increment operator `++` increases the value of a variable by 1. When
 you use the increment operator in a simple statement, no value is returned.
@@ -690,7 +690,7 @@ $a
 file3
 ```
 
-If the first value is an integer, Windows PowerShell treats all operations
+If the first value is an integer, PowerShell treats all operations
 as integer operations and casts new values to integers. This occurs in the
 following example:
 
@@ -754,7 +754,7 @@ In addition, when you precede a variable name with a data type, the type of
 that variable is locked unless you explicitly override the type by
 specifying another data type. If you try to assign a value that is
 incompatible with the existing type, and you do not explicitly override the
-type, Windows PowerShell displays an error, as shown in the following
+type, PowerShell displays an error, as shown in the following
 example:
 
 ```powershell
@@ -775,7 +775,7 @@ At line:1 char:3
 [string]$a = "string"
 ```
 
-In Windows PowerShell, the data types of variables that contain multiple
+In PowerShell, the data types of variables that contain multiple
 items in an array are handled differently from the data types of variables
 that contain a single item. Unless a data type is specifically assigned to
 an array variable, the data type is always `System.Object []`. This data
@@ -789,7 +789,7 @@ array type:
 [string []] $a = "one", "two", "three"
 ```
 
-Windows PowerShell variables can be any .NET Framework data type. In
+PowerShell variables can be any .NET Framework data type. In
 addition, you can assign any fully qualified .NET Framework data type that
 is available in the current process. For example, the following command
 specifies a `System.DateTime` data type:
@@ -806,9 +806,9 @@ following:
 Tuesday, May 31, 2005 12:00:00 AM
 ```
 
-# ASSIGNING MULTIPLE VARIABLES
+## ASSIGNING MULTIPLE VARIABLES
 
-In Windows PowerShell, you can assign values to multiple variables by using
+In PowerShell, you can assign values to multiple variables by using
 a single command. The first element of the assignment value is assigned to
 the first variable, the second element is assigned to the second variable,
 the third element to the third variable, and so on. For example, the
@@ -827,7 +827,7 @@ following command contains three variables and five values:
 $a, $b, $c = 1, 2, 3, 4, 5
 ```
 
-Therefore, Windows PowerShell assigns the value 1 to the $a variable and
+Therefore, PowerShell assigns the value 1 to the $a variable and
 the value 2 to the $b variable. It assigns the values 3, 4, and 5 to the $c
 variable. To assign the values in the $c variable to three other variables,
 use the following format:

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
@@ -7,18 +7,18 @@ title:  about_Command_Syntax
 
 # About Command Syntax
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
-Describes the syntax diagrams that are used in Windows PowerShell.
+Describes the syntax diagrams that are used in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 The [Get-Help](../../Microsoft.PowerShell.Core/Get-Help.md) and
 [Get-Command](../../Microsoft.PowerShell.Core/Get-Command.md) cmdlets display
 syntax diagrams to help you construct commands correctly. This topic
 explains how to interpret the syntax diagrams.
 
-# SYNTAX DIAGRAMS
+## SYNTAX DIAGRAMS
 
 Each paragraph in a command syntax diagram represents a valid form of the
 command.
@@ -26,7 +26,7 @@ command.
 To construct a command, follow the syntax diagram from left to right. Select
 from among the optional parameters and provide values for the placeholders.
 
-Windows PowerShell uses the following notation for syntax diagrams.
+PowerShell uses the following notation for syntax diagrams.
 
 ```powershell
 <command-name> -<Required Parameter Name> <Required Parameter Value>
@@ -44,7 +44,7 @@ New-Alias [-Name] <string> [-Value] <string> [-Description <string>]
 [-PassThru] [-Scope <string>] [-Confirm] [-WhatIf] [<CommonParameters>]
 ```
 
-The syntax is capitalized for readability, but Windows PowerShell is
+The syntax is capitalized for readability, but PowerShell is
 case-insensitive.
 
 The syntax diagram has the following elements.
@@ -63,8 +63,8 @@ For example, the `Get-Help` command has a **Name** parameter that lets you
 specify the name of the topic for which help is displayed. The topic name is
 the value of the **Name** parameter.
 
-In a Windows PowerShell command, parameter names always begin with a hyphen.
-The hyphen tells Windows PowerShell that the item in the command is a
+In a PowerShell command, parameter names always begin with a hyphen.
+The hyphen tells PowerShell that the item in the command is a
 parameter name.
 
 For example, to use the Name parameter of `New-Alias`, you type the following:
@@ -167,7 +167,7 @@ returns a random number.
 
 In each parameter set, the parameters appear in position order. The order of
 parameters in a command matters only when you omit the optional parameter
-names. When parameter names are omitted, Windows PowerShell assigns values to
+names. When parameter names are omitted, PowerShell assigns values to
 parameters by position and type. For more information about parameter
 position, see `about_Parameters`.
 
@@ -310,7 +310,7 @@ In syntax examples, brackets are also used in naming and casting to .NET
 Framework types. In this context, brackets do not indicate an element is
 optional.
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Parameters](about_Parameters.md)
 - [Get-Command](../../Microsoft.PowerShell.Core/Get-Command.md)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -8,14 +8,14 @@ title:  about_Data_Sections
 
 # About Data Sections
 
-### Short Description
+## Short Description
 
 Explains Data sections, which isolate text strings and other read-only
 data from script logic.
 
-### Long Description
+## Long Description
 
-Scripts that are designed for Windows PowerShell can have one or more
+Scripts that are designed for PowerShell can have one or more
 Data sections that contain only data. You can include one or more Data
 sections in any script, function, or advanced function. The content of
 the Data section is restricted to a specified subset of the Windows
@@ -26,7 +26,7 @@ both logic and data. It lets you have separate string resource files for
 text, such as error messages and Help strings. It also isolates the code
 logic, which facilitates security and validation tests.
 
-In Windows PowerShell, the Data section is used to support script
+In PowerShell, the Data section is used to support script
 internationalization. You can use Data sections to make it easier to
 isolate, locate, and process strings that will be translated into many
 user interface (UI) languages.
@@ -47,7 +47,7 @@ The Data keyword is required. It is not case-sensitive.
 
 The permitted content is limited to the following elements:
 
-- All Windows PowerShell operators, except `-match`
+- All PowerShell operators, except `-match`
 
 - `If`, `Else`, and `ElseIf` statements
 
@@ -157,7 +157,7 @@ Simple data strings.
 
 ```powershell
 DATA {
-    "Thank you for using my Windows PowerShell Organize.pst script."
+    "Thank you for using my PowerShell Organize.pst script."
     "It is provided free of charge to the community."
     "I appreciate your comments and feedback."
 }
@@ -203,7 +203,7 @@ DATA -supportedCommand Format-XML {
 }
 ```
 
-# See Also
+## See Also
 
 [about_Automatic_Variables](about_Automatic_Variables.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -8,13 +8,13 @@ title:  about_Functions
 
 # About Functions
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
-Describes how to create and use functions in Windows PowerShell.
+Describes how to create and use functions in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
-A function is a list of Windows PowerShell statements that has a name that you
+A function is a list of PowerShell statements that has a name that you
 assign. When you run a function, you type the function name. The statements in
 the list run as if you had typed them at the command prompt.
 
@@ -64,7 +64,7 @@ A function includes the following items:
 - A scope (optional)
 - A name that you select
 - Any number of named parameters (optional)
-- One or more Windows PowerShell commands enclosed in braces ({})
+- One or more PowerShell commands enclosed in braces ({})
 
 For more information about the Dynamicparam keyword and dynamic parameters in
 functions, see
@@ -79,7 +79,7 @@ have the following format:
 function <function-name> {statements}
 ```
 
-For example, the following function starts Windows PowerShell with the Run as
+For example, the following function starts PowerShell with the Run as
 Administrator option.
 
 ```powershell
@@ -99,26 +99,26 @@ function Get-NewPix
 {
   $start = Get-Date -Month 1 -Day 1 -Year 2010
   $allpix = Get-ChildItem -Path $env:UserProfile\*.jpg -Recurse
-  $allpix | where {$_.LastWriteTime -gt $Start}
+  $allpix | Where-Object {$_.LastWriteTime -gt $Start}
 }
 ```
 
 You can create a toolbox of useful small functions. Add these functions to
-your Windows PowerShell profile, as described in about_Profiles and later in
+your PowerShell profile, as described in about_Profiles and later in
 this topic.
 
 ### Function Names
 
 You can assign any name to a function, but functions that you share with
 others should follow the naming rules that have been established for all
-Windows PowerShell commands.
+PowerShell commands.
 
 Functions names should consist of a verb-noun pair in which the verb
 identifies the action that the function performs and the noun identifies the
 item on which the cmdlet performs its action.
 
 Functions should use the standard verbs that have been approved for all
-Windows PowerShell commands. These verbs help us to keep our command names
+PowerShell commands. These verbs help us to keep our command names
 simple, consistent, and easy for users to understand.
 
 For more information about the standard PowerShell verbs, see
@@ -169,7 +169,7 @@ value of the $size parameter, and it excludes directories:
 ```powershell
 function Get-SmallFiles {
   Param($Size)
-  Get-ChildItem $HOME | where {
+  Get-ChildItem $HOME | Where-Object {
     $_.Length -lt $Size -and !$_.PSIsContainer
   }
 }
@@ -198,7 +198,7 @@ Get-SmallFiles example:
 
 ```powershell
 function Get-SmallFiles ($Size = 100) {
-  Get-ChildItem $HOME | where {
+  Get-ChildItem $HOME | Where-Object {
     $_.Length -lt $Size -and !$_.PSIsContainer
   }
 }
@@ -248,7 +248,7 @@ function Get-Extension {
 ```
 
 ```powershell
-C:\PS> Get-Extension myTextFile
+PS> Get-Extension myTextFile
 myTextFile.txt
 ```
 
@@ -272,10 +272,10 @@ When you type the On switch parameter after the function name, the function
 displays "Switch on". Without the switch parameter, it displays "Switch off".
 
 ```powershell
-C:\PS> Switch-Item -on
+PS> Switch-Item -on
 Switch on
 
-C:\PS> Switch-Item
+PS> Switch-Item
 Switch off
 ```
 
@@ -283,10 +283,10 @@ You can also assign a Boolean value to a switch when you run the function, as
 shown in the following example:
 
 ```powershell
-C:\PS> Switch-Item -on:$true
+PS> Switch-Item -on:$true
 Switch on
 
-C:\PS> Switch-Item -on:$false
+PS> Switch-Item -on:$false
 Switch off
 ```
 
@@ -311,7 +311,7 @@ Get-MyCommand function. The parameters and parameter values are passed to the
 command using @Args.
 
 ```powershell
-PS C:> Get-MyCommand -Name Get-ChildItem
+PS> Get-MyCommand -Name Get-ChildItem
 CommandType     Name                ModuleName
 -----------     ----                ----------
 Cmdlet          Get-ChildItem       Microsoft.PowerShell.Management
@@ -360,7 +360,7 @@ To demonstrate this function, enter an list of numbers separated by commas, as
 shown in the following example:
 
 ```powershell
-C:\PS> 1,2,4 | Get-Pipeline
+PS> 1,2,4 | Get-Pipeline
 The value is: 1
 The value is: 2
 The value is: 4
@@ -387,7 +387,7 @@ If this function is run by using the pipeline, it displays the following
 results:
 
 ```powershell
-C:\PS> 1,2,4 | Get-PipelineBeginEnd
+PS> 1,2,4 | Get-PipelineBeginEnd
 Begin: The input is
 End:   The input is 1 2 4
 ```
@@ -412,7 +412,7 @@ at a time. The $input automatic variable is empty when the function reaches
 the End keyword.
 
 ```powershell
-C:\PS> 1,2,4 | Get-PipelineInput
+PS> 1,2,4 | Get-PipelineInput
 Processing:  1
 Processing:  2
 Processing:  4
@@ -436,7 +436,7 @@ either the whole entry or only the message portion of the entry:
 ```powershell
 filter Get-ErrorLog ([switch]$message)
 {
-  if ($message) { out-host -inputobject $_.Message }
+  if ($message) { Out-Host -InputObject $_.Message }
   else { $_ }
 }
 ```
@@ -454,7 +454,7 @@ the global scope in the following example:
 
 ```powershell
 function global:Get-DependentSvs {
-  Get-Service | where {$_.DependentServices}
+  Get-Service | Where-Object {$_.DependentServices}
 }
 ```
 
@@ -464,20 +464,20 @@ in functions, and at the command line.
 Functions normally create a scope. The items created in a function, such as
 variables, exist only in the function scope.
 
-For more information about scope in Windows PowerShell, see
+For more information about scope in PowerShell, see
 [about_Scopes](about_Scopes.md).
 
 ### Finding and Managing Functions Using the Function: Drive
 
-All the functions and filters in Windows PowerShell are automatically stored
-in the Function: drive. This drive is exposed by the Windows PowerShell
+All the functions and filters in PowerShell are automatically stored
+in the Function: drive. This drive is exposed by the PowerShell
 Function provider.
 
 When referring to the Function: drive, type a colon after Function, just as
 you would do when referencing the C or D drive of a computer.
 
 The following command displays all the functions in the current session of
-Windows PowerShell:
+PowerShell:
 
 ```powershell
 Get-ChildItem function:
@@ -485,7 +485,7 @@ Get-ChildItem function:
 
 The commands in the function are stored as a script block in the definition
 property of the function. For example, to display the commands in the Help
-function that comes with Windows PowerShell, type:
+function that comes with PowerShell, type:
 
 ```powershell
 (Get-ChildItem function:help).Definition
@@ -496,15 +496,15 @@ for the Function provider. Type `Get-Help Function`.
 
 ### Reusing Functions in New Sessions
 
-When you type a function at the Windows PowerShell command prompt, the
+When you type a function at the PowerShell command prompt, the
 function becomes part of the current session. It is available until the
 session ends.
 
-To use your function in all Windows PowerShell sessions, add the function
-to your Windows PowerShell profile. For more information about profiles,
+To use your function in all PowerShell sessions, add the function
+to your PowerShell profile. For more information about profiles,
 see [about_Profiles](about_Profiles.md).
 
-You can also save your function in a Windows PowerShell script file. Type your
+You can also save your function in a PowerShell script file. Type your
 function in a text file, and then save the file with the .ps1 file name
 extension.
 
@@ -547,7 +547,7 @@ methods:
   information about XML-based help, see [How to Write Cmdlet
   Help](https://go.microsoft.com/fwlink/?LinkID=123415) in the MSDN library.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Automatic_Variables](about_Automatic_Variables.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -8,11 +8,11 @@ title:  about_Functions_Advanced
 
 # About Functions Advanced
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Introduces advanced functions that act similar to cmdlets.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Advanced functions allow you to write functions that can perform operations
 that are similar to the operations you can perform with cmdlets. Advanced
@@ -25,7 +25,7 @@ compiled cmdlet.
 There is a difference between authoring a compiled cmdlet and an advanced
 function. Compiled cmdlets are .NET Framework classes that must be written in
 a .NET Framework language such as C#. In contrast, advanced functions are
-written in the Windows PowerShell script language in the same way that other
+written in the PowerShell script language in the same way that other
 functions or script blocks are written.
 
 Advanced functions use the CmdletBinding attribute to identify them as
@@ -51,7 +51,7 @@ function Send-Greeting
 
     Process
     {
-        write-host ("Hello " + $Name + "!")
+        Write-Host ("Hello " + $Name + "!")
     }
 }
 ```
@@ -79,7 +79,7 @@ Advanced functions differ from compiled cmdlets in the following ways:
 
 - Advanced functions cannot be used in transactions.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Functions](about_Functions.md)
 
@@ -91,4 +91,4 @@ Advanced functions differ from compiled cmdlets in the following ways:
 
 [about_Functions_OutputTypeAttribute](about_Functions_OutputTypeAttribute.md)
 
-[Windows PowerShell Cmdlets](http://go.microsoft.com/fwlink/?LinkID=135279)
+[PowerShell Cmdlets](http://go.microsoft.com/fwlink/?LinkID=135279)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -8,28 +8,28 @@ title:  about_Job_Details
 
 # About Job Details
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Provides details about background jobs on local and remote computers.
 
-# DETAILED DESCRIPTION
+## DETAILED DESCRIPTION
 
 This topic explains the concept of a background job and provides technical
-information about how background jobs work in Windows PowerShell.
+information about how background jobs work in PowerShell.
 
 This topic is a supplement to the [about_Jobs](about_Jobs.md) and
 [about_Remote_Jobs](about_Remote_Jobs.md) topics.
 
-# ABOUT BACKGROUND JOBS
+### ABOUT BACKGROUND JOBS
 
 A background job runs a command or expression asynchronously. It might run
 a cmdlet, a function, a script, or any other command-based task. It is
 designed to run commands that take an extended period of time, but you
 can use it to run any command in the background.
 
-When a synchronous command runs, the Windows PowerShell command prompt is
+When a synchronous command runs, the PowerShell command prompt is
 suppressed until the command is complete. But a background job does not
-suppress the Windows PowerShell prompt. A command to start a background job
+suppress the PowerShell prompt. A command to start a background job
 returns a job object. The prompt returns immediately so you can work on
 other tasks while the background job runs.
 
@@ -41,13 +41,13 @@ You can also run commands to stop the job, to wait for the job to be
 completed, and to delete the job.
 
 To make the timing of a background job independent of other commands, each
-background job runs in its own Windows PowerShell environment
+background job runs in its own PowerShell environment
 (a "session"). However, this can be a temporary connection that is created
 only to run the job and is then destroyed, or it can be a persistent
 session (a PSSession) that you can use to run several related jobs or
 commands.
 
-# USING THE JOB CMDLETS
+### USING THE JOB CMDLETS
 
 Use a Start-Job command to start a background job on a local computer.
 Start-Job returns a job object. You can also get objects representing the
@@ -64,7 +64,7 @@ the Remove-Job cmdlet.
 For more information about how the cmdlets work, see the Help topic for
 each cmdlet, and see about_Jobs.
 
-# STARTING BACKGROUND JOBS ON REMOTE COMPUTERS
+### STARTING BACKGROUND JOBS ON REMOTE COMPUTERS
 
 You can create and manage background jobs on a local or remote computer. To
 run a background job remotely, use the AsJob parameter of a cmdlet such as
@@ -74,7 +74,7 @@ session.
 
 For more information about remote background jobs, see about_Remote_Jobs.
 
-# CHILD JOBS
+### CHILD JOBS
 
 Each background job consists of a parent job and one or more child jobs. In
 jobs started by using Start-Job or the AsJob parameter of Invoke-Command,
@@ -93,7 +93,7 @@ parameter of the Get-Job cmdlet. The IncludeChildJob parameter is
 introduced in Windows PowerShell 3.0.
 
 ```powershell
-C:\PS> Get-Job -IncludeChildJob
+PS> Get-Job -IncludeChildJob
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -107,7 +107,7 @@ value, use the ChildJobState parameter of the Get-Job cmdlet. The
 ChildJobState parameter is introduced in Windows PowerShell 3.0.
 
 ```powershell
-C:\PS> Get-Job -ChildJobState Failed
+PS> Get-Job -ChildJobState Failed
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -115,11 +115,11 @@ Id Name   PSJobTypeName State      HasMoreData   Location    Command
 3  Job3                 Failed     False         localhost   Get-Process
 ```
 
-To get the child jobs of a job on all versions of Windows PowerShell,
+To get the child jobs of a job on all versions of PowerShell,
 use the ChildJob property of the parent job.
 
 ```powershell
-C:\PS> (Get-Job Job1).ChildJobs
+PS> (Get-Job Job1).ChildJobs
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -131,7 +131,7 @@ You can also use a Get-Job command on the child job, as shown in the
 following command:
 
 ```powershell
-C:\PS> Get-Job Job3
+PS> Get-Job Job3
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -168,7 +168,7 @@ background jobs on the local computer and two remote computers. The command
 saves the job in the \$j variable.
 
 ```powershell
-PS C:> $j = Invoke-Command -ComputerName localhost, Server01, Server02 `
+PS> $j = Invoke-Command -ComputerName localhost, Server01, Server02 `
 -Command {Get-Date} -AsJob
 ```
 
@@ -177,7 +177,7 @@ shows that the command returned a job object with three child jobs, one for
 each computer.
 
 ```powershell
-PS C:> $j | Format-List Name, ChildJobs
+PS> $j | Format-List Name, ChildJobs
 
 Name      : Job3
 ChildJobs : {Job4, Job5, Job6}
@@ -186,7 +186,7 @@ ChildJobs : {Job4, Job5, Job6}
 When you display the parent job, it shows that the job failed.
 
 ```powershell
-C:\PS> $j
+PS> $j
 
 Id Name   PSJobTypeName State      HasMoreData   Location
 -- ----   ------------- -----      -----------   --------
@@ -197,7 +197,7 @@ But when you run a Get-Job command that gets the child jobs, the output
 shows that only one child job failed.
 
 ```powershell
-PS C:> Get-Job -IncludeChildJobs
+PS> Get-Job -IncludeChildJobs
 
 Id  Name   PSJobTypeName State      HasMoreData   Location    Command
 --  ----   ------------- -----      -----------   --------    -------
@@ -212,47 +212,43 @@ the results of the parent job. But you can also get the results of a
 particular child job, as shown in the following command.
 
 ```powershell
-C:\PS> Receive-Job -Name Job6 -Keep | Format-Table ComputerName,
->> DateTime -Auto
-
+PS> Receive-Job -Name Job6 -Keep | Format-Table ComputerName,
+>> DateTime -AutoSize
 ComputerName DateTime
 ------------ --------
 Server02     Thursday, March 13, 2008 4:16:03 PM
 ```
 
-The child jobs feature of Windows PowerShell background jobs gives you
+The child jobs feature of PowerShell background jobs gives you
 more control over the jobs that you run.
 
-# JOB TYPES
+### JOB TYPES
 
+PowerShell supports different types of jobs for different tasks. Beginning in
+Windows PowerShell 3.0, developers can write "job source adapters" that add
+new job types to PowerShell and include the job source adapters in modules.
+When you import the module, you can use the new job type in your session.
 
-Windows PowerShell supports different types of jobs for different tasks.
-Beginning in Windows PowerShell 3.0, developers can write "job source
-adapters" that add new job types to Windows PowerShell and include the
-job source adapters in modules. When you import the module, you can
-use the new job type in your session.
+For example, the PSScheduledJob module adds scheduled jobs and the PSWorkflow
+module adds workflow jobs.
 
-For example, the PSScheduledJob module adds scheduled jobs and the
-PSWorkflow module adds workflow jobs.
+Custom jobs types might differ significantly from standard Windows PowerShell
+background jobs. For example, scheduled jobs are saved on disk; they do not
+exist only in a particular session. Workflow jobs can be suspended and
+resumed.
 
-Custom jobs types might differ significantly from standard Windows
-PowerShell background jobs. For example, scheduled jobs are saved
-on disk; they do not exist only in a particular session. Workflow
-jobs can be suspended and resumed.
+The cmdlets that you use to manage custom jobs depend on the job type. For
+some, you use the standard job cmdlets, such as Get-Job and Start-Job. Others
+come with specialized cmdlets that manage only a particular type of job. For
+detailed information about custom job types, see the help topics about the job
+type.
 
-The cmdlets that you use to manage custom jobs depend on the job
-type. For some, you use the standard job cmdlets, such as Get-Job
-and Start-Job. Others come with specialized cmdlets that manage
-only a particular type of job. For detailed information about
-custom job types, see the help topics about the job type.
+To find the job type of a job, use the Get-Job cmdlet. Get-Job returns
+different job objects for different types of jobs. The value of the
+PSJobTypeName property of the job objects that Get-Job returns indicates the
+job type.
 
-To find the job type of a job, use the Get-Job cmdlet. Get-Job
-returns different job objects for different types of jobs. The
-value of the PSJobTypeName property of the job objects that
-Get-Job returns indicates the job type.
-
-The following table lists the job types that come with Windows
-PowerShell.
+The following table lists the job types that come with PowerShell.
 
 |Job Type      |Description                                               |
 |--------------|----------------------------------------------------------|
@@ -272,7 +268,7 @@ NOTE: Before using the Get-Job cmdlet to get jobs of a particular type, verify
 that the module that adds the job type is imported into the current session.
 Otherwise, Get-Job does not get jobs of that type.
 
-# EXAMPLE
+## EXAMPLE
 
 The following commands create a local background job, a remote background job,
 a workflow job, and a scheduled job. Then, it uses the Get-Job cmdlet to get
@@ -282,7 +278,7 @@ instances of the scheduled job.
 Start a background job on the local computer.
 
 ```powershell
-PS C:> Start-Job -Name LocalData {Get-Process}
+PS> Start-Job -Name LocalData {Get-Process}
 
 Id Name        PSJobTypeName   State   HasMoreData   Location   Command
 -- ----        -------------   -----   -----------   --------   -------
@@ -292,7 +288,7 @@ Id Name        PSJobTypeName   State   HasMoreData   Location   Command
 Start a background job that runs on a remote computer.
 
 ```powershell
-PS C:> Invoke-Command -ComputerName Server01 {Get-Process} `
+PS> Invoke-Command -ComputerName Server01 {Get-Process} `
 -AsJob -JobName RemoteData
 
 Id  Name        PSJobTypeName  State   HasMoreData   Location   Command
@@ -301,8 +297,9 @@ Id  Name        PSJobTypeName  State   HasMoreData   Location   Command
 ```
 
 Create a scheduled job
+
 ```powershell
-PS C:>  Register-ScheduledJob -Name ScheduledJob -ScriptBlock `
+PS>  Register-ScheduledJob -Name ScheduledJob -ScriptBlock `
  {Get-Process} -Trigger (New-JobTrigger -Once -At "3 PM")
 
 Id         Name            JobTriggers     Command       Enabled
@@ -311,14 +308,16 @@ Id         Name            JobTriggers     Command       Enabled
 ```
 
 Create a workflow.
+
 ```powershell
-PS C:> workflow Test-Workflow {Get-Process}
+PS> workflow Test-Workflow {Get-Process}
 ```
 
 Run the workflow as a job.
+
 ```powershell
 
-PS C:> Test-Workflow -AsJob -JobName TestWFJob
+PS> Test-Workflow -AsJob -JobName TestWFJob
 
 Id  Name       PSJobTypeName   State   HasMoreData   Location   Command
 --  ----       -------------   -----   -----------   --------   -------
@@ -329,7 +328,7 @@ Get the jobs. The `Get-Job` command does not get scheduled jobs, but it gets
 instances of the scheduled job that are started.
 
 ```powershell
-PS C:> Get-Job
+PS> Get-Job
 
 Id  Name         PSJobTypeName  State     HasMoreData  Location  Command
 --  ----         -------------  -----     -----------  --------  -------
@@ -342,14 +341,14 @@ Id  Name         PSJobTypeName  State     HasMoreData  Location  Command
 To get scheduled jobs, use the Get-ScheduledJob cmdlet.
 
 ```powershell
-PS C:> Get-ScheduledJob
+PS> Get-ScheduledJob
 
 Id         Name            JobTriggers     Command       Enabled
 --         ----            -----------     -------       -------
 1          ScheduledJob    1               Get-Process   True
 ```
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Jobs](about_Jobs.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -61,7 +61,8 @@ In RestrictedLanguage language mode, users may run commands (cmdlets,
 functions, CIM commands, and workflows) but are not permitted to use script
 blocks.
 
-Only the following variables are permitted:
+By default, only the following variables are permitted in RestrictedLanguage
+language mode:
 
 - \$PSCulture
 - \$PSUICulture
@@ -240,14 +241,14 @@ NoLanguage session, PowerShell returns the ScriptsNotAllowed error message.
 - ScriptsNotAllowed: The syntax is not supported by this runspace. This
   might be because it is in no-language mode.
 
-# KEYWORDS
+## KEYWORDS
 
 - about_ConstrainedLanguage
 - about_FullLanguage
 - about_NoLanguage
 - about_RestrictedLanguage
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Session_Configuration_Files](about_Session_Configuration_Files.md)
 - [about_Session_Configurations](about_Session_Configurations.md)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -23,7 +23,8 @@ order is the order in which PowerShell evaluates the operators when
 multiple operators appear in the same expression.
 
 When operators have equal precedence, PowerShell evaluates them from
-left to right. The exceptions are the assignment operators, the cast
+left to right as they appear within the expression.
+The exceptions are the assignment operators, the cast
 operators, and the negation operators (!, -not, -bnot), which are evaluated
 from right to left.
 
@@ -41,7 +42,7 @@ the topic, type `get-help <topic-name>`.
 
 |OPERATOR                |REFERENCE|
 |------------------------|---------|
-|`$()  @()`              |[about_Operators](#index-operator)|
+|`$() @() ()`            |[about_Operators](about_Operators.md)|
 |`.` (dereference)       |[about_Operators](about_Operators.md)|
 |`::` (static)           |[about_Operators](about_Operators.md)|
 |`[0]` (index operator)  |[about_Operators](about_Operators.md)|
@@ -54,7 +55,9 @@ the topic, type `get-help <topic-name>`.
 |`! -bNot`               |[about_Comparison_Operators](about_Comparison_Operators.md)|
 |`..` (range operator)   |[about_Operators](about_Operators.md)|
 |`-f` (format operator)  |[about_Operators](about_Operators.md)|
-|`* / % + -`             |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`-` (unary/negative)    |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`* / %`                 |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`+ -`                   |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
 
 The following group of operators have equal precedence. Their case-sensitive
 and explicitly case-insensitive variants have the same precedence.
@@ -80,21 +83,21 @@ order:
 |`-and -or -xor`           |[about_Logical_Operators](about_logical_operators.md)|
 |`.` (dot-source)          |[about_Scopes](about_Scopes.md)|
 |`&` (call)                |[about_Operators](about_Operators.md)|
-|&#124; (pipeline operator)|[about_Operators](about_Operators.md)|
+|<code>&#124;</code> (pipeline operator)|[about_Operators](about_Operators.md)|
 |`> >> 2> 2>> 2>&1`        |[about_Redirection](about_Redirection.md)|
 |`= += -= *= /= %=`        |[about_Assignment_Operators](about_Assignment_Operators.md)|
 
-# EXAMPLES
+## EXAMPLES
 
 The following two commands show the arithmetic operators and the effect of
 using parentheses to force PowerShell to evaluate the enclosed part of
 the expression first.
 
 ```powershell
-C:\PS> 2 + 3 * 4
+PS> 2 + 3 * 4
 14
 
-C:\PS> (2 + 3) * 4
+PS> (2 + 3) * 4
 20
 ```
 
@@ -102,12 +105,13 @@ The following example gets the read-only text files from the local directory
 and saves them in the `$read_only` variable.
 
 ```powershell
-$read_only = get-childitem *.txt | where-object {$_.isReadOnly}
+$read_only = Get-ChildItem *.txt | Where-Object {$_.isReadOnly}
 ```
+
 It is equivalent to the following example.
 
 ```powershell
-$read_only = ( get-childitem *.txt | where-object {$_.isReadOnly} )
+$read_only = ( Get-ChildItem *.txt | Where-Object {$_.isReadOnly} )
 ```
 
 Because the pipeline operator (|) has a higher precedence than the assignment
@@ -124,7 +128,7 @@ which is the first string. Finally, it casts the selected object as a string.
 In this case, the cast has no effect.
 
 ```powershell
-C:\PS> [string]@('Windows','PowerShell','2.0')[0]
+PS> [string]@('Windows','PowerShell','2.0')[0]
 Windows
 ```
 
@@ -134,7 +138,7 @@ before the index selection. As a result, the entire array is cast as a
 array, which is the first character.
 
 ```powershell
-C:\PS> ([string]@('Windows','PowerShell','2.0'))[0]
+PS> ([string]@('Windows','PowerShell','2.0'))[0]
 W
 ```
 
@@ -143,21 +147,21 @@ precedence than the -and (logical AND) operator, the result of the expression
 is FALSE.
 
 ```powershell
-C:\PS> 2 -gt 4 -and 1
+PS> 2 -gt 4 -and 1
 False
 ```
 
 It is equivalent to the following expression.
 
 ```powershell
-C:\PS> (2 -gt 4) -and 1
+PS> (2 -gt 4) -and 1
 False
 ```
 
 If the -and operator had higher precedence, the answer would be TRUE.
 
 ```powershell
-C:\PS> 2 -gt (4 -and 1)
+PS> 2 -gt (4 -and 1)
 True
 ```
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -11,19 +11,19 @@ title:  about_Remote_Requirements
 ## SHORT DESCRIPTION
 
 Describes the system requirements and configuration requirements for running
-remote commands in Windows PowerShell.
+remote commands in PowerShell.
 
 ## LONG DESCRIPTION
 
 This topic describes the system requirements, user requirements, and resource
 requirements for establishing remote connections and running remote commands
-in Windows PowerShell. It also provides instructions for configuring remote
+in PowerShell. It also provides instructions for configuring remote
 operations.
 
 Note: Many cmdlets (including the Get-Service, Get-Process, Get-WMIObject,
 Get-EventLog, and Get-WinEvent cmdlets) get objects from remote computers by
 using Microsoft .NET Framework methods to retrieve the objects. They do not
-use the Windows PowerShell remoting infrastructure. The requirements in this
+use the PowerShell remoting infrastructure. The requirements in this
 document do not apply to these cmdlets.
 
 To find the cmdlets that have a ComputerName parameter but do not use Windows
@@ -51,7 +51,7 @@ You can create remote sessions between computers running Windows PowerShell
 PowerShell 3.0, such as the ability to disconnect and reconnect to sessions,
 are available only when both computers are running Windows PowerShell 3.0.
 
-To find the version number of an installed version of Windows PowerShell,
+To find the version number of an installed version of PowerShell,
 use the $PSVersionTable automatic variable.
 
 Windows Remote Management (WinRM) 3.0 and Microsoft .NET Framework 4 are
@@ -143,7 +143,7 @@ Administrator privileges are required for the following remoting operations:
 - Viewing and changing WS-Management settings on the local computer. These are
   the settings in the LocalHost node of the WSMAN: drive.
 
-To perform these tasks, you must start Windows PowerShell with the "Run as
+To perform these tasks, you must start PowerShell with the "Run as
 administrator" option even if you are a member of the Administrators group on
 the local computer.
 
@@ -170,28 +170,28 @@ the "Run as administrator" option to start the program.
 ## HOW TO CONFIGURE YOUR COMPUTER FOR REMOTING
 
 Computers running all supported versions of Windows can establish remote
-connections to and run remote commands in Windows PowerShell without any
+connections to and run remote commands in PowerShell without any
 configuration. However, to receive connections, and allow users to create
-local and remote user-managed Windows PowerShell sessions ("PSSessions") and
-run commands on the local computer, you must enable Windows PowerShell
+local and remote user-managed PowerShell sessions ("PSSessions") and
+run commands on the local computer, you must enable PowerShell
 remoting on the computer.
 
 Windows Server 2012 and newer releases of Windows Server are enabled for
-Windows PowerShell remoting by default. If the settings are changed, you can
+PowerShell remoting by default. If the settings are changed, you can
 restore the default settings by running the Enable-PSRemoting cmdlet.
 
 On all other supported versions of Windows, you need to run the
-Enable-PSRemoting cmdlet to enable Windows PowerShell remoting.
+Enable-PSRemoting cmdlet to enable PowerShell remoting.
 
-The remoting features of Windows PowerShell are supported by the WinRM
+The remoting features of PowerShell are supported by the WinRM
 service, which is the Microsoft implementation of the Web Services for
-Management (WS-Management) protocol. When you enable Windows PowerShell
+Management (WS-Management) protocol. When you enable PowerShell
 remoting, you change the default configuration of WS-Management and add system
 configuration that allow users to connect to WS-Management.
 
-To configure Windows PowerShell to receive remote commands:
+To configure PowerShell to receive remote commands:
 
-1. Start Windows PowerShell with the "Run as administrator" option.
+1. Start PowerShell with the "Run as administrator" option.
 2. At the command prompt, type: `Enable-PSRemoting`
 
 To verify that remoting is configured correctly, run a test command such as
@@ -216,16 +216,16 @@ If the command fails, for assistance, see
 
 ## UNDERSTAND POLICIES
 
-When you work remotely, you use two instances of Windows PowerShell, one on
+When you work remotely, you use two instances of PowerShell, one on
 the local computer and one on the remote computer. As a result, your work is
-affected by the Windows policies and the Windows PowerShell policies on the
+affected by the Windows policies and the PowerShell policies on the
 local and remote computers.
 
 In general, before you connect and as you are establishing the connection, the
 policies on the local computer are in effect. When you are using the
 connection, the policies on the remote computer are in effect.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Remote](about_Remote.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -10,15 +10,15 @@ title:  about_Remote_Troubleshooting
 
 ## SHORT DESCRIPTION
 
-Describes how to troubleshoot remote operations in Windows PowerShell.
+Describes how to troubleshoot remote operations in PowerShell.
 
 ## LONG DESCRIPTION
 
 This section describes some of the problems that you might encounter when
-using the remoting features of Windows PowerShell that are based on
+using the remoting features of PowerShell that are based on
 WS-Management technology and it suggests solutions to these problems.
 
-Before using Windows PowerShell remoting, see about_Remote and
+Before using PowerShell remoting, see about_Remote and
 about_Remote_Requirements for guidance on configuration and basic use Also,
 the Help topics for each of the remoting cmdlets, particularly the parameter
 descriptions, have useful information that is designed to help you avoid
@@ -26,7 +26,7 @@ problems.
 
 NOTE: To view or change settings for the local computer in the WSMan: drive,
 including changes to the session configurations, trusted hosts, ports, or
-listeners, start Windows PowerShell with the "Run as administrator" option.
+listeners, start PowerShell with the "Run as administrator" option.
 
 ## TROUBLESHOOTING PERMISSION AND AUTHENTICATION ISSUES
 
@@ -68,7 +68,7 @@ WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
 
 No configuration is required to enable a computer to send remote
-commands. However, to receive remote commands, Windows PowerShell remoting
+commands. However, to receive remote commands, PowerShell remoting
 must be enabled on the computer. Enabling includes starting the WinRM
 service, setting the startup type for the WinRM service to Automatic,
 creating listeners for HTTP and HTTPS connections, and creating default
@@ -103,7 +103,7 @@ ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
 
-To enable a single computer to receive remote Windows PowerShell commands
+To enable a single computer to receive remote PowerShell commands
 and accept connections, use the Enable-PSRemoting cmdlet.
 
 To enable remoting for multiple computers in an enterprise, you can use the
@@ -200,7 +200,7 @@ the Windows Remote Management service.
 
 ERROR:  ACCESS IS DENIED
 
-Windows PowerShell remoting depends upon the Windows Remote Management
+PowerShell remoting depends upon the Windows Remote Management
 (WinRM) service. The service must be running to support remote commands.
 
 On server versions of Windows, the startup type of the Windows Remote
@@ -529,9 +529,9 @@ ERROR: The client cannot connect to the destination specified in the
 request. Verify that the service on the destination is running and is
 accepting requests.
 
-Because Windows PowerShell remoting uses the HTTP protocol, it is affected
+Because PowerShell remoting uses the HTTP protocol, it is affected
 by HTTP proxy settings. In enterprises that have proxy servers, users
-cannot access a Windows PowerShell remote computer directly.
+cannot access a PowerShell remote computer directly.
 
 To resolve this problem, use proxy setting options in your remote command.
 The following settings are available:
@@ -569,9 +569,9 @@ the option object that New-PSSessionOption creates in the value of the
 $PSSessionOption preference variable. For more information about the
 $PSSessionOption preference variable, see about_Preference_Variables.
 
-To set these options for all remote commands all Windows PowerShell sessions
+To set these options for all remote commands all PowerShell sessions
 on the local computer, add the $PSSessionOption preference variable to your
-Windows PowerShell profile. For more information about Windows PowerShell
+PowerShell profile. For more information about PowerShell
 profiles, see about_Profiles.
 
 ### HOW TO DETECT A 32-BIT SESSION ON A 64-BIT COMPUTER
@@ -597,8 +597,8 @@ following command finds the processor architecture of the session in the
 \$s variable.
 
 ```powershell
-$s = New-PSSession -ComputerName Server01 -configurationName CustomShell
-invoke-command -session $s {$env:PROCESSOR_ARCHITECTURE}
+$s = New-PSSession -ComputerName Server01 -ConfigurationName CustomShell
+Invoke-Command -Session $s {$env:PROCESSOR_ARCHITECTURE}
 x86
 ```
 
@@ -629,7 +629,7 @@ process.
 
 For example, the following command starts a process with the RemoteSigned
 execution policy. The execution policy change affects only the current
-process and does not change the Windows PowerShell ExecutionPolicy registry
+process and does not change the PowerShell ExecutionPolicy registry
 setting.
 
 ```powershell
@@ -673,7 +673,7 @@ The following quotas are available in the basic configuration.
   MaximumReceivedObjectSizeMB parameters of the Register-PSSessionConfiguration
   cmdlet.
 
-When quotas conflict with a command, Windows PowerShell generates an error.
+When quotas conflict with a command, PowerShell generates an error.
 
 To resolve the error, change the remote command to comply with the quota.
 Or, determine the source of the quota, and then increase the quota to allow
@@ -701,7 +701,7 @@ the time specified in OperationTimeout.
 
 You can use timeouts to protect the local computer and the remote computer
 from excessive resource use, both accidental and malicious. When timeouts
-are set on both the local and remote computer, Windows PowerShell uses the
+are set on both the local and remote computer, PowerShell uses the
 shortest timeout settings.
 
 The following timeouts are available in the basic configuration.
@@ -745,13 +745,13 @@ New-PSSessionOption.
 ## TROUBLESHOOTING UNRESPONSIVE BEHAVIOR
 
 This section discusses remoting problems that prevent a command from completing
-and prevent or delay the return of the Windows PowerShell prompt.
+and prevent or delay the return of the PowerShell prompt.
 
 ### HOW TO INTERRUPT A COMMAND
 
 Some native Windows programs, such as programs with a user interface, console
 applications that prompt for input, and console applications that use the
-Win32 console API, do not work correctly in the Windows PowerShell remote host.
+Win32 console API, do not work correctly in the PowerShell remote host.
 
 When you use these programs, you might see unexpected behavior, such as no
 output, partial output, or a remote command that does not complete.
@@ -771,14 +771,14 @@ WinRM operations are in progress.
 To resolve this issue, verify that the WinRM service is running and try
 the command again.
 
-1. Start Windows PowerShell with the "Run as administrator" option.
+1. Start PowerShell with the "Run as administrator" option.
 2. Run the following command:
 
    Start-Service WinRM
 
 3. Re-run the command that generated the error.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Remote](about_Remote.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -16,22 +16,22 @@ policies.
 ## LONG DESCRIPTION
 
 The Restricted execution policy does not permit any scripts to run. The
-AllSigned and RemoteSigned execution policies prevent PowerShell from running
-scripts that do not have a digital signature.
+**AllSigned** and **RemoteSigned** execution policies prevent PowerShell from
+running scripts that do not have a digital signature.
 
 This topic explains how to run selected scripts that are not signed, even
-while the execution policy is RemoteSigned, and how to sign scripts for your
-own use.
+while the execution policy is **RemoteSigned**, and how to sign scripts for
+your own use.
 
 For more information about PowerShell execution policies, see
 [about_Execution_Policies](about_Execution_Policies.md).
 
 ## TO PERMIT SIGNED SCRIPTS TO RUN
 
-When you start PowerShell on a computer for the first time, the Restricted
+When you start PowerShell on a computer for the first time, the **Restricted**
 execution policy (the default) is likely to be in effect.
 
-The Restricted policy does not permit any scripts to run.
+The **Restricted** policy does not permit any scripts to run.
 
 To find the effective execution policy on your computer, type:
 
@@ -42,23 +42,22 @@ Get-ExecutionPolicy
 To run unsigned scripts that you write on your local computer and signed
 scripts from other users, start PowerShell with the Run as Administrator
 option and then use the following command to change the execution policy on
-the computer to RemoteSigned:
+the computer to **RemoteSigned**:
 
 ```powershell
 Set-ExecutionPolicy RemoteSigned
 ```
 
-For more information, see the help topic for the Set-ExecutionPolicy cmdlet.
+For more information, see the help topic for the `Set-ExecutionPolicy` cmdlet.
 
 ## RUNNING UNSIGNED SCRIPTS (REMOTESIGNED EXECUTION POLICY)
 
-If your PowerShell execution policy is RemoteSigned, Windows
-PowerShell will not run unsigned scripts that are downloaded from the
-Internet, including unsigned scripts you receive through e-mail and instant
-messaging programs.
+If your PowerShell execution policy is **RemoteSigned**, Windows PowerShell
+will not run unsigned scripts that are downloaded from the Internet, including
+unsigned scripts you receive through e-mail and instant messaging programs.
 
-If you try to run a downloaded script, PowerShell displays the
-following error message:
+If you try to run a downloaded script, PowerShell displays the following error
+message:
 
 ```output
 The file <file-name> cannot be loaded. The file <file-name> is not digitally
@@ -98,9 +97,9 @@ this publisher.
 
 ## METHODS OF SIGNING SCRIPTS
 
-You can sign the scripts that you write and the
-scripts that you obtain from other sources. Before you sign any script,
-examine each command to verify that it is safe to run.
+You can sign the scripts that you write and the scripts that you obtain from
+other sources. Before you sign any script, examine each command to verify that
+it is safe to run.
 
 For best practices about code signing, see
 [Code-Signing Best Practices](/previous-versions/windows/hardware/design/dn653556(v=vs.85)).
@@ -289,7 +288,7 @@ signed while the signing certificate was valid.
 Because most signing certificates are valid for one year only, using a time
 stamp server ensures that users can use your script for many years to come.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Execution_Policies](about_Execution_Policies.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -8,20 +8,20 @@ title:  about_Special_Characters
 
 # About Special Characters
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Describes the special characters that you can use to control how Windows
 PowerShell interprets the next character in a command or parameter.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
-Windows PowerShell supports a set of special character sequences that are used
+PowerShell supports a set of special character sequences that are used
 to represent characters that are not part of the standard character set.
 
-The special characters in Windows PowerShell begin with the backtick
+The special characters in PowerShell begin with the backtick
 character, also known as the grave accent (ASCII 96).
 
-The following special characters are recognized by Windows PowerShell:
+The following special characters are recognized by PowerShell:
 
 ```
 | Character | Description             |
@@ -29,10 +29,12 @@ The following special characters are recognized by Windows PowerShell:
 | `0        | Null                    |
 | `a        | Alert                   |
 | `b        | Backspace               |
+| `e        | Escape                  |
 | `f        | Form feed               |
 | `n        | New line                |
 | `r        | Carriage return         |
 | `t        | Horizontal tab          |
+| `u{x}     | Unicode escape sequence |
 | `v        | Vertical tab            |
 | --%       | Stop parsing            |
 ```
@@ -42,9 +44,9 @@ when used within double quoted (") strings.
 
 ## NULL (`0)
 
-Windows PowerShell recognizes a null special character (`0) and represents it
+PowerShell recognizes a null special character (`0) and represents it
 with a character code of 0. It appears as an empty space in the Windows
-PowerShell output. This allows you to use Windows PowerShell to read and
+PowerShell output. This allows you to use PowerShell to read and
 process text files that use null characters, such as string termination or
 record termination indicators. The null special character is not equivalent to
 the $null variable, which stores a value of NULL.
@@ -120,7 +122,7 @@ Delete everything before this point.
 ## HORIZONTAL TAB (`t)
 
 The horizontal tab character (`t) advances to the next tab stop and continues
-writing at that point. By default, the Windows PowerShell console has a tab
+writing at that point. By default, the PowerShell console has a tab
 stop at every eighth space.
 
 For example, the following command inserts two tabs between each column.
@@ -143,8 +145,8 @@ printed documents only. It does not affect screen output.
 
 ## STOP PARSING  (--%)
 
-The stop-parsing symbol (--%) prevents Windows PowerShell from interpreting
-arguments in program calls as Windows PowerShell commands and expressions.
+The stop-parsing symbol (--%) prevents PowerShell from interpreting
+arguments in program calls as PowerShell commands and expressions.
 
 Place the stop-parsing symbol after the program name and before program
 arguments that might cause errors.
@@ -155,7 +157,7 @@ For example, the following Icacls command uses the stop-parsing symbol.
 icacls X:\VMS --% /grant Dom\HVAdmin:(CI)(OI)F
 ```
 
-Windows PowerShell sends the following command to Icacls.
+PowerShell sends the following command to Icacls.
 
 ```output
 X:\VMS /grant Dom\HVAdmin:(CI)(OI)F
@@ -163,6 +165,6 @@ X:\VMS /grant Dom\HVAdmin:(CI)(OI)F
 
 For more information about the stop-parsing symbol, see [about_Parsing](about_Parsing.md).
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Quoting_Rules](about_Quoting_Rules.md)

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -20,10 +20,10 @@ administrator and the winner of the Advanced Division of the 2012 Scripting
 Games. Revised for Windows PowerShell 3.0.]
 
 Splatting is a method of passing a collection of parameter values to a command
-as unit. Windows PowerShell associates each value in the collection with a
+as unit. PowerShell associates each value in the collection with a
 command parameter. Splatted parameter values are stored in named splatting
 variables, which look like standard variables, but begin with an At symbol (@)
-instead of a dollar sign ($). The At symbol tells Windows PowerShell that you
+instead of a dollar sign ($). The At symbol tells PowerShell that you
 are passing a collection of values, instead of a single value.
 
 Splatting makes your commands shorter and easier to read. You can re-use the
@@ -85,7 +85,7 @@ Copy-Item @HashArguments
 ```
 
 Note: In the first command, the At symbol (@) indicates a hash table, not a
-splatted value. The syntax for hash tables in Windows PowerShell is:
+splatted value. The syntax for hash tables in PowerShell is:
 @{\<name\>=\<value\>; \<name\>=\<value\>; …}*
 
 ## SPLATTING WITH ARRAYS
@@ -281,7 +281,7 @@ FileVersionInfo    : File:             C:\Windows\System32\WindowsPowerShell
                      Language:         English (United States)
 ```
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Arrays](about_Arrays.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -8,20 +8,20 @@ title:  about_Types.ps1xml
 
 # About Types.ps1xml
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Explains how to use Types.ps1xml files to extend the types of objects
-that are used in Windows PowerShell.
+that are used in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Extended type data defines additional properties and methods ("members")
-of object types in Windows PowerShell. There are two techniques for adding
-extended type data to a Windows PowerShell session.
+of object types in PowerShell. There are two techniques for adding
+extended type data to a PowerShell session.
 
 - Types.ps1xml file: An XML file that defines extended type data.
 - `Update-TypeData`: A cmdlet that reloads Types.ps1xml files and defines
-extended data for types in the current session.
+  extended data for types in the current session.
 
 This topic describes Types.ps1xml files. For more information about using the
 `Update-TypeData` cmdlet to add dynamic extended type data to the current
@@ -31,11 +31,11 @@ session see
 ## About Extended Type Data
 
 Extended type data defines additional properties and methods ("members") of
-object types in Windows PowerShell. You can extend any type that is supported
-by Windows PowerShell and use the added properties and methods in the same way
+object types in PowerShell. You can extend any type that is supported
+by PowerShell and use the added properties and methods in the same way
 that you use the properties that are defined on the object types.
 
-For example, Windows PowerShell adds a `DateTime` property to all
+For example, PowerShell adds a `DateTime` property to all
 `System.DateTime` objects, such as the ones that the `Get-Date` cmdlet
 returns.
 
@@ -46,19 +46,19 @@ Sunday, January 29, 2012 9:43:57 AM
 
 You won't find the `DateTime` property in the description of the
 [`System.DateTime` structure](http://msdn.microsoft.com/library/system.datetime.aspx),
-because Windows PowerShell adds the property and it is visible only in Windows
+because PowerShell adds the property and it is visible only in Windows
 PowerShell.
 
-To add the `DateTime` property to all Windows PowerShell sessions, Windows
+To add the `DateTime` property to all PowerShell sessions, Windows
 PowerShell defines the `DateTime` property in the Types.ps1xml file in the
-Windows PowerShell installation directory (`$PSHOME`).
+PowerShell installation directory (`$PSHOME`).
 
-## Adding Extended Type Data to Windows PowerShell.
+## Adding Extended Type Data to PowerShell.
 
-There are three sources of extended type data in Windows PowerShell sessions.
+There are three sources of extended type data in PowerShell sessions.
 
-- The Types.ps1xml files in the Windows PowerShell installation directory
-  are loaded automatically into every Windows PowerShell session.
+- The Types.ps1xml files in the PowerShell installation directory
+  are loaded automatically into every PowerShell session.
 
 - The Types.ps1xml files that modules export are loaded when the module
   is imported into the current session.
@@ -73,7 +73,8 @@ types.
 ## The TypeData Cmdlets
 
 The following TypeData cmdlets are included in the Microsoft.PowerShell.Utility
-module in Windows PowerShell 3.0 and later versions of Windows PowerShell.
+module in Windows PowerShell 3.0 and later versions of Windows PowerShell
+and PowerShell Core.
 
 - `Get-TypeData`: Gets extended type data in the current session.
 - `Update-TypeData`: Reloads Types.ps1xml files. Adds extended type data to the
@@ -87,9 +88,9 @@ For more information about these cmdlets, see the help topic for each cmdlet.
 The Types.ps1xml files in the `$PSHOME` directory are added automatically to
 every session.
 
-The Types.ps1xml file in the Windows PowerShell installation directory
+The Types.ps1xml file in the PowerShell installation directory
 (`$PSHOME`) is an XML-based text file that lets you add properties and
-methods to the objects that are used in Windows PowerShell. Windows
+methods to the objects that are used in PowerShell. Windows
 PowerShell has built-in Types.ps1xml files that add several elements
 to the .NET Framework types, but you can create additional Types.ps1xml
 files to further extend the types.
@@ -136,7 +137,7 @@ Get        Method        System.Object Get(Int32)
 ```
 
 As a result, you can use either the Count property or the Length property
-of arrays in Windows PowerShell. For example:
+of arrays in PowerShell. For example:
 
 ```powershell
 C:\PS> (1, 2, 3, 4).count
@@ -150,32 +151,32 @@ C:\PS> (1, 2, 3, 4).length
 
 ## Creating New Types.ps1xml Files
 
-The .ps1xml files that are installed with Windows PowerShell are
+The .ps1xml files that are installed with PowerShell are
 digitally signed to prevent tampering because the formatting can include
 script blocks. Therefore, to add a property or method to a .NET Framework
 type, create your own Types.ps1xml files, and then add them to your
-Windows PowerShell session.
+PowerShell session.
 
 To create a new file, start by copying an existing Types.ps1xml file. The
 new file can have any name, but it must have a .ps1xml file name
 extension. You can place the new file in any directory that is accessible
-to Windows PowerShell, but it is useful to place the files in the Windows
+to PowerShell, but it is useful to place the files in the Windows
 PowerShell installation directory (`$PSHOME`) or in a subdirectory of the
 installation directory.
 
 When you have saved the new file, use the `Update-TypeData` cmdlet to add
-the new file to your Windows PowerShell session. If you want your types
+the new file to your PowerShell session. If you want your types
 to take precedence over the types that are defined in the built-in file,
 use the PrependData parameter of the `Update-TypeData` cmdlet.
 `Update-TypeData` affects only the current session. To make the change to
 all future sessions, export the console, or add the `Update-TypeData`
-command to your Windows PowerShell profile.
+command to your PowerShell profile.
 
 ## Types.ps1xml and Add-Member
 
 The Types.ps1xml files add properties and methods to all the instances
 of the objects of the specified .NET Framework type in the affected
-Windows PowerShell session. However, if you need to add properties or
+PowerShell session. However, if you need to add properties or
 methods only to one instance of an object, use the `Add-Member` cmdlet.
 
 For more information, see [Add-Member](../../Microsoft.PowerShell.Utility/Add-Member.md).
@@ -330,7 +331,7 @@ the name of the new method and a pair of `<GetCodeReference>` tags
 that specify the code in which the method is defined.
 
 For example, the Mode property of directories (`System.IO.DirectoryInfo`
-objects) is a code property defined in the Windows PowerShell
+objects) is a code property defined in the PowerShell
 FileSystem provider.
 
 ```xml
@@ -357,7 +358,7 @@ the name of the new property and a pair of `<GetCodeReference>` tags
 that specify the code in which the property is defined.
 
 For example, the `Mode` property of directories (`System.IO.DirectoryInfo`
-objects) is a code property defined in the Windows PowerShell
+objects) is a code property defined in the PowerShell
 FileSystem provider.
 
 ```xml
@@ -387,7 +388,7 @@ create a property (such as `<NoteProperty>` or `<ScriptProperty>`) or a
 method (such as `<Method>` or `<ScriptMethod>`) can be members of the set.
 
 In Types.ps1xml files, the `<MemberSet>` tag is used to define the
-default views of the .NET Framework objects in Windows PowerShell. In
+default views of the .NET Framework objects in PowerShell. In
 this case, the name of the member set (the value within the `<Name>`
 tags) is always "PsStandardMembers", and the names of the properties
 (the value of the `<Name>` tag) are one of the following:
@@ -397,8 +398,8 @@ tags) is always "PsStandardMembers", and the names of the properties
 - `DefaultDisplayPropertySet`: One or more properties of an object.
 
 - `DefaultKeyPropertySet`: One or more key properties of an object.
-A key property identifies instances of property values, such as
-the ID number of items in a session history.
+  A key property identifies instances of property values, such as
+  the ID number of items in a session history.
 
 For example, the following XML defines the default display of services
 (`System.ServiceProcess.ServiceController` objects) that are returned by
@@ -560,7 +561,7 @@ library](http://go.microsoft.com/fwlink/?LinkId=144538).
 
 ## `Update-TypeData`
 
-To load your Types.ps1xml files into a Windows PowerShell session, run
+To load your Types.ps1xml files into a PowerShell session, run
 the `Update-TypeData` cmdlet. If you want the types in your file to take
 precedence over types in the built-in Types.ps1xml file, add the
 PrependData parameter of `Update-TypeData`. `Update-TypeData` affects only
@@ -589,7 +590,7 @@ To protect users of your Types.ps1xml file, you can sign the file using a
 digital signature. For more information, see
 [about_Signing](about_Signing.md).
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Signing](about_Signing.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -389,7 +389,7 @@ the script.
 
 The Online parameter does not work with About topics. To see the about topics
 for PowerShell Core, including help topics about the PowerShell language, see
-[Windows PowerShell Core Module About Topics](http://go.microsoft.com/fwlink/?LinkID=113206).
+[PowerShell Core Module About Topics](http://go.microsoft.com/fwlink/?LinkID=113206).
 
 ## HOW TO MINIMIZE OR PREVENT INTERNET DOWNLOADS
 
@@ -447,7 +447,7 @@ your modules. For more information, see "Supporting Updatable Help" and
 
 Updatable help not available for PowerShell snap-ins or comment-based help.
 
-# REMARKS
+## REMARKS
 
 The Update-Help and Save-Help cmdlets are not supported on Windows
 Preinstallation Environment (Windows PE).

--- a/reference/5.1/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/About_Using.md
@@ -8,11 +8,11 @@ title:  about_Using
 
 # About Using
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Allows to indicate which namespaces are used in the session.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 The `using` statement allows to indicate which namespaces are used in the
 session. Making easier to mention classes and members, as it requires less
@@ -35,7 +35,7 @@ using module <module-name>
 **Note**: The `using` statetement, for modules, is intended to surface the
 classes in the module. If the module isn't loaded, the `using` fails.
 
-## Example 1
+## Examples
 
 The following script gets the cryptographic hash for the "Hello World" string.
 
@@ -58,8 +58,6 @@ $hashfromstream = Get-FileHash -InputStream $memorystream `
   -Algorithm $algorithm
 $hashfromstream.Hash.ToString()
 ```
-
-## Example 2
 
 The following script assumes a module named 'CardGames' was loaded
 automatically.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -16,7 +16,7 @@ Describes how to use operators to assign values to variables.
 Assignment operators assign one or more values to a variable. They can
 perform numeric operations on the values before the assignment.
 
-Windows PowerShell supports the following assignment operators.
+PowerShell supports the following assignment operators.
 
 |Operator|Description                                                  |
 |--------|-------------------------------------------------------------|
@@ -60,14 +60,14 @@ replace the existing value of the variable, or you can append a new value
 to the existing value.
 
 The basic assignment operator is the equal sign `=` `(ASCII 61)`. For
-example, the following statement assigns the value Windows PowerShell to
+example, the following statement assigns the value PowerShell to
 the $MyShell variable:
 
 ```powershell
-$MyShell = "Windows PowerShell"
+$MyShell = "PowerShell"
 ```
 
-When you assign a value to a variable in Windows PowerShell, the variable
+When you assign a value to a variable in PowerShell, the variable
 is created if it did not already exist. For example, the first of the
 following two assignement statements creates the $a variable and assigns a
 value of 6 to $a. The second assignment statement assigns a value of 12 to
@@ -79,7 +79,7 @@ $a = 6
 $a = 12
 ```
 
-Variables in Windows PowerShell do not have a specific data type unless you
+Variables in PowerShell do not have a specific data type unless you
 cast them. When a variable contains only one object, the variable takes the
 data type of that object. When a variable contains a collection of objects,
 the variable has the System.Object data type. Therefore, you can assign any
@@ -142,7 +142,7 @@ $a = "apple", "orange", "lemon", "grape"
 ```
 
 To assign a hash table to a variable, use the standard hash table notation
-in Windows PowerShell. Type an at sign `@` followed by key/value pairs that
+in PowerShell. Type an at sign `@` followed by key/value pairs that
 are separated by semicolons `;` and enclosed in braces `{ }`. For example,
 to assign a hash table to the $a variable, type:
 
@@ -151,7 +151,7 @@ $a = @{one=1; two=2; three=3}
 ```
 
 To assign hexadecimal values to a variable, precede the value with `0x`.
-Windows PowerShell converts the hexadecimal value (0x10) to a decimal value
+PowerShell converts the hexadecimal value (0x10) to a decimal value
 (in this case, 16) and assigns that value to the $a variable. For example,
 to assign a value of 0x10 to the $a variable, type:
 
@@ -167,7 +167,7 @@ assign a value of 3.1415 to the power of 1,000 to the $a variable, type:
 $a = 3.1415e3
 ```
 
-Windows PowerShell can also convert kilobytes `KB`, megabytes `MB`, and
+PowerShell can also convert kilobytes `KB`, megabytes `MB`, and
 gigabytes `GB` into bytes. For example, to assign a value of 10 kilobytes
 to the $a variable, type:
 
@@ -412,7 +412,7 @@ $a *= 2
 $a = ($a * 2)
 ```
 
-When a variable contains a string value, Windows PowerShell appends the
+When a variable contains a string value, PowerShell appends the
 specified number of strings to the value, as follows:
 
 ```powershell
@@ -499,7 +499,7 @@ $a
 3
 ```
 
-# THE INCREMENT AND DECREMENT OPERATORS
+## THE INCREMENT AND DECREMENT OPERATORS
 
 The increment operator `++` increases the value of a variable by 1. When
 you use the increment operator in a simple statement, no value is returned.
@@ -690,7 +690,7 @@ $a
 file3
 ```
 
-If the first value is an integer, Windows PowerShell treats all operations
+If the first value is an integer, PowerShell treats all operations
 as integer operations and casts new values to integers. This occurs in the
 following example:
 
@@ -754,7 +754,7 @@ In addition, when you precede a variable name with a data type, the type of
 that variable is locked unless you explicitly override the type by
 specifying another data type. If you try to assign a value that is
 incompatible with the existing type, and you do not explicitly override the
-type, Windows PowerShell displays an error, as shown in the following
+type, PowerShell displays an error, as shown in the following
 example:
 
 ```powershell
@@ -775,7 +775,7 @@ At line:1 char:3
 [string]$a = "string"
 ```
 
-In Windows PowerShell, the data types of variables that contain multiple
+In PowerShell, the data types of variables that contain multiple
 items in an array are handled differently from the data types of variables
 that contain a single item. Unless a data type is specifically assigned to
 an array variable, the data type is always `System.Object []`. This data
@@ -789,7 +789,7 @@ array type:
 [string []] $a = "one", "two", "three"
 ```
 
-Windows PowerShell variables can be any .NET Framework data type. In
+PowerShell variables can be any .NET Framework data type. In
 addition, you can assign any fully qualified .NET Framework data type that
 is available in the current process. For example, the following command
 specifies a `System.DateTime` data type:
@@ -806,9 +806,9 @@ following:
 Tuesday, May 31, 2005 12:00:00 AM
 ```
 
-# ASSIGNING MULTIPLE VARIABLES
+## ASSIGNING MULTIPLE VARIABLES
 
-In Windows PowerShell, you can assign values to multiple variables by using
+In PowerShell, you can assign values to multiple variables by using
 a single command. The first element of the assignment value is assigned to
 the first variable, the second element is assigned to the second variable,
 the third element to the third variable, and so on. For example, the
@@ -827,7 +827,7 @@ following command contains three variables and five values:
 $a, $b, $c = 1, 2, 3, 4, 5
 ```
 
-Therefore, Windows PowerShell assigns the value 1 to the $a variable and
+Therefore, PowerShell assigns the value 1 to the $a variable and
 the value 2 to the $b variable. It assigns the values 3, 4, and 5 to the $c
 variable. To assign the values in the $c variable to three other variables,
 use the following format:

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
@@ -7,18 +7,18 @@ title:  about_Command_Syntax
 
 # About Command Syntax
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
-Describes the syntax diagrams that are used in Windows PowerShell.
+Describes the syntax diagrams that are used in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 The [Get-Help](../../Microsoft.PowerShell.Core/Get-Help.md) and
 [Get-Command](../../Microsoft.PowerShell.Core/Get-Command.md) cmdlets display
 syntax diagrams to help you construct commands correctly. This topic
 explains how to interpret the syntax diagrams.
 
-# SYNTAX DIAGRAMS
+## SYNTAX DIAGRAMS
 
 Each paragraph in a command syntax diagram represents a valid form of the
 command.
@@ -26,7 +26,7 @@ command.
 To construct a command, follow the syntax diagram from left to right. Select
 from among the optional parameters and provide values for the placeholders.
 
-Windows PowerShell uses the following notation for syntax diagrams.
+PowerShell uses the following notation for syntax diagrams.
 
 ```powershell
 <command-name> -<Required Parameter Name> <Required Parameter Value>
@@ -44,7 +44,7 @@ New-Alias [-Name] <string> [-Value] <string> [-Description <string>]
 [-PassThru] [-Scope <string>] [-Confirm] [-WhatIf] [<CommonParameters>]
 ```
 
-The syntax is capitalized for readability, but Windows PowerShell is
+The syntax is capitalized for readability, but PowerShell is
 case-insensitive.
 
 The syntax diagram has the following elements.
@@ -63,8 +63,8 @@ For example, the `Get-Help` command has a **Name** parameter that lets you
 specify the name of the topic for which help is displayed. The topic name is
 the value of the **Name** parameter.
 
-In a Windows PowerShell command, parameter names always begin with a hyphen.
-The hyphen tells Windows PowerShell that the item in the command is a
+In a PowerShell command, parameter names always begin with a hyphen.
+The hyphen tells PowerShell that the item in the command is a
 parameter name.
 
 For example, to use the Name parameter of `New-Alias`, you type the following:
@@ -167,7 +167,7 @@ returns a random number.
 
 In each parameter set, the parameters appear in position order. The order of
 parameters in a command matters only when you omit the optional parameter
-names. When parameter names are omitted, Windows PowerShell assigns values to
+names. When parameter names are omitted, PowerShell assigns values to
 parameters by position and type. For more information about parameter
 position, see `about_Parameters`.
 
@@ -310,7 +310,7 @@ In syntax examples, brackets are also used in naming and casting to .NET
 Framework types. In this context, brackets do not indicate an element is
 optional.
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Parameters](about_Parameters.md)
 - [Get-Command](../../Microsoft.PowerShell.Core/Get-Command.md)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -8,14 +8,14 @@ title:  about_Data_Sections
 
 # About Data Sections
 
-### Short Description
+## Short Description
 
 Explains Data sections, which isolate text strings and other read-only
 data from script logic.
 
-### Long Description
+## Long Description
 
-Scripts that are designed for Windows PowerShell can have one or more
+Scripts that are designed for PowerShell can have one or more
 Data sections that contain only data. You can include one or more Data
 sections in any script, function, or advanced function. The content of
 the Data section is restricted to a specified subset of the Windows
@@ -26,7 +26,7 @@ both logic and data. It lets you have separate string resource files for
 text, such as error messages and Help strings. It also isolates the code
 logic, which facilitates security and validation tests.
 
-In Windows PowerShell, the Data section is used to support script
+In PowerShell, the Data section is used to support script
 internationalization. You can use Data sections to make it easier to
 isolate, locate, and process strings that will be translated into many
 user interface (UI) languages.
@@ -47,7 +47,7 @@ The Data keyword is required. It is not case-sensitive.
 
 The permitted content is limited to the following elements:
 
-- All Windows PowerShell operators, except `-match`
+- All PowerShell operators, except `-match`
 
 - `If`, `Else`, and `ElseIf` statements
 
@@ -157,7 +157,7 @@ Simple data strings.
 
 ```powershell
 DATA {
-    "Thank you for using my Windows PowerShell Organize.pst script."
+    "Thank you for using my PowerShell Organize.pst script."
     "It is provided free of charge to the community."
     "I appreciate your comments and feedback."
 }
@@ -203,7 +203,7 @@ DATA -supportedCommand Format-XML {
 }
 ```
 
-# See Also
+## See Also
 
 [about_Automatic_Variables](about_Automatic_Variables.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -8,13 +8,13 @@ title:  about_Functions
 
 # About Functions
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
-Describes how to create and use functions in Windows PowerShell.
+Describes how to create and use functions in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
-A function is a list of Windows PowerShell statements that has a name that you
+A function is a list of PowerShell statements that has a name that you
 assign. When you run a function, you type the function name. The statements in
 the list run as if you had typed them at the command prompt.
 
@@ -64,7 +64,7 @@ A function includes the following items:
 - A scope (optional)
 - A name that you select
 - Any number of named parameters (optional)
-- One or more Windows PowerShell commands enclosed in braces ({})
+- One or more PowerShell commands enclosed in braces ({})
 
 For more information about the Dynamicparam keyword and dynamic parameters in
 functions, see
@@ -79,7 +79,7 @@ have the following format:
 function <function-name> {statements}
 ```
 
-For example, the following function starts Windows PowerShell with the Run as
+For example, the following function starts PowerShell with the Run as
 Administrator option.
 
 ```powershell
@@ -99,26 +99,26 @@ function Get-NewPix
 {
   $start = Get-Date -Month 1 -Day 1 -Year 2010
   $allpix = Get-ChildItem -Path $env:UserProfile\*.jpg -Recurse
-  $allpix | where {$_.LastWriteTime -gt $Start}
+  $allpix | Where-Object {$_.LastWriteTime -gt $Start}
 }
 ```
 
 You can create a toolbox of useful small functions. Add these functions to
-your Windows PowerShell profile, as described in about_Profiles and later in
+your PowerShell profile, as described in about_Profiles and later in
 this topic.
 
 ### Function Names
 
 You can assign any name to a function, but functions that you share with
 others should follow the naming rules that have been established for all
-Windows PowerShell commands.
+PowerShell commands.
 
 Functions names should consist of a verb-noun pair in which the verb
 identifies the action that the function performs and the noun identifies the
 item on which the cmdlet performs its action.
 
 Functions should use the standard verbs that have been approved for all
-Windows PowerShell commands. These verbs help us to keep our command names
+PowerShell commands. These verbs help us to keep our command names
 simple, consistent, and easy for users to understand.
 
 For more information about the standard PowerShell verbs, see
@@ -169,7 +169,7 @@ value of the $size parameter, and it excludes directories:
 ```powershell
 function Get-SmallFiles {
   Param($Size)
-  Get-ChildItem $HOME | where {
+  Get-ChildItem $HOME | Where-Object {
     $_.Length -lt $Size -and !$_.PSIsContainer
   }
 }
@@ -198,7 +198,7 @@ Get-SmallFiles example:
 
 ```powershell
 function Get-SmallFiles ($Size = 100) {
-  Get-ChildItem $HOME | where {
+  Get-ChildItem $HOME | Where-Object {
     $_.Length -lt $Size -and !$_.PSIsContainer
   }
 }
@@ -248,7 +248,7 @@ function Get-Extension {
 ```
 
 ```powershell
-C:\PS> Get-Extension myTextFile
+PS> Get-Extension myTextFile
 myTextFile.txt
 ```
 
@@ -272,10 +272,10 @@ When you type the On switch parameter after the function name, the function
 displays "Switch on". Without the switch parameter, it displays "Switch off".
 
 ```powershell
-C:\PS> Switch-Item -on
+PS> Switch-Item -on
 Switch on
 
-C:\PS> Switch-Item
+PS> Switch-Item
 Switch off
 ```
 
@@ -283,10 +283,10 @@ You can also assign a Boolean value to a switch when you run the function, as
 shown in the following example:
 
 ```powershell
-C:\PS> Switch-Item -on:$true
+PS> Switch-Item -on:$true
 Switch on
 
-C:\PS> Switch-Item -on:$false
+PS> Switch-Item -on:$false
 Switch off
 ```
 
@@ -311,7 +311,7 @@ Get-MyCommand function. The parameters and parameter values are passed to the
 command using @Args.
 
 ```powershell
-PS C:> Get-MyCommand -Name Get-ChildItem
+PS> Get-MyCommand -Name Get-ChildItem
 CommandType     Name                ModuleName
 -----------     ----                ----------
 Cmdlet          Get-ChildItem       Microsoft.PowerShell.Management
@@ -360,7 +360,7 @@ To demonstrate this function, enter an list of numbers separated by commas, as
 shown in the following example:
 
 ```powershell
-C:\PS> 1,2,4 | Get-Pipeline
+PS> 1,2,4 | Get-Pipeline
 The value is: 1
 The value is: 2
 The value is: 4
@@ -387,7 +387,7 @@ If this function is run by using the pipeline, it displays the following
 results:
 
 ```powershell
-C:\PS> 1,2,4 | Get-PipelineBeginEnd
+PS> 1,2,4 | Get-PipelineBeginEnd
 Begin: The input is
 End:   The input is 1 2 4
 ```
@@ -412,7 +412,7 @@ at a time. The $input automatic variable is empty when the function reaches
 the End keyword.
 
 ```powershell
-C:\PS> 1,2,4 | Get-PipelineInput
+PS> 1,2,4 | Get-PipelineInput
 Processing:  1
 Processing:  2
 Processing:  4
@@ -436,7 +436,7 @@ either the whole entry or only the message portion of the entry:
 ```powershell
 filter Get-ErrorLog ([switch]$message)
 {
-  if ($message) { out-host -inputobject $_.Message }
+  if ($message) { Out-Host -InputObject $_.Message }
   else { $_ }
 }
 ```
@@ -454,7 +454,7 @@ the global scope in the following example:
 
 ```powershell
 function global:Get-DependentSvs {
-  Get-Service | where {$_.DependentServices}
+  Get-Service | Where-Object {$_.DependentServices}
 }
 ```
 
@@ -464,20 +464,20 @@ in functions, and at the command line.
 Functions normally create a scope. The items created in a function, such as
 variables, exist only in the function scope.
 
-For more information about scope in Windows PowerShell, see
+For more information about scope in PowerShell, see
 [about_Scopes](about_Scopes.md).
 
 ### Finding and Managing Functions Using the Function: Drive
 
-All the functions and filters in Windows PowerShell are automatically stored
-in the Function: drive. This drive is exposed by the Windows PowerShell
+All the functions and filters in PowerShell are automatically stored
+in the Function: drive. This drive is exposed by the PowerShell
 Function provider.
 
 When referring to the Function: drive, type a colon after Function, just as
 you would do when referencing the C or D drive of a computer.
 
 The following command displays all the functions in the current session of
-Windows PowerShell:
+PowerShell:
 
 ```powershell
 Get-ChildItem function:
@@ -485,7 +485,7 @@ Get-ChildItem function:
 
 The commands in the function are stored as a script block in the definition
 property of the function. For example, to display the commands in the Help
-function that comes with Windows PowerShell, type:
+function that comes with PowerShell, type:
 
 ```powershell
 (Get-ChildItem function:help).Definition
@@ -496,15 +496,15 @@ for the Function provider. Type `Get-Help Function`.
 
 ### Reusing Functions in New Sessions
 
-When you type a function at the Windows PowerShell command prompt, the
+When you type a function at the PowerShell command prompt, the
 function becomes part of the current session. It is available until the
 session ends.
 
-To use your function in all Windows PowerShell sessions, add the function
-to your Windows PowerShell profile. For more information about profiles,
+To use your function in all PowerShell sessions, add the function
+to your PowerShell profile. For more information about profiles,
 see [about_Profiles](about_Profiles.md).
 
-You can also save your function in a Windows PowerShell script file. Type your
+You can also save your function in a PowerShell script file. Type your
 function in a text file, and then save the file with the .ps1 file name
 extension.
 
@@ -547,7 +547,7 @@ methods:
   information about XML-based help, see [How to Write Cmdlet
   Help](https://go.microsoft.com/fwlink/?LinkID=123415) in the MSDN library.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Automatic_Variables](about_Automatic_Variables.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -8,11 +8,11 @@ title:  about_Functions_Advanced
 
 # About Functions Advanced
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Introduces advanced functions that act similar to cmdlets.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Advanced functions allow you to write functions that can perform operations
 that are similar to the operations you can perform with cmdlets. Advanced
@@ -25,7 +25,7 @@ compiled cmdlet.
 There is a difference between authoring a compiled cmdlet and an advanced
 function. Compiled cmdlets are .NET Framework classes that must be written in
 a .NET Framework language such as C#. In contrast, advanced functions are
-written in the Windows PowerShell script language in the same way that other
+written in the PowerShell script language in the same way that other
 functions or script blocks are written.
 
 Advanced functions use the CmdletBinding attribute to identify them as
@@ -51,7 +51,7 @@ function Send-Greeting
 
     Process
     {
-        write-host ("Hello " + $Name + "!")
+        Write-Host ("Hello " + $Name + "!")
     }
 }
 ```
@@ -79,7 +79,7 @@ Advanced functions differ from compiled cmdlets in the following ways:
 
 - Advanced functions cannot be used in transactions.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Functions](about_Functions.md)
 
@@ -91,4 +91,4 @@ Advanced functions differ from compiled cmdlets in the following ways:
 
 [about_Functions_OutputTypeAttribute](about_Functions_OutputTypeAttribute.md)
 
-[Windows PowerShell Cmdlets](http://go.microsoft.com/fwlink/?LinkID=135279)
+[PowerShell Cmdlets](http://go.microsoft.com/fwlink/?LinkID=135279)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -8,28 +8,28 @@ title:  about_Job_Details
 
 # About Job Details
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Provides details about background jobs on local and remote computers.
 
-# DETAILED DESCRIPTION
+## DETAILED DESCRIPTION
 
 This topic explains the concept of a background job and provides technical
-information about how background jobs work in Windows PowerShell.
+information about how background jobs work in PowerShell.
 
 This topic is a supplement to the [about_Jobs](about_Jobs.md) and
 [about_Remote_Jobs](about_Remote_Jobs.md) topics.
 
-# ABOUT BACKGROUND JOBS
+### ABOUT BACKGROUND JOBS
 
 A background job runs a command or expression asynchronously. It might run
 a cmdlet, a function, a script, or any other command-based task. It is
 designed to run commands that take an extended period of time, but you
 can use it to run any command in the background.
 
-When a synchronous command runs, the Windows PowerShell command prompt is
+When a synchronous command runs, the PowerShell command prompt is
 suppressed until the command is complete. But a background job does not
-suppress the Windows PowerShell prompt. A command to start a background job
+suppress the PowerShell prompt. A command to start a background job
 returns a job object. The prompt returns immediately so you can work on
 other tasks while the background job runs.
 
@@ -41,13 +41,13 @@ You can also run commands to stop the job, to wait for the job to be
 completed, and to delete the job.
 
 To make the timing of a background job independent of other commands, each
-background job runs in its own Windows PowerShell environment
+background job runs in its own PowerShell environment
 (a "session"). However, this can be a temporary connection that is created
 only to run the job and is then destroyed, or it can be a persistent
 session (a PSSession) that you can use to run several related jobs or
 commands.
 
-# USING THE JOB CMDLETS
+### USING THE JOB CMDLETS
 
 Use a Start-Job command to start a background job on a local computer.
 Start-Job returns a job object. You can also get objects representing the
@@ -64,7 +64,7 @@ the Remove-Job cmdlet.
 For more information about how the cmdlets work, see the Help topic for
 each cmdlet, and see about_Jobs.
 
-# STARTING BACKGROUND JOBS ON REMOTE COMPUTERS
+### STARTING BACKGROUND JOBS ON REMOTE COMPUTERS
 
 You can create and manage background jobs on a local or remote computer. To
 run a background job remotely, use the AsJob parameter of a cmdlet such as
@@ -74,7 +74,7 @@ session.
 
 For more information about remote background jobs, see about_Remote_Jobs.
 
-# CHILD JOBS
+### CHILD JOBS
 
 Each background job consists of a parent job and one or more child jobs. In
 jobs started by using Start-Job or the AsJob parameter of Invoke-Command,
@@ -93,7 +93,7 @@ parameter of the Get-Job cmdlet. The IncludeChildJob parameter is
 introduced in Windows PowerShell 3.0.
 
 ```powershell
-C:\PS> Get-Job -IncludeChildJob
+PS> Get-Job -IncludeChildJob
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -107,7 +107,7 @@ value, use the ChildJobState parameter of the Get-Job cmdlet. The
 ChildJobState parameter is introduced in Windows PowerShell 3.0.
 
 ```powershell
-C:\PS> Get-Job -ChildJobState Failed
+PS> Get-Job -ChildJobState Failed
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -115,11 +115,11 @@ Id Name   PSJobTypeName State      HasMoreData   Location    Command
 3  Job3                 Failed     False         localhost   Get-Process
 ```
 
-To get the child jobs of a job on all versions of Windows PowerShell,
+To get the child jobs of a job on all versions of PowerShell,
 use the ChildJob property of the parent job.
 
 ```powershell
-C:\PS> (Get-Job Job1).ChildJobs
+PS> (Get-Job Job1).ChildJobs
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -131,7 +131,7 @@ You can also use a Get-Job command on the child job, as shown in the
 following command:
 
 ```powershell
-C:\PS> Get-Job Job3
+PS> Get-Job Job3
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -168,7 +168,7 @@ background jobs on the local computer and two remote computers. The command
 saves the job in the \$j variable.
 
 ```powershell
-PS C:> $j = Invoke-Command -ComputerName localhost, Server01, Server02 `
+PS> $j = Invoke-Command -ComputerName localhost, Server01, Server02 `
 -Command {Get-Date} -AsJob
 ```
 
@@ -177,7 +177,7 @@ shows that the command returned a job object with three child jobs, one for
 each computer.
 
 ```powershell
-PS C:> $j | Format-List Name, ChildJobs
+PS> $j | Format-List Name, ChildJobs
 
 Name      : Job3
 ChildJobs : {Job4, Job5, Job6}
@@ -186,7 +186,7 @@ ChildJobs : {Job4, Job5, Job6}
 When you display the parent job, it shows that the job failed.
 
 ```powershell
-C:\PS> $j
+PS> $j
 
 Id Name   PSJobTypeName State      HasMoreData   Location
 -- ----   ------------- -----      -----------   --------
@@ -197,7 +197,7 @@ But when you run a Get-Job command that gets the child jobs, the output
 shows that only one child job failed.
 
 ```powershell
-PS C:> Get-Job -IncludeChildJobs
+PS> Get-Job -IncludeChildJobs
 
 Id  Name   PSJobTypeName State      HasMoreData   Location    Command
 --  ----   ------------- -----      -----------   --------    -------
@@ -212,47 +212,43 @@ the results of the parent job. But you can also get the results of a
 particular child job, as shown in the following command.
 
 ```powershell
-C:\PS> Receive-Job -Name Job6 -Keep | Format-Table ComputerName,
->> DateTime -Auto
-
+PS> Receive-Job -Name Job6 -Keep | Format-Table ComputerName,
+>> DateTime -AutoSize
 ComputerName DateTime
 ------------ --------
 Server02     Thursday, March 13, 2008 4:16:03 PM
 ```
 
-The child jobs feature of Windows PowerShell background jobs gives you
+The child jobs feature of PowerShell background jobs gives you
 more control over the jobs that you run.
 
-# JOB TYPES
+### JOB TYPES
 
+PowerShell supports different types of jobs for different tasks. Beginning in
+Windows PowerShell 3.0, developers can write "job source adapters" that add
+new job types to PowerShell and include the job source adapters in modules.
+When you import the module, you can use the new job type in your session.
 
-Windows PowerShell supports different types of jobs for different tasks.
-Beginning in Windows PowerShell 3.0, developers can write "job source
-adapters" that add new job types to Windows PowerShell and include the
-job source adapters in modules. When you import the module, you can
-use the new job type in your session.
+For example, the PSScheduledJob module adds scheduled jobs and the PSWorkflow
+module adds workflow jobs.
 
-For example, the PSScheduledJob module adds scheduled jobs and the
-PSWorkflow module adds workflow jobs.
+Custom jobs types might differ significantly from standard Windows PowerShell
+background jobs. For example, scheduled jobs are saved on disk; they do not
+exist only in a particular session. Workflow jobs can be suspended and
+resumed.
 
-Custom jobs types might differ significantly from standard Windows
-PowerShell background jobs. For example, scheduled jobs are saved
-on disk; they do not exist only in a particular session. Workflow
-jobs can be suspended and resumed.
+The cmdlets that you use to manage custom jobs depend on the job type. For
+some, you use the standard job cmdlets, such as Get-Job and Start-Job. Others
+come with specialized cmdlets that manage only a particular type of job. For
+detailed information about custom job types, see the help topics about the job
+type.
 
-The cmdlets that you use to manage custom jobs depend on the job
-type. For some, you use the standard job cmdlets, such as Get-Job
-and Start-Job. Others come with specialized cmdlets that manage
-only a particular type of job. For detailed information about
-custom job types, see the help topics about the job type.
+To find the job type of a job, use the Get-Job cmdlet. Get-Job returns
+different job objects for different types of jobs. The value of the
+PSJobTypeName property of the job objects that Get-Job returns indicates the
+job type.
 
-To find the job type of a job, use the Get-Job cmdlet. Get-Job
-returns different job objects for different types of jobs. The
-value of the PSJobTypeName property of the job objects that
-Get-Job returns indicates the job type.
-
-The following table lists the job types that come with Windows
-PowerShell.
+The following table lists the job types that come with PowerShell.
 
 |Job Type      |Description                                               |
 |--------------|----------------------------------------------------------|
@@ -272,7 +268,7 @@ NOTE: Before using the Get-Job cmdlet to get jobs of a particular type, verify
 that the module that adds the job type is imported into the current session.
 Otherwise, Get-Job does not get jobs of that type.
 
-# EXAMPLE
+## EXAMPLE
 
 The following commands create a local background job, a remote background job,
 a workflow job, and a scheduled job. Then, it uses the Get-Job cmdlet to get
@@ -282,7 +278,7 @@ instances of the scheduled job.
 Start a background job on the local computer.
 
 ```powershell
-PS C:> Start-Job -Name LocalData {Get-Process}
+PS> Start-Job -Name LocalData {Get-Process}
 
 Id Name        PSJobTypeName   State   HasMoreData   Location   Command
 -- ----        -------------   -----   -----------   --------   -------
@@ -292,7 +288,7 @@ Id Name        PSJobTypeName   State   HasMoreData   Location   Command
 Start a background job that runs on a remote computer.
 
 ```powershell
-PS C:> Invoke-Command -ComputerName Server01 {Get-Process} `
+PS> Invoke-Command -ComputerName Server01 {Get-Process} `
 -AsJob -JobName RemoteData
 
 Id  Name        PSJobTypeName  State   HasMoreData   Location   Command
@@ -301,8 +297,9 @@ Id  Name        PSJobTypeName  State   HasMoreData   Location   Command
 ```
 
 Create a scheduled job
+
 ```powershell
-PS C:>  Register-ScheduledJob -Name ScheduledJob -ScriptBlock `
+PS>  Register-ScheduledJob -Name ScheduledJob -ScriptBlock `
  {Get-Process} -Trigger (New-JobTrigger -Once -At "3 PM")
 
 Id         Name            JobTriggers     Command       Enabled
@@ -311,14 +308,16 @@ Id         Name            JobTriggers     Command       Enabled
 ```
 
 Create a workflow.
+
 ```powershell
-PS C:> workflow Test-Workflow {Get-Process}
+PS> workflow Test-Workflow {Get-Process}
 ```
 
 Run the workflow as a job.
+
 ```powershell
 
-PS C:> Test-Workflow -AsJob -JobName TestWFJob
+PS> Test-Workflow -AsJob -JobName TestWFJob
 
 Id  Name       PSJobTypeName   State   HasMoreData   Location   Command
 --  ----       -------------   -----   -----------   --------   -------
@@ -329,7 +328,7 @@ Get the jobs. The `Get-Job` command does not get scheduled jobs, but it gets
 instances of the scheduled job that are started.
 
 ```powershell
-PS C:> Get-Job
+PS> Get-Job
 
 Id  Name         PSJobTypeName  State     HasMoreData  Location  Command
 --  ----         -------------  -----     -----------  --------  -------
@@ -342,14 +341,14 @@ Id  Name         PSJobTypeName  State     HasMoreData  Location  Command
 To get scheduled jobs, use the Get-ScheduledJob cmdlet.
 
 ```powershell
-PS C:> Get-ScheduledJob
+PS> Get-ScheduledJob
 
 Id         Name            JobTriggers     Command       Enabled
 --         ----            -----------     -------       -------
 1          ScheduledJob    1               Get-Process   True
 ```
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Jobs](about_Jobs.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -61,7 +61,8 @@ In RestrictedLanguage language mode, users may run commands (cmdlets,
 functions, CIM commands, and workflows) but are not permitted to use script
 blocks.
 
-Only the following variables are permitted:
+By default, only the following variables are permitted in RestrictedLanguage
+language mode:
 
 - \$PSCulture
 - \$PSUICulture
@@ -240,14 +241,14 @@ NoLanguage session, PowerShell returns the ScriptsNotAllowed error message.
 - ScriptsNotAllowed: The syntax is not supported by this runspace. This
   might be because it is in no-language mode.
 
-# KEYWORDS
+## KEYWORDS
 
 - about_ConstrainedLanguage
 - about_FullLanguage
 - about_NoLanguage
 - about_RestrictedLanguage
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Session_Configuration_Files](about_Session_Configuration_Files.md)
 - [about_Session_Configurations](about_Session_Configurations.md)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -23,7 +23,8 @@ order is the order in which PowerShell evaluates the operators when
 multiple operators appear in the same expression.
 
 When operators have equal precedence, PowerShell evaluates them from
-left to right. The exceptions are the assignment operators, the cast
+left to right as they appear within the expression.
+The exceptions are the assignment operators, the cast
 operators, and the negation operators (!, -not, -bnot), which are evaluated
 from right to left.
 
@@ -41,7 +42,7 @@ the topic, type `get-help <topic-name>`.
 
 |OPERATOR                |REFERENCE|
 |------------------------|---------|
-|`$()  @()`              |[about_Operators](#index-operator)|
+|`$() @() ()`            |[about_Operators](about_Operators.md)|
 |`.` (dereference)       |[about_Operators](about_Operators.md)|
 |`::` (static)           |[about_Operators](about_Operators.md)|
 |`[0]` (index operator)  |[about_Operators](about_Operators.md)|
@@ -54,7 +55,9 @@ the topic, type `get-help <topic-name>`.
 |`! -bNot`               |[about_Comparison_Operators](about_Comparison_Operators.md)|
 |`..` (range operator)   |[about_Operators](about_Operators.md)|
 |`-f` (format operator)  |[about_Operators](about_Operators.md)|
-|`* / % + -`             |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`-` (unary/negative)    |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`* / %`                 |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
+|`+ -`                   |[about_Arithmetic_Operators](about_Arithmetic_Operators.md)|
 
 The following group of operators have equal precedence. Their case-sensitive
 and explicitly case-insensitive variants have the same precedence.
@@ -80,21 +83,21 @@ order:
 |`-and -or -xor`           |[about_Logical_Operators](about_logical_operators.md)|
 |`.` (dot-source)          |[about_Scopes](about_Scopes.md)|
 |`&` (call)                |[about_Operators](about_Operators.md)|
-|&#124; (pipeline operator)|[about_Operators](about_Operators.md)|
+|<code>&#124;</code> (pipeline operator)|[about_Operators](about_Operators.md)|
 |`> >> 2> 2>> 2>&1`        |[about_Redirection](about_Redirection.md)|
 |`= += -= *= /= %=`        |[about_Assignment_Operators](about_Assignment_Operators.md)|
 
-# EXAMPLES
+## EXAMPLES
 
 The following two commands show the arithmetic operators and the effect of
 using parentheses to force PowerShell to evaluate the enclosed part of
 the expression first.
 
 ```powershell
-C:\PS> 2 + 3 * 4
+PS> 2 + 3 * 4
 14
 
-C:\PS> (2 + 3) * 4
+PS> (2 + 3) * 4
 20
 ```
 
@@ -102,12 +105,13 @@ The following example gets the read-only text files from the local directory
 and saves them in the `$read_only` variable.
 
 ```powershell
-$read_only = get-childitem *.txt | where-object {$_.isReadOnly}
+$read_only = Get-ChildItem *.txt | Where-Object {$_.isReadOnly}
 ```
+
 It is equivalent to the following example.
 
 ```powershell
-$read_only = ( get-childitem *.txt | where-object {$_.isReadOnly} )
+$read_only = ( Get-ChildItem *.txt | Where-Object {$_.isReadOnly} )
 ```
 
 Because the pipeline operator (|) has a higher precedence than the assignment
@@ -124,7 +128,7 @@ which is the first string. Finally, it casts the selected object as a string.
 In this case, the cast has no effect.
 
 ```powershell
-C:\PS> [string]@('Windows','PowerShell','2.0')[0]
+PS> [string]@('Windows','PowerShell','2.0')[0]
 Windows
 ```
 
@@ -134,7 +138,7 @@ before the index selection. As a result, the entire array is cast as a
 array, which is the first character.
 
 ```powershell
-C:\PS> ([string]@('Windows','PowerShell','2.0'))[0]
+PS> ([string]@('Windows','PowerShell','2.0'))[0]
 W
 ```
 
@@ -143,21 +147,21 @@ precedence than the -and (logical AND) operator, the result of the expression
 is FALSE.
 
 ```powershell
-C:\PS> 2 -gt 4 -and 1
+PS> 2 -gt 4 -and 1
 False
 ```
 
 It is equivalent to the following expression.
 
 ```powershell
-C:\PS> (2 -gt 4) -and 1
+PS> (2 -gt 4) -and 1
 False
 ```
 
 If the -and operator had higher precedence, the answer would be TRUE.
 
 ```powershell
-C:\PS> 2 -gt (4 -and 1)
+PS> 2 -gt (4 -and 1)
 True
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -11,19 +11,19 @@ title:  about_Remote_Requirements
 ## SHORT DESCRIPTION
 
 Describes the system requirements and configuration requirements for running
-remote commands in Windows PowerShell.
+remote commands in PowerShell.
 
 ## LONG DESCRIPTION
 
 This topic describes the system requirements, user requirements, and resource
 requirements for establishing remote connections and running remote commands
-in Windows PowerShell. It also provides instructions for configuring remote
+in PowerShell. It also provides instructions for configuring remote
 operations.
 
 Note: Many cmdlets (including the Get-Service, Get-Process, Get-WMIObject,
 Get-EventLog, and Get-WinEvent cmdlets) get objects from remote computers by
 using Microsoft .NET Framework methods to retrieve the objects. They do not
-use the Windows PowerShell remoting infrastructure. The requirements in this
+use the PowerShell remoting infrastructure. The requirements in this
 document do not apply to these cmdlets.
 
 To find the cmdlets that have a ComputerName parameter but do not use Windows
@@ -51,7 +51,7 @@ You can create remote sessions between computers running Windows PowerShell
 PowerShell 3.0, such as the ability to disconnect and reconnect to sessions,
 are available only when both computers are running Windows PowerShell 3.0.
 
-To find the version number of an installed version of Windows PowerShell,
+To find the version number of an installed version of PowerShell,
 use the $PSVersionTable automatic variable.
 
 Windows Remote Management (WinRM) 3.0 and Microsoft .NET Framework 4 are
@@ -143,7 +143,7 @@ Administrator privileges are required for the following remoting operations:
 - Viewing and changing WS-Management settings on the local computer. These are
   the settings in the LocalHost node of the WSMAN: drive.
 
-To perform these tasks, you must start Windows PowerShell with the "Run as
+To perform these tasks, you must start PowerShell with the "Run as
 administrator" option even if you are a member of the Administrators group on
 the local computer.
 
@@ -170,28 +170,28 @@ the "Run as administrator" option to start the program.
 ## HOW TO CONFIGURE YOUR COMPUTER FOR REMOTING
 
 Computers running all supported versions of Windows can establish remote
-connections to and run remote commands in Windows PowerShell without any
+connections to and run remote commands in PowerShell without any
 configuration. However, to receive connections, and allow users to create
-local and remote user-managed Windows PowerShell sessions ("PSSessions") and
-run commands on the local computer, you must enable Windows PowerShell
+local and remote user-managed PowerShell sessions ("PSSessions") and
+run commands on the local computer, you must enable PowerShell
 remoting on the computer.
 
 Windows Server 2012 and newer releases of Windows Server are enabled for
-Windows PowerShell remoting by default. If the settings are changed, you can
+PowerShell remoting by default. If the settings are changed, you can
 restore the default settings by running the Enable-PSRemoting cmdlet.
 
 On all other supported versions of Windows, you need to run the
-Enable-PSRemoting cmdlet to enable Windows PowerShell remoting.
+Enable-PSRemoting cmdlet to enable PowerShell remoting.
 
-The remoting features of Windows PowerShell are supported by the WinRM
+The remoting features of PowerShell are supported by the WinRM
 service, which is the Microsoft implementation of the Web Services for
-Management (WS-Management) protocol. When you enable Windows PowerShell
+Management (WS-Management) protocol. When you enable PowerShell
 remoting, you change the default configuration of WS-Management and add system
 configuration that allow users to connect to WS-Management.
 
-To configure Windows PowerShell to receive remote commands:
+To configure PowerShell to receive remote commands:
 
-1. Start Windows PowerShell with the "Run as administrator" option.
+1. Start PowerShell with the "Run as administrator" option.
 2. At the command prompt, type: `Enable-PSRemoting`
 
 To verify that remoting is configured correctly, run a test command such as
@@ -216,16 +216,16 @@ If the command fails, for assistance, see
 
 ## UNDERSTAND POLICIES
 
-When you work remotely, you use two instances of Windows PowerShell, one on
+When you work remotely, you use two instances of PowerShell, one on
 the local computer and one on the remote computer. As a result, your work is
-affected by the Windows policies and the Windows PowerShell policies on the
+affected by the Windows policies and the PowerShell policies on the
 local and remote computers.
 
 In general, before you connect and as you are establishing the connection, the
 policies on the local computer are in effect. When you are using the
 connection, the policies on the remote computer are in effect.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Remote](about_Remote.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -10,15 +10,15 @@ title:  about_Remote_Troubleshooting
 
 ## SHORT DESCRIPTION
 
-Describes how to troubleshoot remote operations in Windows PowerShell.
+Describes how to troubleshoot remote operations in PowerShell.
 
 ## LONG DESCRIPTION
 
 This section describes some of the problems that you might encounter when
-using the remoting features of Windows PowerShell that are based on
+using the remoting features of PowerShell that are based on
 WS-Management technology and it suggests solutions to these problems.
 
-Before using Windows PowerShell remoting, see about_Remote and
+Before using PowerShell remoting, see about_Remote and
 about_Remote_Requirements for guidance on configuration and basic use Also,
 the Help topics for each of the remoting cmdlets, particularly the parameter
 descriptions, have useful information that is designed to help you avoid
@@ -26,7 +26,7 @@ problems.
 
 NOTE: To view or change settings for the local computer in the WSMan: drive,
 including changes to the session configurations, trusted hosts, ports, or
-listeners, start Windows PowerShell with the "Run as administrator" option.
+listeners, start PowerShell with the "Run as administrator" option.
 
 ## TROUBLESHOOTING PERMISSION AND AUTHENTICATION ISSUES
 
@@ -68,7 +68,7 @@ WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
 
 No configuration is required to enable a computer to send remote
-commands. However, to receive remote commands, Windows PowerShell remoting
+commands. However, to receive remote commands, PowerShell remoting
 must be enabled on the computer. Enabling includes starting the WinRM
 service, setting the startup type for the WinRM service to Automatic,
 creating listeners for HTTP and HTTPS connections, and creating default
@@ -103,7 +103,7 @@ ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
 
-To enable a single computer to receive remote Windows PowerShell commands
+To enable a single computer to receive remote PowerShell commands
 and accept connections, use the Enable-PSRemoting cmdlet.
 
 To enable remoting for multiple computers in an enterprise, you can use the
@@ -200,7 +200,7 @@ the Windows Remote Management service.
 
 ERROR:  ACCESS IS DENIED
 
-Windows PowerShell remoting depends upon the Windows Remote Management
+PowerShell remoting depends upon the Windows Remote Management
 (WinRM) service. The service must be running to support remote commands.
 
 On server versions of Windows, the startup type of the Windows Remote
@@ -529,9 +529,9 @@ ERROR: The client cannot connect to the destination specified in the
 request. Verify that the service on the destination is running and is
 accepting requests.
 
-Because Windows PowerShell remoting uses the HTTP protocol, it is affected
+Because PowerShell remoting uses the HTTP protocol, it is affected
 by HTTP proxy settings. In enterprises that have proxy servers, users
-cannot access a Windows PowerShell remote computer directly.
+cannot access a PowerShell remote computer directly.
 
 To resolve this problem, use proxy setting options in your remote command.
 The following settings are available:
@@ -569,9 +569,9 @@ the option object that New-PSSessionOption creates in the value of the
 $PSSessionOption preference variable. For more information about the
 $PSSessionOption preference variable, see about_Preference_Variables.
 
-To set these options for all remote commands all Windows PowerShell sessions
+To set these options for all remote commands all PowerShell sessions
 on the local computer, add the $PSSessionOption preference variable to your
-Windows PowerShell profile. For more information about Windows PowerShell
+PowerShell profile. For more information about PowerShell
 profiles, see about_Profiles.
 
 ### HOW TO DETECT A 32-BIT SESSION ON A 64-BIT COMPUTER
@@ -597,8 +597,8 @@ following command finds the processor architecture of the session in the
 \$s variable.
 
 ```powershell
-$s = New-PSSession -ComputerName Server01 -configurationName CustomShell
-invoke-command -session $s {$env:PROCESSOR_ARCHITECTURE}
+$s = New-PSSession -ComputerName Server01 -ConfigurationName CustomShell
+Invoke-Command -Session $s {$env:PROCESSOR_ARCHITECTURE}
 x86
 ```
 
@@ -629,7 +629,7 @@ process.
 
 For example, the following command starts a process with the RemoteSigned
 execution policy. The execution policy change affects only the current
-process and does not change the Windows PowerShell ExecutionPolicy registry
+process and does not change the PowerShell ExecutionPolicy registry
 setting.
 
 ```powershell
@@ -673,7 +673,7 @@ The following quotas are available in the basic configuration.
   MaximumReceivedObjectSizeMB parameters of the Register-PSSessionConfiguration
   cmdlet.
 
-When quotas conflict with a command, Windows PowerShell generates an error.
+When quotas conflict with a command, PowerShell generates an error.
 
 To resolve the error, change the remote command to comply with the quota.
 Or, determine the source of the quota, and then increase the quota to allow
@@ -701,7 +701,7 @@ the time specified in OperationTimeout.
 
 You can use timeouts to protect the local computer and the remote computer
 from excessive resource use, both accidental and malicious. When timeouts
-are set on both the local and remote computer, Windows PowerShell uses the
+are set on both the local and remote computer, PowerShell uses the
 shortest timeout settings.
 
 The following timeouts are available in the basic configuration.
@@ -745,13 +745,13 @@ New-PSSessionOption.
 ## TROUBLESHOOTING UNRESPONSIVE BEHAVIOR
 
 This section discusses remoting problems that prevent a command from completing
-and prevent or delay the return of the Windows PowerShell prompt.
+and prevent or delay the return of the PowerShell prompt.
 
 ### HOW TO INTERRUPT A COMMAND
 
 Some native Windows programs, such as programs with a user interface, console
 applications that prompt for input, and console applications that use the
-Win32 console API, do not work correctly in the Windows PowerShell remote host.
+Win32 console API, do not work correctly in the PowerShell remote host.
 
 When you use these programs, you might see unexpected behavior, such as no
 output, partial output, or a remote command that does not complete.
@@ -771,14 +771,14 @@ WinRM operations are in progress.
 To resolve this issue, verify that the WinRM service is running and try
 the command again.
 
-1. Start Windows PowerShell with the "Run as administrator" option.
+1. Start PowerShell with the "Run as administrator" option.
 2. Run the following command:
 
    Start-Service WinRM
 
 3. Re-run the command that generated the error.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Remote](about_Remote.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -16,22 +16,22 @@ policies.
 ## LONG DESCRIPTION
 
 The Restricted execution policy does not permit any scripts to run. The
-AllSigned and RemoteSigned execution policies prevent PowerShell from running
-scripts that do not have a digital signature.
+**AllSigned** and **RemoteSigned** execution policies prevent PowerShell from
+running scripts that do not have a digital signature.
 
 This topic explains how to run selected scripts that are not signed, even
-while the execution policy is RemoteSigned, and how to sign scripts for your
-own use.
+while the execution policy is **RemoteSigned**, and how to sign scripts for
+your own use.
 
 For more information about PowerShell execution policies, see
 [about_Execution_Policies](about_Execution_Policies.md).
 
 ## TO PERMIT SIGNED SCRIPTS TO RUN
 
-When you start PowerShell on a computer for the first time, the Restricted
+When you start PowerShell on a computer for the first time, the **Restricted**
 execution policy (the default) is likely to be in effect.
 
-The Restricted policy does not permit any scripts to run.
+The **Restricted** policy does not permit any scripts to run.
 
 To find the effective execution policy on your computer, type:
 
@@ -42,23 +42,22 @@ Get-ExecutionPolicy
 To run unsigned scripts that you write on your local computer and signed
 scripts from other users, start PowerShell with the Run as Administrator
 option and then use the following command to change the execution policy on
-the computer to RemoteSigned:
+the computer to **RemoteSigned**:
 
 ```powershell
 Set-ExecutionPolicy RemoteSigned
 ```
 
-For more information, see the help topic for the Set-ExecutionPolicy cmdlet.
+For more information, see the help topic for the `Set-ExecutionPolicy` cmdlet.
 
 ## RUNNING UNSIGNED SCRIPTS (REMOTESIGNED EXECUTION POLICY)
 
-If your PowerShell execution policy is RemoteSigned, Windows
-PowerShell will not run unsigned scripts that are downloaded from the
-Internet, including unsigned scripts you receive through e-mail and instant
-messaging programs.
+If your PowerShell execution policy is **RemoteSigned**, Windows PowerShell
+will not run unsigned scripts that are downloaded from the Internet, including
+unsigned scripts you receive through e-mail and instant messaging programs.
 
-If you try to run a downloaded script, PowerShell displays the
-following error message:
+If you try to run a downloaded script, PowerShell displays the following error
+message:
 
 ```output
 The file <file-name> cannot be loaded. The file <file-name> is not digitally
@@ -98,9 +97,9 @@ this publisher.
 
 ## METHODS OF SIGNING SCRIPTS
 
-You can sign the scripts that you write and the
-scripts that you obtain from other sources. Before you sign any script,
-examine each command to verify that it is safe to run.
+You can sign the scripts that you write and the scripts that you obtain from
+other sources. Before you sign any script, examine each command to verify that
+it is safe to run.
 
 For best practices about code signing, see
 [Code-Signing Best Practices](/previous-versions/windows/hardware/design/dn653556(v=vs.85)).
@@ -289,7 +288,7 @@ signed while the signing certificate was valid.
 Because most signing certificates are valid for one year only, using a time
 stamp server ensures that users can use your script for many years to come.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Execution_Policies](about_Execution_Policies.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -8,20 +8,20 @@ title:  about_Special_Characters
 
 # About Special Characters
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Describes the special characters that you can use to control how Windows
 PowerShell interprets the next character in a command or parameter.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
-Windows PowerShell supports a set of special character sequences that are used
+PowerShell supports a set of special character sequences that are used
 to represent characters that are not part of the standard character set.
 
-The special characters in Windows PowerShell begin with the backtick
+The special characters in PowerShell begin with the backtick
 character, also known as the grave accent (ASCII 96).
 
-The following special characters are recognized by Windows PowerShell:
+The following special characters are recognized by PowerShell:
 
 ```
 | Character | Description             |
@@ -42,9 +42,9 @@ when used within double quoted (") strings.
 
 ## NULL (`0)
 
-Windows PowerShell recognizes a null special character (`0) and represents it
+PowerShell recognizes a null special character (`0) and represents it
 with a character code of 0. It appears as an empty space in the Windows
-PowerShell output. This allows you to use Windows PowerShell to read and
+PowerShell output. This allows you to use PowerShell to read and
 process text files that use null characters, such as string termination or
 record termination indicators. The null special character is not equivalent to
 the $null variable, which stores a value of NULL.
@@ -120,7 +120,7 @@ Delete everything before this point.
 ## HORIZONTAL TAB (`t)
 
 The horizontal tab character (`t) advances to the next tab stop and continues
-writing at that point. By default, the Windows PowerShell console has a tab
+writing at that point. By default, the PowerShell console has a tab
 stop at every eighth space.
 
 For example, the following command inserts two tabs between each column.
@@ -143,8 +143,8 @@ printed documents only. It does not affect screen output.
 
 ## STOP PARSING  (--%)
 
-The stop-parsing symbol (--%) prevents Windows PowerShell from interpreting
-arguments in program calls as Windows PowerShell commands and expressions.
+The stop-parsing symbol (--%) prevents PowerShell from interpreting
+arguments in program calls as PowerShell commands and expressions.
 
 Place the stop-parsing symbol after the program name and before program
 arguments that might cause errors.
@@ -155,7 +155,7 @@ For example, the following Icacls command uses the stop-parsing symbol.
 icacls X:\VMS --% /grant Dom\HVAdmin:(CI)(OI)F
 ```
 
-Windows PowerShell sends the following command to Icacls.
+PowerShell sends the following command to Icacls.
 
 ```output
 X:\VMS /grant Dom\HVAdmin:(CI)(OI)F
@@ -163,6 +163,6 @@ X:\VMS /grant Dom\HVAdmin:(CI)(OI)F
 
 For more information about the stop-parsing symbol, see [about_Parsing](about_Parsing.md).
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Quoting_Rules](about_Quoting_Rules.md)

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -20,10 +20,10 @@ administrator and the winner of the Advanced Division of the 2012 Scripting
 Games. Revised for Windows PowerShell 3.0.]
 
 Splatting is a method of passing a collection of parameter values to a command
-as unit. Windows PowerShell associates each value in the collection with a
+as unit. PowerShell associates each value in the collection with a
 command parameter. Splatted parameter values are stored in named splatting
 variables, which look like standard variables, but begin with an At symbol (@)
-instead of a dollar sign ($). The At symbol tells Windows PowerShell that you
+instead of a dollar sign ($). The At symbol tells PowerShell that you
 are passing a collection of values, instead of a single value.
 
 Splatting makes your commands shorter and easier to read. You can re-use the
@@ -85,7 +85,7 @@ Copy-Item @HashArguments
 ```
 
 Note: In the first command, the At symbol (@) indicates a hash table, not a
-splatted value. The syntax for hash tables in Windows PowerShell is:
+splatted value. The syntax for hash tables in PowerShell is:
 @{\<name\>=\<value\>; \<name\>=\<value\>; …}*
 
 ## SPLATTING WITH ARRAYS
@@ -281,7 +281,7 @@ FileVersionInfo    : File:             C:\Windows\System32\WindowsPowerShell
                      Language:         English (United States)
 ```
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Arrays](about_Arrays.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -8,20 +8,20 @@ title:  about_Types.ps1xml
 
 # About Types.ps1xml
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Explains how to use Types.ps1xml files to extend the types of objects
-that are used in Windows PowerShell.
+that are used in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Extended type data defines additional properties and methods ("members")
-of object types in Windows PowerShell. There are two techniques for adding
-extended type data to a Windows PowerShell session.
+of object types in PowerShell. There are two techniques for adding
+extended type data to a PowerShell session.
 
 - Types.ps1xml file: An XML file that defines extended type data.
 - `Update-TypeData`: A cmdlet that reloads Types.ps1xml files and defines
-extended data for types in the current session.
+  extended data for types in the current session.
 
 This topic describes Types.ps1xml files. For more information about using the
 `Update-TypeData` cmdlet to add dynamic extended type data to the current
@@ -31,11 +31,11 @@ session see
 ## About Extended Type Data
 
 Extended type data defines additional properties and methods ("members") of
-object types in Windows PowerShell. You can extend any type that is supported
-by Windows PowerShell and use the added properties and methods in the same way
+object types in PowerShell. You can extend any type that is supported
+by PowerShell and use the added properties and methods in the same way
 that you use the properties that are defined on the object types.
 
-For example, Windows PowerShell adds a `DateTime` property to all
+For example, PowerShell adds a `DateTime` property to all
 `System.DateTime` objects, such as the ones that the `Get-Date` cmdlet
 returns.
 
@@ -46,19 +46,19 @@ Sunday, January 29, 2012 9:43:57 AM
 
 You won't find the `DateTime` property in the description of the
 [`System.DateTime` structure](http://msdn.microsoft.com/library/system.datetime.aspx),
-because Windows PowerShell adds the property and it is visible only in Windows
+because PowerShell adds the property and it is visible only in Windows
 PowerShell.
 
-To add the `DateTime` property to all Windows PowerShell sessions, Windows
+To add the `DateTime` property to all PowerShell sessions, Windows
 PowerShell defines the `DateTime` property in the Types.ps1xml file in the
-Windows PowerShell installation directory (`$PSHOME`).
+PowerShell installation directory (`$PSHOME`).
 
-## Adding Extended Type Data to Windows PowerShell.
+## Adding Extended Type Data to PowerShell.
 
-There are three sources of extended type data in Windows PowerShell sessions.
+There are three sources of extended type data in PowerShell sessions.
 
-- The Types.ps1xml files in the Windows PowerShell installation directory
-  are loaded automatically into every Windows PowerShell session.
+- The Types.ps1xml files in the PowerShell installation directory
+  are loaded automatically into every PowerShell session.
 
 - The Types.ps1xml files that modules export are loaded when the module
   is imported into the current session.
@@ -73,7 +73,8 @@ types.
 ## The TypeData Cmdlets
 
 The following TypeData cmdlets are included in the Microsoft.PowerShell.Utility
-module in Windows PowerShell 3.0 and later versions of Windows PowerShell.
+module in Windows PowerShell 3.0 and later versions of Windows PowerShell
+and PowerShell Core.
 
 - `Get-TypeData`: Gets extended type data in the current session.
 - `Update-TypeData`: Reloads Types.ps1xml files. Adds extended type data to the
@@ -87,9 +88,9 @@ For more information about these cmdlets, see the help topic for each cmdlet.
 The Types.ps1xml files in the `$PSHOME` directory are added automatically to
 every session.
 
-The Types.ps1xml file in the Windows PowerShell installation directory
+The Types.ps1xml file in the PowerShell installation directory
 (`$PSHOME`) is an XML-based text file that lets you add properties and
-methods to the objects that are used in Windows PowerShell. Windows
+methods to the objects that are used in PowerShell. Windows
 PowerShell has built-in Types.ps1xml files that add several elements
 to the .NET Framework types, but you can create additional Types.ps1xml
 files to further extend the types.
@@ -136,7 +137,7 @@ Get        Method        System.Object Get(Int32)
 ```
 
 As a result, you can use either the Count property or the Length property
-of arrays in Windows PowerShell. For example:
+of arrays in PowerShell. For example:
 
 ```powershell
 C:\PS> (1, 2, 3, 4).count
@@ -150,32 +151,32 @@ C:\PS> (1, 2, 3, 4).length
 
 ## Creating New Types.ps1xml Files
 
-The .ps1xml files that are installed with Windows PowerShell are
+The .ps1xml files that are installed with PowerShell are
 digitally signed to prevent tampering because the formatting can include
 script blocks. Therefore, to add a property or method to a .NET Framework
 type, create your own Types.ps1xml files, and then add them to your
-Windows PowerShell session.
+PowerShell session.
 
 To create a new file, start by copying an existing Types.ps1xml file. The
 new file can have any name, but it must have a .ps1xml file name
 extension. You can place the new file in any directory that is accessible
-to Windows PowerShell, but it is useful to place the files in the Windows
+to PowerShell, but it is useful to place the files in the Windows
 PowerShell installation directory (`$PSHOME`) or in a subdirectory of the
 installation directory.
 
 When you have saved the new file, use the `Update-TypeData` cmdlet to add
-the new file to your Windows PowerShell session. If you want your types
+the new file to your PowerShell session. If you want your types
 to take precedence over the types that are defined in the built-in file,
 use the PrependData parameter of the `Update-TypeData` cmdlet.
 `Update-TypeData` affects only the current session. To make the change to
 all future sessions, export the console, or add the `Update-TypeData`
-command to your Windows PowerShell profile.
+command to your PowerShell profile.
 
 ## Types.ps1xml and Add-Member
 
 The Types.ps1xml files add properties and methods to all the instances
 of the objects of the specified .NET Framework type in the affected
-Windows PowerShell session. However, if you need to add properties or
+PowerShell session. However, if you need to add properties or
 methods only to one instance of an object, use the `Add-Member` cmdlet.
 
 For more information, see [Add-Member](../../Microsoft.PowerShell.Utility/Add-Member.md).
@@ -330,7 +331,7 @@ the name of the new method and a pair of `<GetCodeReference>` tags
 that specify the code in which the method is defined.
 
 For example, the Mode property of directories (`System.IO.DirectoryInfo`
-objects) is a code property defined in the Windows PowerShell
+objects) is a code property defined in the PowerShell
 FileSystem provider.
 
 ```xml
@@ -357,7 +358,7 @@ the name of the new property and a pair of `<GetCodeReference>` tags
 that specify the code in which the property is defined.
 
 For example, the `Mode` property of directories (`System.IO.DirectoryInfo`
-objects) is a code property defined in the Windows PowerShell
+objects) is a code property defined in the PowerShell
 FileSystem provider.
 
 ```xml
@@ -387,7 +388,7 @@ create a property (such as `<NoteProperty>` or `<ScriptProperty>`) or a
 method (such as `<Method>` or `<ScriptMethod>`) can be members of the set.
 
 In Types.ps1xml files, the `<MemberSet>` tag is used to define the
-default views of the .NET Framework objects in Windows PowerShell. In
+default views of the .NET Framework objects in PowerShell. In
 this case, the name of the member set (the value within the `<Name>`
 tags) is always "PsStandardMembers", and the names of the properties
 (the value of the `<Name>` tag) are one of the following:
@@ -397,8 +398,8 @@ tags) is always "PsStandardMembers", and the names of the properties
 - `DefaultDisplayPropertySet`: One or more properties of an object.
 
 - `DefaultKeyPropertySet`: One or more key properties of an object.
-A key property identifies instances of property values, such as
-the ID number of items in a session history.
+  A key property identifies instances of property values, such as
+  the ID number of items in a session history.
 
 For example, the following XML defines the default display of services
 (`System.ServiceProcess.ServiceController` objects) that are returned by
@@ -560,7 +561,7 @@ library](http://go.microsoft.com/fwlink/?LinkId=144538).
 
 ## `Update-TypeData`
 
-To load your Types.ps1xml files into a Windows PowerShell session, run
+To load your Types.ps1xml files into a PowerShell session, run
 the `Update-TypeData` cmdlet. If you want the types in your file to take
 precedence over types in the built-in Types.ps1xml file, add the
 PrependData parameter of `Update-TypeData`. `Update-TypeData` affects only
@@ -589,7 +590,7 @@ To protect users of your Types.ps1xml file, you can sign the file using a
 digital signature. For more information, see
 [about_Signing](about_Signing.md).
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Signing](about_Signing.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -389,7 +389,7 @@ the script.
 
 The Online parameter does not work with About topics. To see the about topics
 for PowerShell Core, including help topics about the PowerShell language, see
-[Windows PowerShell Core Module About Topics](http://go.microsoft.com/fwlink/?LinkID=113206).
+[PowerShell Core Module About Topics](http://go.microsoft.com/fwlink/?LinkID=113206).
 
 ## HOW TO MINIMIZE OR PREVENT INTERNET DOWNLOADS
 
@@ -447,7 +447,7 @@ your modules. For more information, see "Supporting Updatable Help" and
 
 Updatable help not available for PowerShell snap-ins or comment-based help.
 
-# REMARKS
+## REMARKS
 
 The Update-Help and Save-Help cmdlets are not supported on Windows
 Preinstallation Environment (Windows PE).

--- a/reference/6/Microsoft.PowerShell.Core/About/About_Using.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/About_Using.md
@@ -8,11 +8,11 @@ title:  about_Using
 
 # About Using
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Allows to indicate which namespaces are used in the session.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 The `using` statement allows to indicate which namespaces are used in the
 session. Making easier to mention classes and members, as it requires less
@@ -35,7 +35,7 @@ using module <module-name>
 **Note**: The `using` statetement, for modules, is intended to surface the
 classes in the module. If the module isn't loaded, the `using` fails.
 
-## Example 1
+## Examples
 
 The following script gets the cryptographic hash for the "Hello World" string.
 
@@ -58,8 +58,6 @@ $hashfromstream = Get-FileHash -InputStream $memorystream `
   -Algorithm $algorithm
 $hashfromstream.Hash.ToString()
 ```
-
-## Example 2
 
 The following script assumes a module named 'CardGames' was loaded
 automatically.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Assignment_Operators.md
@@ -217,7 +217,7 @@ $a
 ```
 
 ```
-PowerShell
+Windows PowerShell
 ```
 
 When the value of the variable is an array, the `+=` operator appends the
@@ -499,7 +499,7 @@ $a
 3
 ```
 
-# THE INCREMENT AND DECREMENT OPERATORS
+## THE INCREMENT AND DECREMENT OPERATORS
 
 The increment operator `++` increases the value of a variable by 1. When
 you use the increment operator in a simple statement, no value is returned.
@@ -806,7 +806,7 @@ following:
 Tuesday, May 31, 2005 12:00:00 AM
 ```
 
-# ASSIGNING MULTIPLE VARIABLES
+## ASSIGNING MULTIPLE VARIABLES
 
 In PowerShell, you can assign values to multiple variables by using
 a single command. The first element of the assignment value is assigned to

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Command_Syntax.md
@@ -7,18 +7,18 @@ title:  about_Command_Syntax
 
 # About Command Syntax
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Describes the syntax diagrams that are used in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 The [Get-Help](../../Microsoft.PowerShell.Core/Get-Help.md) and
 [Get-Command](../../Microsoft.PowerShell.Core/Get-Command.md) cmdlets display
 syntax diagrams to help you construct commands correctly. This topic
 explains how to interpret the syntax diagrams.
 
-# SYNTAX DIAGRAMS
+## SYNTAX DIAGRAMS
 
 Each paragraph in a command syntax diagram represents a valid form of the
 command.
@@ -310,7 +310,7 @@ In syntax examples, brackets are also used in naming and casting to .NET
 Framework types. In this context, brackets do not indicate an element is
 optional.
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Parameters](about_Parameters.md)
 - [Get-Command](../../Microsoft.PowerShell.Core/Get-Command.md)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Data_Sections.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Data_Sections.md
@@ -8,12 +8,12 @@ title:  about_Data_Sections
 
 # About Data Sections
 
-### Short Description
+## Short Description
 
 Explains Data sections, which isolate text strings and other read-only
 data from script logic.
 
-### Long Description
+## Long Description
 
 Scripts that are designed for PowerShell can have one or more
 Data sections that contain only data. You can include one or more Data
@@ -203,7 +203,7 @@ DATA -supportedCommand Format-XML {
 }
 ```
 
-# See Also
+## See Also
 
 [about_Automatic_Variables](about_Automatic_Variables.md)
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions.md
@@ -8,11 +8,11 @@ title:  about_Functions
 
 # About Functions
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Describes how to create and use functions in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 A function is a list of PowerShell statements that has a name that you
 assign. When you run a function, you type the function name. The statements in
@@ -99,7 +99,7 @@ function Get-NewPix
 {
   $start = Get-Date -Month 1 -Day 1 -Year 2010
   $allpix = Get-ChildItem -Path $env:UserProfile\*.jpg -Recurse
-  $allpix | where {$_.LastWriteTime -gt $Start}
+  $allpix | Where-Object {$_.LastWriteTime -gt $Start}
 }
 ```
 
@@ -169,7 +169,7 @@ value of the $size parameter, and it excludes directories:
 ```powershell
 function Get-SmallFiles {
   Param($Size)
-  Get-ChildItem $HOME | where {
+  Get-ChildItem $HOME | Where-Object {
     $_.Length -lt $Size -and !$_.PSIsContainer
   }
 }
@@ -198,7 +198,7 @@ Get-SmallFiles example:
 
 ```powershell
 function Get-SmallFiles ($Size = 100) {
-  Get-ChildItem $HOME | where {
+  Get-ChildItem $HOME | Where-Object {
     $_.Length -lt $Size -and !$_.PSIsContainer
   }
 }
@@ -248,7 +248,7 @@ function Get-Extension {
 ```
 
 ```powershell
-C:\PS> Get-Extension myTextFile
+PS> Get-Extension myTextFile
 myTextFile.txt
 ```
 
@@ -272,10 +272,10 @@ When you type the On switch parameter after the function name, the function
 displays "Switch on". Without the switch parameter, it displays "Switch off".
 
 ```powershell
-C:\PS> Switch-Item -on
+PS> Switch-Item -on
 Switch on
 
-C:\PS> Switch-Item
+PS> Switch-Item
 Switch off
 ```
 
@@ -283,10 +283,10 @@ You can also assign a Boolean value to a switch when you run the function, as
 shown in the following example:
 
 ```powershell
-C:\PS> Switch-Item -on:$true
+PS> Switch-Item -on:$true
 Switch on
 
-C:\PS> Switch-Item -on:$false
+PS> Switch-Item -on:$false
 Switch off
 ```
 
@@ -311,7 +311,7 @@ Get-MyCommand function. The parameters and parameter values are passed to the
 command using @Args.
 
 ```powershell
-PS C:> Get-MyCommand -Name Get-ChildItem
+PS> Get-MyCommand -Name Get-ChildItem
 CommandType     Name                ModuleName
 -----------     ----                ----------
 Cmdlet          Get-ChildItem       Microsoft.PowerShell.Management
@@ -360,7 +360,7 @@ To demonstrate this function, enter an list of numbers separated by commas, as
 shown in the following example:
 
 ```powershell
-C:\PS> 1,2,4 | Get-Pipeline
+PS> 1,2,4 | Get-Pipeline
 The value is: 1
 The value is: 2
 The value is: 4
@@ -387,7 +387,7 @@ If this function is run by using the pipeline, it displays the following
 results:
 
 ```powershell
-C:\PS> 1,2,4 | Get-PipelineBeginEnd
+PS> 1,2,4 | Get-PipelineBeginEnd
 Begin: The input is
 End:   The input is 1 2 4
 ```
@@ -412,7 +412,7 @@ at a time. The $input automatic variable is empty when the function reaches
 the End keyword.
 
 ```powershell
-C:\PS> 1,2,4 | Get-PipelineInput
+PS> 1,2,4 | Get-PipelineInput
 Processing:  1
 Processing:  2
 Processing:  4
@@ -436,7 +436,7 @@ either the whole entry or only the message portion of the entry:
 ```powershell
 filter Get-ErrorLog ([switch]$message)
 {
-  if ($message) { out-host -inputobject $_.Message }
+  if ($message) { Out-Host -InputObject $_.Message }
   else { $_ }
 }
 ```
@@ -454,7 +454,7 @@ the global scope in the following example:
 
 ```powershell
 function global:Get-DependentSvs {
-  Get-Service | where {$_.DependentServices}
+  Get-Service | Where-Object {$_.DependentServices}
 }
 ```
 
@@ -547,7 +547,7 @@ methods:
   information about XML-based help, see [How to Write Cmdlet
   Help](https://go.microsoft.com/fwlink/?LinkID=123415) in the MSDN library.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Automatic_Variables](about_Automatic_Variables.md)
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Functions_Advanced.md
@@ -8,11 +8,11 @@ title:  about_Functions_Advanced
 
 # About Functions Advanced
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Introduces advanced functions that act similar to cmdlets.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Advanced functions allow you to write functions that can perform operations
 that are similar to the operations you can perform with cmdlets. Advanced
@@ -51,7 +51,7 @@ function Send-Greeting
 
     Process
     {
-        write-host ("Hello " + $Name + "!")
+        Write-Host ("Hello " + $Name + "!")
     }
 }
 ```
@@ -79,7 +79,7 @@ Advanced functions differ from compiled cmdlets in the following ways:
 
 - Advanced functions cannot be used in transactions.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Functions](about_Functions.md)
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Job_Details.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Job_Details.md
@@ -8,11 +8,11 @@ title:  about_Job_Details
 
 # About Job Details
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Provides details about background jobs on local and remote computers.
 
-# DETAILED DESCRIPTION
+## DETAILED DESCRIPTION
 
 This topic explains the concept of a background job and provides technical
 information about how background jobs work in PowerShell.
@@ -20,7 +20,7 @@ information about how background jobs work in PowerShell.
 This topic is a supplement to the [about_Jobs](about_Jobs.md) and
 [about_Remote_Jobs](about_Remote_Jobs.md) topics.
 
-# ABOUT BACKGROUND JOBS
+### ABOUT BACKGROUND JOBS
 
 A background job runs a command or expression asynchronously. It might run
 a cmdlet, a function, a script, or any other command-based task. It is
@@ -47,7 +47,7 @@ only to run the job and is then destroyed, or it can be a persistent
 session (a PSSession) that you can use to run several related jobs or
 commands.
 
-# USING THE JOB CMDLETS
+### USING THE JOB CMDLETS
 
 Use a Start-Job command to start a background job on a local computer.
 Start-Job returns a job object. You can also get objects representing the
@@ -64,7 +64,7 @@ the Remove-Job cmdlet.
 For more information about how the cmdlets work, see the Help topic for
 each cmdlet, and see about_Jobs.
 
-# STARTING BACKGROUND JOBS ON REMOTE COMPUTERS
+### STARTING BACKGROUND JOBS ON REMOTE COMPUTERS
 
 You can create and manage background jobs on a local or remote computer. To
 run a background job remotely, use the AsJob parameter of a cmdlet such as
@@ -74,7 +74,7 @@ session.
 
 For more information about remote background jobs, see about_Remote_Jobs.
 
-# CHILD JOBS
+### CHILD JOBS
 
 Each background job consists of a parent job and one or more child jobs. In
 jobs started by using Start-Job or the AsJob parameter of Invoke-Command,
@@ -93,7 +93,7 @@ parameter of the Get-Job cmdlet. The IncludeChildJob parameter is
 introduced in Windows PowerShell 3.0.
 
 ```powershell
-C:\PS> Get-Job -IncludeChildJob
+PS> Get-Job -IncludeChildJob
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -107,7 +107,7 @@ value, use the ChildJobState parameter of the Get-Job cmdlet. The
 ChildJobState parameter is introduced in Windows PowerShell 3.0.
 
 ```powershell
-C:\PS> Get-Job -ChildJobState Failed
+PS> Get-Job -ChildJobState Failed
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -119,7 +119,7 @@ To get the child jobs of a job on all versions of PowerShell,
 use the ChildJob property of the parent job.
 
 ```powershell
-C:\PS> (Get-Job Job1).ChildJobs
+PS> (Get-Job Job1).ChildJobs
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -131,7 +131,7 @@ You can also use a Get-Job command on the child job, as shown in the
 following command:
 
 ```powershell
-C:\PS> Get-Job Job3
+PS> Get-Job Job3
 
 Id Name   PSJobTypeName State      HasMoreData   Location    Command
 -- ----   ------------- -----      -----------   --------    -------
@@ -168,7 +168,7 @@ background jobs on the local computer and two remote computers. The command
 saves the job in the \$j variable.
 
 ```powershell
-PS C:> $j = Invoke-Command -ComputerName localhost, Server01, Server02 `
+PS> $j = Invoke-Command -ComputerName localhost, Server01, Server02 `
 -Command {Get-Date} -AsJob
 ```
 
@@ -177,7 +177,7 @@ shows that the command returned a job object with three child jobs, one for
 each computer.
 
 ```powershell
-PS C:> $j | Format-List Name, ChildJobs
+PS> $j | Format-List Name, ChildJobs
 
 Name      : Job3
 ChildJobs : {Job4, Job5, Job6}
@@ -186,7 +186,7 @@ ChildJobs : {Job4, Job5, Job6}
 When you display the parent job, it shows that the job failed.
 
 ```powershell
-C:\PS> $j
+PS> $j
 
 Id Name   PSJobTypeName State      HasMoreData   Location
 -- ----   ------------- -----      -----------   --------
@@ -197,7 +197,7 @@ But when you run a Get-Job command that gets the child jobs, the output
 shows that only one child job failed.
 
 ```powershell
-PS C:> Get-Job -IncludeChildJobs
+PS> Get-Job -IncludeChildJobs
 
 Id  Name   PSJobTypeName State      HasMoreData   Location    Command
 --  ----   ------------- -----      -----------   --------    -------
@@ -212,9 +212,8 @@ the results of the parent job. But you can also get the results of a
 particular child job, as shown in the following command.
 
 ```powershell
-C:\PS> Receive-Job -Name Job6 -Keep | Format-Table ComputerName,
->> DateTime -Auto
-
+PS> Receive-Job -Name Job6 -Keep | Format-Table ComputerName,
+>> DateTime -AutoSize
 ComputerName DateTime
 ------------ --------
 Server02     Thursday, March 13, 2008 4:16:03 PM
@@ -223,36 +222,33 @@ Server02     Thursday, March 13, 2008 4:16:03 PM
 The child jobs feature of PowerShell background jobs gives you
 more control over the jobs that you run.
 
-# JOB TYPES
+### JOB TYPES
 
+PowerShell supports different types of jobs for different tasks. Beginning in
+Windows PowerShell 3.0, developers can write "job source adapters" that add
+new job types to PowerShell and include the job source adapters in modules.
+When you import the module, you can use the new job type in your session.
 
-PowerShell supports different types of jobs for different tasks.
-Beginning in Windows PowerShell 3.0, developers can write "job source
-adapters" that add new job types to PowerShell and include the
-job source adapters in modules. When you import the module, you can
-use the new job type in your session.
+For example, the PSScheduledJob module adds scheduled jobs and the PSWorkflow
+module adds workflow jobs.
 
-For example, the PSScheduledJob module adds scheduled jobs and the
-PSWorkflow module adds workflow jobs.
+Custom jobs types might differ significantly from standard Windows PowerShell
+background jobs. For example, scheduled jobs are saved on disk; they do not
+exist only in a particular session. Workflow jobs can be suspended and
+resumed.
 
-Custom jobs types might differ significantly from standard Windows
-PowerShell background jobs. For example, scheduled jobs are saved
-on disk; they do not exist only in a particular session. Workflow
-jobs can be suspended and resumed.
+The cmdlets that you use to manage custom jobs depend on the job type. For
+some, you use the standard job cmdlets, such as Get-Job and Start-Job. Others
+come with specialized cmdlets that manage only a particular type of job. For
+detailed information about custom job types, see the help topics about the job
+type.
 
-The cmdlets that you use to manage custom jobs depend on the job
-type. For some, you use the standard job cmdlets, such as Get-Job
-and Start-Job. Others come with specialized cmdlets that manage
-only a particular type of job. For detailed information about
-custom job types, see the help topics about the job type.
+To find the job type of a job, use the Get-Job cmdlet. Get-Job returns
+different job objects for different types of jobs. The value of the
+PSJobTypeName property of the job objects that Get-Job returns indicates the
+job type.
 
-To find the job type of a job, use the Get-Job cmdlet. Get-Job
-returns different job objects for different types of jobs. The
-value of the PSJobTypeName property of the job objects that
-Get-Job returns indicates the job type.
-
-The following table lists the job types that come with Windows
-PowerShell.
+The following table lists the job types that come with PowerShell.
 
 |Job Type      |Description                                               |
 |--------------|----------------------------------------------------------|
@@ -272,7 +268,7 @@ NOTE: Before using the Get-Job cmdlet to get jobs of a particular type, verify
 that the module that adds the job type is imported into the current session.
 Otherwise, Get-Job does not get jobs of that type.
 
-# EXAMPLE
+## EXAMPLE
 
 The following commands create a local background job, a remote background job,
 a workflow job, and a scheduled job. Then, it uses the Get-Job cmdlet to get
@@ -282,7 +278,7 @@ instances of the scheduled job.
 Start a background job on the local computer.
 
 ```powershell
-PS C:> Start-Job -Name LocalData {Get-Process}
+PS> Start-Job -Name LocalData {Get-Process}
 
 Id Name        PSJobTypeName   State   HasMoreData   Location   Command
 -- ----        -------------   -----   -----------   --------   -------
@@ -292,7 +288,7 @@ Id Name        PSJobTypeName   State   HasMoreData   Location   Command
 Start a background job that runs on a remote computer.
 
 ```powershell
-PS C:> Invoke-Command -ComputerName Server01 {Get-Process} `
+PS> Invoke-Command -ComputerName Server01 {Get-Process} `
 -AsJob -JobName RemoteData
 
 Id  Name        PSJobTypeName  State   HasMoreData   Location   Command
@@ -301,8 +297,9 @@ Id  Name        PSJobTypeName  State   HasMoreData   Location   Command
 ```
 
 Create a scheduled job
+
 ```powershell
-PS C:>  Register-ScheduledJob -Name ScheduledJob -ScriptBlock `
+PS>  Register-ScheduledJob -Name ScheduledJob -ScriptBlock `
  {Get-Process} -Trigger (New-JobTrigger -Once -At "3 PM")
 
 Id         Name            JobTriggers     Command       Enabled
@@ -311,14 +308,16 @@ Id         Name            JobTriggers     Command       Enabled
 ```
 
 Create a workflow.
+
 ```powershell
-PS C:> workflow Test-Workflow {Get-Process}
+PS> workflow Test-Workflow {Get-Process}
 ```
 
 Run the workflow as a job.
+
 ```powershell
 
-PS C:> Test-Workflow -AsJob -JobName TestWFJob
+PS> Test-Workflow -AsJob -JobName TestWFJob
 
 Id  Name       PSJobTypeName   State   HasMoreData   Location   Command
 --  ----       -------------   -----   -----------   --------   -------
@@ -329,7 +328,7 @@ Get the jobs. The `Get-Job` command does not get scheduled jobs, but it gets
 instances of the scheduled job that are started.
 
 ```powershell
-PS C:> Get-Job
+PS> Get-Job
 
 Id  Name         PSJobTypeName  State     HasMoreData  Location  Command
 --  ----         -------------  -----     -----------  --------  -------
@@ -342,14 +341,14 @@ Id  Name         PSJobTypeName  State     HasMoreData  Location  Command
 To get scheduled jobs, use the Get-ScheduledJob cmdlet.
 
 ```powershell
-PS C:> Get-ScheduledJob
+PS> Get-ScheduledJob
 
 Id         Name            JobTriggers     Command       Enabled
 --         ----            -----------     -------       -------
 1          ScheduledJob    1               Get-Process   True
 ```
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Jobs](about_Jobs.md)
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Language_Modes.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Language_Modes.md
@@ -249,14 +249,14 @@ NoLanguage session, PowerShell returns the ScriptsNotAllowed error message.
 - ScriptsNotAllowed: The syntax is not supported by this runspace. This
   might be because it is in no-language mode.
 
-# KEYWORDS
+## KEYWORDS
 
 - about_ConstrainedLanguage
 - about_FullLanguage
 - about_NoLanguage
 - about_RestrictedLanguage
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Session_Configuration_Files](about_Session_Configuration_Files.md)
 - [about_Session_Configurations](about_Session_Configurations.md)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Operator_Precedence.md
@@ -87,17 +87,17 @@ order:
 |`> >> 2> 2>> 2>&1`        |[about_Redirection](about_Redirection.md)|
 |`= += -= *= /= %=`        |[about_Assignment_Operators](about_Assignment_Operators.md)|
 
-# EXAMPLES
+## EXAMPLES
 
 The following two commands show the arithmetic operators and the effect of
 using parentheses to force PowerShell to evaluate the enclosed part of
 the expression first.
 
 ```powershell
-C:\PS> 2 + 3 * 4
+PS> 2 + 3 * 4
 14
 
-C:\PS> (2 + 3) * 4
+PS> (2 + 3) * 4
 20
 ```
 
@@ -105,12 +105,13 @@ The following example gets the read-only text files from the local directory
 and saves them in the `$read_only` variable.
 
 ```powershell
-$read_only = get-childitem *.txt | where-object {$_.isReadOnly}
+$read_only = Get-ChildItem *.txt | Where-Object {$_.isReadOnly}
 ```
+
 It is equivalent to the following example.
 
 ```powershell
-$read_only = ( get-childitem *.txt | where-object {$_.isReadOnly} )
+$read_only = ( Get-ChildItem *.txt | Where-Object {$_.isReadOnly} )
 ```
 
 Because the pipeline operator (|) has a higher precedence than the assignment
@@ -127,7 +128,7 @@ which is the first string. Finally, it casts the selected object as a string.
 In this case, the cast has no effect.
 
 ```powershell
-C:\PS> [string]@('Windows','PowerShell','2.0')[0]
+PS> [string]@('Windows','PowerShell','2.0')[0]
 Windows
 ```
 
@@ -137,7 +138,7 @@ before the index selection. As a result, the entire array is cast as a
 array, which is the first character.
 
 ```powershell
-C:\PS> ([string]@('Windows','PowerShell','2.0'))[0]
+PS> ([string]@('Windows','PowerShell','2.0'))[0]
 W
 ```
 
@@ -146,21 +147,21 @@ precedence than the -and (logical AND) operator, the result of the expression
 is FALSE.
 
 ```powershell
-C:\PS> 2 -gt 4 -and 1
+PS> 2 -gt 4 -and 1
 False
 ```
 
 It is equivalent to the following expression.
 
 ```powershell
-C:\PS> (2 -gt 4) -and 1
+PS> (2 -gt 4) -and 1
 False
 ```
 
 If the -and operator had higher precedence, the answer would be TRUE.
 
 ```powershell
-C:\PS> 2 -gt (4 -and 1)
+PS> 2 -gt (4 -and 1)
 True
 ```
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Requirements.md
@@ -276,8 +276,7 @@ $session = New-PSSession -Computer <hostname> -Credential $cred `
 > Authentication in
 > [Authentication for Remote Connections](https://msdn.microsoft.com/en-us/library/aa384295(v=vs.85).aspx)
 
-
-# SEE ALSO
+## SEE ALSO
 
 [about_Remote](about_Remote.md)
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -597,8 +597,8 @@ following command finds the processor architecture of the session in the
 \$s variable.
 
 ```powershell
-$s = New-PSSession -ComputerName Server01 -configurationName CustomShell
-invoke-command -session $s {$env:PROCESSOR_ARCHITECTURE}
+$s = New-PSSession -ComputerName Server01 -ConfigurationName CustomShell
+Invoke-Command -Session $s {$env:PROCESSOR_ARCHITECTURE}
 x86
 ```
 
@@ -788,7 +788,7 @@ attempting to use other authentication schemes may result in the process crashin
 Please see the [OMI authentication](https://github.com/PowerShell/psl-omi-provider#connecting-from-linux-to-windows)
 instructions.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Remote](about_Remote.md)
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Signing.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Signing.md
@@ -16,22 +16,22 @@ policies.
 ## LONG DESCRIPTION
 
 The Restricted execution policy does not permit any scripts to run. The
-AllSigned and RemoteSigned execution policies prevent PowerShell from running
-scripts that do not have a digital signature.
+**AllSigned** and **RemoteSigned** execution policies prevent PowerShell from
+running scripts that do not have a digital signature.
 
 This topic explains how to run selected scripts that are not signed, even
-while the execution policy is RemoteSigned, and how to sign scripts for your
-own use.
+while the execution policy is **RemoteSigned**, and how to sign scripts for
+your own use.
 
 For more information about PowerShell execution policies, see
 [about_Execution_Policies](about_Execution_Policies.md).
 
 ## TO PERMIT SIGNED SCRIPTS TO RUN
 
-When you start PowerShell on a computer for the first time, the Restricted
+When you start PowerShell on a computer for the first time, the **Restricted**
 execution policy (the default) is likely to be in effect.
 
-The Restricted policy does not permit any scripts to run.
+The **Restricted** policy does not permit any scripts to run.
 
 To find the effective execution policy on your computer, type:
 
@@ -42,23 +42,22 @@ Get-ExecutionPolicy
 To run unsigned scripts that you write on your local computer and signed
 scripts from other users, start PowerShell with the Run as Administrator
 option and then use the following command to change the execution policy on
-the computer to RemoteSigned:
+the computer to **RemoteSigned**:
 
 ```powershell
 Set-ExecutionPolicy RemoteSigned
 ```
 
-For more information, see the help topic for the Set-ExecutionPolicy cmdlet.
+For more information, see the help topic for the `Set-ExecutionPolicy` cmdlet.
 
 ## RUNNING UNSIGNED SCRIPTS (REMOTESIGNED EXECUTION POLICY)
 
-If your PowerShell execution policy is RemoteSigned, Windows
-PowerShell will not run unsigned scripts that are downloaded from the
-Internet, including unsigned scripts you receive through e-mail and instant
-messaging programs.
+If your PowerShell execution policy is **RemoteSigned**, Windows PowerShell
+will not run unsigned scripts that are downloaded from the Internet, including
+unsigned scripts you receive through e-mail and instant messaging programs.
 
-If you try to run a downloaded script, PowerShell displays the
-following error message:
+If you try to run a downloaded script, PowerShell displays the following error
+message:
 
 ```output
 The file <file-name> cannot be loaded. The file <file-name> is not digitally
@@ -98,9 +97,9 @@ this publisher.
 
 ## METHODS OF SIGNING SCRIPTS
 
-You can sign the scripts that you write and the
-scripts that you obtain from other sources. Before you sign any script,
-examine each command to verify that it is safe to run.
+You can sign the scripts that you write and the scripts that you obtain from
+other sources. Before you sign any script, examine each command to verify that
+it is safe to run.
 
 For best practices about code signing, see
 [Code-Signing Best Practices](/previous-versions/windows/hardware/design/dn653556(v=vs.85)).
@@ -289,7 +288,7 @@ signed while the signing certificate was valid.
 Because most signing certificates are valid for one year only, using a time
 stamp server ensures that users can use your script for many years to come.
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Execution_Policies](about_Execution_Policies.md)
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Special_Characters.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Special_Characters.md
@@ -8,12 +8,12 @@ title:  about_Special_Characters
 
 # About Special Characters
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Describes the special characters that you can use to control how Windows
 PowerShell interprets the next character in a command or parameter.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 PowerShell supports a set of special character sequences that are used
 to represent characters that are not part of the standard character set.
@@ -206,6 +206,6 @@ X:\VMS /grant Dom\HVAdmin:(CI)(OI)F
 
 For more information about the stop-parsing symbol, see [about_Parsing](about_Parsing.md).
 
-# SEE ALSO
+## SEE ALSO
 
 - [about_Quoting_Rules](about_Quoting_Rules.md)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Splatting.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Splatting.md
@@ -281,7 +281,7 @@ FileVersionInfo    : File:             C:\Windows\System32\WindowsPowerShell
                      Language:         English (United States)
 ```
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Arrays](about_Arrays.md)
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Types.ps1xml.md
@@ -8,12 +8,12 @@ title:  about_Types.ps1xml
 
 # About Types.ps1xml
 
-# SHORT DESCRIPTION
+## SHORT DESCRIPTION
 
 Explains how to use Types.ps1xml files to extend the types of objects
 that are used in PowerShell.
 
-# LONG DESCRIPTION
+## LONG DESCRIPTION
 
 Extended type data defines additional properties and methods ("members")
 of object types in PowerShell. There are two techniques for adding
@@ -21,7 +21,7 @@ extended type data to a PowerShell session.
 
 - Types.ps1xml file: An XML file that defines extended type data.
 - `Update-TypeData`: A cmdlet that reloads Types.ps1xml files and defines
-extended data for types in the current session.
+  extended data for types in the current session.
 
 This topic describes Types.ps1xml files. For more information about using the
 `Update-TypeData` cmdlet to add dynamic extended type data to the current
@@ -398,8 +398,8 @@ tags) is always "PsStandardMembers", and the names of the properties
 - `DefaultDisplayPropertySet`: One or more properties of an object.
 
 - `DefaultKeyPropertySet`: One or more key properties of an object.
-A key property identifies instances of property values, such as
-the ID number of items in a session history.
+  A key property identifies instances of property values, such as
+  the ID number of items in a session history.
 
 For example, the following XML defines the default display of services
 (`System.ServiceProcess.ServiceController` objects) that are returned by
@@ -590,7 +590,7 @@ To protect users of your Types.ps1xml file, you can sign the file using a
 digital signature. For more information, see
 [about_Signing](about_Signing.md).
 
-# SEE ALSO
+## SEE ALSO
 
 [about_Signing](about_Signing.md)
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Updatable_Help.md
@@ -447,7 +447,7 @@ your modules. For more information, see "Supporting Updatable Help" and
 
 Updatable help not available for PowerShell snap-ins or comment-based help.
 
-# REMARKS
+## REMARKS
 
 The Update-Help and Save-Help cmdlets are not supported on Windows
 Preinstallation Environment (Windows PE).

--- a/reference/docs-conceptual/core-powershell/web-access/install-and-use-windows-powershell-web-access.md
+++ b/reference/docs-conceptual/core-powershell/web-access/install-and-use-windows-powershell-web-access.md
@@ -30,7 +30,7 @@ run a web-based Windows PowerShell console after successful authentication.
 
 Windows PowerShell Web Access setup and configuration is a three-step process:
 
-1. [Install Windows PowerShell Web Access](#install-windows-powershell-web-access)
+1. [Install Windows PowerShell Web Access](#install-windows-powershell-web-access-using-powershell-cmdlets)
 1. [Configure the Gateway](#configure-the-gateway)
 1. [Configure a restrictive authorization rule](#configure-a-restrictive-authorization-rule)
 
@@ -107,7 +107,7 @@ Server 2012 R2 or Windows Server 2012 by using either Windows PowerShell cmdlets
 Add Roles and Features Wizard that is opened from within Server Manager. For quick installation and
 configuration, use Windows PowerShell cmdlets, as described in this section.
 
-1. [Install Windows PowerShell Web Access](#install-Windows-powershell-web-access)
+1. [Install Windows PowerShell Web Access](#install-windows-powershell-web-access-using-powershell-cmdlets)
 1. [Configure the Gateway](#configure-the-gateway)
 1. [Configure a restrictive authorization rule](#configure-a-restrictive-authorization-rule)
 

--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Linux.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Linux.md
@@ -26,7 +26,7 @@ Once the package is installed, run `pwsh` from a terminal.
 [deb9]: #debian-9
 [cos]: #centos-7
 [rhel7]: #red-hat-enterprise-linux-rhel-7
-[opensuse]: #opensuse-423
+[opensuse]: #opensuse
 [fedora]: #fedora
 [arch]: #arch-linux
 [snap]: #snap-package

--- a/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Windows.md
+++ b/reference/docs-conceptual/setup/Installing-PowerShell-Core-on-Windows.md
@@ -98,7 +98,7 @@ In both cases, you will need the Windows 10 x64 ZIP release package and will nee
 1. Use your favorite zip utility to unzip the package to a directory within the mounted Nano Server image.
 2. Unmount the image and boot it.
 3. Connect to the inbox instance of Windows PowerShell.
-4. Follow the instructions to create a remoting endpoint using the ["another instance technique"](#executed-by-another-instance-of-powershell-on-behalf-of-the-instance-that-it-will-register).
+4. Follow the instructions to create a remoting endpoint using the ["another instance technique"](../core-powershell/wsman-remoting-in-powershell-core.md#executed-by-another-instance-of-powershell-on-behalf-of-the-instance-that-it-will-register).
 
 ### Online Deployment of PowerShell Core
 

--- a/reference/docs-conceptual/whats-new/What-s-New-in-Windows-PowerShell-50.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-Windows-PowerShell-50.md
@@ -9,7 +9,7 @@ Windows PowerShell 5.0 includes significant new features that extend its use, im
 
 Windows PowerShell 5.0 is backward-compatible. Cmdlets, providers, modules, snap-ins, scripts, functions, and profiles that were designed for Windows PowerShell 4.0, Windows PowerShell 3.0, and Windows PowerShell 2.0 generally work in Windows PowerShell 5.0 without changes.
 
-# Installing Windows PowerShell
+## Installing Windows PowerShell
 Windows PowerShell 5.0 is installed by default on Windows Server  2016 Technical Preview and Windows 10 .
 
 To install Windows PowerShell 5.0 on Windows Server 2012 R2, Windows 8.1 Enterprise, or Windows 8.1 Pro, download and install [Windows Management Framework 5.0](http://aka.ms/wmf5download). Be sure to read the download details, and meet all system requirements, before you install Windows Management Framework 5.0.
@@ -25,98 +25,61 @@ To install Windows PowerShell 5.0 on Windows Server 2012 R2, Windows 8.1 Enterpr
 Many updates and improvements to Windows PowerShell Desired State Configuration (DSC) in Windows PowerShell 4.0 are available in the [November 2014 update rollup for Windows RT 8.1, Windows 8.1, and Windows Server 2012 R2](https://support.microsoft.com/kb/3000850/) (KB 3000850). You can determine if KB 3000850 is installed on your system by running `Get-Hotfix -Id KB3000850` in Windows PowerShell.
 
 - Updates to existing cmdlets in the [PSDesiredStateConfiguration](https://technet.microsoft.com/library/dn391651(v=wps.640).aspx) module
-
-    -   [Get-DscResource](http://technet.microsoft.com/library/dn521625.aspx) is faster (especially in ISE).
-
-    -   [Start-DscConfiguration](http://technet.microsoft.com/library/dn521623.aspx) has a new parameter, -UseExisting, which reapplies the last applied configuration.
-
-    -   [Start-DscConfiguration](http://technet.microsoft.com/library/dn521623.aspx) -Force has been fixed.
-
-    -   [Get-DscLocalConfigurationManager](http://technet.microsoft.com/library/dn407378.aspx) displays more useful information about the engine state.
-
-    -   [Test-DscConfiguration](http://technet.microsoft.com/library/dn407382.aspx) now returns the computer name along with True or False.
-
-    -   [New-DscChecksum](http://technet.microsoft.com/library/dn521622.aspx) now supports UNC paths.
+  - [Get-DscResource](http://technet.microsoft.com/library/dn521625.aspx) is faster (especially in ISE).
+  - [Start-DscConfiguration](http://technet.microsoft.com/library/dn521623.aspx) has a new parameter, -UseExisting, which reapplies the last applied configuration.
+  - [Start-DscConfiguration](http://technet.microsoft.com/library/dn521623.aspx) -Force has been fixed.
+  - [Get-DscLocalConfigurationManager](http://technet.microsoft.com/library/dn407378.aspx) displays more useful information about the engine state.
+  - [Test-DscConfiguration](http://technet.microsoft.com/library/dn407382.aspx) now returns the computer name along with True or False.
+  - [New-DscChecksum](http://technet.microsoft.com/library/dn521622.aspx) now supports UNC paths.
 
 - New cmdlets in the [PSDesiredStateConfiguration](http://technet.microsoft.com/library/dn391651(v=wps.640).aspx) module
-
-    -   [Update-DscConfiguration](http://technet.microsoft.com/library/mt143541(v=wps.630).aspx):  Performs an on-demand pull server check.
-
-    -   [Stop-DscConfiguration](http://technet.microsoft.com/library/mt143542(v=wps.630).aspx):  Stops a configuration that is already running.
-
-    -   [Remove-DscConfigurationDocument](http://technet.microsoft.com/library/mt143544(v=wps.630).aspx):  Lets you remove configuration documents in various stages (pending, previous, or current).
+  - [Update-DscConfiguration](http://technet.microsoft.com/library/mt143541(v=wps.630).aspx):  Performs an on-demand pull server check.
+  - [Stop-DscConfiguration](http://technet.microsoft.com/library/mt143542(v=wps.630).aspx):  Stops a configuration that is already running.
+  - [Remove-DscConfigurationDocument](http://technet.microsoft.com/library/mt143544(v=wps.630).aspx):  Lets you remove configuration documents in various stages (pending, previous, or current).
 
 - Language enhancements
-
-    -   DependsOn now supports composite resources.
-
-    -   DependsOn now supports numbers in resource instance names.
-
-    -   Node expressions that evaluate to empty no longer throw errors.
-
-    -   An error that occurs if a node expression evaluates to empty has been fixed.
-
-    -   Configurations calling configurations now work in the Windows PowerShell console.
+  - DependsOn now supports composite resources.
+  - DependsOn now supports numbers in resource instance names.
+  - Node expressions that evaluate to empty no longer throw errors.
+  - An error that occurs if a node expression evaluates to empty has been fixed.
+  - Configurations calling configurations now work in the Windows PowerShell console.
 
 - Pull mode enhancements
-
-    -   Pull mode now supports all ZIP files.
-
-    -   **AllowModuleOverwrite** now works correctly.
+  - Pull mode now supports all ZIP files.
+  - **AllowModuleOverwrite** now works correctly.
 
 - Resiliency improvements
-
-    -   New **DebugMode** lets you reload resource modules.
-
-    -   If a configuration failure occurs, the pending.mof file is not deleted.
-
-    -   The Local Configuration Manager (LCM) is now more resilient when metaconfiguration settings have become corrupted.
+  - New **DebugMode** lets you reload resource modules.
+  - If a configuration failure occurs, the pending.mof file is not deleted.
+  - The Local Configuration Manager (LCM) is now more resilient when metaconfiguration settings have become corrupted.
 
 - Diagnostic improvements
-
-    -   A warning is displayed when the LCM sets the timer to different settings than you have specified.
-
-    -   Error log files now contain the call stack for Windows PowerShell resources.
+  - A warning is displayed when the LCM sets the timer to different settings than you have specified.
+  - Error log files now contain the call stack for Windows PowerShell resources.
 
 - Flexibility improvements
-
-    -   The LocalConfigurationManager resource has a new property, **ActionAfterReboot**.
-
-        -   ContinueConfiguration (default value): Automatically resumes a configuration after a target node restarts.
-
-        -   StopConfiguration: Do not automatically resume a configuration after a node restarts.
-
-    -   A consistency run can now occur more often than a PULL operation, or vice-versa.
-
-    -   Versioning support:  DSC can now recognize a document that was generated on a newer client (included with [WMF 5.0](http://aka.ms/wmf5download)).
+  - The LocalConfigurationManager resource has a new property, **ActionAfterReboot**.
+    - ContinueConfiguration (default value): Automatically resumes a configuration after a target node restarts.
+    - StopConfiguration: Do not automatically resume a configuration after a node restarts.
+  - A consistency run can now occur more often than a PULL operation, or vice-versa.
+  - Versioning support:  DSC can now recognize a document that was generated on a newer client (included with [WMF 5.0](http://aka.ms/wmf5download)).
 
 - Error prevention improvements
-
-    -   Module version is now enforced before a configuration is applied.
-
-    -   **DebugPreference** is now set correctly for Get-, Set-, or Test-TargetResource calls.
+  - Module version is now enforced before a configuration is applied.
+  - **DebugPreference** is now set correctly for Get-, Set-, or Test-TargetResource calls.
 
 - Credential handling improvements
-
-    -   A certificate is now used, if both **Certificate** and **PSDscAllowPlainTextPassword** are specified.
-
-    -   Credentials are decrypted, even for Get-TargetResource.
-
-    -   Metaconfiguration credentials are encrypted and decrypted.
-
-    -   PSCredentials are now decrypted when they are in an embedded object.
+  - A certificate is now used, if both **Certificate** and **PSDscAllowPlainTextPassword** are specified.
+  - Credentials are decrypted, even for Get-TargetResource.
+  - Metaconfiguration credentials are encrypted and decrypted.
+  - PSCredentials are now decrypted when they are in an embedded object.
 
 - Built-in resource improvements
-
-    -   The Package resource
-
-        -   No longer installs the wrong package (either from local or web sources).
-
-        -   Now supports HTTPS.
-
-    -   There is now support for HTTPS in the [Package resource](http://technet.microsoft.com/library/dn282132.aspx).
-
-    -   [Archive resource](http://technet.microsoft.com/library/dn249917.aspx) now supports credentials.
+  - The Package resource
+    - No longer installs the wrong package (either from local or web sources).
+    - Now supports HTTPS.
+  - There is now support for HTTPS in the [Package resource](http://technet.microsoft.com/library/dn282132.aspx).
+  - [Archive resource](http://technet.microsoft.com/library/dn249917.aspx) now supports credentials.
 
 ## New features in Windows PowerShell 5.0
 
@@ -131,159 +94,87 @@ Many updates and improvements to Windows PowerShell Desired State Configuration 
 - Starting in Windows PowerShell 5.0, you can develop by using classes, by using formal syntax and semantics that are similar to other object-oriented programming languages. **Class**, **Enum**, and other keywords have been added to the Windows PowerShell language to support the new feature. For more information about working with classes, see about_Classes.
 
 - Windows PowerShell 5.0 introduces a new, structured information stream that you can use to transmit structured data between a script and its callers (or hosting environment). You can now use Write-Host to emit output to the information stream. Information streams also work for PowerShell.Streams, jobs, scheduled jobs, and workflows. The following features support the information stream.
-
-    -   A new Write-Information cmdlet that lets you specify how Windows PowerShell handles information stream data for a command. Write-Host is a wrapper for Write-Information. Write-Information is also a supported workflow activity.
-
-    -   Two new common parameters, InformationVariable and InformationAction, let you determine how information streams from a command are displayed. Valid values for InformationAction are SilentlyContinue, Stop, Continue, Inquire, Ignore, or Suspend, with SilentlyContinue being the default. InformationVariable specifies a string as the name of a variable to which you want the Write-Host data from a command saved.
-
-    -   A new preference variable, InformationPreference, specifies your default preference for information stream data in a Windows PowerShell session. The default value is SilentlyContinue.
-
-    -   Two new workflow common parameters, PSInformation and InformationAction, have been added.
-
-    -   When you use the Format-Table command, table columns are now automatically formatted by evaluating the first 300ms of data that passes through the stream.
+  - A new Write-Information cmdlet that lets you specify how Windows PowerShell handles information stream data for a command. Write-Host is a wrapper for Write-Information. Write-Information is also a supported workflow activity.
+  - Two new common parameters, InformationVariable and InformationAction, let you determine how information streams from a command are displayed. Valid values for InformationAction are SilentlyContinue, Stop, Continue, Inquire, Ignore, or Suspend, with SilentlyContinue being the default. InformationVariable specifies a string as the name of a variable to which you want the Write-Host data from a command saved.
+  - A new preference variable, InformationPreference, specifies your default preference for information stream data in a Windows PowerShell session. The default value is SilentlyContinue.
+  - Two new workflow common parameters, PSInformation and InformationAction, have been added.
+  - When you use the Format-Table command, table columns are now automatically formatted by evaluating the first 300ms of data that passes through the stream.
 
 - In collaboration with [Microsoft Research](http://research.microsoft.com/), a new cmdlet, ConvertFrom-String, has been added. ConvertFrom-String lets you extract and parse structured objects from the content of text strings. For more information, see ConvertFrom-String.
-
 - A new Convert-String cmdlet automatically formats text based on an example that you provide in an -Example parameter.
-
 - A new module, Microsoft.PowerShell.Archive, includes cmdlets that let you compress files and folders into archive (also known as ZIP) files, extract files from existing ZIP files, and update ZIP files with newer versions of files compressed within them.
-
 - A new module, PackageManagement, lets you discover and install software packages on the Internet. The PackageManagement (formerly known as OneGet) module is a manager or multiplexer of existing package managers (also called package providers) to unify Windows package management with a single Windows PowerShell interface.
-
 - A new module, PowerShellGet, lets you find, install, publish, and update modules and DSC resources on the [PowerShell Gallery](http://www.powershellgallery.com/), or on an internal module repository that you can set up by running the Register-PSRepository cmdlet.
-
 - A new language keyword, **Hidden**, has been added to specify that a member (a property or a method) is not shown by default in Get-Member results (unless you add the -Force parameter). Properties or methods that have been marked hidden also do not show up in IntelliSense results, unless you are in a context where the member should be visible; for example, the automatic variable $This should show hidden members when in the class method.
-
 - New-Item, Remove-Item, and Get-ChildItem have been enhanced to support creating and managing [symbolic links](http://en.wikipedia.org/wiki/Symbolic_link). The **-ItemType** parameter for New-Item accepts a new value, **SymbolicLink**. Now you can create symbolic links in a single line by running the New-Item cmdlet.
-
 - Get-ChildItem also has a new -Depth parameter, which you use with the -Recurse parameter to limit the recursion. For example, Get-ChildItem -Recurse -Depth 2 returns results from the current folder, all of the child folders within the current folder, and all of the folders within the child folders.
-
 - Copy-Item now lets you copy files or folders from one Windows PowerShell session to another, meaning that you can copy files to sessions that are connected to remote computers, (including computers that are running [Nano Server](http://blogs.technet.com/b/windowsserver/archive/2015/04/08/microsoft-announces-nano-server-for-modern-apps-and-cloud.aspx), and thus have no other interface). To copy files, specify PSSession IDs as the value of the new -FromSession and -ToSession parameters, and add -Path and -Destination to specify origin path and destination, respectively. For example, Copy-Item -Path c:\\myFile.txt -ToSession $s -Destination d:\\destinationFolder.
-
 - Windows PowerShell transcription has been improved to apply to all hosting applications (such as Windows PowerShell ISE) in addition to the console host (**powershell.exe**). Transcription options (including enabling a system-wide transcript) can be configured by enabling the **Turn on PowerShell Transcription** Group Policy setting, found in Administrative Templates/Windows Components/Windows PowerShell.
-
 - A new detailed script tracing feature lets you enable detailed tracking and analysis of Windows PowerShell scripting use on a system. After you enable detailed script tracing, Windows PowerShell logs all script blocks to the Event Tracing for Windows (ETW) event log, **Microsoft-Windows-PowerShell/Operational**.
-
 - Starting in Windows PowerShell 5.0, new Cryptographic Message Syntax cmdlets support encryption and decryption of content by using the IETF standard format for cryptographically protecting messages as documented by [RFC5652](http://tools.ietf.org/html/rfc5652). The Get-CmsMessage, Protect-CmsMessage, and Unprotect-CmsMessage cmdlets have been added to the [Microsoft.PowerShell.Security](http://technet.microsoft.com/library/hh849807.aspx) module.
-
 - New cmdlets in the [Microsoft.PowerShell.Utility](http://technet.microsoft.com/library/hh849958.aspx) module, Get-Runspace, Debug-Runspace, Get-RunspaceDebug, Enable-RunspaceDebug, and Disable-RunspaceDebug, let you set debug options on a runspace, and start and stop debugging on a runspace. For debugging arbitrary runspaces'”that is, runspaces that are not the default runspace for a Windows PowerShell console or Windows PowerShell ISE session'”Windows PowerShell lets you set breakpoints in a script, and have added breakpoints stop the script from running until you can attach a debugger to debug the runspace script. Nested debugging support for arbitrary runspaces has been added to the Windows PowerShell script debugger for runspaces.
-
 - A new Format-Hex cmdlet has been added to the [Microsoft.PowerShell.Utility](http://technet.microsoft.com/library/hh849958.aspx) module. Format-Hex lets you view text or binary data in hexadecimal format.
-
 - Get-Clipboard and Set-Clipboard cmdlets have been added to the [Microsoft.PowerShell.Utility](http://technet.microsoft.com/library/hh849958.aspx) module; they ease the transfer of content to and from a Windows PowerShell session. The Clipboard cmdlets support images, audio files, file lists, and text.
-
 - A new cmdlet, Clear-RecycleBin, has been added to the [Microsoft.PowerShell.Management](http://technet.microsoft.com/library/hh849827(v=wps.640).aspx) module; this cmdlet empties the Recycle Bin for a fixed drive, which includes external drives. By default, you are prompted to confirm a Clear-RecycleBin command, because the ConfirmImpact property of the cmdlet is set to ConfirmImpact.High.
-
 - A new cmdlet, New-TemporaryFile, lets you create a temporary file as part of scripting. By default, the new temporary file is created in ```C:\Users\<user name>\AppData\Local\Temp```.
-
 - The Out-File, Add-Content, and Set-Content cmdlets now have a new -NoNewline parameter, which omits a new line after the output.
-
 - The New-Guid cmdlet leverages the .NET Framework Guid class to generate a GUID, useful when you are writing scripts or DSC resources.
-
 - Because file version information can be misleading, particularly after a file is patched, new FileVersionRaw and ProductVersionRaw script properties are available for FileInfo objects. For example, you can run the following command to display the values of these properties for powershell.exe, where $pid contains the process ID for a running session of Windows PowerShell:  ```Get-Process -Id $pid -FileVersionInfo | Format-List *version* -Force```
-
 - New cmdlets Enter-PSHostProcess and Exit-PSHostProcess let you debug Windows PowerShell scripts in processes separate from the current process that is running in the Windows PowerShell console. Run Enter-PSHostProcess to enter, or attach to, a specific process ID, and then run Get-Runspace to return the active runspaces within the process. Run Exit-PSHostProcess to detach from the process when you are finished debugging the script within the process.
-
 - A new Wait-Debugger cmdlet has been added to the [Microsoft.PowerShell.Utility](http://technet.microsoft.com/library/hh849958.aspx) module. You can run Wait-Debugger to stop a script in the debugger before running the next statement in the script.
-
 - The Windows PowerShell Workflow debugger now supports command or tab completion, and you can debug nested workflow functions. You can now press **Ctrl+Break** to enter the debugger in a running script, in both local and remote sessions, and in a workflow script.
-
 - A Debug-Job cmdlet has been added to the [Microsoft.PowerShell.Core](http://technet.microsoft.com/library/hh849695.aspx) module to debug running job scripts for Windows PowerShell Workflow, background, and jobs running in remote sessions.
-
 - A new state, AtBreakpoint, has been added for Windows PowerShell jobs. The AtBreakpoint state applies when a job is running a script that includes set breakpoints, and the script has hit a breakpoint. When a job is stopped at a debug breakpoint, you must debug the job by running the Debug-Job cmdlet.
-
 - Windows PowerShell 5.0 implements support for multiple versions of a single Windows PowerShell module in the same folder in $PSModulePath. A RequiredVersion property has been added to the ModuleSpecification class to help you get the desired version of a module; this property is mutually exclusive with the ModuleVersion property. RequiredVersion is now supported as part of the value of the FullyQualifiedName parameter of the Get-Module, Import-Module, and Remove-Module cmdlets.
-
 - You can now perform module version validation by running the Test-ModuleManifest cmdlet.
-
 - Results of the Get-Command cmdlet now display a Version column; a new Version property has been added to the CommandInfo class. Get-Command shows commands from multiple versions of the same module. The Version property is also part of derived classes of CmdletInfo: CmdletInfo and ApplicationInfo.
-
 - Get-Command has a new parameter, -ShowCommandInfo, that returns ShowCommand information as PSObjects. This is especially useful functionality for when Show-Command is run in Windows PowerShell ISE by using Windows PowerShell remoting. The -ShowCommandInfo parameter replaces the existing Get-SerializedCommand function in the Microsoft.PowerShell.Utility module, but the Get-SerializedCommand script is still available to support downlevel scripting.
-
 - A new Get-ItemPropertyValue cmdlet lets you get the value of a property without using dot notation. For example, in older releases of Windows PowerShell, you can run the following command to get the value of the Application Base property of the PowerShellEngine registry key: **(Get-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\3\\PowerShellEngine -Name ApplicationBase).ApplicationBase**. Starting in Windows PowerShell 5.0, you can run **Get-ItemPropertyValue -Path HKLM:\\SOFTWARE\\Microsoft\\PowerShell\\3\\PowerShellEngine -Name ApplicationBase**.
-
 - The Windows PowerShell console now uses syntax coloring, just as in Windows PowerShell ISE.
-
 - A new NetworkSwitch module contains cmdlets that enable you to apply switch, virtual LAN (VLAN), and basic Layer 2 network switch port configuration to Windows Server 2012 R2 logo-certified network switches.
-
 - The FullyQualifiedName parameter has been added to Import-Module and Remove-Module cmdlets, to support storing multiple versions of a single module.
-
 - Save-Help, Update-Help, Import-PSSession, Export-PSSession, and Get-Command have a new parameter, FullyQualifiedModule, of type ModuleSpecification. Add this parameter to specify a module by its fully qualified name.
-
 - The value of **$PSVersionTable.PSVersion** has been updated to 5.0.
 
 ### New features in Windows PowerShell Desired State Configuration
 
 - Windows PowerShell language enhancements let you define Windows PowerShell Desired State Configuration (DSC) resources by using classes. Import-DscResource is now a true dynamic keyword; Windows PowerShell parses the specified module'™s root module, searching for classes that contain the DscResource attribute. You can now use classes to define DSC resources, in which neither a MOF file nor a DSCResource subfolder in the module folder is required. A Windows PowerShell module file can contain multiple DSC resource classes.
-
 - A new parameter, ThrottleLimit, has been added to the following cmdlets in the PSDesiredStateConfiguration module. Add the ThrottleLimit parameter to specify the number of target computers or devices on which you want the command to work at the same time.
-
-    -   Get-DscConfiguration
-
-    -   Get-DscConfigurationStatus
-
-    -   Get-DscLocalConfigurationManager
-
-    -   Restore-DscConfiguration
-
-    -   Test-DscConfiguration
-
-    -   Compare-DscConfiguration
-
-    -   Publish-DscConfiguration
-
-    -   Set-DscLocalConfigurationManager
-
-    -   Start-DscConfiguration
-
-    -   Update-DscConfiguration
-
+  - Get-DscConfiguration
+  - Get-DscConfigurationStatus
+  - Get-DscLocalConfigurationManager
+  - Restore-DscConfiguration
+  - Test-DscConfiguration
+  - Compare-DscConfiguration
+  - Publish-DscConfiguration
+  - Set-DscLocalConfigurationManager
+  - Start-DscConfiguration
+  - Update-DscConfiguration
 - With centralized DSC error reporting, rich error information is not only logged in the event log, but it can be sent to a central location for later analysis. You can use this central location to store DSC configuration errors that have occurred for any server in their environment. After the report server is defined in the meta-configuration, all errors are sent to the report server, and then stored in a database. You can set up this functionality regardless of whether or not a target node is configured to pull configurations from a pull server.
-
 - Improvements to Windows PowerShell ISE ease DSC resource authoring. You can now do the following.
-
-    -   List all DSC resources within a **configuration** or **node** block by entering **Ctrl+Space** on a blank line within the block.
-
-    -   Automatic completion on resource properties of the **enumeration** type.
-
-    -   Automatic completion on the **DependsOn** property of DSC resources, based on other resource instances in the configuration.
-
-    -   Improved tab completion of resource property values.
-
+  - List all DSC resources within a **configuration** or **node** block by entering **Ctrl+Space** on a blank line within the block.
+  - Automatic completion on resource properties of the **enumeration** type.
+  - Automatic completion on the **DependsOn** property of DSC resources, based on other resource instances in the configuration.
+  - Improved tab completion of resource property values.
 - A user can now run a resource under a specified set of credentials by adding the **PSDscRunAsCredential** attribute to a Node block. For example, PSDscRunAsCredential = Get-Credential Contoso\\DscUser. This functionality is useful for creating configurations that run Windows Installer and executable installers, access the per-user registry hive, or perform other tasks outside the current user context.
-
 - 32-bit (x86-based) support has been added for the **Configuration** keyword.
-
 - Windows PowerShell now includes support for custom help for DSC configurations, defined by adding \[CmdletBinding()] to the generated configuration function.
-
 - A new **DscLocalConfigurationManager** attribute designates a configuration block as a meta-configuration, which is used to configure the DSC Local Configuration Manager. This attribute restricts a configuration to containing only items which configure the DSC Local Configuration Manager. During processing, this configuration generates a \*.meta.mof file that is then sent to the appropriate target nodes by running the Set-DscLocalConfigurationManager cmdlet.
-
 - Partial configurations are now allowed in Windows PowerShell 5.0. You can deliver configuration documents to a node in fragments. For a node to receive multiple fragments of a configuration document, the node'™s Local Configuration Manager must be first set to specify the expected fragments
-
 - Cross-computer synchronization is new in DSC in Windows PowerShell 5.0. By using the built-in WaitFor\* resources (**WaitForAll**, **WaitForAny**, and **WaitForSome**), you can now specify dependencies across computers during configuration runs, without external orchestrations. These resources provide node-to-node synchronization by using CIM connections over the WS-Man protocol. A configuration can wait for another computer'™s specific resource state to change.
-
 - Just Enough Administration (JEA), a new delegation security feature, leverages DSC and Windows PowerShell constrained runspaces to help secure enterprises from data loss or compromise by employees, whether intentional or unintentional. For more information about JEA, including where you can download the xJEA DSC resource, see [Just Enough Administration, Step by Step](http://blogs.technet.com/b/privatecloud/archive/2014/05/14/just-enough-administration-step-by-step.aspx).
-
 - The following new cmdlets have been added to the PSDesiredStateConfiguration module.
-
-    -   A new Get-DscConfigurationStatus cmdlet gets high-level information about configuration status from a target node. You can obtain the status of the last, or of all configurations.
-
-    -   A new Compare-DscConfiguration cmdlet compares a specified configuration with the actual state of one or more target nodes.
-
-    -   A new Publish-DscConfiguration cmdlet copies a configuration MOF file to a target node, but does not apply the configuration. The configuration is applied during the next consistency pass, or when you run the Update-DscConfiguration cmdlet.
-
-    -   A new Test-DscConfiguration cmdlet lets you verify that a resulting configuration matches the desired configuration, returning either True if the configuration matches the desired configuration, or False if the actual configuration does not match the desired configuration.
-
-    -   A new Update-DscConfiguration cmdlet forces a configuration to be processed. If the Local Configuration Manager is in pull mode, the cmdlet gets the configuration from the pull server before applying it.
+  - A new Get-DscConfigurationStatus cmdlet gets high-level information about configuration status from a target node. You can obtain the status of the last, or of all configurations.
+  - A new Compare-DscConfiguration cmdlet compares a specified configuration with the actual state of one or more target nodes.
+  - A new Publish-DscConfiguration cmdlet copies a configuration MOF file to a target node, but does not apply the configuration. The configuration is applied during the next consistency pass, or when you run the Update-DscConfiguration cmdlet.
+  - A new Test-DscConfiguration cmdlet lets you verify that a resulting configuration matches the desired configuration, returning either True if the configuration matches the desired configuration, or False if the actual configuration does not match the desired configuration.
+  - A new Update-DscConfiguration cmdlet forces a configuration to be processed. If the Local Configuration Manager is in pull mode, the cmdlet gets the configuration from the pull server before applying it.
 
 ### New features in Windows PowerShell ISE
 
 - You can now edit remote Windows PowerShell scripts and files in a local copy of Windows PowerShell ISE, by running Enter-PSSession to start a remote session on the computer that'™s storing the files you want to edit, and then running **PSEdit <path and file name on the remote computer>**. This feature eases editing Windows PowerShell files that are stored on the Server Core installation option of Windows Server, where Windows PowerShell ISE cannot run.
-
 - The Start-Transcript cmdlet is now supported in Windows PowerShell ISE.
-
 - You can now debug remote scripts in Windows PowerShell ISE.
-
 - A new menu command, **Break All** (Ctrl+B), breaks into the debugger for both local and remotely-running scripts.
 
 ### New features in Windows PowerShell Web Services (Management OData IIS Extension)
@@ -293,10 +184,10 @@ Many updates and improvements to Windows PowerShell Desired State Configuration 
 ### Notable bug fixes in Windows PowerShell 5.0
 
 - Windows PowerShell 5.0 includes a new COM implementation, which offers significant performance improvements when you are working with COM objects. For a video demonstration of the effect, see [Com_Perf_Improvements](http://1drv.ms/1qu3UPZ).
-
 - Significant performance improvements have been made to the first tab completion in a Windows PowerShell session, shortening tab completion time by nearly 500 ms.
 
 ## New features in Windows PowerShell 4.0
+
 Windows PowerShell 4.0 is backward-compatible. Cmdlets, providers, modules, snap-ins, scripts, functions, and profiles that were designed for Windows PowerShell 3.0 and Windows PowerShell 2.0 work in Windows PowerShell 4.0 without changes.
 
 Windows PowerShell 4.0 is installed by default on Windows 8.1 and Windows Server 2012 R2. To install Windows PowerShell 4.0 on Windows 7 with SP1, or Windows Server 2008 R2, download and install [Windows Management Framework 4.0](http://www.microsoft.com/download/details.aspx?id=40855). Be sure to read the download details, and meet all system requirements, before you install Windows Management Framework 4.0.
@@ -313,130 +204,80 @@ Windows PowerShell 4.0 includes the following new features.
 ### New features in Windows PowerShell
 
 - **Windows PowerShell Desired State Configuration** (DSC) is a new management system in Windows PowerShell 4.0 that enables the deployment and management of configuration data for software services and the environment in which these services run. For more information about DSC, see [Get Started with Windows PowerShell Desired State Configuration](https://technet.microsoft.com/library/c134aa32-b085-4656-9a89-955d8ff768d0).
-
 - **Save-Help** now lets you save help for modules that are installed on remote computers. You can use Save-Help to download module Help from an Internet-connected client (on which not all of the modules for which you want help are necessarily installed), and then copy the saved Help to a remote shared folder or a remote computer that does not have Internet access.
-
 - The Windows PowerShell debugger has been enhanced to allow debugging of Windows PowerShell workflows, as well as scripts that are running on remote computers. Windows PowerShell workflows can now be debugged at the script level from either the Windows PowerShell command line or Windows PowerShell ISE. Windows PowerShell scripts, including script workflows, can now be debugged over remote sessions. Remote debugging sessions are preserved over Windows PowerShell remote sessions that are disconnected and then later reconnected.
-
 - A **RunNow** parameter for **Register-ScheduledJob** and **Set-ScheduledJob** eliminates the need to set an immediate start date and time for jobs by using the **Trigger** parameter.
-
 - **Invoke-RestMethod** and **Invoke-WebRequest** now let you set all headers by using the Headers parameter. Although this parameter has always existed, it was one of several parameters for the web cmdlets that resulted in exceptions or errors.
-
 - **Get-Module** has a new parameter, **FullyQualifiedName**, of the type **ModuleSpecification\[]**. The **FullyQualifiedName** parameter of Get-Module now lets you specify a module by using the module's name, version, and optionally, its GUID.
-
 - The default execution policy setting on Windows Server 2012 R2 is **RemoteSigned**. On Windows 8.1, there is no change in default setting.
-
 - Starting in Windows PowerShell 4.0, method invocation by using dynamic method names is supported. You can use a variable to store a method name, and then dynamically invoke the method by calling the variable.
-
 - Asynchronous workflow jobs are no longer deleted when the time-out period that is specified by the **PSElapsedTimeoutSec** workflow common parameter has elapsed.
-
 - A new parameter, **RepeatIndefinitely**, has been added to the **New-JobTrigger** and **Set-JobTrigger** cmdlets. This eliminates the necessity of specifying a **TimeSpan.MaxValue** value for the **RepetitionDuration** parameter to run a scheduled job repeatedly for an indefinite period.
-
 - A **Passthru** parameter has been added to the **Enable-JobTrigger** and **Disable-JobTrigger** cmdlets. The Passthru parameter displays any objects that are created or modified by your command.
-
 - The parameter names for specifying a workgroup in the **Add-Computer** and **Remove-Computer** cmdlets are now consistent. Both cmdlets now use the parameter **WorkgroupName**.
-
 - A new common parameter, **PipelineVariable**, has been added. PipelineVariable lets you save the results of a piped command (or part of a piped command) as a variable that can be passed through the remainder of the pipeline.
-
 - Collection filtering by using a method syntax is now supported. This means that you can now filter a collection of objects by using simplified syntax, similar to that for Where() or Where-Object, formatted as a method call. The following is an example: (Get-Process).where({$_.Name -match 'powershell'})
-
 - The **Get-Process** cmdlet has a new switch parameter, **IncludeUserName**.
-
 - A new cmdlet, **Get-FileHash**, that returns a file hash in one of several formats for a specified file, has been added.
-
 - In Windows PowerShell 4.0, if a module uses the **DefaultCommandPrefix** key in its manifest, or if the user imports a module with the **Prefix** parameter, the **ExportedCommands** property of the module shows the commands in the module with the prefix. When you run the commands by using the module-qualified syntax, ModuleName\\CommandName, the command names must include the prefix.
-
 - The value of **$PSVersionTable.PSVersion** has been updated to 4.0.
-
 - **Where()** operator behavior has changed. `Collection.Where('property -match name')` accepting a string expression in the format `"Property -CompareOperator Value"` is no longer supported. However, the **Where()** operator accepts string expressions in the format of a scriptblock; this is still supported.
 
 ### New features in Windows PowerShell Integrated Scripting Environment (ISE)
 
 - Windows PowerShell ISE supports both Windows PowerShell Workflow debugging and remote script debugging.
-
 - IntelliSense support has been added for Windows PowerShell Desired State Configuration providers and configurations.
 
 ### New features in Windows PowerShell Workflow
 
 - Support has been added for a new **PipelineVariable** common parameter in the context of iterative pipelines, such as those used by System Center Orchestrator; that is, pipelines that run commands simply left-to-right, as opposed to interspersed running by using streaming.
-
 - Parameter binding has been significantly enhanced to work outside of tab completion scenarios, such as with commands that do not exist in the current runspace.
-
 - Support for custom container activities has been added to Windows PowerShell Workflow. If an activity parameter is of the types **Activity**, **Activity\[]**'”or is a generic collection of activities'”and the user has supplied a script block as an argument, then Windows PowerShell Workflow converts the script block to XAML, as with normal Windows PowerShell script-to-workflow compilation.
-
 - After a crash, Windows PowerShell Workflow automatically reconnects to managed nodes.
-
 - You can now throttle **Foreach -Parallel** activity statements by using the **ThrottleLimit** property.
-
 - The **ErrorAction** common parameter has a new valid value, **Suspend**, that is exclusively for workflows.
-
 - A workflow endpoint now automatically closes if there are no active sessions, no in-progress jobs, and no pending jobs. This feature conserves resources on the computer that is acting as the workflow server, when the automatic closure conditions have been met.
 
 ### New features in Windows PowerShell Web Services
 
 - When an error occurs in Windows PowerShell Web Services (PSWS, also called Management OData IIS Extension), while a cmdlet is running, more detailed error messages are returned to the caller. In addition, error codes follow [Windows Azure REST API error code guidelines](http://msdn.microsoft.com/library/windowsazure/dd179357.aspx).
-
 - An endpoint can now define the API version, as well as enforce the usage of a specific API version. Whenever version mismatches occur between client and server, errors are displayed to both the client and the server.
-
 - Management of the dispatch schema has been simplified by automatically generating values for any missing fields in the schema. Generation occurs, as a helpful starting point, even if the dispatch schema does not exist.
-
 - Type handling in PSWS has been improved to support types that use a different constructor than the default constructor, by behaving similarly to the **PSTypeConverter** in Windows PowerShell. This lets you use complex types with PSWS.
-
 - PSWS now allows expanding an associated instance while running a query. For larger binary contents (such as images, audio, or video), the transfer cost is significant, and it is better to transfer binary data without encoding. PSWS uses named resource streams for transferring without encoding. The named resource stream is a property of an entity of the **Edm.Stream** type. Each named resource stream has a separate URI for GET or UPDATE operations.
-
 - OData actions now provide a mechanism for invoking non-CRUD (Create, Read, Update, and Delete) methods on a resource. You can invoke an action by sending an HTTP POST request to the URI that is defined for the action. The parameters for the action are defined in the body of the POST request.
-
 - To be consistent with Windows Azure guidelines, all URLs should be simplified. A change included in **Key As Segment** allows single keys to be represented as segments. Note that references that use multiple key values require comma-separated values in parenthetical notation, as before.
-
 - Before this release of PSWS, the only way to perform Create, Update, or Delete operations was to invoke Post, Put, or Delete on a top-level resource. New in this release of PSWS, Contained Resource operations let users achieve the same results while reaching the same resource less directly, approaching as if these resources were contained.
 
 ### New features in Windows PowerShell Web Access
 
 - You can disconnect from and reconnect to existing sessions in the web-based Windows PowerShell Web Access console. A **Save** button in the web-based console lets you disconnect from a session without deleting it and reconnect to the session another time.
-
 - Default parameters can be displayed on the sign-in page. To display default parameters, configure values for all of the settings displayed in the **Optional Connection Settings** area of the sign-in page in a file named **web.config**. You can use the **web.config** file to configure all optional connection settings except for a second or alternate set of credentials.
-
 - In Windows Server 2012 R2, you can remotely manage authorization rules for Windows PowerShell Web Access. The **Add-PswaAuthorizationRule** and **Test-PswaAuthorizationRule** cmdlets now include a Credential parameter that enables administrators to manage authorization rules from a remote computer or in a Windows PowerShell Web Access session.
-
 - You can now have multiple Windows PowerShell Web Access sessions in a single browser session by using a new browser tab for each session. You no longer need to open a new browser session to connect to a new session in the web-based Windows PowerShell console.
 
 ### Notable bug fixes in Windows PowerShell 4.0
 
 - **Get-Counter** can now return counters that contain an apostrophe character in French editions of Windows.
-
 - You can now view the **GetType** method on deserialized objects.
-
 - **#Requires** statements now let users require Administrator access rights, if needed.
-
 - The **Import-Csv** cmdlet now ignores blank lines.
-
 - A problem where Windows PowerShell ISE uses too much memory when you are running an **Invoke-WebRequest** command has been fixed.
-
 - **Get-Module** now displays module versions in a **Version** column.
-
 - Remove-Item -Recurse now removes items from subfolders as expected.
-
 - A **UserName** property has been added to **Get-Process** output objects.
-
 - The **Invoke-RestMethod** cmdlet now returns all available results.
-
 - **Add-Member** now takes effect on hashtables, even if the hashtables have not yet been accessed.
-
 - **Select-Object -Expand** no longer fails or generates an exception if the value of the property is null or empty.
-
 - **Get-Process** can now be used in a pipeline with other commands that get the **ComputerName** property from objects.
-
 - **ConvertTo-Json** and **ConvertFrom-Json** can now accept terms within double quotes, and its error messages are now localizable.
-
 - **Get-Job** now returns any completed scheduled jobs, even in new sessions.
-
 - Issues with mounting and unmounting VHDs by using the **FileSystem** provider in Windows PowerShell 4.0 have been fixed. Windows PowerShell is now able to detect new drives when they are mounted in the same session.
-
 - You no longer need to explicitly load **ScheduledJob** or **Workflow** modules to work with their job types.
-
 - Performance improvements have been made to the process of importing workflows that define nested workflows; this process is now faster.
 
 ## New features in Windows PowerShell 3.0
+
 Windows PowerShell 3.0 includes the following new features.
 
 - [Windows PowerShell Workflow](#windows-powershell-workflow)
@@ -468,6 +309,7 @@ Windows PowerShell 3.0 includes the following new features.
 - [Special Character Handling Improvements](#special-character-handling-improvements)
 
 ### Windows PowerShell Workflow
+
 Windows PowerShell Workflow brings the power of Windows Workflow Foundation to Windows PowerShell. You can write workflows in XAML or in the Windows PowerShell language and run them just as you would run a cmdlet. The [Get-Command](https://technet.microsoft.com/library/59c6d302-6e8c-48b7-a6f6-f0172df936ad) cmdlet gets workflw commands and the [Get-Help](https://technet.microsoft.com/library/1f46eeb4-49d7-4bec-bb29-395d9b42f54a) cmdlet gets help for workflows.
 
 Workflows are sequences of multicomputer management activities that are long-running, repeatable, frequent, parallelizable, interruptible, suspendable, and restartable. Workflows can be resumed from an intentional or accidental interruption, such as a network outage, a Windows restart, or a power failure.
@@ -477,38 +319,35 @@ Workflows are also portable; they can be exported as or imported from XAML files
 The following are the benefits of Windows PowerShell Workflow
 
 - Automation of sequenced, long-running tasks.
-
 - **Remote monitoring of long-running tasks**. Status and progress of activities are visible at any time.
-
 - **Multicomputer management.** Simultaneously run tasks as workflows on hundreds of managed nodes. Windows PowerShell Workflow includes a built-in library of common management parameters, such as **PSComputerName**, which enable multi-computer management scenarios.
-
 - **Single task execution of complex processes.** You can combine related scripts that implement an entire end-to-end scenario into a single workflow.
-
 - **Persistence.**: a workflow is saved (or check-pointed) at specific points defined by its author so you can resume the workflow from the last persisted task (or checkpoint), instead of restarting the workflow from the beginning.
-
 - **Robustness.** Automated failure recovery. Workflows survive planned and unplanned restarts. You can suspend workflow execution and then resume the workflow from the last persistence point. Workflow authors can designate specific activities to be re-run in case of failure on one or more managed nodes.
-
 - **Ability to disconnect, reconnect, and run in disconnected sessions.** Users can connect and disconnect from the workflow server, but the workflow runs continuously. You can log off of the client computer or restart the client computer and monitor the workflow execution from another computer without interrupting the workflow.
-
 - **Scheduling.** Workflow tasks can be scheduled like any Windows PowerShell cmdlet or script.
-
 - **Workflow and Connection Throttling.** Workflow execution and connections to nodes can be throttled, thus enabling scalability and high-availability scenarios.
 
 ### Windows PowerShell Web Access
+
 Windows PowerShell Web Access is a Windows Server 2012 feature that lets users run Windows PowerShell commands and scripts in a web-based console. Devices that use the web-based console do not require Windows PowerShell, remote management software, or browser plug-in installations. All that is required is a properly-configured Windows PowerShell Web Access gateway and a client device browser that supports JavaScript and accepts cookies.
 
 For more information, see [Deploy Windows PowerShell Web Access](http://go.microsoft.com/fwlink/p/?LinkID=221050).
 
 ### New Windows PowerShell ISE Features
+
 For Windows PowerShell 3.0, Windows PowerShell Integrated Scripting Environment (ISE) has many new features, including IntelliSense, Show-Command window, a unified Console Pane, snippets, brace-matching, expand-collapse sections, auto-save, recent items list, rich copy, block copy, and full support for writing Windows PowerShell script workflows. For more information, see [about_Windows_PowerShell_ISE [v3]](https://technet.microsoft.com/library/dfa54d47-60c6-4fff-8197-c747e8d411bb).
 
 ### Support for Microsoft .NET Framework 4
+
 Windows PowerShell is built against the Common Language Runtime 4.0. Cmdlet, script, and workflow authors can use the new Microsoft .NET Framework 4 classes in Windows PowerShell, with features that include Application Compatibility and Deployment, Managed Extensibility Framework, Parallel Computing, Networking, Windows Communication Foundation and Windows Workflow Foundation.
 
 ### Support for Windows Preinstallation Environment
+
 Windows PowerShell 3.0 is an optional component of Windows Preinstallation Environment (Windows PE) 4.0 for Windows 8. Windows PE is a minimal operating system that starts a computer that has no operating system and prepares it for Windows installation. Windows PE can be used to partition and format hard drives, copy disk images to a computer, and initiate Windows Setup from a network share. Windows PowerShell 3.0 can be used on Windows PE to manage deployment, diagnostics, and recovery scenarios.
 
 ### Disconnected Sessions
+
 Beginning in Windows PowerShell 3.0, persistent user-managed sessions ("PSSessions") that you create by using the New-PSSession cmdlet are saved on the remote computer. They are no longer dependent on the session in which they were created.
 
 You can now disconnect from a session without disrupting the commands that are running in the session. You can close the session and shut down your computer. Later, you can reconnect to the session from a different session on the same or on a different computer.
@@ -520,6 +359,7 @@ New cmdlets have been added to support the Disconnected Sessions feature, includ
 The Disconnected Sessions feature is supported only when the computers at both the originating ("client") and terminating ("server") ends of the connection are running Windows PowerShell 3.0.
 
 ### Robust Session Connectivity
+
 Windows PowerShell 3.0 detects unexpected losses of connectivity between the client and server and attempts to reestablish connectivity and resume execution automatically. If the client-server connection cannot be reestablished in the allotted time, the user is notified and the session is disconnected. During the attempt to reconnect, Windows PowerShell provides continuous feedback to the user.
 
 If the disconnected session was started by using the InvokeCommand, Windows PowerShell creates a job for the disconnected session to make it easier to reconnect and resume execution.
@@ -527,6 +367,7 @@ If the disconnected session was started by using the InvokeCommand, Windows Powe
 These features provide a more reliable and recoverable remoting experience and allow users to perform long-running tasks that require robust sessions, such as workflows.
 
 ### Updatable Help System
+
 You can now download updated help files for the cmdlets in your modules. The [Update-Help](https://technet.microsoft.com/library/93e1d870-ace6-432b-8778-8920291d7545) cmdlet identifies the newest help files, downloads them from the Internet, unpacks them, validates them, and installs them in the correct language-specific directory for the module.
 
 To use the updated help files, just type `Get-Help`. You do not need to restart Windows or Windows PowerShell. To update help for modules in the $pshome directory, start Windows PowerShell with the "Run as administrator" option.
@@ -542,6 +383,7 @@ When the help files for a cmdlet are not installed on the computer, the [Get-Hel
 Any module author can support Updatable Help for their module. You can include help files in the module and use Updatable Help to update them or omit the help files and use Updatable Help to install them. For more information about supporting Updatable Help, see [Supporting Updatable Help](http://go.microsoft.com/FWLink/?LinkID=242129) in MSDN.
 
 ### Enhanced Online Help
+
 Windows PowerShell online help is a valuable resource for all users, but it is especially important to users who do not or cannot install updated help files.
 
 To get online help for any Windows PowerShell cmdlet, type:
@@ -566,9 +408,11 @@ You can also include a **HelpUri** value in the first related link of an XML-bas
 For more information about supporting online help, see [Supporting Online Help](http://go.microsoft.com/fwlink/?LinkId=242132) in MSDN.
 
 ### CIM integration
+
 Windows PowerShell 3.0 includes support for the Common Information Model (CIM), which provides common definitions of management information for systems, networks, applications, and services, allowing them the exchange of management information between heterogeneous systems. Support for CIM in Windows PowerShell 3.0, including the ability to author Windows PowerShell cmdlets based on new or existing CIM classes, commands based on cmdlet definition XML files, support for CIM .NET Framework. API, CIM management cmdlets and WMI 2.0 providers.
 
 ### Session Configuration Files
+
 Beginning in Windows PowerShell 3.0, you can design a custom session configuration by using a file. The new session configuration file lets you determine the environment of sessions that use the session configuration, including which modules, scripts, and format files are loaded into sessions, which cmdlets and language elements users can use, which modules and scripts they can run, and which variables they can see.
 
 You can design a session in which users can only run the cmdlets from one particular module, or a session in which users have full language, access to all modules, and access to scripts that perform advanced tasks.
@@ -580,6 +424,7 @@ To create a session configuration file, use the [New-PSSessionConfigurationFile]
 For more information, see [about_Session_Configuration_Files](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_session_configuration_files?view=powershell-5.0) and [New-PSSessionConfigurationFile](https://technet.microsoft.com/library/5f3e3633-6e90-479c-aea9-ba45a1954866).
 
 ### Scheduled Jobs and Task Scheduler Integration
+
 You can now schedule Windows PowerShell background jobs and manage them in Windows PowerShell and in Task Scheduler.
 
 Windows PowerShell scheduled jobs are a useful hybrid of Windows PowerShell background jobs and Task Scheduler tasks.
@@ -593,9 +438,11 @@ In addition, scheduled jobs come with a customized set of cmdlets for managing t
 For more information about scheduled jobs, see [about_Scheduled_Jobs](https://technet.microsoft.com/library/3b546629-703c-4939-b44f-52dd567bce92).
 
 ### Windows PowerShell Language Enhancements
+
 Windows PowerShell 3.0 includes many features that are designed to make its language simpler, easier to use, and to avoid common errors. The improvements include property enumeration, count and length properties on scalar objects, new redirection operators, the $Using scope modifier, PSItem automatic variable, flexible script formatting, attributes of variables, simplified attribute arguments, numeric command names, the Stop-Parsing operator, improved array splatting, new bit operators, ordered dictionaries, PSCustomObject casting, and improved comment-based help.
 
 ### New Core Cmdlets
+
 New cmdlets were added to the Windows PowerShell Core installation, including cmdlets to manage scheduled jobs, disconnected sessions, CIM integration and the Updatable Help System.
 
 |||
@@ -629,20 +476,22 @@ New cmdlets were added to the Windows PowerShell Core installation, including cm
 |New-CimSessionOption|Update-Help|
 |New-IseSnippet||
 
-### Improvements to Existing Core Cmdlets and Providers
-Windows PowerShell 3.0 includes new features for existing cmdlets including the simplified syntax, and new parameters for the following cmdlets: Computer cmdlets, CSV cmdlets, Get-ChildItem, Get-Command, Get-Content, Get-History, Measure-Object, Security cmdlets, Select-Object, Select-String, Split-Path, Start-Process, Tee-Object, Test-Connection, Add-Member, and WMI cmdlets.
+### Improvements to Existing Core Cmdlets and ProvidersWindows PowerShell 3.0 includes new features for existing cmdlets including the simplified syntax, and new parameters for the following cmdlets: Computer cmdlets, CSV cmdlets, Get-ChildItem, Get-Command, Get-Content, Get-History, Measure-Object, Security cmdlets, Select-Object, Select-String, Split-Path, Start-Process, Tee-Object, Test-Connection, Add-Member, and WMI cmdlets.
 
 The Windows PowerShell providers were also improved significantly, including Certificate provider support for managing Secure Socket Layer (SSL) certificates for web hosting, support for credential, persistent network drives, and alternate data streams in file system drives.
 
 ### Remote module import and discovery
+
 Windows PowerShell 3.0 extends module discovery, importing, and implicit remoting capabilities on remote computers. The Module cmdlets get modules on remote computers and import the modules to the remote or local computer by using Windows PowerShell remoting. New CIM session support allows you to use CIM and WMI to manage non-Windows computers by importing commands to the local computer that run implicitly on the remote computer.
 
 For more information, see the help topics for the [Get-Module](https://technet.microsoft.com/library/2cccd4c4-9a21-4c77-b691-984ee57242e1) and [Import-Module](https://technet.microsoft.com/library/af616c24-e122-4098-930e-1e3ea2080ade) cmdlets.
 
 ### Enhanced Tab Completion
+
 Tab completion in the Windows PowerShell console now completes the names of cmdlets, parameters, parameter values, enumerations, .NET Frameworks types, COM objects, hidden directories, and more. The tab completion feature is completely rewritten based on a new parser and abstract syntax tree to support more scenarios, including in-memory parsing trees and midline tab completion.
 
 ### Module Auto-Loading
+
 The [Get-Command](https://technet.microsoft.com/library/59c6d302-6e8c-48b7-a6f6-f0172df936ad) cmdlet now gets all cmdlets and functions from all modules that are installed on the computer, even if the module is not imported into the current session.
 
 When you get the cmdlet that you need, you can use it immediately without importing any modules. Windows PowerShell modules are now imported automatically when you use any cmdlet in the module. You no longer need to search for the module and import it to use its cmdlets.
@@ -654,49 +503,49 @@ You can enable, disable, and configure automatic importing of modules by using t
 For more information, see [about_Modules](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_modules?view=powershell-5.0), [about_Preference_Variables [v4]](https://technet.microsoft.com/library/31344314-be29-4286-b039-afa5460cbe8b), and the help topics for the [Get-Command](https://technet.microsoft.com/library/59c6d302-6e8c-48b7-a6f6-f0172df936ad) and [Import-Module](https://technet.microsoft.com/library/af616c24-e122-4098-930e-1e3ea2080ade) cmdlets.
 
 ### Module Experience Improvements
+
 Windows PowerShell 3.0 brings advanced feature support to modules, including the following new features.
 
 1. Module logging for individual modules (LogPipelineExecutionDetails) and the new "Turn on Module Logging" Group Policy setting
-
 2. Extended module objects that expose the values from the module manifest
-
 3. New **ExportedCommands** property of modules, including nested modules, that combines commands of all types
-
 4. Improved discovery of available (un-imported) modules, including allowing the **Path** and **ListAvailable** parameters in the same command
-
 5. New **DefaultCommandPrefix** key in module manifests that avoids name conflicts without changing module code.
-
 6. Improved module requirements, including fully-qualified required modules with version and GUID and automatic importing of required modules
-
 7. Quieter, streamlined operation of the [New-ModuleManifest](https://technet.microsoft.com/library/512adced-f42f-4e88-ba7c-834fc9e5d047) cmdlet.
-
 8. New **Module** parameter for #Requires
-
 9. Improved [Import-Module](https://technet.microsoft.com/library/af616c24-e122-4098-930e-1e3ea2080ade) cmdlet with both **MinimumVersion** and **RequiredVersion** parameters.
 
 ### Simplified Command Discovery
+
 You no longer need to import all modules to discover the commands available to your session. In Windows PowerShell 3.0, the [Get-Command](https://technet.microsoft.com/library/59c6d302-6e8c-48b7-a6f6-f0172df936ad) cmdlet gets all commands from all installed modules. And, if you use a command, the module that exports the command is automatically imported into your session.
 
 The new [Show-Command](https://technet.microsoft.com/library/65bba50b-91a8-49d5-80a2-a30fc684ba41) cmdlet is designed especially for beginners. You can search for commands in a window. You can view all commands or filter by module, import a module by clicking a button, use text boxes and drop-down lists to construct a valid command, and then copy or run the command without ever leaving the window.
 
 ### Improved Logging, Diagnostics, and Group Policy Support
+
 Windows PowerShell 3.0 improves the logging and tracing support for commands and modules with support for Event Tracing in Windows (ETW) logs, an editable **LogPipelineExecutionDetails** property of modules, and the "Turn on Module Logging" Group Policy setting. You can now get parameter values from log details by displaying the log properties.
 
 ### Formatting and Output Improvements
+
 New formatting and output improvements improve the efficiency of all Windows PowerShell users. The improvements include output redirection for all streams, an enhanced Update-Type cmdlet that adds types dynamically without Format.ps1xml files, word wrap in output, default formatting properties of custom objects, the **PSCustomObject** type, improved formatting for WMI objects and heterogeneous objects, and support for discovering method overloads.
 
 ### Enhanced Console Host Experience
+
 The Windows PowerShell console host program has new features in Windows PowerShell 3.0 including single threaded apartment by default. The new "Run with PowerShell" option in File Explorer lets you run scripts in a unrestricted session just by right-clicking. New console host launch logic starts Windows PowerShell faster and new fonts allow you to personalize the familiar console window experience.
 
 For more information, see [about_Run_With_PowerShell](https://technet.microsoft.com/library/c9d9ca5f-eff9-4409-be9d-e43b5b4087eb).
 
 ### New Cmdlet and Hosting APIs
+
 The new Cmdlet API and Hosting API include public advanced syntax tree (AST) APIs, and APIs for pipeline paging, nested pipelines, runspace pools tab completion, Windows RT, the Obsolete cmdlet attribute, and Verb and Noun properties of the FunctionInfo object.
 
 ### Performance Improvements
+
 Significant performance improvements in Windows PowerShell come from the new language parser, which is built on Dynamic Runtime Language (DLR) in .NET Framework 4., along with runtime script compilation, engine reliability improvements, and changes to the algorithm of the [Get-ChildItem](https://technet.microsoft.com/library/75cf79bb-4db6-4a67-8c36-3d20754e2190) that improve its performance, especially when searching network shares.
 
 ### RunAs and Shared Host Support
+
 Windows PowerShell 3.0 includes support for RunAs and Shared Host features.
 
 The *RunAs* feature, designed for Windows PowerShell Workflow, lets users of a session configuration create sessions that run with the permission of a shared user account. This enables less privileged users to run particular commands and scripts with administrator permissions, and reduces the need for adding less senior users to the Administrators group.
@@ -704,8 +553,10 @@ The *RunAs* feature, designed for Windows PowerShell Workflow, lets users of a s
 The **SharedHost** feature allows multiple users on multiple computers to connect to a workflow session concurrently and monitor the progress of a workflow. Users can start a workflow on one computer and then connect to the workflow session on another computer without disconnecting the session from the original computer. Users must have the same permissions and be using the same session configuration. For more information, see "Running a Windows PowerShell Workflow" in Getting Started with Windows PowerShell Workflow.
 
 ### Special Character Handling Improvements
+
 To improve the ability of Windows PowerShell 3.0 to interpret and correctly handle special characters, the **LiteralPath** parameter, which handles special characters in paths, is valid on almost all cmdlets that have a **Path** parameter, including the new [Update-Help](https://technet.microsoft.com/library/93e1d870-ace6-432b-8778-8920291d7545) and [Save-Help](https://technet.microsoft.com/library/aed94f90-b73f-4e25-a25d-7c18d9f161fa) cmdlets. The parser also includes special logic to improve handling of the backtick character (\`) and square brackets in file names and paths.
 
 ## See Also
+
 - [about_Windows_PowerShell_5.0](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_windows_powershell_5.0?view=powershell-5.0)
 - [Windows PowerShell](http://go.microsoft.com/fwlink/?LinkID=107116)


### PR DESCRIPTION
Fixed the following issues identified by CATS

Case Name | Total Number | Failed Number | Passed Number
-- | -- | -- | --
Missing or Extra H1 heading | 552 | 17 | 535
Broken bookmarks | 12251 | 5 | 12246

