### PR TITLE
Added example to fix parameter format problem

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Format-Custom.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Format-Custom.md
@@ -50,6 +50,34 @@ This command formats information about the Winlogon process in an alternate cust
 Because the command does not use the **View** parameter, `Format-Custom` uses a default custom view
 to format the data.
 
+### Example 3: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -DisplayError
+
+class DateTime
+{
+  DayOfWeek = Friday
+   $_ / $null  = #ERR
+}
+
+
+PC /> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -ShowError
+
+class DateTime
+{
+  DayOfWeek = Friday
+   $_ / $null  =
+}
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 8:01:04 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -Depth
@@ -72,16 +100,7 @@ Accept wildcard characters: False
 
 Displays errors at the command line. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Custom` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **DisplayError**
-parameter with an expression.
-
-```powershell
-Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -DisplayError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -210,19 +229,7 @@ Accept wildcard characters: False
 
 Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Custom` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **ShowError**
-parameter with an expression.
-
-```powershell
-PS \> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/3.0/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Format-List.md
@@ -86,22 +86,34 @@ Because the name of the *Property* parameter is optional, you can omit it and ty
 `Format-List *`. `Format-List` automatically sends the results to the default output cmdlet for
 display.
 
+### Example 5: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-List DayOfWeek,{ $_ / $null } -DisplayError
+
+DayOfWeek    : Friday
+ $_ / $null  : #ERR
+
+PC /> Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
+
+DayOfWeek    : Friday
+ $_ / $null  :
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 7:59:23 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -DisplayError
 
 Indicates that this cmdlet displays errors at the command line. This parameter is rarely used, but
 can be used as a debugging aid when you are formatting expressions in a `Format-List` command, and
-the expressions do not appear to be working. The following shows an example of the results of
-adding the **DisplayError** parameter with an expression.
-
-```powershell
-PS C:\> Get-Date | Format-List DayOfWeek, { $_ / $null } -DisplayError
-
-
-DayOfWeek    : Monday
- $_ / $null  : #ERR
-```
+the expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -229,20 +241,7 @@ Accept wildcard characters: False
 
 Indicates that the cmdlet sends errors through the pipeline. This parameter is rarely used, but can
 be used as a debugging aid when you are formatting expressions in a `Format-List` command, and the
-expressions do not appear to be working. The following shows an example of the results of adding
-the ShowError parameter with an expression.
-
-```powershell
-Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
+expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/3.0/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Format-Table.md
@@ -147,6 +147,29 @@ has been running by subtracting the creation date of the process from the curren
 **DateTime** object that can be compared with the output of `Get-Date`. Then, the converted
 creation date is subtracted from the current date. The result is the value of **Total Running Time**.
 
+### Example 7: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -DisplayError
+
+DayOfWeek  $_ / $null
+--------- ------------
+Wednesday #ERR
+
+PC /> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
+
+DayOfWeek  $_ / $null
+--------- ------------
+Wednesday
+
+Failed to evaluate expression " $_ / $null ".
+    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
+    + FullyQualifiedErrorId : mshExpressionError
+```
+
 ## PARAMETERS
 
 ### -AutoSize
@@ -170,16 +193,7 @@ Accept wildcard characters: False
 
 Indicates that the cmdlet displays errors at the command line. This parameter is rarely used, but
 can be used as a debugging aid when you are formatting expressions in a `Format-Table` command, and
-the expressions do not appear to be working. The following shows an example of the results of
-adding the DisplayError parameter with an expression.
-
-```powershell
-Get-Date | Format-Table DayOfWeek,{ $_ / $null } -DisplayError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
+the expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -330,20 +344,7 @@ Accept wildcard characters: False
 
 Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Table` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **ShowError**
-parameter with an expression.
-
-```powershell
-Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-Failed to evaluate expression " $_ / $null ".
-+ CategoryInfo          : InvalidArgument: (12/19/2018 9:04:32 AM:PSObject) [], RuntimeException
-+ FullyQualifiedErrorId : PSPropertyExpressionError
-
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/3.0/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -55,6 +55,25 @@ operator (|) passes the registry key objects through the pipeline to `Format-Wid
 them for output. The **Property** parameter specifies the name of the property, and the
 **AutoSize** parameter adjusts the columns for readability.
 
+### Example 3: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PS /> Get-Date | Format-Wide { $_ / $null } -DisplayError
+
+
+#ERR
+
+PS /> Get-Date | Format-Wide { $_ / $null } -ShowError
+
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 8:18:01 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -AutoSize
@@ -96,15 +115,7 @@ Accept wildcard characters: False
 
 Displays errors at the command line. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **DisplayError**
-parameter with an expression.
-
-```powershell
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -235,20 +246,7 @@ Accept wildcard characters: False
 
 Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **ShowError**
-parameter with an expression.
-
-```powershell
-Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/4.0/Microsoft.PowerShell.Utility/Format-Custom.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Format-Custom.md
@@ -50,6 +50,34 @@ This command formats information about the Winlogon process in an alternate cust
 Because the command does not use the **View** parameter, `Format-Custom` uses a default custom view
 to format the data.
 
+### Example 3: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -DisplayError
+
+class DateTime
+{
+  DayOfWeek = Friday
+   $_ / $null  = #ERR
+}
+
+
+PC /> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -ShowError
+
+class DateTime
+{
+  DayOfWeek = Friday
+   $_ / $null  =
+}
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 8:01:04 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -Depth
@@ -72,16 +100,7 @@ Accept wildcard characters: False
 
 Displays errors at the command line. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Custom` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **DisplayError**
-parameter with an expression.
-
-```powershell
-Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -DisplayError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -210,19 +229,7 @@ Accept wildcard characters: False
 
 Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Custom` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **ShowError**
-parameter with an expression.
-
-```powershell
-PS \> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/4.0/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Format-List.md
@@ -86,22 +86,34 @@ Because the name of the *Property* parameter is optional, you can omit it and ty
 `Format-List *`. `Format-List` automatically sends the results to the default output cmdlet for
 display.
 
+### Example 5: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-List DayOfWeek,{ $_ / $null } -DisplayError
+
+DayOfWeek    : Friday
+ $_ / $null  : #ERR
+
+PC /> Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
+
+DayOfWeek    : Friday
+ $_ / $null  :
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 7:59:23 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -DisplayError
 
 Indicates that this cmdlet displays errors at the command line. This parameter is rarely used, but
 can be used as a debugging aid when you are formatting expressions in a `Format-List` command, and
-the expressions do not appear to be working. The following shows an example of the results of
-adding the **DisplayError** parameter with an expression.
-
-```powershell
-PS C:\> Get-Date | Format-List DayOfWeek, { $_ / $null } -DisplayError
-
-
-DayOfWeek    : Monday
- $_ / $null  : #ERR
-```
+the expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -229,20 +241,7 @@ Accept wildcard characters: False
 
 Indicates that the cmdlet sends errors through the pipeline. This parameter is rarely used, but can
 be used as a debugging aid when you are formatting expressions in a `Format-List` command, and the
-expressions do not appear to be working. The following shows an example of the results of adding
-the ShowError parameter with an expression.
-
-```powershell
-Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
+expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/4.0/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Format-Table.md
@@ -147,6 +147,29 @@ has been running by subtracting the creation date of the process from the curren
 **DateTime** object that can be compared with the output of `Get-Date`. Then, the converted
 creation date is subtracted from the current date. The result is the value of **Total Running Time**.
 
+### Example 7: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -DisplayError
+
+DayOfWeek  $_ / $null
+--------- ------------
+Wednesday #ERR
+
+PC /> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
+
+DayOfWeek  $_ / $null
+--------- ------------
+Wednesday
+
+Failed to evaluate expression " $_ / $null ".
+    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
+    + FullyQualifiedErrorId : mshExpressionError
+```
+
 ## PARAMETERS
 
 ### -AutoSize
@@ -170,16 +193,7 @@ Accept wildcard characters: False
 
 Indicates that the cmdlet displays errors at the command line. This parameter is rarely used, but
 can be used as a debugging aid when you are formatting expressions in a `Format-Table` command, and
-the expressions do not appear to be working. The following shows an example of the results of
-adding the DisplayError parameter with an expression.
-
-```powershell
-Get-Date | Format-Table DayOfWeek,{ $_ / $null } -DisplayError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
+the expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -330,20 +344,7 @@ Accept wildcard characters: False
 
 Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Table` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **ShowError**
-parameter with an expression.
-
-```powershell
-Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-Failed to evaluate expression " $_ / $null ".
-+ CategoryInfo          : InvalidArgument: (12/19/2018 9:04:32 AM:PSObject) [], RuntimeException
-+ FullyQualifiedErrorId : PSPropertyExpressionError
-
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/4.0/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -55,6 +55,25 @@ operator (|) passes the registry key objects through the pipeline to `Format-Wid
 them for output. The **Property** parameter specifies the name of the property, and the
 **AutoSize** parameter adjusts the columns for readability.
 
+### Example 3: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PS /> Get-Date | Format-Wide { $_ / $null } -DisplayError
+
+
+#ERR
+
+PS /> Get-Date | Format-Wide { $_ / $null } -ShowError
+
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 8:18:01 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -AutoSize
@@ -96,15 +115,7 @@ Accept wildcard characters: False
 
 Displays errors at the command line. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **DisplayError**
-parameter with an expression.
-
-```powershell
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -235,20 +246,7 @@ Accept wildcard characters: False
 
 Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **ShowError**
-parameter with an expression.
-
-```powershell
-Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-Custom.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-Custom.md
@@ -50,6 +50,34 @@ This command formats information about the Winlogon process in an alternate cust
 Because the command does not use the **View** parameter, `Format-Custom` uses a default custom view
 to format the data.
 
+### Example 3: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -DisplayError
+
+class DateTime
+{
+  DayOfWeek = Friday
+   $_ / $null  = #ERR
+}
+
+
+PC /> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -ShowError
+
+class DateTime
+{
+  DayOfWeek = Friday
+   $_ / $null  =
+}
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 8:01:04 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -Depth
@@ -72,16 +100,7 @@ Accept wildcard characters: False
 
 Displays errors at the command line. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Custom` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **DisplayError**
-parameter with an expression.
-
-```powershell
-Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -DisplayError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -210,19 +229,7 @@ Accept wildcard characters: False
 
 Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Custom` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **ShowError**
-parameter with an expression.
-
-```powershell
-PS \> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-List.md
@@ -86,22 +86,34 @@ Because the name of the *Property* parameter is optional, you can omit it and ty
 `Format-List *`. `Format-List` automatically sends the results to the default output cmdlet for
 display.
 
+### Example 5: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-List DayOfWeek,{ $_ / $null } -DisplayError
+
+DayOfWeek    : Friday
+ $_ / $null  : #ERR
+
+PC /> Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
+
+DayOfWeek    : Friday
+ $_ / $null  :
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 7:59:23 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -DisplayError
 
 Indicates that this cmdlet displays errors at the command line. This parameter is rarely used, but
 can be used as a debugging aid when you are formatting expressions in a `Format-List` command, and
-the expressions do not appear to be working. The following shows an example of the results of
-adding the **DisplayError** parameter with an expression.
-
-```powershell
-PS C:\> Get-Date | Format-List DayOfWeek, { $_ / $null } -DisplayError
-
-
-DayOfWeek    : Monday
- $_ / $null  : #ERR
-```
+the expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -229,20 +241,7 @@ Accept wildcard characters: False
 
 Indicates that the cmdlet sends errors through the pipeline. This parameter is rarely used, but can
 be used as a debugging aid when you are formatting expressions in a `Format-List` command, and the
-expressions do not appear to be working. The following shows an example of the results of adding
-the ShowError parameter with an expression.
-
-```powershell
-Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
+expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-Table.md
@@ -147,6 +147,29 @@ has been running by subtracting the creation date of the process from the curren
 **DateTime** object that can be compared with the output of `Get-Date`. Then, the converted
 creation date is subtracted from the current date. The result is the value of **Total Running Time**.
 
+### Example 7: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -DisplayError
+
+DayOfWeek  $_ / $null
+--------- ------------
+Wednesday #ERR
+
+PC /> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
+
+DayOfWeek  $_ / $null
+--------- ------------
+Wednesday
+
+Failed to evaluate expression " $_ / $null ".
+    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
+    + FullyQualifiedErrorId : mshExpressionError
+```
+
 ## PARAMETERS
 
 ### -AutoSize
@@ -170,16 +193,7 @@ Accept wildcard characters: False
 
 Indicates that the cmdlet displays errors at the command line. This parameter is rarely used, but
 can be used as a debugging aid when you are formatting expressions in a `Format-Table` command, and
-the expressions do not appear to be working. The following shows an example of the results of
-adding the DisplayError parameter with an expression.
-
-```powershell
-Get-Date | Format-Table DayOfWeek,{ $_ / $null } -DisplayError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
+the expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -330,20 +344,7 @@ Accept wildcard characters: False
 
 Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Table` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **ShowError**
-parameter with an expression.
-
-```powershell
-Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-Failed to evaluate expression " $_ / $null ".
-+ CategoryInfo          : InvalidArgument: (12/19/2018 9:04:32 AM:PSObject) [], RuntimeException
-+ FullyQualifiedErrorId : PSPropertyExpressionError
-
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.0/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -55,6 +55,25 @@ operator (|) passes the registry key objects through the pipeline to `Format-Wid
 them for output. The **Property** parameter specifies the name of the property, and the
 **AutoSize** parameter adjusts the columns for readability.
 
+### Example 3: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PS /> Get-Date | Format-Wide { $_ / $null } -DisplayError
+
+
+#ERR
+
+PS /> Get-Date | Format-Wide { $_ / $null } -ShowError
+
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 8:18:01 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -AutoSize
@@ -96,15 +115,7 @@ Accept wildcard characters: False
 
 Displays errors at the command line. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **DisplayError**
-parameter with an expression.
-
-```powershell
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -235,20 +246,7 @@ Accept wildcard characters: False
 
 Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **ShowError**
-parameter with an expression.
-
-```powershell
-Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Custom.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Custom.md
@@ -51,6 +51,34 @@ This command formats information about the Winlogon process in an alternate cust
 Because the command does not use the **View** parameter, `Format-Custom` uses a default custom view
 to format the data.
 
+### Example 3: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -DisplayError
+
+class DateTime
+{
+  DayOfWeek = Friday
+   $_ / $null  = #ERR
+}
+
+
+PC /> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -ShowError
+
+class DateTime
+{
+  DayOfWeek = Friday
+   $_ / $null  =
+}
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 8:01:04 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -Depth
@@ -73,16 +101,7 @@ Accept wildcard characters: False
 
 Displays errors at the command line. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Custom` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **DisplayError**
-parameter with an expression.
-
-```powershell
-Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -DisplayError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -211,19 +230,7 @@ Accept wildcard characters: False
 
 Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Custom` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **ShowError**
-parameter with an expression.
-
-```powershell
-PS \> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-List.md
@@ -87,22 +87,34 @@ Because the name of the *Property* parameter is optional, you can omit it and ty
 `Format-List *`. `Format-List` automatically sends the results to the default output cmdlet for
 display.
 
+### Example 5: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-List DayOfWeek,{ $_ / $null } -DisplayError
+
+DayOfWeek    : Friday
+ $_ / $null  : #ERR
+
+PC /> Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
+
+DayOfWeek    : Friday
+ $_ / $null  :
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 7:59:23 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -DisplayError
 
 Indicates that this cmdlet displays errors at the command line. This parameter is rarely used, but
 can be used as a debugging aid when you are formatting expressions in a `Format-List` command, and
-the expressions do not appear to be working. The following shows an example of the results of
-adding the **DisplayError** parameter with an expression.
-
-```powershell
-PS C:\> Get-Date | Format-List DayOfWeek, { $_ / $null } -DisplayError
-
-
-DayOfWeek    : Monday
- $_ / $null  : #ERR
-```
+the expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -230,20 +242,7 @@ Accept wildcard characters: False
 
 Indicates that the cmdlet sends errors through the pipeline. This parameter is rarely used, but can
 be used as a debugging aid when you are formatting expressions in a `Format-List` command, and the
-expressions do not appear to be working. The following shows an example of the results of adding
-the ShowError parameter with an expression.
-
-```powershell
-Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
+expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Table.md
@@ -85,6 +85,7 @@ The `DotNetTypes.format.ps1xml` file also contains a *Priority* view for process
 your own format.ps1xml files with customized views.
 
 ### Example 4: Format services
+
 ```powershell
 Get-Service | Format-Table -Property Name, DependentServices
 ```
@@ -147,6 +148,29 @@ has been running by subtracting the creation date of the process from the curren
 **DateTime** object that can be compared with the output of `Get-Date`. Then, the converted
 creation date is subtracted from the current date. The result is the value of **Total Running Time**.
 
+### Example 7: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -DisplayError
+
+DayOfWeek  $_ / $null
+--------- ------------
+Wednesday #ERR
+
+PC /> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
+
+DayOfWeek  $_ / $null
+--------- ------------
+Wednesday
+
+Failed to evaluate expression " $_ / $null ".
+    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
+    + FullyQualifiedErrorId : mshExpressionError
+```
+
 ## PARAMETERS
 
 ### -AutoSize
@@ -170,16 +194,7 @@ Accept wildcard characters: False
 
 Indicates that the cmdlet displays errors at the command line. This parameter is rarely used, but
 can be used as a debugging aid when you are formatting expressions in a `Format-Table` command, and
-the expressions do not appear to be working. The following shows an example of the results of
-adding the DisplayError parameter with an expression.
-
-```powershell
-Get-Date | Format-Table DayOfWeek,{ $_ / $null } -DisplayError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
+the expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -330,20 +345,7 @@ Accept wildcard characters: False
 
 Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Table` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **ShowError**
-parameter with an expression.
-
-```powershell
-Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-Failed to evaluate expression " $_ / $null ".
-+ CategoryInfo          : InvalidArgument: (12/19/2018 9:04:32 AM:PSObject) [], RuntimeException
-+ FullyQualifiedErrorId : PSPropertyExpressionError
-
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/5.1/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -56,6 +56,25 @@ operator (|) passes the registry key objects through the pipeline to `Format-Wid
 them for output. The **Property** parameter specifies the name of the property, and the
 **AutoSize** parameter adjusts the columns for readability.
 
+### Example 3: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PS /> Get-Date | Format-Wide { $_ / $null } -DisplayError
+
+
+#ERR
+
+PS /> Get-Date | Format-Wide { $_ / $null } -ShowError
+
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 8:18:01 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -AutoSize
@@ -97,15 +116,7 @@ Accept wildcard characters: False
 
 Displays errors at the command line. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **DisplayError**
-parameter with an expression.
-
-```powershell
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -236,20 +247,7 @@ Accept wildcard characters: False
 
 Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
 aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not
-appear to be working. The following shows an example of the results of adding the **ShowError**
-parameter with an expression.
-
-```powershell
-Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
+appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/6/Microsoft.PowerShell.Utility/Format-Custom.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Format-Custom.md
@@ -51,6 +51,34 @@ This command formats information about the Winlogon process in an alternate cust
 Because the command does not use the **View** parameter, `Format-Custom` uses a default custom view
 to format the data.
 
+### Example 3: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -DisplayError
+
+class DateTime
+{
+  DayOfWeek = Friday
+   $_ / $null  = #ERR
+}
+
+
+PC /> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -ShowError
+
+class DateTime
+{
+  DayOfWeek = Friday
+   $_ / $null  =
+}
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 8:01:04 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -Depth
@@ -71,19 +99,9 @@ Accept wildcard characters: False
 
 ### -DisplayError
 
-Displays errors at the command line. The following shows an example of the results of adding the
-**DisplayError** parameter with an expression.
-
-```powershell
-Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -DisplayError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
-
-This parameter is rarely used, but can be used as a debugging aid when you are formatting
-expressions in a `Format-Custom` command, and the expressions do not appear to be working.
+Displays errors at the command line. This parameter is rarely used, but can be used as a debugging
+aid when you are formatting expressions in a `Format-Custom` command, and the expressions do not
+appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -210,22 +228,9 @@ Accept wildcard characters: False
 
 ### -ShowError
 
-Sends errors through the pipeline. The following shows an example of the results of adding the
-**ShowError** parameter with an expression.
-
-```powershell
-PS \> Get-Date | Format-Custom DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
-
-This parameter is rarely used, but can be used as a debugging aid when you are formatting
-expressions in a `Format-Custom` command, and the expressions do not appear to be working.
+Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
+aid when you are formatting expressions in a `Format-Custom` command, and the expressions do not
+appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/6/Microsoft.PowerShell.Utility/Format-List.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Format-List.md
@@ -87,23 +87,34 @@ Because the name of the *Property* parameter is optional, you can omit it and ty
 `Format-List *`. `Format-List` automatically sends the results to the default output cmdlet for
 display.
 
+### Example 5: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-List DayOfWeek,{ $_ / $null } -DisplayError
+
+DayOfWeek    : Friday
+ $_ / $null  : #ERR
+
+PC /> Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
+
+DayOfWeek    : Friday
+ $_ / $null  :
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 7:59:23 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -DisplayError
 
-Indicates that this cmdlet displays errors at the command line. The following shows an example of
-the results of adding the **DisplayError** parameter with an expression.
-
-```powershell
-PS C:\> Get-Date | Format-List DayOfWeek, { $_ / $null } -DisplayError
-
-
-DayOfWeek    : Monday
- $_ / $null  : #ERR
-```
-
-This parameter is rarely used, but can be used as a debugging aid when you are formatting
-expressions in a `Format-List` command, and the expressions do not appear to be working.
+Indicates that this cmdlet displays errors at the command line. This parameter is rarely used, but
+can be used as a debugging aid when you are formatting expressions in a `Format-List` command, and
+the expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -229,23 +240,9 @@ Accept wildcard characters: False
 
 ### -ShowError
 
-Indicates that the cmdlet sends errors through the pipeline. The following shows an example of the
-results of adding the ShowError parameter with an expression.
-
-```powershell
-Get-Date | Format-List DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
-
-This parameter is rarely used, but can be used as a debugging aid when you are formatting
-expressions in a `Format-List` command, and the expressions do not appear to be working.
+Indicates that the cmdlet sends errors through the pipeline. This parameter is rarely used, but can
+be used as a debugging aid when you are formatting expressions in a `Format-List` command, and the
+expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/6/Microsoft.PowerShell.Utility/Format-Table.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Format-Table.md
@@ -148,6 +148,29 @@ has been running by subtracting the creation date of the process from the curren
 **DateTime** object that can be compared with the output of `Get-Date`. Then, the converted
 creation date is subtracted from the current date. The result is the value of **Total Running Time**.
 
+### Example 7: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PC /> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -DisplayError
+
+DayOfWeek  $_ / $null
+--------- ------------
+Wednesday #ERR
+
+PC /> Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
+
+DayOfWeek  $_ / $null
+--------- ------------
+Wednesday
+
+Failed to evaluate expression " $_ / $null ".
+    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
+    + FullyQualifiedErrorId : mshExpressionError
+```
+
 ## PARAMETERS
 
 ### -AutoSize
@@ -169,19 +192,9 @@ Accept wildcard characters: False
 
 ### -DisplayError
 
-Indicates that the cmdlet displays errors at the command line. The following shows an example of
-the results of adding the DisplayError parameter with an expression.
-
-```powershell
-Get-Date | Format-Table DayOfWeek,{ $_ / $null } -DisplayError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
-
-This parameter is rarely used, but can be used as a debugging aid when you are formatting
-expressions in a `Format-Table` command, and the expressions do not appear to be working.
+Indicates that the cmdlet displays errors at the command line. This parameter is rarely used, but
+can be used as a debugging aid when you are formatting expressions in a `Format-Table` command, and
+the expressions do not appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -330,23 +343,9 @@ Accept wildcard characters: False
 
 ### -ShowError
 
-Sends errors through the pipeline. The following shows an example of the results of adding the
-**ShowError** parameter with an expression.
-
-```powershell
-Get-Date | Format-Table DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-Failed to evaluate expression " $_ / $null ".
-+ CategoryInfo          : InvalidArgument: (12/19/2018 9:04:32 AM:PSObject) [], RuntimeException
-+ FullyQualifiedErrorId : PSPropertyExpressionError
-
-```
-
-This parameter is rarely used, but can be used as a debugging aid when you are formatting
-expressions in a `Format-Table` command, and the expressions do not appear to be working.
+Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
+aid when you are formatting expressions in a `Format-Table` command, and the expressions do not
+appear to be working.
 
 ```yaml
 Type: SwitchParameter

--- a/reference/6/Microsoft.PowerShell.Utility/Format-Wide.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Format-Wide.md
@@ -56,6 +56,25 @@ operator (|) passes the registry key objects through the pipeline to `Format-Wid
 them for output. The **Property** parameter specifies the name of the property, and the
 **AutoSize** parameter adjusts the columns for readability.
 
+### Example 3: Troubleshooting format errors
+
+The following examples show of the results of adding the **DisplayError** or **ShowError**
+parameters with an expression.
+
+```powershell
+PS /> Get-Date | Format-Wide { $_ / $null } -DisplayError
+
+
+#ERR
+
+PS /> Get-Date | Format-Wide { $_ / $null } -ShowError
+
+
+Failed to evaluate expression " $_ / $null ".
++ CategoryInfo          : InvalidArgument: (12/21/2018 8:18:01 AM:PSObject) [], RuntimeException
++ FullyQualifiedErrorId : PSPropertyExpressionError
+```
+
 ## PARAMETERS
 
 ### -AutoSize
@@ -95,18 +114,9 @@ Accept wildcard characters: False
 
 ### -DisplayError
 
-Displays errors at the command line. The following shows an example of the results of adding the
-**DisplayError** parameter with an expression.
-
-```powershell
-PS \> Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday #ERR
-```
-
-This parameter is rarely used, but can be used as a debugging aid when you are formatting
-expressions in a `Format-Wide` command, and the expressions do not appear to be working.
+Displays errors at the command line. This parameter is rarely used, but can be used as a debugging
+aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not
+appear to be working.
 
 ```yaml
 Type: SwitchParameter
@@ -235,23 +245,9 @@ Accept wildcard characters: False
 
 ### -ShowError
 
-Sends errors through the pipeline. The following shows an example of the results of adding the
-**ShowError** parameter with an expression.
-
-```powershell
-Get-Date | Format-Wide DayOfWeek,{ $_ / $null } -ShowError
-
-DayOfWeek  $_ / $null
---------- ------------
-Wednesday
-
-Failed to evaluate expression " $_ / $null ".
-    + CategoryInfo          : InvalidArgument: (10/30/2013 2:28:07 PM:PSObject) \[\], RuntimeException
-    + FullyQualifiedErrorId : mshExpressionError
-```
-
-This parameter is rarely used, but can be used as a debugging aid when you are formatting
-expressions in a `Format-Wide` command, and the expressions do not appear to be working.
+Sends errors through the pipeline. This parameter is rarely used, but can be used as a debugging
+aid when you are formatting expressions in a `Format-Wide` command, and the expressions do not
+appear to be working.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->

Work around problem caused by PowerShell/PlatyPS#422

Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
