### PR TITLE
updated broken fwlink, ensured urls are locale neutral in the documents

### DIFF
--- a/reference/4.0/PSDesiredStateConfiguration/Start-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Start-DscConfiguration.md
@@ -92,7 +92,7 @@ The command creates **Job** objects for each configured computer.
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -212,7 +212,8 @@ Accept wildcard characters: False
 ### -UseExisting
 Indicates that this cmdlet applies the existing configuration.
 
-Before you specify this parameter for this cmdlet, review the information in What's New in Windows PowerShellhttp://technet.microsoft.com/library/hh857339.aspx (http://technet.microsoft.com/library/hh857339.aspx) in the TechNet library.
+Before you specify this parameter for this cmdlet, review the information in [What's New in Windows PowerShell 5.0](https://docs.microsoft.com/powershell/scripting/whats-new/what-s-new-in-windows-powershell-50)
+
 
 ```yaml
 Type: SwitchParameter
@@ -285,7 +286,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Windows PowerShell Desired State Configuration Overview](http://go.microsoft.com/fwlink/?LinkID=311940)
+[Windows PowerShell Desired State Configuration Overview](https://docs.microsoft.com/powershell/dsc/overview/overview)
 
 [Get-DscConfiguration](Get-DscConfiguration.md)
 

--- a/reference/5.0/PSDesiredStateConfiguration/Start-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Start-DscConfiguration.md
@@ -96,7 +96,7 @@ The command creates **Job** objects for each configured computer.
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -233,7 +233,8 @@ Accept wildcard characters: False
 Indicates that this cmdlet applies the existing configuration.
 The configuration can exist on the target computer by enactment using **Start-DscConfiguration** or by publication using the Publish-DscConfiguration cmdlet.
 
-Before you specify this parameter for this cmdlet, review the information in What's New in Windows PowerShellhttp://technet.microsoft.com/library/hh857339.aspx (http://technet.microsoft.com/library/hh857339.aspx) in the TechNet library.
+Before you specify this parameter for this cmdlet, review the information in [What's New in Windows PowerShell 5.0](https://docs.microsoft.com//powershell/scripting/whats-new/what-s-new-in-windows-powershell-50)
+
 
 ```yaml
 Type: SwitchParameter
@@ -291,7 +292,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Windows PowerShell Desired State Configuration Overview](http://go.microsoft.com/fwlink/?LinkID=311940)
+[Windows PowerShell Desired State Configuration Overview](https://docs.microsoft.com/powershell/dsc/overview/overview)
 
 [Get-DscConfiguration](Get-DscConfiguration.md)
 

--- a/reference/5.1/PSDesiredStateConfiguration/Start-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Start-DscConfiguration.md
@@ -97,7 +97,7 @@ The command creates **Job** objects for each configured computer.
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml
@@ -219,7 +219,7 @@ Accept wildcard characters: False
 Indicates that this cmdlet applies the existing configuration.
 The configuration can exist on the target computer by enactment using **Start-DscConfiguration** or by publication using the Publish-DscConfiguration cmdlet.
 
-Before you specify this parameter for this cmdlet, review the information in What's New in Windows PowerShellhttp://technet.microsoft.com/library/hh857339.aspx (http://technet.microsoft.com/library/hh857339.aspx) in the TechNet library.
+Before you specify this parameter for this cmdlet, review the information in [What's New in Windows PowerShell 5.0](https://docs.microsoft.com/powershell/scripting/whats-new/what-s-new-in-windows-powershell-50)
 
 ```yaml
 Type: SwitchParameter
@@ -292,7 +292,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Windows PowerShell Desired State Configuration Overview](http://go.microsoft.com/fwlink/?LinkID=311940)
+[Windows PowerShell Desired State Configuration Overview](https://docs.microsoft.com/powershell/dsc/overview/overview)
 
 [Get-DscConfiguration](Get-DscConfiguration.md)
 


### PR DESCRIPTION
1. Changed FWLink to a direct link into docs (addresses issue #3479 )
2. Fixed a typo pointing to an old technet article that was missing anyway
3. Ensured the urls are local neutral.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [x ] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [x ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
