### PR TITLE
Document removal of `Persist` parameter from `New-PSDrive` on UNIX

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Management/New-WebServiceProxy.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/New-WebServiceProxy.md
@@ -3,7 +3,7 @@ ms.date:  06/09/2017
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
-online version:  http://go.microsoft.com/fwlink/?LinkId=821608
+online version:  http://go.microsoft.com/fwlink/?LinkId=821609
 external help file:  Microsoft.PowerShell.Commands.Management.dll-Help.xml
 title:  New-WebServiceProxy
 ---

--- a/reference/5.1/Microsoft.PowerShell.Management/New-WebServiceProxy.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-WebServiceProxy.md
@@ -4,7 +4,7 @@ keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
 ms.date: 06/09/2017
-online version: http://go.microsoft.com/fwlink/?LinkId=821608
+online version: http://go.microsoft.com/fwlink/?LinkId=821609
 schema: 2.0.0
 title: New-WebServiceProxy
 ---

--- a/reference/6/Microsoft.PowerShell.Management/New-PSDrive.md
+++ b/reference/6/Microsoft.PowerShell.Management/New-PSDrive.md
@@ -265,6 +265,8 @@ Accept wildcard characters: False
 ### -Persist
 
 Indicates that this cmdlet creates a Windows mapped network drive.
+This parameter is only available on Windows.
+
 Mapped network drives are saved in Windows on the local computer.
 They are persistent, not session-specific, and can be viewed and managed in File Explorer and other tools.
 

--- a/reference/6/Microsoft.PowerShell.Utility/Write-Information.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Write-Information.md
@@ -177,9 +177,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### System.Object
 
-`Write-Information` does not accept piped input.
+`Write-Information` accepts piped objects to pass to the information stream.
 
 ## OUTPUTS
 

--- a/reference/docs-conceptual/getting-started/fundamental/Learning-PowerShell-Names.md
+++ b/reference/docs-conceptual/getting-started/fundamental/Learning-PowerShell-Names.md
@@ -8,7 +8,7 @@ ms.assetid:  b4d0fd22-8298-4ee6-82ae-9b6f2907c986
 # Learning PowerShell names
 
 Learning names of commands and parameters requires a significant time investment with most
-command-line interfaces. The issue is that there are few patterns. Memorization is only way to
+command-line interfaces. The issue is that there are few patterns. Memorization is the only way to
 learn the commands and parameters that you need to use on a regular basis.
 
 When you work with a new command or parameter, you can't always use what you already know. You have


### PR DESCRIPTION
The `Persist` parameter of `New-PSDrive` is only supported on Windows. Persist will be removed on UNIX by https://github.com/PowerShell/PowerShell/pull/8291. Add this information to the documentation of the `Persist` parameter.

Fix #3316.

Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version 6.2 of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
