### PR TITLE
Fixed broken bulleted list

### DIFF
--- a/reference/6/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
+++ b/reference/6/Microsoft.PowerShell.Security/ConvertFrom-SecureString.md
@@ -136,11 +136,9 @@ You can pipe a **SecureString** object to **ConvertFrom-SecureString**.
 ## NOTES
 * To create a secure string from characters that are typed at the command prompt, use the *AsSecureString* parameter of the Read-Host cmdlet.
 
-  When you use the *Key* or *SecureKey* parameters to specify a key, the key length must be correct.
+* When you use the *Key* or *SecureKey* parameters to specify a key, the key length must be correct.
 For example, a key of 128 bits can be specified as a byte array of 16 digits.
 Similarly, 192-bit and 256-bit keys correspond to byte arrays of 24 and 32 digits, respectively.
-
-*
 
 ## RELATED LINKS
 


### PR DESCRIPTION
Second item was missing bullet, and there was a trailing extraneous bullet

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [X] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
