### PR TITLE
Fix mandatory parameter error in Expand-Archive

### DIFF
--- a/reference/5.0/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/5.0/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -54,27 +54,10 @@ This command extracts the contents of an existing archive file in the current fo
 
 ## PARAMETERS
 
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DestinationPath
 
 Specifies the path to the folder in which you want the command to save extracted files.
 Enter the path to a folder, but do not specify a file name or file name extension.
-This parameter is required.
 
 ```yaml
 Type: String
@@ -83,7 +66,7 @@ Aliases:
 
 Required: False
 Position: 1
-Default value: None
+Default value: Current location
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -109,7 +92,7 @@ Accept wildcard characters: False
 Specifies the path to an archive file.
 Unlike the **Path** parameter, the value of **LiteralPath** is used exactly as it is typed.
 Wildcard characters are not supported.
-If the path includes escape characters, enclose each escape character in single quotation marks, to instruct Windows PowerShell not to interpret any characters as escape sequences.
+If the path includes escape characters, enclose each escape character in single quotation marks, to instruct PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -139,6 +122,22 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -WhatIf
 
 Shows what would happen if the cmdlet runs.
@@ -157,8 +156,10 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/5.1/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/5.1/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -169,10 +169,7 @@ You can pipe a string that contains a path to an existing archive file.
 
 ## OUTPUTS
 
-### System.IO.FileSystemInfo
-
-When the `-PassThru` parameter is used, the cmdlet outputs a list of files that where expanded from
-the archive.
+### None
 
 ## NOTES
 

--- a/reference/5.1/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/5.1/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -58,7 +58,6 @@ This command extracts the contents of an existing archive file in the current fo
 
 Specifies the path to the folder in which you want the command to save extracted files.
 Enter the path to a folder, but do not specify a file name or file name extension.
-This parameter is required.
 
 ```yaml
 Type: String
@@ -67,7 +66,7 @@ Aliases:
 
 Required: False
 Position: 1
-Default value: None
+Default value: Current location
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -93,7 +92,7 @@ Accept wildcard characters: False
 Specifies the path to an archive file.
 Unlike the **Path** parameter, the value of **LiteralPath** is used exactly as it is typed.
 Wildcard characters are not supported.
-If the path includes escape characters, enclose each escape character in single quotation marks, to instruct Windows PowerShell not to interpret any characters as escape sequences.
+If the path includes escape characters, enclose each escape character in single quotation marks, to instruct PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -157,7 +156,10 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -167,10 +169,13 @@ You can pipe a string that contains a path to an existing archive file.
 
 ## OUTPUTS
 
-### None
+### System.IO.FileSystemInfo
+
+When the `-PassThru` parameter is used, the cmdlet outputs a list of files that where expanded from
+the archive.
 
 ## NOTES
 
 ## RELATED LINKS
 
-## RELATED LINKS
+[Compress-Archive](compress-archive.md)

--- a/reference/6/Microsoft.PowerShell.Archive/Expand-Archive.md
+++ b/reference/6/Microsoft.PowerShell.Archive/Expand-Archive.md
@@ -12,20 +12,21 @@ title: Expand-Archive
 # Expand-Archive
 
 ## SYNOPSIS
-
 Extracts files from a specified archive (zipped) file.
 
 ## SYNTAX
 
 ### Path (Default)
+
 ```
-Expand-Archive [-Path] <String> [-DestinationPath] <String> [-Force] [-PassThru] [-WhatIf] [-Confirm]
+Expand-Archive [-Path] <String> [[-DestinationPath] <String>] [-Force] [-PassThru] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ### LiteralPath
+
 ```
-Expand-Archive -LiteralPath <String> [-DestinationPath] <String> [-Force] [-PassThru] [-WhatIf] [-Confirm]
+Expand-Archive -LiteralPath <String> [[-DestinationPath] <String>] [-Force] [-PassThru] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -58,7 +59,6 @@ This command extracts the contents of an existing archive file in the current fo
 
 Specifies the path to the folder in which you want the command to save extracted files.
 Enter the path to a folder, but do not specify a file name or file name extension.
-This parameter is required.
 
 ```yaml
 Type: String
@@ -67,7 +67,7 @@ Aliases:
 
 Required: False
 Position: 1
-Default value: None
+Default value: Current location
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
