### PR TITLE
Fix typo in install docs

### DIFF
--- a/reference/docs-conceptual/install/Windows-PowerShell-System-Requirements.md
+++ b/reference/docs-conceptual/install/Windows-PowerShell-System-Requirements.md
@@ -31,7 +31,7 @@ Windows PowerShell 5.1 runs on the following versions of Windows.
 
 - Windows 7 with Service Pack 1, install [Windows Management Framework 5.1](https://aka.ms/wmf5download) to run Windows PowerShell 5.1
 
-Windows PowerShell 5.0 (Superceeded by Windows PowerShell 5.1) runs on the following versions of Windows.
+Windows PowerShell 5.0 (Superseded by Windows PowerShell 5.1) runs on the following versions of Windows.
 
 - Windows Server 2019, higher version installed by default
 


### PR DESCRIPTION
**superceeded** -> **superseded**

in Windows-PowerShell-System-Requirements.md

`supercede` is generally considered to be less correct than `supersede`, but either way the past-tense is never spelled with a double-e.

Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document