### PR TITLE
Fixed a technical error

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -343,7 +343,7 @@ function Test {
 }
 ```
 
-### $PSCMDLET
+### $PSCmdlet
 
 Contains an object that represents the cmdlet or advanced function that is
 being run.
@@ -355,7 +355,7 @@ being used, and the ShouldProcess method adds the WhatIf and Confirm
 parameters to the cmdlet dynamically.
 
 For more information about the $PSCmdlet automatic variable, see
-[about_Functions_Advanced](about_Functions_Advanced.md).
+[about_Functions_Advanced_Methods](about_Functions_Advanced_Methods.md).
 
 ### $PSCommandPath
 
@@ -371,12 +371,12 @@ System.Globalization.CultureInfo.CurrentCulture.Name property of the
 system. To get the System.Globalization.CultureInfo object for the system,
 use the Get-Culture cmdlet.
 
-### $PSDEBUGCONTEXT
+### $PSDebugContext
 
 While debugging, this variable contains information about the debugging
 environment. Otherwise, it contains a NULL value. As a result, you can use
 it to indicate whether the debugger has control. When populated, it
-contains a PsDebugContext object that has Breakpoints and InvocationInfo
+contains a PSDebugContext object that has Breakpoints and InvocationInfo
 properties. The InvocationInfo property has several useful properties,
 including the Location property. The Location property indicates the path
 of the script that is being debugged.


### PR DESCRIPTION
Fixed a technical error: $PSCmdlet is explained in  **about_Functions_Advanced_Methods**, not _about_Functions_Advanced_.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
