### PR TITLE
Update "Sorting Objects" examples for non-Windows users

### DIFF
--- a/reference/docs-conceptual/getting-started/cookbooks/Sorting-Objects.md
+++ b/reference/docs-conceptual/getting-started/cookbooks/Sorting-Objects.md
@@ -6,42 +6,53 @@ ms.assetid:  8530caa8-3ed4-4c56-aed7-1295dd9ba199
 ---
 # Sorting Objects
 
-We can organize displayed data to make it easier to scan by using the **Sort-Object** cmdlet. **Sort-Object** takes the name of one or more properties to sort on, and returns data sorted by the values of those properties.
+We can organize displayed data to make it easier to scan by using the `Sort-Object` cmdlet. `Sort-Object` takes the name of one or more properties to sort on, and returns data sorted by the values of those properties.
 
-Consider the problem of listing Win32_SystemDriver instances. If we want to sort by **State** and then by **Name**, we can do it by typing:
+Consider the problem of listing subdirectories and files in the current directory.
+If we want to sort by **LastWriteTime** and then by **Name**, we can do it by typing:
 
 ```powershell
-Get-WmiObject -Class Win32_SystemDriver | Sort-Object -Property State,Name | Format-Table -Property Name,State,Started,DisplayName -AutoSize -Wrap
+Get-ChildItem |
+  Sort-Object -Property LastWriteTime, Name |
+  Format-Table -Property LastWriteTime, Name
 ```
-
-Although this is a lengthy display, you can see items with the same state grouped together:
 
 ```output
-Name           State   Started DisplayName
-----           -----   ------- -----------
-ACPI           Running    True Microsoft ACPI Driver
-AFD            Running    True AFD
-AmdK7          Running    True AMD K7 Processor Driver
-AsyncMac       Running    True RAS Asynchronous Media Driver
-...
-Abiosdsk       Stopped   False Abiosdsk
-ACPIEC         Stopped   False ACPIEC
-aec            Stopped   False Microsoft Kernel Acoustic Echo Canceller
+LastWriteTime          Name
+-------------          ----
+11/6/2017 10:10:11 AM  .localization-config
+11/6/2017 10:10:11 AM  .openpublishing.build.ps1
+11/6/2017 10:10:11 AM  appveyor.yml
+11/6/2017 10:10:11 AM  LICENSE
+11/6/2017 10:10:11 AM  LICENSE-CODE
+11/6/2017 10:10:11 AM  ThirdPartyNotices
+11/6/2017 10:10:15 AM  tests
+6/6/2018 7:58:59 PM    CONTRIBUTING.md
+6/6/2018 7:58:59 PM    README.md
 ...
 ```
 
-You can also sort the objects in reverse order by specifying the **Descending** parameter. This reverses the sort order so that names are sorted in reverse alphabetical order and numbers are sorted by descending size.
+You can also sort the objects in reverse order by specifying the **Descending** switch parameter.
 
+```powershell
+Get-ChildItem |
+  Sort-Object -Property LastWriteTime, Name -Descending |
+  Format-Table -Property LastWriteTime, Name
 ```
-PS> Get-WmiObject -Class Win32_SystemDriver | Sort-Object -Property State,Name -Descending | Format-Table -Property Name,State,Started,DisplayName -AutoSize -Wrap
 
-Name           State   Started DisplayName
-----           -----   ------- -----------
-WS2IFSL        Stopped   False Windows Socket 2.0 Non-IFS Service Provider Supp
-                               ort Environment
-wceusbsh       Stopped   False Windows CE USB Serial Host Driver...
+```output
+LastWriteTime          Name
+-------------          ----
+12/1/2018 10:13:50 PM  reference
+12/1/2018 10:13:50 PM  dsc
 ...
-wdmaud         Running    True Microsoft WINMM WDM Audio Compatibility Driver
-Wanarp         Running    True Remote Access IP ARP Driver
-...
+6/6/2018 7:58:59 PM    README.md
+6/6/2018 7:58:59 PM    CONTRIBUTING.md
+11/6/2017 10:10:15 AM  tests
+11/6/2017 10:10:11 AM  ThirdPartyNotices
+11/6/2017 10:10:11 AM  LICENSE-CODE
+11/6/2017 10:10:11 AM  LICENSE
+11/6/2017 10:10:11 AM  appveyor.yml
+11/6/2017 10:10:11 AM  .openpublishing.build.ps1
+11/6/2017 10:10:11 AM  .localization-config
 ```


### PR DESCRIPTION
* Replaced `Get-WmiObject` cmdlet with `Get-ChildItem` cmdlet for non-Windows users
* Fixed formatting
* Simplified description
