### PR TITLE
Update doc about '-Encoding' for 'Set-Content' and 'Add-Content' for downlevel powershell versions

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Add-Content.md
@@ -102,16 +102,23 @@ Specifies the file encoding. The default is ASCII.
 
 Valid values are:
 
-- **ASCII**:  Uses the encoding for the ASCII (7-bit) character set.
-- **BigEndianUnicode**:  Encodes in UTF-16 format using the big-endian byte order.
-- **Byte**:   Encodes a set of characters into a sequence of bytes.
-- **String**:  Uses the encoding type for a string.
-- **Unicode**:  Encodes in UTF-16 format using the little-endian byte order.
-- **UTF7**:   Encodes in UTF-7 format.
-- **UTF8**:  Encodes in UTF-8 format.
-- **Unknown**:  The encoding type is unknown or invalid. The data can be treated as binary.
+- **Unknown** Same as **Unicode**.
+- **String** Same as **Unicode**.
+- **Unicode** Uses UTF-16 with the little-endian byte order.
+- **Byte** Encodes a set of characters into a sequence of bytes.
+- **BigEndianUnicode** Uses UTF-16 with the big-endian byte order.
+- **UTF8** Uses UTF-8.
+- **UTF7** Uses UTF-7.
+- **UTF32** Uses UTF-32 with the little-endian byte order.
+- **ASCII** Uses ASCII (7-bit) character set.
+- **Default** Uses the encoding that corresponds to the system's active code page.
+- **Oem** Uses the encoding that corresponds to the system's current OEM code page.
+- **BigEndianUTF32** Uses UTF-32 with the big-endian byte order.
 
-Encoding is a dynamic parameter that the FileSystem provider adds to the `Add-Content` cmdlet. This parameter works only in file system drives.
+The default value is **Default**.
+
+Encoding is a dynamic parameter that the FileSystem provider adds to the `Add-Content` cmdlet.
+This parameter works only in file system drives.
 
 ```yaml
 Type: FileSystemCmdletProviderEncoding

--- a/reference/3.0/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Set-Content.md
@@ -123,16 +123,20 @@ Accept wildcard characters: False
 Specifies the file encoding.
 The acceptable values for this parameter are:
 
-- **ASCII** Uses the encoding for the ASCII (7-bit) character set.
-- **BigEndianUnicode** Encodes in UTF-16 format using the big-endian byte order.
+- **Unknown** Same as **Unicode**.
+- **String** Same as **Unicode**.
+- **Unicode** Uses UTF-16 with the little-endian byte order.
 - **Byte** Encodes a set of characters into a sequence of bytes.
-- **String** Uses the encoding type for a string.
-- **Unicode** Encodes in UTF-16 format using the little-endian byte order.
-- **UTF7** Encodes in UTF-7 format.
-- **UTF8** Encodes in UTF-8 format.
-- **Unknown** The encoding type is unknown or invalid; the data can be treated as binary.
+- **BigEndianUnicode** Uses UTF-16 with the big-endian byte order.
+- **UTF8** Uses UTF-8.
+- **UTF7** Uses UTF-7.
+- **UTF32** Uses UTF-32 with the little-endian byte order.
+- **ASCII** Uses ASCII (7-bit) character set.
+- **Default** Uses the encoding that corresponds to the system's active code page.
+- **Oem** Uses the encoding that corresponds to the system's current OEM code page.
+- **BigEndianUTF32** Uses UTF-32 with the big-endian byte order.
 
-The default value is ASCII.
+The default value is **Default**.
 
 Encoding is a dynamic parameter that the FileSystem provider adds to `Set-Content`.
 This parameter works only in file system drives.

--- a/reference/4.0/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Add-Content.md
@@ -141,20 +141,23 @@ Specifies the encoding that this cmdlet applies to the content.
 
 The acceptable values for this parameter are:
 
-- **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
-- **String**: Uses the encoding type for a string.
-- **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
-- **Byte**: Encodes a set of characters into a sequence of bytes.
-- **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
-- **UTF8**: Encodes in UTF-8 format.
-- **UTF7**: Encodes in UTF-7 format.
-- **UTF32**:  Encodes in UTF-32 format.
-- **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
-- **Default**: Encodes using the default value: ASCII.
-- **OEM**: Uses the default encoding for MS-DOS and console programs.
-- **BigEndianUTF32**:  Encodes in UTF-32 format using the big-endian byte order.
+- **Unknown** Same as **Unicode**.
+- **String** Same as **Unicode**.
+- **Unicode** Uses UTF-16 with the little-endian byte order.
+- **Byte** Encodes a set of characters into a sequence of bytes.
+- **BigEndianUnicode** Uses UTF-16 with the big-endian byte order.
+- **UTF8** Uses UTF-8.
+- **UTF7** Uses UTF-7.
+- **UTF32** Uses UTF-32 with the little-endian byte order.
+- **ASCII** Uses ASCII (7-bit) character set.
+- **Default** Uses the encoding that corresponds to the system's active code page.
+- **Oem** Uses the encoding that corresponds to the system's current OEM code page.
+- **BigEndianUTF32** Uses UTF-32 with the big-endian byte order.
 
-Encoding is a dynamic parameter that the FileSystem provider adds to the `Add-Content` cmdlet. This parameter works only in file system drives.
+The default value is **Default**.
+
+Encoding is a dynamic parameter that the FileSystem provider adds to the `Add-Content` cmdlet.
+This parameter works only in file system drives.
 
 ```yaml
 Type: FileSystemCmdletProviderEncoding

--- a/reference/4.0/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Set-Content.md
@@ -123,16 +123,20 @@ Accept wildcard characters: False
 Specifies the file encoding.
 The acceptable values for this parameter are:
 
-- **ASCII** Uses the encoding for the ASCII (7-bit) character set.
-- **BigEndianUnicode** Encodes in UTF-16 format using the big-endian byte order.
+- **Unknown** Same as **Unicode**.
+- **String** Same as **Unicode**.
+- **Unicode** Uses UTF-16 with the little-endian byte order.
 - **Byte** Encodes a set of characters into a sequence of bytes.
-- **String** Uses the encoding type for a string.
-- **Unicode** Encodes in UTF-16 format using the little-endian byte order.
-- **UTF7** Encodes in UTF-7 format.
-- **UTF8** Encodes in UTF-8 format.
-- **Unknown** The encoding type is unknown or invalid; the data can be treated as binary.
+- **BigEndianUnicode** Uses UTF-16 with the big-endian byte order.
+- **UTF8** Uses UTF-8.
+- **UTF7** Uses UTF-7.
+- **UTF32** Uses UTF-32 with the little-endian byte order.
+- **ASCII** Uses ASCII (7-bit) character set.
+- **Default** Uses the encoding that corresponds to the system's active code page.
+- **Oem** Uses the encoding that corresponds to the system's current OEM code page.
+- **BigEndianUTF32** Uses UTF-32 with the big-endian byte order.
 
-The default value is ASCII.
+The default value is **Default**.
 
 Encoding is a dynamic parameter that the FileSystem provider adds to `Set-Content`.
 This parameter works only in file system drives.

--- a/reference/5.0/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Add-Content.md
@@ -141,20 +141,23 @@ Specifies the encoding that this cmdlet applies to the content.
 
 The acceptable values for this parameter are:
 
-- **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
-- **String**: Uses the encoding type for a string.
-- **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
-- **Byte**: Encodes a set of characters into a sequence of bytes.
-- **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
-- **UTF8**: Encodes in UTF-8 format.
-- **UTF7**: Encodes in UTF-7 format.
-- **UTF32**:  Encodes in UTF-32 format.
-- **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
-- **Default**: Encodes using the default value: ASCII.
-- **OEM**: Uses the default encoding for MS-DOS and console programs.
-- **BigEndianUTF32**:  Encodes in UTF-32 format using the big-endian byte order.
+- **Unknown** Same as **Unicode**.
+- **String** Same as **Unicode**.
+- **Unicode** Uses UTF-16 with the little-endian byte order.
+- **Byte** Encodes a set of characters into a sequence of bytes.
+- **BigEndianUnicode** Uses UTF-16 with the big-endian byte order.
+- **UTF8** Uses UTF-8.
+- **UTF7** Uses UTF-7.
+- **UTF32** Uses UTF-32 with the little-endian byte order.
+- **ASCII** Uses ASCII (7-bit) character set.
+- **Default** Uses the encoding that corresponds to the system's active code page.
+- **Oem** Uses the encoding that corresponds to the system's current OEM code page.
+- **BigEndianUTF32** Uses UTF-32 with the big-endian byte order.
 
-Encoding is a dynamic parameter that the FileSystem provider adds to the `Add-Content` cmdlet. This parameter works only in file system drives.
+The default value is **Default**.
+
+Encoding is a dynamic parameter that the FileSystem provider adds to the `Add-Content` cmdlet.
+This parameter works only in file system drives.
 
 ```yaml
 Type: FileSystemCmdletProviderEncoding

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-Content.md
@@ -123,18 +123,20 @@ Accept wildcard characters: False
 Specifies the file encoding.
 The acceptable values for this parameter are:
 
-- **ASCII** Uses the encoding for the ASCII (7-bit) character set.
-- **BigEndianUnicode** Encodes in UTF-16 format using the big-endian byte order.
-- **BigEndianUTF32** Encodes in UTF-32 format using the big-endian byte order.
-- **Default** Encodes using the default value: ASCII.
+- **Unknown** Same as **Unicode**.
+- **String** Same as **Unicode**.
+- **Unicode** Uses UTF-16 with the little-endian byte order.
 - **Byte** Encodes a set of characters into a sequence of bytes.
-- **String** Uses the encoding type for a string.
-- **Unicode** Encodes in UTF-16 format using the little-endian byte order.
-- **UTF7** Encodes in UTF-7 format.
-- **UTF8** Encodes in UTF-8 format.
-- **Unknown** The encoding type is unknown or invalid; the data can be treated as binary.
+- **BigEndianUnicode** Uses UTF-16 with the big-endian byte order.
+- **UTF8** Uses UTF-8.
+- **UTF7** Uses UTF-7.
+- **UTF32** Uses UTF-32 with the little-endian byte order.
+- **ASCII** Uses ASCII (7-bit) character set.
+- **Default** Uses the encoding that corresponds to the system's active code page.
+- **Oem** Uses the encoding that corresponds to the system's current OEM code page.
+- **BigEndianUTF32** Uses UTF-32 with the big-endian byte order.
 
-The default value is ASCII.
+The default value is **Default**.
 
 Encoding is a dynamic parameter that the FileSystem provider adds to `Set-Content`.
 This parameter works only in file system drives.

--- a/reference/5.1/Microsoft.PowerShell.Management/Add-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Add-Content.md
@@ -125,20 +125,23 @@ Specifies the encoding that this cmdlet applies to the content.
 
 The acceptable values for this parameter are:
 
-- **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
-- **String**: Uses the encoding type for a string.
-- **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
-- **Byte**: Encodes a set of characters into a sequence of bytes.
-- **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
-- **UTF8**: Encodes in UTF-8 format.
-- **UTF7**: Encodes in UTF-7 format.
-- **UTF32**:  Encodes in UTF-32 format.
-- **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
-- **Default**: Encodes using the default value: ASCII.
-- **OEM**: Uses the default encoding for MS-DOS and console programs.
-- **BigEndianUTF32**:  Encodes in UTF-32 format using the big-endian byte order.
+- **Unknown** Same as **Unicode**.
+- **String** Same as **Unicode**.
+- **Unicode** Uses UTF-16 with the little-endian byte order.
+- **Byte** Encodes a set of characters into a sequence of bytes.
+- **BigEndianUnicode** Uses UTF-16 with the big-endian byte order.
+- **UTF8** Uses UTF-8.
+- **UTF7** Uses UTF-7.
+- **UTF32** Uses UTF-32 with the little-endian byte order.
+- **ASCII** Uses ASCII (7-bit) character set.
+- **Default** Uses the encoding that corresponds to the system's active code page.
+- **Oem** Uses the encoding that corresponds to the system's current OEM code page.
+- **BigEndianUTF32** Uses UTF-32 with the big-endian byte order.
 
-Encoding is a dynamic parameter that the FileSystem provider adds to the `Add-Content` cmdlet. This parameter works only in file system drives.
+The default value is **Default**.
+
+Encoding is a dynamic parameter that the FileSystem provider adds to the `Add-Content` cmdlet.
+This parameter works only in file system drives.
 
 ```yaml
 Type: FileSystemCmdletProviderEncoding

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-Content.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-Content.md
@@ -107,18 +107,20 @@ Accept wildcard characters: False
 Specifies the file encoding.
 The acceptable values for this parameter are:
 
-- **ASCII** Uses the encoding for the ASCII (7-bit) character set.
-- **BigEndianUnicode** Encodes in UTF-16 format using the big-endian byte order.
-- **BigEndianUTF32** Encodes in UTF-32 format using the big-endian byte order.
-- **Default** Encodes using the default value: ASCII.
+- **Unknown** Same as **Unicode**.
+- **String** Same as **Unicode**.
+- **Unicode** Uses UTF-16 with the little-endian byte order.
 - **Byte** Encodes a set of characters into a sequence of bytes.
-- **String** Uses the encoding type for a string.
-- **Unicode** Encodes in UTF-16 format using the little-endian byte order.
-- **UTF7** Encodes in UTF-7 format.
-- **UTF8** Encodes in UTF-8 format.
-- **Unknown** The encoding type is unknown or invalid; the data can be treated as binary.
+- **BigEndianUnicode** Uses UTF-16 with the big-endian byte order.
+- **UTF8** Uses UTF-8.
+- **UTF7** Uses UTF-7.
+- **UTF32** Uses UTF-32 with the little-endian byte order.
+- **ASCII** Uses ASCII (7-bit) character set.
+- **Default** Uses the encoding that corresponds to the system's active code page.
+- **Oem** Uses the encoding that corresponds to the system's current OEM code page.
+- **BigEndianUTF32** Uses UTF-32 with the big-endian byte order.
 
-The default value is ASCII.
+The default value is **Default**.
 
 Encoding is a dynamic parameter that the FileSystem provider adds to `Set-Content`.
 This parameter works only in file system drives.


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [x] This PR doesn't update doc for PS 6.x, and issue #2000 tracks the remaining work
