### PR TITLE
Fixing #3369 - Added docs for `-passthru`

### DIFF
--- a/reference/6/Microsoft.PowerShell.Archive/Compress-Archive.md
+++ b/reference/6/Microsoft.PowerShell.Archive/Compress-Archive.md
@@ -177,7 +177,8 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-{{Fill PassThru Description}}
+
+Causes the cmdlet to output a file object representing the archive file created.
 
 ```yaml
 Type: SwitchParameter
@@ -271,3 +272,5 @@ You can pipe a string that contains a path to one or more files.
 ## NOTES
 
 ## RELATED LINKS
+
+[Expand-Archive](expand-archive.md)

--- a/reference/6/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/6/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -19,13 +19,13 @@ Extracts files from a specified archive (zipped) file.
 
 ### Path (Default)
 ```
-Expand-Archive [-Path] <String> [[-DestinationPath] <String>] [-Force] [-PassThru] [-WhatIf] [-Confirm]
+Expand-Archive [-Path] <String> [-DestinationPath] <String> [-Force] [-PassThru] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ### LiteralPath
 ```
-Expand-Archive -LiteralPath <String> [[-DestinationPath] <String>] [-Force] [-PassThru] [-WhatIf] [-Confirm]
+Expand-Archive -LiteralPath <String> [-DestinationPath] <String> [-Force] [-PassThru] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -108,7 +108,8 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-{{Fill PassThru Description}}
+
+Causes the cmdlet to output a list of the files expanded from the archive.
 
 ```yaml
 Type: SwitchParameter
@@ -172,7 +173,10 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -182,10 +186,13 @@ You can pipe a string that contains a path to an existing archive file.
 
 ## OUTPUTS
 
-### None
+### System.IO.FileSystemInfo
+
+When the `-PassThru` parameter is used, the cmdlet outputs a list of files that where expanded from
+the archive.
 
 ## NOTES
 
 ## RELATED LINKS
 
-## RELATED LINKS
+[Compress-Archive](compress-archive.md)


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->

Added docs for `-passthru`

Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
