### PR TITLE
Example 3 incorrectly says directory instead of sub-directories

### DIFF
--- a/reference/6/Microsoft.PowerShell.Management/Get-ChildItem.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-ChildItem.md
@@ -66,7 +66,7 @@ Get-ChildItem -Path *.txt -Recurse -Force
 
 This command lists the ".txt" files in the "Logs" subdirectory, except for those whose names start with the letter 'A'.
 It uses the wildcard character (`*`) to indicate the contents of the "Logs" subdirectory, not the directory container.
-Because the command does not include the `-Recurse` parameter, `Get-ChildItem` does not include the content of directory automatically; you need to specify it.
+Because the command does not include the `-Recurse` parameter, `Get-ChildItem` does not include the content of sub-directories automatically; you need to specify it.
 
 ```powershell
 Get-ChildItem -Path C:\Windows\Logs\* -Include *.txt -Exclude A*


### PR DESCRIPTION
I think Example 3 incorrectly says directory instead of sub-directories

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
