### PR TITLE
Fixed a typo, a link and a fact

### DIFF
--- a/reference/6/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -23,8 +23,8 @@ modules to their PowerShell sessions and use them just like the built-in
 commands.
 
 This topic explains how to use PowerShell modules. For information about how
-to write PowerShell modules, see [Writing a PowerShell Module](https://go.microsoft.com/fwlink/?LinkId=144916)
-in the MSDN library.
+to write PowerShell modules, see [Writing a Windows PowerShell Module](/developer/module/writing-a-windows-powershell-module.md)
+in Windows PowerShell SDK.
 
 ## What Is a Module?
 


### PR DESCRIPTION
The article "Writing a Windows PowerShell Module" is no longer on MSDN; it is now on Microsoft Docs. Also, "Windows" was omitted. Now, it is true that "Windows PowerShell" has become "PowerShell" since version 6, but the former MSDN contents have not changed; both their links and contents still say "Windows PowerShell".

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [X] Impacts 6.next document
- [X] Impacts 6 document
- [X] Impacts 5.1 document
- [X] Impacts 5.0 document
- [X] Impacts 4.0 document
- [X] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
