### PR TITLE
Fix Example for Get-Member -InputObject

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Member.md
@@ -158,20 +158,28 @@ The results show that only process objects (System.Diagnostics.Process) and serv
 ### Example 6
 
 ```
-PS> $a = get-member -inputobject @(1)
-PS> $a.count
+PS C:\> $A = @(1)
+PS C:\> $A.Count
 1
-PS> $a = get-member -inputobject 1,2,3
+PS C:\> Get-Member -InputObject $A
 TypeName: System.Object[]
-
 Name               MemberType    Definition
 ----               ----------    ----------
 Count              AliasProperty Count = Length
 Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
-PS> $a.count
-1
+PS C:\> $A = @(1,2,3)
+PS C:\> Get-Member -InputObject $A
+TypeName: System.Object[]
+Name               MemberType    Definition
+----               ----------    ----------
+Count              AliasProperty Count = Length
+Address            Method        System.Object& Address(Int32 )
+Clone              Method        System.Object Clone()
+...
+PS C:\> $A.Count
+3
 ```
 
 This example demonstrates how to find the properties and methods of an array of objects when you have only one object of the given type.

--- a/reference/3.0/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Get-Member.md
@@ -115,7 +115,7 @@ In this case, the extended member is the Name property, which is an alias proper
 ### Example 4
 
 ```powershell
-PS C:\> Get-EventLog -Log System | Get-Member -MemberType ScriptProperty
+PS> Get-EventLog -Log System | Get-Member -MemberType ScriptProperty
 
 
    TypeName: System.Diagnostics.EventLogEntry
@@ -158,10 +158,10 @@ The results show that only process objects (System.Diagnostics.Process) and serv
 ### Example 6
 
 ```
-PS C:\> $A = @(1)
-PS C:\> $A.Count
+PS> $A = @(1)
+PS> $A.Count
 1
-PS C:\> Get-Member -InputObject $A
+PS> Get-Member -InputObject $A
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
@@ -169,8 +169,8 @@ Count              AliasProperty Count = Length
 Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
-PS C:\> $A = @(1,2,3)
-PS C:\> Get-Member -InputObject $A
+PS> $A = @(1,2,3)
+PS> Get-Member -InputObject $A
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
@@ -178,7 +178,7 @@ Count              AliasProperty Count = Length
 Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
-PS C:\> $A.Count
+PS> $A.Count
 3
 ```
 

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Member.md
@@ -151,20 +151,28 @@ The results show that only process objects (System.Diagnostics.Process) and serv
 
 ### Example 6
 ```
-PS C:\> $a = get-member -inputobject @(1)
-PS C:\> $a.count
+PS C:\> $A = @(1)
+PS C:\> $A.Count
 1
-PS C:\> $a = get-member -inputobject 1,2,3
+PS C:\> Get-Member -InputObject $A
 TypeName: System.Object[]
-
 Name               MemberType    Definition
 ----               ----------    ----------
 Count              AliasProperty Count = Length
 Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
-PS C:\> $a.count
-1
+PS C:\> $A = @(1,2,3)
+PS C:\> Get-Member -InputObject $A
+TypeName: System.Object[]
+Name               MemberType    Definition
+----               ----------    ----------
+Count              AliasProperty Count = Length
+Address            Method        System.Object& Address(Int32 )
+Clone              Method        System.Object Clone()
+...
+PS C:\> $A.Count
+3
 ```
 
 This example demonstrates how to find the properties and methods of an array of objects when you have only one object of the given type.

--- a/reference/4.0/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Get-Member.md
@@ -32,7 +32,7 @@ To get only certain types of members, such as NoteProperties, use the MemberType
 
 ### Example 1
 ```
-PS C:\> get-service | get-member
+PS> get-service | get-member
 TypeName: System.ServiceProcess.ServiceController
 
 Name                      MemberType    Definition
@@ -78,8 +78,8 @@ As such, it gets all member types, but it does not get static members and does n
 
 ### Example 2
 ```
-PS C:\> Get-Service | Get-Member -Force
-PS C:\> (Get-Service Schedule).PSBase
+PS> Get-Service | Get-Member -Force
+PS> (Get-Service Schedule).PSBase
 ```
 
 This example gets all of the members (properties and methods) of the service objects (System.ServiceProcess.ServiceController) retrieved by the Get-Service cmdlet, including the intrinsic members, such as PSBase and PSObject, and the get_ and set_ methods.
@@ -95,7 +95,7 @@ The second command shows how to display the value of the PSBase property of the 
 
 ### Example 3
 ```
-PS C:\> get-service| get-member -view extended
+PS> get-service| get-member -view extended
 TypeName: System.ServiceProcess.ServiceController
 
 Name MemberType    Definition
@@ -110,7 +110,7 @@ In this case, the extended member is the Name property, which is an alias proper
 
 ### Example 4
 ```powershell
-PS C:\> Get-EventLog -Log System | Get-Member -MemberType ScriptProperty
+PS> Get-EventLog -Log System | Get-Member -MemberType ScriptProperty
 
 
    TypeName: System.Diagnostics.EventLogEntry
@@ -126,8 +126,8 @@ The command returns the EventID property of the **EventLog** object.
 
 ### Example 5
 ```
-PS C:\> $a = "get-process", "get-service", "get-culture", "get-psdrive", "get-executionpolicy"
-PS C:\> foreach ($cmdlet in $a) {invoke-command $cmdlet | get-member -name machinename}
+PS> $a = "get-process", "get-service", "get-culture", "get-psdrive", "get-executionpolicy"
+PS> foreach ($cmdlet in $a) {invoke-command $cmdlet | get-member -name machinename}
 TypeName: System.Diagnostics.Process
 
 Name        MemberType Definition
@@ -151,10 +151,10 @@ The results show that only process objects (System.Diagnostics.Process) and serv
 
 ### Example 6
 ```
-PS C:\> $A = @(1)
-PS C:\> $A.Count
+PS> $A = @(1)
+PS> $A.Count
 1
-PS C:\> Get-Member -InputObject $A
+PS> Get-Member -InputObject $A
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
@@ -162,8 +162,8 @@ Count              AliasProperty Count = Length
 Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
-PS C:\> $A = @(1,2,3)
-PS C:\> Get-Member -InputObject $A
+PS> $A = @(1,2,3)
+PS> Get-Member -InputObject $A
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
@@ -187,8 +187,8 @@ The fourth command uses the Count property of the array to find the number of ob
 
 ### Example 7
 ```
-PS C:\> $file = get-item c:\test\textFile.txt
-PS C:\> $file.psobject.properties | where-object {$_.issettable} | format-table -property name
+PS> $file = get-item c:\test\textFile.txt
+PS> $file.psobject.properties | where-object {$_.issettable} | format-table -property name
 
 Name
 ----
@@ -207,7 +207,7 @@ LastWriteTime
 LastWriteTimeUtc
 Attributes
 
-PS C:\> [appdomain]::CurrentDomain.GetAssemblies() | foreach-object { $_.getexportedtypes() } | foreach-object {$_.getproperties() | where-object {$_.canwrite }} | select-object reflectedtype, name
+PS> [appdomain]::CurrentDomain.GetAssemblies() | foreach-object { $_.getexportedtypes() } | foreach-object {$_.getproperties() | where-object {$_.canwrite }} | select-object reflectedtype, name
 ```
 
 This example shows how to determine which properties of an object can be changed.
@@ -221,8 +221,8 @@ The third command gets the changeable properties of all objects in your Windows 
 
 ### Example 8
 ```
-PS C:\> $s = get-service
-PS C:\> $s | get-member
+PS> $s = get-service
+PS> $s | get-member
 TypeName: System.ServiceProcess.ServiceController
 
 Name                      MemberType    Definition
@@ -235,7 +235,7 @@ Continue                  Method        System.Void Continue()
 CreateObjRef              Method        System.Runtime.Remoting.ObjRef CreateObjRef(type requestedTy
 Dispose                   Method        System.Void Dispose()
 ...
-PS C:\> get-member -inputObject $s
+PS> get-member -inputObject $s
 TypeName: System.Object[]
 
 Name           MemberType    Definition

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Member.md
@@ -32,7 +32,7 @@ To get only certain types of members, such as **NoteProperties**, use the *Membe
 
 ### Example 1: Get the members of process objects
 ```
-PS C:\> Get-Service | Get-Member
+PS> Get-Service | Get-Member
 TypeName: System.ServiceProcess.ServiceController
 Name                      MemberType    Definition
 ----                      ----------    ----------
@@ -77,8 +77,8 @@ As such, it gets all member types, but it does not get static members and does n
 
 ### Example 2: Get members of service objects
 ```
-PS C:\> Get-Service | Get-Member -Force
-PS C:\> (Get-Service Schedule).PSBase
+PS> Get-Service | Get-Member -Force
+PS> (Get-Service Schedule).PSBase
 ```
 
 This example gets all of the members (properties and methods) of the service objects (System.ServiceProcess.ServiceController) retrieved by the Get-Service cmdlet, including the intrinsic members, such as PSBase and PSObject, and the get_ and set_ methods.
@@ -94,7 +94,7 @@ The second command shows how to display the value of the PSBase property of the 
 
 ### Example 3: Get extended members of service objects
 ```
-PS C:\> Get-Service| Get-Member -View Extended
+PS> Get-Service| Get-Member -View Extended
 TypeName: System.ServiceProcess.ServiceController
 Name MemberType    Definition
 ---- ----------    ----------
@@ -108,7 +108,7 @@ In this case, the extended member is the Name property, which is an alias proper
 
 ### Example 4: Get script properties of event log objects
 ```
-PS C:\> Get-EventLog -Log System | Get-Member -MemberType ScriptProperty
+PS> Get-EventLog -Log System | Get-Member -MemberType ScriptProperty
 TypeName: System.Diagnostics.EventLogEntry
 Name    MemberType     Definition
 ----    ----------     ----------
@@ -123,8 +123,8 @@ The command returns the EventID property of the **EventLog** object.
 
 ### Example 5: Get objects with a specified property
 ```
-PS C:\> $A = "Get-Process", "Get-Service", "Get-Culture", "Get-PSDrive", "Get-ExecutionPolicy"
-PS C:\> ForEach ($Cmdlet in $A) {Invoke-Command $Cmdlet | Get-Member -Name MachineName}
+PS> $A = "Get-Process", "Get-Service", "Get-Culture", "Get-PSDrive", "Get-ExecutionPolicy"
+PS> ForEach ($Cmdlet in $A) {Invoke-Command $Cmdlet | Get-Member -Name MachineName}
 TypeName: System.Diagnostics.Process
 Name        MemberType Definition
 ----        ---------- ----------
@@ -145,10 +145,10 @@ The results show that only process objects (**System.Diagnostics.Process**) and 
 
 ### Example 6: Get members for an array
 ```
-PS C:\> $A = @(1)
-PS C:\> $A.Count
+PS> $A = @(1)
+PS> $A.Count
 1
-PS C:\> Get-Member -InputObject $A
+PS> Get-Member -InputObject $A
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
@@ -156,8 +156,8 @@ Count              AliasProperty Count = Length
 Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
-PS C:\> $A = @(1,2,3)
-PS C:\> Get-Member -InputObject $A
+PS> $A = @(1,2,3)
+PS > Get-Member -InputObject $A
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
@@ -165,7 +165,7 @@ Count              AliasProperty Count = Length
 Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
-PS C:\> $A.Count
+PS> $A.Count
 3
 ```
 
@@ -181,8 +181,8 @@ The fourth command uses the Count property of the array to find the number of ob
 
 ### Example 7: Determine which object properties you can set
 ```
-PS C:\> $File = Get-Item c:\test\textFile.txt
-PS C:\> $File.psobject.properties | Where-Object {$_.issettable} | Format-Table -Property name
+PS> $File = Get-Item c:\test\textFile.txt
+PS> $File.psobject.properties | Where-Object {$_.issettable} | Format-Table -Property name
 Name
 ----
 PSPath
@@ -224,7 +224,8 @@ Close                     Method        System.Void Close()
 Continue                  Method        System.Void Continue()
 CreateObjRef              Method        System.Runtime.Remoting.ObjRef CreateObjRef(type requestedTy
 Dispose                   Method        System.Void Dispose()
-... PS C:\> Get-Member -InputObject $S
+... 
+PS> Get-Member -InputObject $S
 TypeName: System.Object[]
 Name           MemberType    Definition
 ----           ----------    ----------

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Member.md
@@ -145,10 +145,19 @@ The results show that only process objects (**System.Diagnostics.Process**) and 
 
 ### Example 6: Get members for an array
 ```
-PS C:\> $A = Get-Member - InputObject @(1)
+PS C:\> $A = @(1)
 PS C:\> $A.Count
 1
-PS C:\> $A = Get-Member -InputObject 1,2,3
+PS C:\> Get-Member -InputObject $A
+TypeName: System.Object[]
+Name               MemberType    Definition
+----               ----------    ----------
+Count              AliasProperty Count = Length
+Address            Method        System.Object& Address(Int32 )
+Clone              Method        System.Object Clone()
+...
+PS C:\> $A = @(1,2,3)
+PS C:\> Get-Member -InputObject $A
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
@@ -157,7 +166,7 @@ Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
 PS C:\> $A.Count
-1
+3
 ```
 
 This example demonstrates how to find the properties and methods of an array of objects when you have only one object of the given type.

--- a/reference/5.0/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Get-Member.md
@@ -157,7 +157,7 @@ Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
 PS> $A = @(1,2,3)
-PS > Get-Member -InputObject $A
+PS> Get-Member -InputObject $A
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
@@ -198,7 +198,8 @@ LastAccessTime
 LastAccessTimeUtc
 LastWriteTime
 LastWriteTimeUtc
-Attributes PS C:\> [appdomain]::CurrentDomain.GetAssemblies() | ForEach-Object { $_.getexportedtypes() } | ForEach-Object {$_.getproperties() | Where-Object {$_.canwrite }} | Select-Object reflectedtype, name
+Attributes
+PS> [appdomain]::CurrentDomain.GetAssemblies() | ForEach-Object { $_.getexportedtypes() } | ForEach-Object {$_.getproperties() | Where-Object {$_.canwrite }} | Select-Object reflectedtype, name
 ```
 
 This example shows how to determine which properties of an object can be changed.
@@ -212,8 +213,8 @@ The third command gets the changeable properties of all objects in your Windows 
 
 ### Example 8: Get members of each item in a collection
 ```
-PS C:\> $S = Get-Service
-PS C:\> $S | Get-Member
+PS> $S = Get-Service
+PS> $S | Get-Member
 TypeName: System.ServiceProcess.ServiceController
 Name                      MemberType    Definition
 ----                      ----------    ----------

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
@@ -145,10 +145,19 @@ The results show that only process objects (**System.Diagnostics.Process**) and 
 
 ### Example 6: Get members for an array
 ```
-PS C:\> $A = Get-Member - InputObject @(1)
+PS C:\> $A = @(1)
 PS C:\> $A.Count
 1
-PS C:\> $A = Get-Member -InputObject 1,2,3
+PS C:\> Get-Member -InputObject $A
+TypeName: System.Object[]
+Name               MemberType    Definition
+----               ----------    ----------
+Count              AliasProperty Count = Length
+Address            Method        System.Object& Address(Int32 )
+Clone              Method        System.Object Clone()
+...
+PS C:\> $A = @(1,2,3)
+PS C:\> Get-Member -InputObject $A
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
@@ -157,7 +166,7 @@ Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
 PS C:\> $A.Count
-1
+3
 ```
 
 This example demonstrates how to find the properties and methods of an array of objects when you have only one object of the given type.

--- a/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Get-Member.md
@@ -32,7 +32,7 @@ To get only certain types of members, such as **NoteProperties**, use the *Membe
 
 ### Example 1: Get the members of process objects
 ```
-PS C:\> Get-Service | Get-Member
+PS> Get-Service | Get-Member
 TypeName: System.ServiceProcess.ServiceController
 Name                      MemberType    Definition
 ----                      ----------    ----------
@@ -77,8 +77,8 @@ As such, it gets all member types, but it does not get static members and does n
 
 ### Example 2: Get members of service objects
 ```
-PS C:\> Get-Service | Get-Member -Force
-PS C:\> (Get-Service Schedule).PSBase
+PS> Get-Service | Get-Member -Force
+PS> (Get-Service Schedule).PSBase
 ```
 
 This example gets all of the members (properties and methods) of the service objects (System.ServiceProcess.ServiceController) retrieved by the Get-Service cmdlet, including the intrinsic members, such as PSBase and PSObject, and the get_ and set_ methods.
@@ -94,7 +94,7 @@ The second command shows how to display the value of the PSBase property of the 
 
 ### Example 3: Get extended members of service objects
 ```
-PS C:\> Get-Service| Get-Member -View Extended
+PS> Get-Service| Get-Member -View Extended
 TypeName: System.ServiceProcess.ServiceController
 Name MemberType    Definition
 ---- ----------    ----------
@@ -108,7 +108,7 @@ In this case, the extended member is the Name property, which is an alias proper
 
 ### Example 4: Get script properties of event log objects
 ```
-PS C:\> Get-EventLog -Log System | Get-Member -MemberType ScriptProperty
+PS> Get-EventLog -Log System | Get-Member -MemberType ScriptProperty
 TypeName: System.Diagnostics.EventLogEntry
 Name    MemberType     Definition
 ----    ----------     ----------
@@ -123,8 +123,8 @@ The command returns the EventID property of the **EventLog** object.
 
 ### Example 5: Get objects with a specified property
 ```
-PS C:\> $A = "Get-Process", "Get-Service", "Get-Culture", "Get-PSDrive", "Get-ExecutionPolicy"
-PS C:\> ForEach ($Cmdlet in $A) {Invoke-Command $Cmdlet | Get-Member -Name MachineName}
+PS> $A = "Get-Process", "Get-Service", "Get-Culture", "Get-PSDrive", "Get-ExecutionPolicy"
+PS> ForEach ($Cmdlet in $A) {Invoke-Command $Cmdlet | Get-Member -Name MachineName}
 TypeName: System.Diagnostics.Process
 Name        MemberType Definition
 ----        ---------- ----------
@@ -145,10 +145,10 @@ The results show that only process objects (**System.Diagnostics.Process**) and 
 
 ### Example 6: Get members for an array
 ```
-PS C:\> $A = @(1)
-PS C:\> $A.Count
+PS> $A = @(1)
+PS> $A.Count
 1
-PS C:\> Get-Member -InputObject $A
+PS> Get-Member -InputObject $A
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
@@ -156,8 +156,8 @@ Count              AliasProperty Count = Length
 Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
-PS C:\> $A = @(1,2,3)
-PS C:\> Get-Member -InputObject $A
+PS> $A = @(1,2,3)
+PS> Get-Member -InputObject $A
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
@@ -165,7 +165,7 @@ Count              AliasProperty Count = Length
 Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
-PS C:\> $A.Count
+PS> $A.Count
 3
 ```
 
@@ -181,8 +181,8 @@ The fourth command uses the Count property of the array to find the number of ob
 
 ### Example 7: Determine which object properties you can set
 ```
-PS C:\> $File = Get-Item c:\test\textFile.txt
-PS C:\> $File.psobject.properties | Where-Object {$_.issettable} | Format-Table -Property name
+PS> $File = Get-Item c:\test\textFile.txt
+PS> $File.psobject.properties | Where-Object {$_.issettable} | Format-Table -Property name
 Name
 ----
 PSPath
@@ -198,7 +198,8 @@ LastAccessTime
 LastAccessTimeUtc
 LastWriteTime
 LastWriteTimeUtc
-Attributes PS C:\> [appdomain]::CurrentDomain.GetAssemblies() | ForEach-Object { $_.getexportedtypes() } | ForEach-Object {$_.getproperties() | Where-Object {$_.canwrite }} | Select-Object reflectedtype, name
+Attributes 
+PS> [appdomain]::CurrentDomain.GetAssemblies() | ForEach-Object { $_.getexportedtypes() } | ForEach-Object {$_.getproperties() | Where-Object {$_.canwrite }} | Select-Object reflectedtype, name
 ```
 
 This example shows how to determine which properties of an object can be changed.
@@ -212,8 +213,8 @@ The third command gets the changeable properties of all objects in your Windows 
 
 ### Example 8: Get members of each item in a collection
 ```
-PS C:\> $S = Get-Service
-PS C:\> $S | Get-Member
+PS> $S = Get-Service
+PS> $S | Get-Member
 TypeName: System.ServiceProcess.ServiceController
 Name                      MemberType    Definition
 ----                      ----------    ----------
@@ -224,7 +225,8 @@ Close                     Method        System.Void Close()
 Continue                  Method        System.Void Continue()
 CreateObjRef              Method        System.Runtime.Remoting.ObjRef CreateObjRef(type requestedTy
 Dispose                   Method        System.Void Dispose()
-... PS C:\> Get-Member -InputObject $S
+... 
+PS> Get-Member -InputObject $S
 TypeName: System.Object[]
 Name           MemberType    Definition
 ----           ----------    ----------

--- a/reference/6/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Member.md
@@ -145,10 +145,19 @@ The results show that only process objects (**System.Diagnostics.Process**) and 
 
 ### Example 6: Get members for an array
 ```
-PS C:\> $A = Get-Member - InputObject @(1)
+PS C:\> $A = @(1)
 PS C:\> $A.Count
 1
-PS C:\> $A = Get-Member -InputObject 1,2,3
+PS C:\> Get-Member -InputObject $A
+TypeName: System.Object[]
+Name               MemberType    Definition
+----               ----------    ----------
+Count              AliasProperty Count = Length
+Address            Method        System.Object& Address(Int32 )
+Clone              Method        System.Object Clone()
+...
+PS C:\> $A = @(1,2,3)
+PS C:\> Get-Member -InputObject $A
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
@@ -157,7 +166,7 @@ Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
 PS C:\> $A.Count
-1
+3
 ```
 
 This example demonstrates how to find the properties and methods of an array of objects when you have only one object of the given type.

--- a/reference/6/Microsoft.PowerShell.Utility/Get-Member.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Get-Member.md
@@ -32,7 +32,7 @@ To get only certain types of members, such as **NoteProperties**, use the *Membe
 
 ### Example 1: Get the members of process objects
 ```
-PS C:\> Get-Service | Get-Member
+PS> Get-Service | Get-Member
 TypeName: System.ServiceProcess.ServiceController
 Name                      MemberType    Definition
 ----                      ----------    ----------
@@ -77,8 +77,8 @@ As such, it gets all member types, but it does not get static members and does n
 
 ### Example 2: Get members of service objects
 ```
-PS C:\> Get-Service | Get-Member -Force
-PS C:\> (Get-Service Schedule).PSBase
+PS> Get-Service | Get-Member -Force
+PS> (Get-Service Schedule).PSBase
 ```
 
 This example gets all of the members (properties and methods) of the service objects (System.ServiceProcess.ServiceController) retrieved by the Get-Service cmdlet, including the intrinsic members, such as PSBase and PSObject, and the get_ and set_ methods.
@@ -94,7 +94,7 @@ The second command shows how to display the value of the PSBase property of the 
 
 ### Example 3: Get extended members of service objects
 ```
-PS C:\> Get-Service| Get-Member -View Extended
+PS> Get-Service| Get-Member -View Extended
 TypeName: System.ServiceProcess.ServiceController
 Name MemberType    Definition
 ---- ----------    ----------
@@ -108,7 +108,7 @@ In this case, the extended member is the Name property, which is an alias proper
 
 ### Example 4: Get script properties of event log objects
 ```
-PS C:\> Get-EventLog -Log System | Get-Member -MemberType ScriptProperty
+PS> Get-EventLog -Log System | Get-Member -MemberType ScriptProperty
 TypeName: System.Diagnostics.EventLogEntry
 Name    MemberType     Definition
 ----    ----------     ----------
@@ -123,8 +123,8 @@ The command returns the EventID property of the **EventLog** object.
 
 ### Example 5: Get objects with a specified property
 ```
-PS C:\> $A = "Get-Process", "Get-Service", "Get-Culture", "Get-PSDrive", "Get-ExecutionPolicy"
-PS C:\> ForEach ($Cmdlet in $A) {Invoke-Command $Cmdlet | Get-Member -Name MachineName}
+PS> $A = "Get-Process", "Get-Service", "Get-Culture", "Get-PSDrive", "Get-ExecutionPolicy"
+PS> ForEach ($Cmdlet in $A) {Invoke-Command $Cmdlet | Get-Member -Name MachineName}
 TypeName: System.Diagnostics.Process
 Name        MemberType Definition
 ----        ---------- ----------
@@ -145,10 +145,10 @@ The results show that only process objects (**System.Diagnostics.Process**) and 
 
 ### Example 6: Get members for an array
 ```
-PS C:\> $A = @(1)
-PS C:\> $A.Count
+PS> $A = @(1)
+PS> $A.Count
 1
-PS C:\> Get-Member -InputObject $A
+PS> Get-Member -InputObject $A
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
@@ -156,8 +156,8 @@ Count              AliasProperty Count = Length
 Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
-PS C:\> $A = @(1,2,3)
-PS C:\> Get-Member -InputObject $A
+PS> $A = @(1,2,3)
+PS> Get-Member -InputObject $A
 TypeName: System.Object[]
 Name               MemberType    Definition
 ----               ----------    ----------
@@ -165,7 +165,7 @@ Count              AliasProperty Count = Length
 Address            Method        System.Object& Address(Int32 )
 Clone              Method        System.Object Clone()
 ...
-PS C:\> $A.Count
+PS> $A.Count
 3
 ```
 
@@ -181,8 +181,8 @@ The fourth command uses the Count property of the array to find the number of ob
 
 ### Example 7: Determine which object properties you can set
 ```
-PS C:\> $File = Get-Item c:\test\textFile.txt
-PS C:\> $File.psobject.properties | Where-Object {$_.issettable} | Format-Table -Property name
+PS> $File = Get-Item c:\test\textFile.txt
+PS> $File.psobject.properties | Where-Object {$_.issettable} | Format-Table -Property name
 Name
 ----
 PSPath
@@ -198,7 +198,8 @@ LastAccessTime
 LastAccessTimeUtc
 LastWriteTime
 LastWriteTimeUtc
-Attributes PS C:\> [appdomain]::CurrentDomain.GetAssemblies() | ForEach-Object { $_.getexportedtypes() } | ForEach-Object {$_.getproperties() | Where-Object {$_.canwrite }} | Select-Object reflectedtype, name
+Attributes
+PS> [appdomain]::CurrentDomain.GetAssemblies() | ForEach-Object { $_.getexportedtypes() } | ForEach-Object {$_.getproperties() | Where-Object {$_.canwrite }} | Select-Object reflectedtype, name
 ```
 
 This example shows how to determine which properties of an object can be changed.
@@ -212,8 +213,8 @@ The third command gets the changeable properties of all objects in your PowerShe
 
 ### Example 8: Get members of each item in a collection
 ```
-PS C:\> $S = Get-Service
-PS C:\> $S | Get-Member
+PS> $S = Get-Service
+PS> $S | Get-Member
 TypeName: System.ServiceProcess.ServiceController
 Name                      MemberType    Definition
 ----                      ----------    ----------
@@ -224,7 +225,8 @@ Close                     Method        System.Void Close()
 Continue                  Method        System.Void Continue()
 CreateObjRef              Method        System.Runtime.Remoting.ObjRef CreateObjRef(type requestedTy
 Dispose                   Method        System.Void Dispose()
-... PS C:\> Get-Member -InputObject $S
+...
+PS> Get-Member -InputObject $S
 TypeName: System.Object[]
 Name           MemberType    Definition
 ----           ----------    ----------


### PR DESCRIPTION
* Fix syntax error
* Fix command sequence and commands used
* Fix unclear example sequence

Thanks to [Ramon TAN](https://powershell.org/forums/topic/get-member-examples-different-results-on-my-pc/#post-127867) for stumbling across this in confusion!

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
