### PR TITLE
Update examples to use code tags

### DIFF
--- a/gallery/how-to/publishing-packages/publishing-a-package.md
+++ b/gallery/how-to/publishing-packages/publishing-a-package.md
@@ -114,7 +114,7 @@ This will save considerable time, since every time you publish to the PowerShell
 
 Examples would be:
 
-* `Publish-Module -Path ".\MyModule" -RequiredVersion "0.0.1" -NugetAPIKey "GUID" -Whatif -Verbose`
+* `Publish-Module -Path ".\MyModule" -NugetAPIKey "GUID" -Whatif -Verbose`
 * `Publish-Script -Path ".\MyScriptFile.PS1" -NugetAPIKey "GUID" -Whatif -Verbose`
 
 Review the output carefully, and if you see no errors or warnings, repeat the command without -Whatif.

--- a/gallery/how-to/publishing-packages/publishing-a-package.md
+++ b/gallery/how-to/publishing-packages/publishing-a-package.md
@@ -113,8 +113,9 @@ To avoid errors, it is strongly recommended that you try the commands using -Wha
 This will save considerable time, since every time you publish to the PowerShell Gallery, you must update the version number in the manifest section of the item.
 
 Examples would be:
-'Publish-Module -Path ".\MyModule" -RequiredVersion "0.0.1" -NugetAPIKey "GUID" -Whatif -Verbose'
-'Publish-Script -Path ".\MyScriptFile.PS1" -NugetAPIKey "GUID" -Whatif -Verbose'
+
+* `Publish-Module -Path ".\MyModule" -RequiredVersion "0.0.1" -NugetAPIKey "GUID" -Whatif -Verbose`
+* `Publish-Script -Path ".\MyScriptFile.PS1" -NugetAPIKey "GUID" -Whatif -Verbose`
 
 Review the output carefully, and if you see no errors or warnings, repeat the command without -Whatif.
 


### PR DESCRIPTION
Update the examples to use code tags to differentiate them on the page. Also make them bullet points so they stand apart from each other.

Also fix the `Publish-Module` Example to use working command.

Fixes #3471 