### PR TITLE
BellStyle Visual not Visible

### DIFF
--- a/reference/5.0/PSReadline/Set-PSReadlineOption.md
+++ b/reference/5.0/PSReadline/Set-PSReadlineOption.md
@@ -142,7 +142,7 @@ Specifies how PSReadLine responds to various error and ambiguous conditions.
 Valid values are:
 
 - Audible: A short beep
-- Visible: Text flashes briefly
+- Visual: Text flashes briefly
 - None: No feedback
 
 ```yaml

--- a/reference/5.1/PSReadline/Set-PSReadlineOption.md
+++ b/reference/5.1/PSReadline/Set-PSReadlineOption.md
@@ -142,7 +142,7 @@ Specifies how PSReadLine responds to various error and ambiguous conditions.
 Valid values are:
 
 - Audible: A short beep
-- Visible: Text flashes briefly
+- Visual: Text flashes briefly
 - None: No feedback
 
 ```yaml

--- a/reference/6/PSReadLine/Set-PSReadlineOption.md
+++ b/reference/6/PSReadLine/Set-PSReadlineOption.md
@@ -145,7 +145,7 @@ Specifies how PSReadLine responds to various error and ambiguous conditions.
 Valid values are:
 
 - Audible: A short beep
-- Visible: Text flashes briefly
+- Visual: Text flashes briefly
 - None: No feedback
 
 ```yaml


### PR DESCRIPTION
Using `Visible` fails with:

```powershell
> Set-PSReadlineOption -BellStyle Visible
Set-PSReadlineOption : Cannot bind parameter 'BellStyle'. Cannot convert value "Visible" to type "Microsoft.PowerShell.BellStyle". Error: "Unable to
match the identifier name Visible to a valid enumerator name. Specify one of the following enumerator names and try again:
None, Visual, Audible"
```

Modify all documentation versions; not present in 4.0.

I'm not seeing a 6.next documentation, but if 6.next was copied from 6.0 it also needs the fix.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [?] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [x] The documented feature was introduced in version **5.0** of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
