### PR TITLE
Update manual-download.md

### DIFF
--- a/gallery/how-to/working-with-packages/manual-download.md
+++ b/gallery/how-to/working-with-packages/manual-download.md
@@ -53,7 +53,7 @@ PowerShell code created by the package author. The steps are:
 3. Rename the folder. The default folder name is usually `<name>.<version>`. The version can
    include "-prerelease" if the module is tagged as a prerelease version. Rename the folder to just
    the module name. For example, "azurerm.storage.5.0.4-preview" becomes "azurerm.storage".
-4. Copy the folder to one of the folders in the $env:PSModulePath value. $env:PSModulePath is a semicolon delimited set of paths in which PowerShell should look for modules.
+4. Copy the folder to one of the folders in the `$env:PSModulePath value`. `$env:PSModulePath` is a semicolon delimited set of paths in which PowerShell should look for modules.
 
 > [!IMPORTANT]
 > The manual download does not include any dependencies required by the module. If the package has

--- a/gallery/how-to/working-with-packages/manual-download.md
+++ b/gallery/how-to/working-with-packages/manual-download.md
@@ -7,8 +7,8 @@ title:  Manual Package Download
 # Manual Package Download
 
 The Powershell Gallery supports downloading a package from the website directly, without using the
-PowerShellGet cmdlets. The package will be downloaded as a NuGet package (.nupkg) file, which can
-then be easily copied to an internal repository.
+PowerShellGet cmdlets. You can download any package as a NuGet package (.nupkg) file, which you can
+then copy to an internal repository.
 
 > [!NOTE]
 > Manual package download is **not** intended as a replacement for the Install-Module cmdlet.
@@ -53,7 +53,7 @@ PowerShell code created by the package author. The steps are:
 3. Rename the folder. The default folder name is usually `<name>.<version>`. The version can
    include "-prerelease" if the module is tagged as a prerelease version. Rename the folder to just
    the module name. For example, "azurerm.storage.5.0.4-preview" becomes "azurerm.storage".
-4. Copy the folder to your PSModulePath.
+4. Copy the folder to one of the folders in the $env:PSModulePath value. $env:PSModulePath is a semicolon delimited set of paths in which PowerShell should look for modules.
 
 > [!IMPORTANT]
 > The manual download does not include any dependencies required by the module. If the package has


### PR DESCRIPTION
1. removed future tense and make sentence in the intro of this page a bit easier to read.
2. Made the point that the $env:PSModulePath is a semi-colon delimited string, as noted in issue #3351

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
