### PR TITLE
removing %-style environment variables and other cleanup

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -14,8 +14,9 @@ variables are created and maintained by PowerShell.
 
 ## LONG DESCRIPTION
 
-Conceptually, these variables are considered to be read-only.
-Even though they **can** be written to, for backward compatibility they **should not** be written to.
+Conceptually, these variables are considered to be read-only. Even though they
+**can** be written to, for backward compatibility they **should not** be
+written to.
 
 Here is a list of the automatic variables in  PowerShell:
 
@@ -34,7 +35,7 @@ Contains the first token in the last line received by the session.
 
 ### $_
 
-Same as $PSItem. Contains the current object in the pipeline object. You
+Same as `$PSItem`. Contains the current object in the pipeline object. You
 can use this variable in commands that perform an action on every object or
 on selected objects in a pipeline.
 
@@ -46,41 +47,40 @@ function, you can declare the parameters by using the param keyword or by
 adding a comma-separated list of parameters in parentheses after the
 function name.
 
-In an event action, the $Args variable contains objects that represent the
+In an event action, the `$Args` variable contains objects that represent the
 event arguments of the event that is being processed. This variable is
 populated only within the Action block of an event registration command.
 The value of this variable can also be found in the SourceArgs property of
-the PSEventArgs object (System.Management.Automation.PSEventArgs) that
-Get-Event returns.
+the **PSEventArgs** object that `Get-Event` returns.
 
 ### $CONSOLEFILENAME
 
 Contains the path of the console file (.psc1) that was most recently used
 in the session. This variable is populated when you start PowerShell with
-the PSConsoleFile parameter or when you use the Export-Console cmdlet to
+the PSConsoleFile parameter or when you use the `Export-Console` cmdlet to
 export snap-in names to a console file.
 
-When you use the Export-Console cmdlet without parameters, it automatically
+When you use the `Export-Console` cmdlet without parameters, it automatically
 updates the console file that was most recently used in the session. You
 can use this automatic variable to determine which file will be updated.
 
 ### $ERROR
 
 Contains an array of error objects that represent the most recent errors.
-The most recent error is the first error object in the array ($Error[0]).
+The most recent error is the first error object in the array `$Error[0]`.
 
-To prevent an error from being added to the $Error array, use the
-ErrorAction common parameter with a value of Ignore. For more information,
-see [about_CommonParameters](about_CommonParameters.md).
+To prevent an error from being added to the `$Error` array, use the
+**ErrorAction** common parameter with a value of **Ignore**. For more
+information, see [about_CommonParameters](about_CommonParameters.md).
 
 ### $EVENT
 
-Contains a PSEventArgs object that represents the event that is being
+Contains a **PSEventArgs** object that represents the event that is being
 processed. This variable is populated only within the Action block of an
-event registration command, such as Register-ObjectEvent. The value of this
-variable is the same object that the Get-Event cmdlet returns. Therefore,
-you can use the properties of the $Event variable, such as
-$Event.TimeGenerated , in an Action script block.
+event registration command, such as `Register-ObjectEvent`. The value of this
+variable is the same object that the `Get-Event` cmdlet returns. Therefore,
+you can use the properties of the `Event` variable, such as
+`$Event.TimeGenerated`, in an Action script block.
 
 ### $EVENTARGS
 
@@ -88,19 +88,18 @@ Contains an object that represents the first event argument that derives
 from EventArgs of the event that is being processed. This variable is
 populated only within the Action block of an event registration command.
 The value of this variable can also be found in the SourceEventArgs
-property of the PSEventArgs (System.Management.Automation.PSEventArgs)
-object that Get-Event returns.
+property of the **PSEventArgs** object that `Get-Event` returns.
 
 ### $EVENTSUBSCRIBER
 
-Contains a PSEventSubscriber object that represents the event subscriber of
+Contains a **PSEventSubscriber** object that represents the event subscriber of
 the event that is being processed. This variable is populated only within
 the Action block of an event registration command. The value of this
-variable is the same object that the Get-EventSubscriber cmdlet returns.
+variable is the same object that the `Get-EventSubscriber` cmdlet returns.
 
 ### $EXECUTIONCONTEXT
 
-Contains an EngineIntrinsics object that represents the execution context
+Contains an **EngineIntrinsics** object that represents the execution context
 of the PowerShell host. You can use this variable to find the execution
 objects that are available to cmdlets.
 
@@ -115,33 +114,33 @@ non-zero integer.
 
 Contains the enumerator (not the resulting values) of a ForEach loop. You
 can use the properties and methods of enumerators on the value of the
-$ForEach variable. This variable exists only while the ForEach loop is
+`$ForEach` variable. This variable exists only while the `ForEach` loop is
 running; it is deleted after the loop is completed. For detailed
 information, see [about_ForEach](about_ForEach.md).
 
 ### $HOME
 
 Contains the full path of the user's home directory. This variable is the
-equivalent of the `%homedrive%%homepath%` Windows environment variables,
-typically C:\\Users\\<UserName>.
+equivalent of the `"$env:homedrive$env:homepath"` Windows environment variables,
+typically `C:\Users\<UserName>`.
 
 ### $HOST
 
 Contains an object that represents the current host application for
 PowerShell. You can use this variable to represent the current host in
 commands or to display or change the properties of the host, such as
-$Host.version or $Host.CurrentCulture, or
-$host.ui.rawui.setbackgroundcolor("Red").
+`$Host.version` or `$Host.CurrentCulture`, or
+`$host.ui.rawui.setbackgroundcolor("Red")`.
 
 ### $INPUT
 
 Contains an enumerator that enumerates all input that is passed to a
-function. The $input variable is available only to functions and script
+function. The `$input` variable is available only to functions and script
 blocks (which are unnamed functions). In the Process block of a function,
-the $input variable enumerates the object that is currently in the
+the `$input` variable enumerates the object that is currently in the
 pipeline. When the Process block completes, there are no objects left in
-the pipeline, so the $input variable enumerates an empty collection. If the
-function does not have a Process block, then in the End block, the $input
+the pipeline, so the `$input` variable enumerates an empty collection. If the
+function does not have a Process block, then in the End block, the `$input`
 variable enumerates the collection of all input to the function.
 
 ### $LASTEXITCODE
@@ -150,11 +149,11 @@ Contains the exit code of the last Windows-based program that was run.
 
 ### $MATCHES
 
-The $Matches variable works with the `-match` and `-notmatch` operators.
+The `Matches` variable works with the `-match` and `-notmatch` operators.
 When you submit scalar input to the `-match` or `-notmatch` operator, and
 either one detects a match, they return a Boolean value and populate the
 $Matches automatic variable with a hash table of any string values that
-were matched. For more information about the -match operator, see
+were matched. For more information about the `-match` operator, see
 [about_comparison_operators](about_comparison_operators.md).
 
 ### $MYINVOCATION
@@ -164,14 +163,14 @@ parameters, parameter values, and information about how the command was
 started, called, or "invoked," such as the name of the script that called
 the current command.
 
-\$MyInvocation is populated only for scripts, function, and script blocks.
+`$MyInvocation` is populated only for scripts, function, and script blocks.
 You can use the information in the System.Management.Automation.InvocationInfo
-object that \$MyInvocation returns in the current script, such as the path and
-file name of the script (\$MyInvocation.MyCommand.Path) or the name of a
-function (\$MyInvocation.MyCommand.Name) to identify the current command. This
+object that `$MyInvocation` returns in the current script, such as the path and
+file name of the script (`$MyInvocation.MyCommand.Path`) or the name of a
+function (`$MyInvocation.MyCommand.Name`) to identify the current command. This
 is particularly useful for finding the name of the current script.
 
-Beginning in PowerShell 3.0, $MyInvocation has the following new
+Beginning in PowerShell 3.0, `MyInvocation` has the following new
 properties.
 
 | Property      | Description                                         |
@@ -184,10 +183,10 @@ properties.
 |               | property is populated only when the caller is a     |
 |               | script.                                             |
 
-Unlike the $PSScriptRoot and $PSCommandPath automatic variables, the
-PSScriptRoot and PSCommandPath properties of the $MyInvocation automatic
-variable contain information about the invoker or calling script, not the
-current script.
+Unlike the `$PSScriptRoot` and `$PSCommandPath` automatic variables, the
+**PSScriptRoot** and **PSCommandPath** properties of the `$MyInvocation`
+automatic variable contain information about the invoker or calling script,
+not the current script.
 
 ### $NESTEDPROMPTLEVEL
 
@@ -196,30 +195,30 @@ prompt level. The value is incremented when you enter a nested level and
 decremented when you exit it.
 
 For example, PowerShell presents a nested command prompt when you use the
-$Host.EnterNestedPrompt method. PowerShell also presents a nested command
+`$Host.EnterNestedPrompt` method. PowerShell also presents a nested command
 prompt when you reach a breakpoint in the PowerShell debugger.
 
 When you enter a nested prompt, PowerShell pauses the current command,
 saves the execution context, and increments the value of the
-$NestedPromptLevel variable. To create additional nested command prompts
+`$NestedPromptLevel` variable. To create additional nested command prompts
 (up to 128 levels) or to return to the original command prompt, complete
-the command, or type "exit".
+the command, or type `exit`.
 
-The $NestedPromptLevel variable helps you track the prompt level. You can
+The `$NestedPromptLevel` variable helps you track the prompt level. You can
 create an alternative PowerShell command prompt that includes this value so
 that it is always visible.
 
 ### $NULL
 
-$null is an automatic variable that contains a NULL or empty value. You can
+`$null` is an automatic variable that contains a NULL or empty value. You can
 use this variable to represent an absent or undefined value in commands and
 scripts.
 
-PowerShell treats $null as an object with a value, that is, as an explicit
-placeholder, so you can use $null to represent an empty value in a series
+PowerShell treats `$null` as an object with a value, that is, as an explicit
+placeholder, so you can use `$null` to represent an empty value in a series
 of values.
 
-For example, when $null is included in a collection, it is counted as one
+For example, when `$null` is included in a collection, it is counted as one
 of the objects.
 
 ```powershell
@@ -231,8 +230,8 @@ $a.count
 3
 ```
 
-If you pipe the $null variable to the ForEach-Object cmdlet, it generates a
-value for $null, just as it does for the other objects
+If you pipe the `$null` variable to the `ForEach-Object` cmdlet, it generates a
+value for `$null`, just as it does for the other objects
 
 ```powershell
 "one", $null, "three" | ForEach-Object { "Hello " + $_}
@@ -244,11 +243,11 @@ Hello
 Hello three
 ```
 
-As a result, you cannot use $null to mean "no parameter value." A parameter
-value of $null overrides the default parameter value.
+As a result, you cannot use `$null` to mean "no parameter value." A parameter
+value of `$null` overrides the default parameter value.
 
-However, because PowerShell treats the $null variable as a placeholder, you
-can use it in scripts like the following one, which would not work if $null
+However, because PowerShell treats the `$null` variable as a placeholder, you
+can use it in scripts like the following one, which would not work if `$null`
 were ignored.
 
 ```powershell
@@ -285,13 +284,13 @@ profile in commands. For example, you can use it in a command to determine
 whether a profile has been created:
 
 ```powershell
-Test-Path $profile
+Test-Path $PROFILE
 ```
 
 Or, you can use it in a command to create a profile:
 
 ```powershell
-New-Item -ItemType file -Path $pshome -Force
+New-Item -ItemType file -Path $PSHOME -Force
 ```
 
 You can also use it in a command to open the profile in Notepad:
@@ -329,11 +328,11 @@ being run.
 
 You can use the properties and methods of the object in your cmdlet or
 function code to respond to the conditions of use. For example, the
-ParameterSetName property contains the name of the parameter set that is
-being used, and the ShouldProcess method adds the WhatIf and Confirm
-parameters to the cmdlet dynamically.
+**ParameterSetName** property contains the name of the parameter set that is
+being used, and the **ShouldProcess** method adds the **WhatIf** and
+**Confirm** parameters to the cmdlet dynamically.
 
-For more information about the $PSCmdlet automatic variable, see
+For more information about the `$PSCmdlet` automatic variable, see
 [about_Functions_Advanced](about_Functions_Advanced.md).
 
 ### $PSCOMMANDPATH
@@ -346,24 +345,24 @@ variable is valid in all scripts.
 Contains the name of the culture currently in use in the operating system.
 The culture determines the display format of items such as numbers,
 currency, and dates. This is the value of the
-System.Globalization.CultureInfo.CurrentCulture.Name property of the
-system. To get the System.Globalization.CultureInfo object for the system,
-use the Get-Culture cmdlet.
+**System.Globalization.CultureInfo.CurrentCulture.Name** property of the
+system. To get the **System.Globalization.CultureInfo** object for the system,
+use the `Get-Culture` cmdlet.
 
 ### $PSDEBUGCONTEXT
 
 While debugging, this variable contains information about the debugging
-environment. Otherwise, it contains a NULL value. As a result, you can use
-it to indicate whether the debugger has control. When populated, it
-contains a PsDebugContext object that has Breakpoints and InvocationInfo
-properties. The InvocationInfo property has several useful properties,
-including the Location property. The Location property indicates the path
-of the script that is being debugged.
+environment. Otherwise, it contains a NULL value. As a result, you can use it
+to indicate whether the debugger has control. When populated, it contains a
+**PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
+properties. The **InvocationInfo** property has several useful properties,
+including the **Location** property. The **Location** property indicates the
+path of the script that is being debugged.
 
 ### $PSHOME
 
 Contains the full path of the installation directory for PowerShell,
-typically, `%windir%\System32\PowerShell\v1.0` in Windows systems. You can
+typically, `$env:windir\System32\PowerShell\v1.0` in Windows systems. You can
 use this variable in the paths of PowerShell files. For example, the
 following command searches the conceptual Help topics for the word
 "variable":
@@ -374,7 +373,7 @@ Select-String -Pattern Variable -Path $pshome\*.txt
 
 ### $PSITEM
 
-Same as $_. Contains the current object in the pipeline object. You can use
+Same as `$_`. Contains the current object in the pipeline object. You can use
 this variable in commands that perform an action on every object or on
 selected objects in a pipeline.
 
@@ -391,20 +390,20 @@ Contains information about the user who started the PSSession, including
 the user identity and the time zone of the originating computer. This
 variable is available only in PSSessions.
 
-The $PSSenderInfo variable includes a user-configurable property,
-ApplicationArguments, which, by default, contains only the $PSVersionTable
-from the originating session. To add data to the ApplicationArguments
-property, use the ApplicationArguments parameter of the New-PSSessionOption
-cmdlet.
+The `$PSSenderInfo` variable includes a user-configurable property,
+**ApplicationArguments**, which, by default, contains only the
+`$PSVersionTable` from the originating session. To add data to the
+**ApplicationArguments** property, use the **ApplicationArguments** parameter
+of the `New-PSSessionOption` cmdlet.
 
 ### $PSUICULTURE
 
-Contains the name of the user interface (UI) culture that is currently in
-use in the operating system. The UI culture determines which text strings
-are used for user interface elements, such as menus and messages. This is
-the value of the System.Globalization.CultureInfo.CurrentUICulture.Name
-property of the system. To get the System.Globalization.CultureInfo object
-for the system, use the Get-UICulture cmdlet.
+Contains the name of the user interface (UI) culture that is currently in use
+in the operating system. The UI culture determines which text strings are used
+for user interface elements, such as menus and messages. This is the value of
+the **System.Globalization.CultureInfo.CurrentUICulture.Name** property of the
+system. To get the **System.Globalization.CultureInfo** object for the system,
+use the `Get-UICulture` cmdlet.
 
 ### $PSVERSIONTABLE
 
@@ -434,13 +433,12 @@ following items:
 
 ### $PWD
 
-Contains a path object that represents the full path of the current
-directory.
+Contains a path object that represents the full path of the current directory.
 
 ### REPORTERRORSHOW VARIABLES
 
-The "ReportErrorShow" variables are defined in PowerShell, but they are not
-implemented. Get-Variable gets them, but they do not contain valid data.
+The **ReportErrorShow** variables are defined in PowerShell, but they are not
+implemented. `Get-Variable` gets them, but they do not contain valid data.
 
 - $REPORTERRORSHOWEXCEPTIONCLASS
 - $REPORTERRORSHOWINNEREXCEPTION
@@ -451,8 +449,8 @@ implemented. Get-Variable gets them, but they do not contain valid data.
 
 Contains the object that generated this event. This variable is populated
 only within the Action block of an event registration command. The value of
-this variable can also be found in the Sender property of the PSEventArgs
-(System.Management.Automation.PSEventArgs) object that Get-Event returns.
+this variable can also be found in the Sender property of the **PSEventArgs**
+object that `Get-Event` returns.
 
 ### $SHELLID
 
@@ -465,7 +463,7 @@ Contains a stack trace for the most recent error.
 ### $THIS
 
 In a script block that defines a script property or script method, the
-$This variable refers to the object that is being extended.
+`$This` variable refers to the object that is being extended.
 
 ### $TRUE
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -523,6 +523,7 @@ Statement syntax:
 while (<condition>) {
    <statements>
  }
+```
 
 When used in a `Do` statement, `while` is part of a looping construct where
 the statement list is executed at least one time.

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -1,8 +1,10 @@
+---
 ms.date:  06/09/2017
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Language_Keywords
+---
 
 # About Language Keywords
 
@@ -54,18 +56,18 @@ Language Keywords
 
 ### Begin
 
-Specifies one part of the body of a function, along with the DynamicParam,
-Process, and End keywords. The Begin statement list runs one time before any
+Specifies one part of the body of a function, along with the `DynamicParam`,
+`Process`, and `End` keywords. The `Begin` statement list runs one time before any
 objects are received from the pipeline.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
-DynamicParam {<statement list>}
-begin {<statement list>}
-process {<statement list>}
-end {<statement list>}
+    DynamicParam {<statement list>}
+    begin {<statement list>}
+    process {<statement list>}
+    end {<statement list>}
 }
 ```
 
@@ -75,7 +77,7 @@ Causes a script to exit a loop.
 
 Syntax:
 
-```powershell
+```Syntax
 while (<condition>) {
    <statements>
    ...
@@ -95,7 +97,7 @@ indicates that the error type is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [[<error type>]] {<statement list>}
 ```
@@ -107,7 +109,7 @@ condition is met, the script begins the loop again.
 
 Syntax:
 
-```powershell
+```Syntax
 while (<condition>) {
    <statements>
    ...
@@ -122,40 +124,39 @@ while (<condition>) {
 ### Data
 
 In a script, defines a section that isolates data from the script logic. Can
-also include If statements and some limited commands.
+also include `If` statements and some limited commands.
 
 Syntax:
 
-```powershell
+```Syntax
 data <variable> [-supportedCommand <cmdlet-name>] {<permitted content>}
 ```
 
 ### Do
 
-Used with the While or Until keyword as a looping construct. Windows
-PowerShell runs the statement list at least one time, unlike a loop that uses
-While.
+Used with the `While` or `Until` keyword as a looping construct. PowerShell
+runs the statement list at least one time, unlike a loop that uses `While`.
 
-Syntax for _While_:
+Syntax for `While`:
 
-```powershell
+```Syntax
 do {<statement list>} while (<condition>)
 ```
 
-Syntax for _Until_:
+Syntax for `Until`:
 
-```powershell
+```Syntax
 do {<statement list>} until (<condition>)
 ```
 
 ### DynamicParam
 
-Specifies one part of the body of a function, along with the Begin, Process,
-and End keywords. Dynamic parameters are added at run time.
+Specifies one part of the body of a function, along with the `Begin`, `Process`,
+and `End` keywords. Dynamic parameters are added at run time.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -166,23 +167,23 @@ function <name> {
 
 ### Else
 
-Used with the If keyword to specify the default statement list.
+Used with the `If` keyword to specify the default statement list.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 else {<statement list>}
 ```
 
 ### Elseif
 
-Used with the If and Else keywords to specify additional conditionals. The
-Else keyword is optional.
+Used with the `If` and `Else` keywords to specify additional conditionals. The
+`Else` keyword is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 elseif (<condition>) {<statement list>}
 else {<statement list>}
@@ -190,13 +191,13 @@ else {<statement list>}
 
 ### End
 
-Specifies one part of the body of a function, along with the DynamicParam,
-Begin, and End keywords. The End statement list runs one time after all the
+Specifies one part of the body of a function, along with the `DynamicParam`,
+`Begin`, and `End` keywords. The `End` statement list runs one time after all the
 objects have been received from the pipeline.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -211,7 +212,7 @@ Causes PowerShell to exit a script or a PowerShell instance.
 
 Syntax:
 
-```
+```Syntax
 exit
 exit <exitcode>
 ```
@@ -223,10 +224,10 @@ to indicate the post-execution status of the script.
 
 In PowerShell, the exit statement sets the value of the `$LASTEXITCODE`
 variable. In the Windows Command Shell (cmd.exe), the exit statement sets the
-value of the `%ERRORLEVEL% environment variable.
+value of the `%ERRORLEVEL%` environment variable.
 
 In the following example, the user sets the error level variable value to 4 by
-adding 'exit 4' to the script file _test.ps1_.
+adding `exit 4` to the script file _test.ps1_.
 
 ```cmd
 C:\scripts\test>type test.ps1
@@ -261,19 +262,19 @@ block.
 
 Syntax:
 
-```powershell
+```Syntax
 filter <name> {<statement list>}
 ```
 
 ### Finally
 
 Defines a statement list that runs after statements that are associated with
-Try and Catch. A Finally statement list runs even if you press CTRL+C to leave
+Try and Catch. A `Finally` statement list runs even if you press `CTRL+C` to leave
 a script or if you use the Exit keyword in the script.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [<error type>] {<statement list>}
 finally {<statement list>}
@@ -285,7 +286,7 @@ Defines a loop by using a condition.
 
 Syntax:
 
-```powershell
+```Syntax
 for (<initialize>; <condition>; <iterate>) { <statement list> }
 ```
 
@@ -295,7 +296,7 @@ Defines a loop by using each member of a collection.
 
 Syntax:
 
-```powershell
+```Syntax
 ForEach (<item> in <collection>) { <statement list> }
 ```
 
@@ -307,12 +308,12 @@ Reserved for future use.
 
 Creates a named statement list of reusable code. You can name the scope a
 function belongs to. And, you can specify one or more named parameters by
-using the Param keyword. Within the function statement list, you can include
-DynamicParam, Begin, Process, and End statement lists.
+using the `Param` keyword. Within the function statement list, you can include
+`DynamicParam`, `Begin`, `Process`, and `End` statement lists.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> {
    param ([type]<$pname1> [, [type]<$pname2>])
    DynamicParam {<statement list>}
@@ -327,7 +328,7 @@ statement list after the function name.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> [([type]<$pname1>, [[type]<$pname2>])] {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -342,18 +343,18 @@ Defines a conditional.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 ```
 
 ### In
 
-Used in a ForEach statement to create a loop that uses each member of a
+Used in a `ForEach` statement to create a loop that uses each member of a
 collection.
 
 Syntax:
 
-```powershell
+```Syntax
 ForEach (<item> in <collection>){<statement list>}
 ```
 
@@ -364,7 +365,7 @@ only in a PowerShell Workflow.
 
 Syntax:
 
-```powershell
+```Syntax
 workflow <verb>-<noun>
 {
    InlineScript
@@ -376,14 +377,13 @@ workflow <verb>-<noun>
 }
 ```
 
-The InlineScript keyword indicates an InlineScript activity, which runs
+The `InlineScript` keyword indicates an `InlineScript` activity, which runs
 commands in a shared standard (non-workflow) session. You can use the
-InlineScript keyword to run commands that are not otherwise valid in a
+`InlineScript` keyword to run commands that are not otherwise valid in a
 workflow, and to run commands that share data. By default, the commands in an
 InlineScript script block run in a separate process.
 
-For more information, see about_InlineScript and
-[Running PowerShell Commands in a Workflow](http://technet.microsoft.com/library/jj574197.aspx).
+For more information, see [Running PowerShell Commands in a Workflow](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/jj574197(v=ws.11)).
 
 ### Param
 
@@ -391,7 +391,7 @@ Defines the parameters in a function.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> {
    param ([type]<$pname1>[, [[type]<$pname2>]])
    <statement list>
@@ -400,16 +400,16 @@ function [<scope:>]<name> {
 
 ### Process
 
-Specifies a part of the body of a function, along with the DynamicParam,
-Begin, and End keywords. When a Process statement list receives input from the
-pipeline, the Process statement list runs one time for each element from the
-pipeline. If the pipeline provides no objects, the Process statement list does
-not run. If the command is the first command in the pipeline, the Process
-statement list runs one time.
+Specifies a part of the body of a function, along with the `DynamicParam`,
+`Begin`, and `End` keywords. When a `Process` statement list receives input
+from the pipeline, the `Process` statement list runs one time for each element
+from the pipeline. If the pipeline provides no objects, the `Process`
+statement list does not run. If the command is the first command in the
+pipeline, the `Process` statement list runs one time.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -425,21 +425,21 @@ and writes the optional expression to the output.
 
 Syntax:
 
-```powershell
+```Syntax
 return [<expression>]
 ```
 
 ### Switch
 
-To check multiple conditions, use a Switch statement. The Switch statement is
+To check multiple conditions, use a `Switch` statement. The `Switch` statement is
 equivalent to a series of If statements, but it is simpler.
 
-The Switch statement lists each condition and an optional action. If a
+The `Switch` statement lists each condition and an optional action. If a
 condition obtains, the action is performed.
 
 Syntax 1:
 
-```powershell
+```Syntax
 switch [-regex|-wildcard|-exact][-casesensitive] ( <value> )
 {
    <string>|<number>|<variable>|{ <expression> } {<statement list>}
@@ -452,7 +452,7 @@ switch [-regex|-wildcard|-exact][-casesensitive] ( <value> )
 
 Syntax 2:
 
-```powershell
+```Syntax
 switch [-regex|-wildcard|-exact][-casesensitive] -file <filename>
 {
    <string>|<number>|<variable>|{ <expression> } {<statement list>}
@@ -469,7 +469,7 @@ Throws an object as an error.
 
 Syntax:
 
-```powershell
+```Syntax
 throw [<object>]
 ```
 
@@ -481,20 +481,20 @@ is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 trap [[<error type>]] {<statement list>}
 ```
 
 ### Try
 
 Defines a statement list to be checked for errors while the statements run. If
-an error occurs, PowerShell continues running in a Catch or Finally statement.
-An error type requires brackets. The second pair of brackets indicates that
-the error type is optional.
+an error occurs, PowerShell continues running in a `Catch` or `Finally`
+statement. An error type requires brackets. The second pair of brackets
+indicates that the error type is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [[<error type>]] {<statement list>}
 finally {<statement list>}
@@ -502,23 +502,34 @@ finally {<statement list>}
 
 ### Until
 
-Used in a Do statement as a looping construct where the statement list is
+Used in a `Do` statement as a looping construct where the statement list is
 executed at least one time.
 
 Syntax:
 
-```powershell
+```Syntax
 do {<statement list>} until (<condition>)
 ```
 
 ### While
 
-Used in a Do statement as a looping construct where the statement list is
-executed at least one time.
+The `while` statement is a looping construct where the condition is tested
+before the statements are executed. If the condition is FALSE, then the
+statements do not execute.
 
-Syntax:
+Statement syntax:
 
-```powershell
+```Syntax
+while (<condition>) {
+   <statements>
+ }
+
+When used in a `Do` statement, `while` is part of a looping construct where
+the statement list is executed at least one time.
+
+Do loop Syntax:
+
+```Syntax
 do {<statement list>} while (<condition>)
 ```
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -22,8 +22,8 @@ modules to their PowerShell sessions and use them just like the built-in
 commands.
 
 This topic explains how to use PowerShell modules. For information about how
-to write PowerShell modules, see [Writing a PowerShell Module](https://go.microsoft.com/fwlink/?LinkId=144916)
-in the MSDN library.
+to write PowerShell modules, see
+[Writing a PowerShell Module](/powershell/developer/module/writing-a-windows-powershell-module).
 
 ## What Is a Module?
 
@@ -68,14 +68,14 @@ Only modules that are stored in the location specified by the PSModulePath
 environment variable are automatically imported. Modules in other locations
 must be imported by running the `Import-Module` cmdlet.
 
-Also, commands that use PowerShell providers do not automatically
-import a module. For example, if you use a command that requires the WSMan:
-drive, such as the `Get-PSSessionConfiguration` cmdlet, you might need to
-run the `Import-Module` cmdlet to import the Microsoft.WSMan.Management
-module that includes the WSMan: drive.
+Also, commands that use PowerShell providers do not automatically import a
+module. For example, if you use a command that requires the WSMan: drive, such
+as the `Get-PSSessionConfiguration` cmdlet, you might need to run the
+`Import-Module` cmdlet to import the **Microsoft.WSMan.Management** module that
+includes the `WSMan:` drive.
 
 You can still run the `Import-Module` command to import a module and
-use the $PSModuleAutoloadingPreference variable to enable, disable and
+use the `$PSModuleAutoloadingPreference` variable to enable, disable and
 configure automatic importing of modules. For more information, see
 [about_Preference_Variables](about_Preference_Variables.md).
 
@@ -104,7 +104,6 @@ the Turn Windows features on or off dialog box in Control Panel, any
 PowerShell modules that are part of the feature are installed. Many other
 modules come in an installer or Setup program that installs the module.
 
-
 Create a Modules directory for the current user if one does not exist. To
 create a Modules directory, type:
 
@@ -115,7 +114,7 @@ New-Item -Type Directory -Path $HOME\Documents\WindowsPowerShell\Modules
 Copy the entire module folder into the Modules directory. You can use any
 method to copy the folder, including Windows Explorer and Cmd.exe, as well as
 PowerShell. In PowerShell use the `Copy-Item` cmdlet. For example, to copy the
-MyModule folder from C:\\ps-test\\MyModule to the Modules directory, type:
+MyModule folder from `C:\ps-test\MyModule` to the Modules directory, type:
 
 ```powershell
 Copy-Item -Path C:\ps-test\MyModule -Destination `
@@ -201,9 +200,9 @@ For more information, see [Get-Help](../Get-Help.md) and
 
 You might have to import a module or import a module file. Importing is
 required when a module is not installed in the locations specified by the
-PSModulePath environment variable ($env:PSModulePath), or the module consists
-of file, such as a .dll or .psm1 file, instead of typical module that is
-delivered as a folder.
+**PSModulePath** environment variable, `$env:PSModulePath`, or the module
+consists of file, such as a .dll or .psm1 file, instead of typical module that
+is delivered as a folder.
 
 You might also choose to import a module so that you can use the parameters of
 the `Import-Module` command, such as the Prefix parameter, which adds a
@@ -291,42 +290,43 @@ PowerShell 4.0, with the introduction of DSC, a new default module and DSC
 resource folder was introduced. For more information about DSC, see
 about_DesiredStateConfiguration.
 
-- System: $pshome\Modules (%windir%\System32\WindowsPowerShell\v1.0\Modules)
+- System: `$pshome\Modules` or
+  (`$env:windir\System32\WindowsPowerShell\v1.0\Modules`)
   System modules are those that ship with Windows and PowerShell.
 
   Starting in PowerShell 4.0, when PowerShell Desired State Configuration
   (DSC) was introduced, DSC resources that are included with PowerShell are
-  also stored in \$pshome\\Modules, in the
-  \$pshome\\Modules\\PSDesiredStateConfiguration\\DSCResources folder.
+  also stored in `$PSHOME\Modules`, in the
+  `$pshome\Modules\PSDesiredStateConfiguration\DSCResources` folder.
 
-- Current user: \$home\\Documents\\WindowsPowerShell\\Modules
-  (%UserProfile%\Documents\WindowsPowerShell\Modules)
+- Current user: `$home\Documents\WindowsPowerShell\Modules`
+  (`$env:UserProfile\Documents\WindowsPowerShell\Modules`)
 
   or
 
-  \$home\\My Documents\\WindowsPowerShell\\Modules
-  (%UserProfile%\My Documents\WindowsPowerShell\Modules)
+  `$home\My Documents\WindowsPowerShell\Modules`
+  (`$env:UserProfile\My Documents\WindowsPowerShell\Modules`)
   This is the location for user-added modules prior to PowerShell 4.0.
 
 In PowerShell 4.0 and later releases of PowerShell, user-added modules and DSC
-resources are stored in C:\\Program Files\\WindowsPowerShell\\Modules. Modules
+resources are stored in `C:\Program Files\WindowsPowerShell\Modules`. Modules
 and DSC resources in this location are accessible by all users of the
 computer. This change was required because the DSC engine runs as local
 system, and could not access user-specific paths, such as
-\$home\\Documents\\WindowsPowerShell\\Modules.
+`$home\Documents\WindowsPowerShell\Modules`.
 
 Starting in PowerShell 5.0, with the addition of the PowerShellGet module, and
-the [PowerShell Gallery](https://www.powershellgallery.com) of community- and
+the [PowerShell Gallery](https://www.powershellgallery.com) of community and
 Microsoft-created resources, the `Install-Module` command installs modules and
-DSC resources to C:\\Program Files\\WindowsPowerShell\\Modules by default.
+DSC resources to `C:\Program Files\WindowsPowerShell\Modules` by default.
 
-Note: To add or change files in the %Windir%\\System32 directory, start
+Note: To add or change files in the `$env:Windir\System32` directory, start
 PowerShell with the "Run as administrator" option.
 
 You can change the default module locations on your system by changing the
-value of the PSModulePath environment variable ($Env:PSModulePath). The
-PSModulePath environment variable is modeled on the Path environment variable
-and has the same format.
+value of the **PSModulePath** environment variable, `$Env:PSModulePath`. The
+**PSModulePath** environment variable is modeled on the Path environment
+variable and has the same format.
 
 To view the default module locations, type:
 
@@ -343,23 +343,23 @@ $Env:PSModulePath = $Env:PSModulePath + ";<path>"
 The semi-colon (;) in the command separates the new path from the
 path that precedes it in the list.
 
-For example, to add the "C:\ps-test\Modules" directory, type:
+For example, to add the `C:\ps-test\Modules` directory, type:
 
 ```powershell
 $Env:PSModulePath + ";C:\ps-test\Modules"
 ```
 
-When you add a path to PSModulePath, `Get-Module` and `Import-Module`
+When you add a path to **PSModulePath**, `Get-Module` and `Import-Module`
 commands include modules in that path.
 
 The value that you set affects only the current session. To make the
 change persistent, add the command to your PowerShell profile
-or use System in Control Panel to change the value of the PSModulePath
+or use System in Control Panel to change the value of the **PSModulePath**
 environment variable in the registry.
 
 Also, to make the change persistent, you can also use the
-SetEnvironmentVariable method of the System.Environment class to add
-a Path to the PSModulePath environment variable.
+**SetEnvironmentVariable** method of the **System.Environment** class to add a
+Path to the **PSModulePath** environment variable.
 
 For more information about the PSModulePath variable, see
 [about_Environment_Variables](about_Environment_Variables.md).
@@ -502,9 +502,9 @@ The following modules (or snap-ins) are installed with PowerShell.
 
 Beginning in PowerShell 3.0, you can record execution events for the cmdlets
 and functions in PowerShell modules and snap-ins by setting the
-LogPipelineExecutionDetails property of modules and snap-ins to \$True. You can
-also use a Group Policy setting, Turn on Module Logging, to enable module
-logging in all PowerShell sessions. For more information, see
+**LogPipelineExecutionDetails** property of modules and snap-ins to `$True`. 
+You can also use a Group Policy setting, Turn on Module Logging, to enable
+module logging in all PowerShell sessions. For more information, see
 [about_EventLogs](about_EventLogs.md) and
 [about_Group_Policy_Settings](about_Group_Policy_Settings.md).
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -502,7 +502,7 @@ The following modules (or snap-ins) are installed with PowerShell.
 
 Beginning in PowerShell 3.0, you can record execution events for the cmdlets
 and functions in PowerShell modules and snap-ins by setting the
-**LogPipelineExecutionDetails** property of modules and snap-ins to `$True`. 
+**LogPipelineExecutionDetails** property of modules and snap-ins to `$True`.
 You can also use a Group Policy setting, Turn on Module Logging, to enable
 module logging in all PowerShell sessions. For more information, see
 [about_EventLogs](about_EventLogs.md) and

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -15,8 +15,9 @@ variables are created and maintained by PowerShell.
 
 ## LONG DESCRIPTION
 
-Conceptually, these variables are considered to be read-only.
-Even though they **can** be written to, for backward compatibility they **should not** be written to.
+Conceptually, these variables are considered to be read-only. Even though they
+**can** be written to, for backward compatibility they **should not** be
+written to.
 
 Here is a list of the automatic variables in  PowerShell:
 
@@ -35,7 +36,7 @@ Contains the first token in the last line received by the session.
 
 ### $_
 
-Same as $PSItem. Contains the current object in the pipeline object. You
+Same as `$PSItem`. Contains the current object in the pipeline object. You
 can use this variable in commands that perform an action on every object or
 on selected objects in a pipeline.
 
@@ -47,41 +48,40 @@ function, you can declare the parameters by using the param keyword or by
 adding a comma-separated list of parameters in parentheses after the
 function name.
 
-In an event action, the $Args variable contains objects that represent the
+In an event action, the `$Args` variable contains objects that represent the
 event arguments of the event that is being processed. This variable is
 populated only within the Action block of an event registration command.
 The value of this variable can also be found in the SourceArgs property of
-the PSEventArgs object (System.Management.Automation.PSEventArgs) that
-Get-Event returns.
+the **PSEventArgs** object that `Get-Event` returns.
 
 ### $CONSOLEFILENAME
 
 Contains the path of the console file (.psc1) that was most recently used
 in the session. This variable is populated when you start PowerShell with
-the PSConsoleFile parameter or when you use the Export-Console cmdlet to
+the PSConsoleFile parameter or when you use the `Export-Console` cmdlet to
 export snap-in names to a console file.
 
-When you use the Export-Console cmdlet without parameters, it automatically
+When you use the `Export-Console` cmdlet without parameters, it automatically
 updates the console file that was most recently used in the session. You
 can use this automatic variable to determine which file will be updated.
 
 ### $ERROR
 
 Contains an array of error objects that represent the most recent errors.
-The most recent error is the first error object in the array ($Error[0]).
+The most recent error is the first error object in the array `$Error[0]`.
 
-To prevent an error from being added to the $Error array, use the
-ErrorAction common parameter with a value of Ignore. For more information,
-see [about_CommonParameters](about_CommonParameters.md).
+To prevent an error from being added to the `$Error` array, use the
+**ErrorAction** common parameter with a value of **Ignore**. For more
+information, see [about_CommonParameters](about_CommonParameters.md).
 
 ### $EVENT
 
-Contains a PSEventArgs object that represents the event that is being
+Contains a **PSEventArgs** object that represents the event that is being
 processed. This variable is populated only within the Action block of an
-event registration command, such as Register-ObjectEvent. The value of this
-variable is the same object that the Get-Event cmdlet returns. Therefore,
-you can use the properties of the $Event variable, such as
-$Event.TimeGenerated , in an Action script block.
+event registration command, such as `Register-ObjectEvent`. The value of this
+variable is the same object that the `Get-Event` cmdlet returns. Therefore,
+you can use the properties of the `Event` variable, such as
+`$Event.TimeGenerated`, in an Action script block.
 
 ### $EVENTARGS
 
@@ -89,19 +89,18 @@ Contains an object that represents the first event argument that derives
 from EventArgs of the event that is being processed. This variable is
 populated only within the Action block of an event registration command.
 The value of this variable can also be found in the SourceEventArgs
-property of the PSEventArgs (System.Management.Automation.PSEventArgs)
-object that Get-Event returns.
+property of the **PSEventArgs** object that `Get-Event` returns.
 
 ### $EVENTSUBSCRIBER
 
-Contains a PSEventSubscriber object that represents the event subscriber of
+Contains a **PSEventSubscriber** object that represents the event subscriber of
 the event that is being processed. This variable is populated only within
 the Action block of an event registration command. The value of this
-variable is the same object that the Get-EventSubscriber cmdlet returns.
+variable is the same object that the `Get-EventSubscriber` cmdlet returns.
 
 ### $EXECUTIONCONTEXT
 
-Contains an EngineIntrinsics object that represents the execution context
+Contains an **EngineIntrinsics** object that represents the execution context
 of the PowerShell host. You can use this variable to find the execution
 objects that are available to cmdlets.
 
@@ -116,33 +115,33 @@ non-zero integer.
 
 Contains the enumerator (not the resulting values) of a ForEach loop. You
 can use the properties and methods of enumerators on the value of the
-$ForEach variable. This variable exists only while the ForEach loop is
+`$ForEach` variable. This variable exists only while the `ForEach` loop is
 running; it is deleted after the loop is completed. For detailed
 information, see [about_ForEach](about_ForEach.md).
 
 ### $HOME
 
 Contains the full path of the user's home directory. This variable is the
-equivalent of the `%homedrive%%homepath%` Windows environment variables,
-typically C:\\Users\\<UserName>.
+equivalent of the `"$env:homedrive$env:homepath"` Windows environment variables,
+typically `C:\Users\<UserName>`.
 
 ### $HOST
 
 Contains an object that represents the current host application for
 PowerShell. You can use this variable to represent the current host in
 commands or to display or change the properties of the host, such as
-$Host.version or $Host.CurrentCulture, or
-$host.ui.rawui.setbackgroundcolor("Red").
+`$Host.version` or `$Host.CurrentCulture`, or
+`$host.ui.rawui.setbackgroundcolor("Red")`.
 
 ### $INPUT
 
 Contains an enumerator that enumerates all input that is passed to a
-function. The $input variable is available only to functions and script
+function. The `$input` variable is available only to functions and script
 blocks (which are unnamed functions). In the Process block of a function,
-the $input variable enumerates the object that is currently in the
+the `$input` variable enumerates the object that is currently in the
 pipeline. When the Process block completes, there are no objects left in
-the pipeline, so the $input variable enumerates an empty collection. If the
-function does not have a Process block, then in the End block, the $input
+the pipeline, so the `$input` variable enumerates an empty collection. If the
+function does not have a Process block, then in the End block, the `$input`
 variable enumerates the collection of all input to the function.
 
 ### $LASTEXITCODE
@@ -151,11 +150,11 @@ Contains the exit code of the last Windows-based program that was run.
 
 ### $MATCHES
 
-The $Matches variable works with the `-match` and `-notmatch` operators.
+The `Matches` variable works with the `-match` and `-notmatch` operators.
 When you submit scalar input to the `-match` or `-notmatch` operator, and
 either one detects a match, they return a Boolean value and populate the
 $Matches automatic variable with a hash table of any string values that
-were matched. For more information about the -match operator, see
+were matched. For more information about the `-match` operator, see
 [about_comparison_operators](about_comparison_operators.md).
 
 ### $MYINVOCATION
@@ -165,14 +164,14 @@ parameters, parameter values, and information about how the command was
 started, called, or "invoked," such as the name of the script that called
 the current command.
 
-\$MyInvocation is populated only for scripts, function, and script blocks.
+`$MyInvocation` is populated only for scripts, function, and script blocks.
 You can use the information in the System.Management.Automation.InvocationInfo
-object that \$MyInvocation returns in the current script, such as the path and
-file name of the script (\$MyInvocation.MyCommand.Path) or the name of a
-function (\$MyInvocation.MyCommand.Name) to identify the current command. This
+object that `$MyInvocation` returns in the current script, such as the path and
+file name of the script (`$MyInvocation.MyCommand.Path`) or the name of a
+function (`$MyInvocation.MyCommand.Name`) to identify the current command. This
 is particularly useful for finding the name of the current script.
 
-Beginning in PowerShell 3.0, $MyInvocation has the following new
+Beginning in PowerShell 3.0, `MyInvocation` has the following new
 properties.
 
 | Property      | Description                                         |
@@ -185,10 +184,10 @@ properties.
 |               | property is populated only when the caller is a     |
 |               | script.                                             |
 
-Unlike the $PSScriptRoot and $PSCommandPath automatic variables, the
-PSScriptRoot and PSCommandPath properties of the $MyInvocation automatic
-variable contain information about the invoker or calling script, not the
-current script.
+Unlike the `$PSScriptRoot` and `$PSCommandPath` automatic variables, the
+**PSScriptRoot** and **PSCommandPath** properties of the `$MyInvocation`
+automatic variable contain information about the invoker or calling script,
+not the current script.
 
 ### $NESTEDPROMPTLEVEL
 
@@ -197,30 +196,30 @@ prompt level. The value is incremented when you enter a nested level and
 decremented when you exit it.
 
 For example, PowerShell presents a nested command prompt when you use the
-$Host.EnterNestedPrompt method. PowerShell also presents a nested command
+`$Host.EnterNestedPrompt` method. PowerShell also presents a nested command
 prompt when you reach a breakpoint in the PowerShell debugger.
 
 When you enter a nested prompt, PowerShell pauses the current command,
 saves the execution context, and increments the value of the
-$NestedPromptLevel variable. To create additional nested command prompts
+`$NestedPromptLevel` variable. To create additional nested command prompts
 (up to 128 levels) or to return to the original command prompt, complete
-the command, or type "exit".
+the command, or type `exit`.
 
-The $NestedPromptLevel variable helps you track the prompt level. You can
+The `$NestedPromptLevel` variable helps you track the prompt level. You can
 create an alternative PowerShell command prompt that includes this value so
 that it is always visible.
 
 ### $NULL
 
-$null is an automatic variable that contains a NULL or empty value. You can
+`$null` is an automatic variable that contains a NULL or empty value. You can
 use this variable to represent an absent or undefined value in commands and
 scripts.
 
-PowerShell treats $null as an object with a value, that is, as an explicit
-placeholder, so you can use $null to represent an empty value in a series
+PowerShell treats `$null` as an object with a value, that is, as an explicit
+placeholder, so you can use `$null` to represent an empty value in a series
 of values.
 
-For example, when $null is included in a collection, it is counted as one
+For example, when `$null` is included in a collection, it is counted as one
 of the objects.
 
 ```powershell
@@ -232,8 +231,8 @@ $a.count
 3
 ```
 
-If you pipe the $null variable to the ForEach-Object cmdlet, it generates a
-value for $null, just as it does for the other objects
+If you pipe the `$null` variable to the `ForEach-Object` cmdlet, it generates a
+value for `$null`, just as it does for the other objects
 
 ```powershell
 "one", $null, "three" | ForEach-Object { "Hello " + $_}
@@ -245,11 +244,11 @@ Hello
 Hello three
 ```
 
-As a result, you cannot use $null to mean "no parameter value." A parameter
-value of $null overrides the default parameter value.
+As a result, you cannot use `$null` to mean "no parameter value." A parameter
+value of `$null` overrides the default parameter value.
 
-However, because PowerShell treats the $null variable as a placeholder, you
-can use it in scripts like the following one, which would not work if $null
+However, because PowerShell treats the `$null` variable as a placeholder, you
+can use it in scripts like the following one, which would not work if `$null`
 were ignored.
 
 ```powershell
@@ -286,13 +285,13 @@ profile in commands. For example, you can use it in a command to determine
 whether a profile has been created:
 
 ```powershell
-test-path $profile
+Test-Path $PROFILE
 ```
 
 Or, you can use it in a command to create a profile:
 
 ```powershell
-new-item -type file -path $pshome -force
+New-Item -ItemType file -Path $PSHOME -Force
 ```
 
 You can also use it in a command to open the profile in Notepad:
@@ -330,11 +329,11 @@ being run.
 
 You can use the properties and methods of the object in your cmdlet or
 function code to respond to the conditions of use. For example, the
-ParameterSetName property contains the name of the parameter set that is
-being used, and the ShouldProcess method adds the WhatIf and Confirm
-parameters to the cmdlet dynamically.
+**ParameterSetName** property contains the name of the parameter set that is
+being used, and the **ShouldProcess** method adds the **WhatIf** and
+**Confirm** parameters to the cmdlet dynamically.
 
-For more information about the $PSCmdlet automatic variable, see
+For more information about the `$PSCmdlet` automatic variable, see
 [about_Functions_Advanced](about_Functions_Advanced.md).
 
 ### $PSCOMMANDPATH
@@ -347,24 +346,24 @@ variable is valid in all scripts.
 Contains the name of the culture currently in use in the operating system.
 The culture determines the display format of items such as numbers,
 currency, and dates. This is the value of the
-System.Globalization.CultureInfo.CurrentCulture.Name property of the
-system. To get the System.Globalization.CultureInfo object for the system,
-use the Get-Culture cmdlet.
+**System.Globalization.CultureInfo.CurrentCulture.Name** property of the
+system. To get the **System.Globalization.CultureInfo** object for the system,
+use the `Get-Culture` cmdlet.
 
 ### $PSDEBUGCONTEXT
 
 While debugging, this variable contains information about the debugging
-environment. Otherwise, it contains a NULL value. As a result, you can use
-it to indicate whether the debugger has control. When populated, it
-contains a PsDebugContext object that has Breakpoints and InvocationInfo
-properties. The InvocationInfo property has several useful properties,
-including the Location property. The Location property indicates the path
-of the script that is being debugged.
+environment. Otherwise, it contains a NULL value. As a result, you can use it
+to indicate whether the debugger has control. When populated, it contains a
+**PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
+properties. The **InvocationInfo** property has several useful properties,
+including the **Location** property. The **Location** property indicates the
+path of the script that is being debugged.
 
 ### $PSHOME
 
 Contains the full path of the installation directory for PowerShell,
-typically, `%windir%\System32\PowerShell\v1.0` in Windows systems. You can
+typically, `$env:windir\System32\PowerShell\v1.0` in Windows systems. You can
 use this variable in the paths of PowerShell files. For example, the
 following command searches the conceptual Help topics for the word
 "variable":
@@ -375,7 +374,7 @@ Select-String -Pattern Variable -Path $pshome\*.txt
 
 ### $PSITEM
 
-Same as $_. Contains the current object in the pipeline object. You can use
+Same as `$_`. Contains the current object in the pipeline object. You can use
 this variable in commands that perform an action on every object or on
 selected objects in a pipeline.
 
@@ -392,20 +391,20 @@ Contains information about the user who started the PSSession, including
 the user identity and the time zone of the originating computer. This
 variable is available only in PSSessions.
 
-The $PSSenderInfo variable includes a user-configurable property,
-ApplicationArguments, which, by default, contains only the $PSVersionTable
-from the originating session. To add data to the ApplicationArguments
-property, use the ApplicationArguments parameter of the New-PSSessionOption
-cmdlet.
+The `$PSSenderInfo` variable includes a user-configurable property,
+**ApplicationArguments**, which, by default, contains only the
+`$PSVersionTable` from the originating session. To add data to the
+**ApplicationArguments** property, use the **ApplicationArguments** parameter
+of the `New-PSSessionOption` cmdlet.
 
 ### $PSUICULTURE
 
-Contains the name of the user interface (UI) culture that is currently in
-use in the operating system. The UI culture determines which text strings
-are used for user interface elements, such as menus and messages. This is
-the value of the System.Globalization.CultureInfo.CurrentUICulture.Name
-property of the system. To get the System.Globalization.CultureInfo object
-for the system, use the Get-UICulture cmdlet.
+Contains the name of the user interface (UI) culture that is currently in use
+in the operating system. The UI culture determines which text strings are used
+for user interface elements, such as menus and messages. This is the value of
+the **System.Globalization.CultureInfo.CurrentUICulture.Name** property of the
+system. To get the **System.Globalization.CultureInfo** object for the system,
+use the `Get-UICulture` cmdlet.
 
 ### $PSVERSIONTABLE
 
@@ -435,13 +434,12 @@ following items:
 
 ### $PWD
 
-Contains a path object that represents the full path of the current
-directory.
+Contains a path object that represents the full path of the current directory.
 
 ### REPORTERRORSHOW VARIABLES
 
-The "ReportErrorShow" variables are defined in PowerShell, but they are not
-implemented. Get-Variable gets them, but they do not contain valid data.
+The **ReportErrorShow** variables are defined in PowerShell, but they are not
+implemented. `Get-Variable` gets them, but they do not contain valid data.
 
 - $REPORTERRORSHOWEXCEPTIONCLASS
 - $REPORTERRORSHOWINNEREXCEPTION
@@ -452,20 +450,21 @@ implemented. Get-Variable gets them, but they do not contain valid data.
 
 Contains the object that generated this event. This variable is populated
 only within the Action block of an event registration command. The value of
-this variable can also be found in the Sender property of the PSEventArgs
-(System.Management.Automation.PSEventArgs) object that Get-Event returns.
+this variable can also be found in the Sender property of the **PSEventArgs**
+object that `Get-Event` returns.
 
 ### $SHELLID
 
 Contains the identifier of the current shell.
 
 ### $STACKTRACE
+
 Contains a stack trace for the most recent error.
 
 ### $THIS
 
 In a script block that defines a script property or script method, the
-$This variable refers to the object that is being extended.
+`$This` variable refers to the object that is being extended.
 
 ### $TRUE
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -523,6 +523,7 @@ Statement syntax:
 while (<condition>) {
    <statements>
  }
+```
 
 When used in a `Do` statement, `while` is part of a looping construct where
 the statement list is executed at least one time.

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -1,8 +1,10 @@
+---
 ms.date:  06/09/2017
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Language_Keywords
+---
 
 # About Language Keywords
 
@@ -54,18 +56,18 @@ Language Keywords
 
 ### Begin
 
-Specifies one part of the body of a function, along with the DynamicParam,
-Process, and End keywords. The Begin statement list runs one time before any
+Specifies one part of the body of a function, along with the `DynamicParam`,
+`Process`, and `End` keywords. The `Begin` statement list runs one time before any
 objects are received from the pipeline.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
-DynamicParam {<statement list>}
-begin {<statement list>}
-process {<statement list>}
-end {<statement list>}
+    DynamicParam {<statement list>}
+    begin {<statement list>}
+    process {<statement list>}
+    end {<statement list>}
 }
 ```
 
@@ -75,7 +77,7 @@ Causes a script to exit a loop.
 
 Syntax:
 
-```powershell
+```Syntax
 while (<condition>) {
    <statements>
    ...
@@ -95,7 +97,7 @@ indicates that the error type is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [[<error type>]] {<statement list>}
 ```
@@ -107,7 +109,7 @@ condition is met, the script begins the loop again.
 
 Syntax:
 
-```powershell
+```Syntax
 while (<condition>) {
    <statements>
    ...
@@ -122,40 +124,39 @@ while (<condition>) {
 ### Data
 
 In a script, defines a section that isolates data from the script logic. Can
-also include If statements and some limited commands.
+also include `If` statements and some limited commands.
 
 Syntax:
 
-```powershell
+```Syntax
 data <variable> [-supportedCommand <cmdlet-name>] {<permitted content>}
 ```
 
 ### Do
 
-Used with the While or Until keyword as a looping construct. Windows
-PowerShell runs the statement list at least one time, unlike a loop that uses
-While.
+Used with the `While` or `Until` keyword as a looping construct. PowerShell
+runs the statement list at least one time, unlike a loop that uses `While`.
 
-Syntax for _While_:
+Syntax for `While`:
 
-```powershell
+```Syntax
 do {<statement list>} while (<condition>)
 ```
 
-Syntax for _Until_:
+Syntax for `Until`:
 
-```powershell
+```Syntax
 do {<statement list>} until (<condition>)
 ```
 
 ### DynamicParam
 
-Specifies one part of the body of a function, along with the Begin, Process,
-and End keywords. Dynamic parameters are added at run time.
+Specifies one part of the body of a function, along with the `Begin`, `Process`,
+and `End` keywords. Dynamic parameters are added at run time.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -166,23 +167,23 @@ function <name> {
 
 ### Else
 
-Used with the If keyword to specify the default statement list.
+Used with the `If` keyword to specify the default statement list.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 else {<statement list>}
 ```
 
 ### Elseif
 
-Used with the If and Else keywords to specify additional conditionals. The
-Else keyword is optional.
+Used with the `If` and `Else` keywords to specify additional conditionals. The
+`Else` keyword is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 elseif (<condition>) {<statement list>}
 else {<statement list>}
@@ -190,13 +191,13 @@ else {<statement list>}
 
 ### End
 
-Specifies one part of the body of a function, along with the DynamicParam,
-Begin, and End keywords. The End statement list runs one time after all the
+Specifies one part of the body of a function, along with the `DynamicParam`,
+`Begin`, and `End` keywords. The `End` statement list runs one time after all the
 objects have been received from the pipeline.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -211,7 +212,7 @@ Causes PowerShell to exit a script or a PowerShell instance.
 
 Syntax:
 
-```
+```Syntax
 exit
 exit <exitcode>
 ```
@@ -223,10 +224,10 @@ to indicate the post-execution status of the script.
 
 In PowerShell, the exit statement sets the value of the `$LASTEXITCODE`
 variable. In the Windows Command Shell (cmd.exe), the exit statement sets the
-value of the `%ERRORLEVEL% environment variable.
+value of the `%ERRORLEVEL%` environment variable.
 
 In the following example, the user sets the error level variable value to 4 by
-adding 'exit 4' to the script file _test.ps1_.
+adding `exit 4` to the script file _test.ps1_.
 
 ```cmd
 C:\scripts\test>type test.ps1
@@ -261,19 +262,19 @@ block.
 
 Syntax:
 
-```powershell
+```Syntax
 filter <name> {<statement list>}
 ```
 
 ### Finally
 
 Defines a statement list that runs after statements that are associated with
-Try and Catch. A Finally statement list runs even if you press CTRL+C to leave
+Try and Catch. A `Finally` statement list runs even if you press `CTRL+C` to leave
 a script or if you use the Exit keyword in the script.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [<error type>] {<statement list>}
 finally {<statement list>}
@@ -285,7 +286,7 @@ Defines a loop by using a condition.
 
 Syntax:
 
-```powershell
+```Syntax
 for (<initialize>; <condition>; <iterate>) { <statement list> }
 ```
 
@@ -295,7 +296,7 @@ Defines a loop by using each member of a collection.
 
 Syntax:
 
-```powershell
+```Syntax
 ForEach (<item> in <collection>) { <statement list> }
 ```
 
@@ -307,12 +308,12 @@ Reserved for future use.
 
 Creates a named statement list of reusable code. You can name the scope a
 function belongs to. And, you can specify one or more named parameters by
-using the Param keyword. Within the function statement list, you can include
-DynamicParam, Begin, Process, and End statement lists.
+using the `Param` keyword. Within the function statement list, you can include
+`DynamicParam`, `Begin`, `Process`, and `End` statement lists.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> {
    param ([type]<$pname1> [, [type]<$pname2>])
    DynamicParam {<statement list>}
@@ -327,7 +328,7 @@ statement list after the function name.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> [([type]<$pname1>, [[type]<$pname2>])] {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -342,18 +343,18 @@ Defines a conditional.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 ```
 
 ### In
 
-Used in a ForEach statement to create a loop that uses each member of a
+Used in a `ForEach` statement to create a loop that uses each member of a
 collection.
 
 Syntax:
 
-```powershell
+```Syntax
 ForEach (<item> in <collection>){<statement list>}
 ```
 
@@ -364,7 +365,7 @@ only in a PowerShell Workflow.
 
 Syntax:
 
-```powershell
+```Syntax
 workflow <verb>-<noun>
 {
    InlineScript
@@ -376,14 +377,13 @@ workflow <verb>-<noun>
 }
 ```
 
-The InlineScript keyword indicates an InlineScript activity, which runs
+The `InlineScript` keyword indicates an `InlineScript` activity, which runs
 commands in a shared standard (non-workflow) session. You can use the
-InlineScript keyword to run commands that are not otherwise valid in a
+`InlineScript` keyword to run commands that are not otherwise valid in a
 workflow, and to run commands that share data. By default, the commands in an
 InlineScript script block run in a separate process.
 
-For more information, see about_InlineScript and
-[Running PowerShell Commands in a Workflow](http://technet.microsoft.com/library/jj574197.aspx).
+For more information, see [Running PowerShell Commands in a Workflow](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/jj574197(v=ws.11)).
 
 ### Param
 
@@ -391,7 +391,7 @@ Defines the parameters in a function.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> {
    param ([type]<$pname1>[, [[type]<$pname2>]])
    <statement list>
@@ -400,16 +400,16 @@ function [<scope:>]<name> {
 
 ### Process
 
-Specifies a part of the body of a function, along with the DynamicParam,
-Begin, and End keywords. When a Process statement list receives input from the
-pipeline, the Process statement list runs one time for each element from the
-pipeline. If the pipeline provides no objects, the Process statement list does
-not run. If the command is the first command in the pipeline, the Process
-statement list runs one time.
+Specifies a part of the body of a function, along with the `DynamicParam`,
+`Begin`, and `End` keywords. When a `Process` statement list receives input
+from the pipeline, the `Process` statement list runs one time for each element
+from the pipeline. If the pipeline provides no objects, the `Process`
+statement list does not run. If the command is the first command in the
+pipeline, the `Process` statement list runs one time.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -425,21 +425,21 @@ and writes the optional expression to the output.
 
 Syntax:
 
-```powershell
+```Syntax
 return [<expression>]
 ```
 
 ### Switch
 
-To check multiple conditions, use a Switch statement. The Switch statement is
+To check multiple conditions, use a `Switch` statement. The `Switch` statement is
 equivalent to a series of If statements, but it is simpler.
 
-The Switch statement lists each condition and an optional action. If a
+The `Switch` statement lists each condition and an optional action. If a
 condition obtains, the action is performed.
 
 Syntax 1:
 
-```powershell
+```Syntax
 switch [-regex|-wildcard|-exact][-casesensitive] ( <value> )
 {
    <string>|<number>|<variable>|{ <expression> } {<statement list>}
@@ -452,7 +452,7 @@ switch [-regex|-wildcard|-exact][-casesensitive] ( <value> )
 
 Syntax 2:
 
-```powershell
+```Syntax
 switch [-regex|-wildcard|-exact][-casesensitive] -file <filename>
 {
    <string>|<number>|<variable>|{ <expression> } {<statement list>}
@@ -469,7 +469,7 @@ Throws an object as an error.
 
 Syntax:
 
-```powershell
+```Syntax
 throw [<object>]
 ```
 
@@ -481,20 +481,20 @@ is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 trap [[<error type>]] {<statement list>}
 ```
 
 ### Try
 
 Defines a statement list to be checked for errors while the statements run. If
-an error occurs, PowerShell continues running in a Catch or Finally statement.
-An error type requires brackets. The second pair of brackets indicates that
-the error type is optional.
+an error occurs, PowerShell continues running in a `Catch` or `Finally`
+statement. An error type requires brackets. The second pair of brackets
+indicates that the error type is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [[<error type>]] {<statement list>}
 finally {<statement list>}
@@ -502,23 +502,34 @@ finally {<statement list>}
 
 ### Until
 
-Used in a Do statement as a looping construct where the statement list is
+Used in a `Do` statement as a looping construct where the statement list is
 executed at least one time.
 
 Syntax:
 
-```powershell
+```Syntax
 do {<statement list>} until (<condition>)
 ```
 
 ### While
 
-Used in a Do statement as a looping construct where the statement list is
-executed at least one time.
+The `while` statement is a looping construct where the condition is tested
+before the statements are executed. If the condition is FALSE, then the
+statements do not execute.
 
-Syntax:
+Statement syntax:
 
-```powershell
+```Syntax
+while (<condition>) {
+   <statements>
+ }
+
+When used in a `Do` statement, `while` is part of a looping construct where
+the statement list is executed at least one time.
+
+Do loop Syntax:
+
+```Syntax
 do {<statement list>} while (<condition>)
 ```
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -5,7 +5,6 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Modules
 ---
-
 # About Modules
 
 ## Short Description
@@ -23,8 +22,8 @@ modules to their PowerShell sessions and use them just like the built-in
 commands.
 
 This topic explains how to use PowerShell modules. For information about how
-to write PowerShell modules, see [Writing a PowerShell Module](https://go.microsoft.com/fwlink/?LinkId=144916)
-in the MSDN library.
+to write PowerShell modules, see
+[Writing a PowerShell Module](/powershell/developer/module/writing-a-windows-powershell-module).
 
 ## What Is a Module?
 
@@ -43,6 +42,7 @@ gets all commands in all installed modules, even if they are not yet in the
 session, so you can find a command and use it without importing.
 
 Any of the following commands will import a module into your session.
+
 ### Run the Command
 
 ```powershell
@@ -68,14 +68,14 @@ Only modules that are stored in the location specified by the PSModulePath
 environment variable are automatically imported. Modules in other locations
 must be imported by running the `Import-Module` cmdlet.
 
-Also, commands that use PowerShell providers do not automatically
-import a module. For example, if you use a command that requires the WSMan:
-drive, such as the `Get-PSSessionConfiguration` cmdlet, you might need to
-run the `Import-Module` cmdlet to import the Microsoft.WSMan.Management
-module that includes the WSMan: drive.
+Also, commands that use PowerShell providers do not automatically import a
+module. For example, if you use a command that requires the WSMan: drive, such
+as the `Get-PSSessionConfiguration` cmdlet, you might need to run the
+`Import-Module` cmdlet to import the **Microsoft.WSMan.Management** module that
+includes the `WSMan:` drive.
 
 You can still run the `Import-Module` command to import a module and
-use the $PSModuleAutoloadingPreference variable to enable, disable and
+use the `$PSModuleAutoloadingPreference` variable to enable, disable and
 configure automatic importing of modules. For more information, see
 [about_Preference_Variables](about_Preference_Variables.md).
 
@@ -104,7 +104,6 @@ the Turn Windows features on or off dialog box in Control Panel, any
 PowerShell modules that are part of the feature are installed. Many other
 modules come in an installer or Setup program that installs the module.
 
-
 Create a Modules directory for the current user if one does not exist. To
 create a Modules directory, type:
 
@@ -115,7 +114,7 @@ New-Item -Type Directory -Path $HOME\Documents\WindowsPowerShell\Modules
 Copy the entire module folder into the Modules directory. You can use any
 method to copy the folder, including Windows Explorer and Cmd.exe, as well as
 PowerShell. In PowerShell use the `Copy-Item` cmdlet. For example, to copy the
-MyModule folder from C:\\ps-test\\MyModule to the Modules directory, type:
+MyModule folder from `C:\ps-test\MyModule` to the Modules directory, type:
 
 ```powershell
 Copy-Item -Path C:\ps-test\MyModule -Destination `
@@ -201,9 +200,9 @@ For more information, see [Get-Help](../Get-Help.md) and
 
 You might have to import a module or import a module file. Importing is
 required when a module is not installed in the locations specified by the
-PSModulePath environment variable ($env:PSModulePath), or the module consists
-of file, such as a .dll or .psm1 file, instead of typical module that is
-delivered as a folder.
+**PSModulePath** environment variable, `$env:PSModulePath`, or the module
+consists of file, such as a .dll or .psm1 file, instead of typical module that
+is delivered as a folder.
 
 You might also choose to import a module so that you can use the parameters of
 the `Import-Module` command, such as the Prefix parameter, which adds a
@@ -291,42 +290,43 @@ PowerShell 4.0, with the introduction of DSC, a new default module and DSC
 resource folder was introduced. For more information about DSC, see
 about_DesiredStateConfiguration.
 
-- System: $pshome\Modules (%windir%\System32\WindowsPowerShell\v1.0\Modules)
+- System: `$pshome\Modules` or
+  (`$env:windir\System32\WindowsPowerShell\v1.0\Modules`)
   System modules are those that ship with Windows and PowerShell.
 
   Starting in PowerShell 4.0, when PowerShell Desired State Configuration
   (DSC) was introduced, DSC resources that are included with PowerShell are
-  also stored in \$pshome\\Modules, in the
-  \$pshome\\Modules\\PSDesiredStateConfiguration\\DSCResources folder.
+  also stored in `$PSHOME\Modules`, in the
+  `$pshome\Modules\PSDesiredStateConfiguration\DSCResources` folder.
 
-- Current user: \$home\\Documents\\WindowsPowerShell\\Modules
-  (%UserProfile%\Documents\WindowsPowerShell\Modules)
+- Current user: `$home\Documents\WindowsPowerShell\Modules`
+  (`$env:UserProfile\Documents\WindowsPowerShell\Modules`)
 
   or
 
-  \$home\\My Documents\\WindowsPowerShell\\Modules
-  (%UserProfile%\My Documents\WindowsPowerShell\Modules)
+  `$home\My Documents\WindowsPowerShell\Modules`
+  (`$env:UserProfile\My Documents\WindowsPowerShell\Modules`)
   This is the location for user-added modules prior to PowerShell 4.0.
 
 In PowerShell 4.0 and later releases of PowerShell, user-added modules and DSC
-resources are stored in C:\\Program Files\\WindowsPowerShell\\Modules. Modules
+resources are stored in `C:\Program Files\WindowsPowerShell\Modules`. Modules
 and DSC resources in this location are accessible by all users of the
 computer. This change was required because the DSC engine runs as local
 system, and could not access user-specific paths, such as
-\$home\\Documents\\WindowsPowerShell\\Modules.
+`$home\Documents\WindowsPowerShell\Modules`.
 
 Starting in PowerShell 5.0, with the addition of the PowerShellGet module, and
-the [PowerShell Gallery](https://www.powershellgallery.com) of community- and
+the [PowerShell Gallery](https://www.powershellgallery.com) of community and
 Microsoft-created resources, the `Install-Module` command installs modules and
-DSC resources to C:\\Program Files\\WindowsPowerShell\\Modules by default.
+DSC resources to `C:\Program Files\WindowsPowerShell\Modules` by default.
 
-Note: To add or change files in the %Windir%\\System32 directory, start
+Note: To add or change files in the `$env:Windir\System32` directory, start
 PowerShell with the "Run as administrator" option.
 
 You can change the default module locations on your system by changing the
-value of the PSModulePath environment variable ($Env:PSModulePath). The
-PSModulePath environment variable is modeled on the Path environment variable
-and has the same format.
+value of the **PSModulePath** environment variable, `$Env:PSModulePath`. The
+**PSModulePath** environment variable is modeled on the Path environment
+variable and has the same format.
 
 To view the default module locations, type:
 
@@ -343,23 +343,23 @@ $Env:PSModulePath = $Env:PSModulePath + ";<path>"
 The semi-colon (;) in the command separates the new path from the
 path that precedes it in the list.
 
-For example, to add the "C:\ps-test\Modules" directory, type:
+For example, to add the `C:\ps-test\Modules` directory, type:
 
 ```powershell
 $Env:PSModulePath + ";C:\ps-test\Modules"
 ```
 
-When you add a path to PSModulePath, `Get-Module` and `Import-Module`
+When you add a path to **PSModulePath**, `Get-Module` and `Import-Module`
 commands include modules in that path.
 
 The value that you set affects only the current session. To make the
 change persistent, add the command to your PowerShell profile
-or use System in Control Panel to change the value of the PSModulePath
+or use System in Control Panel to change the value of the **PSModulePath**
 environment variable in the registry.
 
 Also, to make the change persistent, you can also use the
-SetEnvironmentVariable method of the System.Environment class to add
-a Path to the PSModulePath environment variable.
+**SetEnvironmentVariable** method of the **System.Environment** class to add a
+Path to the **PSModulePath** environment variable.
 
 For more information about the PSModulePath variable, see
 [about_Environment_Variables](about_Environment_Variables.md).
@@ -506,9 +506,9 @@ The following modules (or snap-ins) are installed with PowerShell.
 
 Beginning in PowerShell 3.0, you can record execution events for the cmdlets
 and functions in PowerShell modules and snap-ins by setting the
-LogPipelineExecutionDetails property of modules and snap-ins to \$True. You can
-also use a Group Policy setting, Turn on Module Logging, to enable module
-logging in all PowerShell sessions. For more information, see
+**LogPipelineExecutionDetails** property of modules and snap-ins to `$True`. 
+You can also use a Group Policy setting, Turn on Module Logging, to enable
+module logging in all PowerShell sessions. For more information, see
 [about_EventLogs](about_EventLogs.md) and
 [about_Group_Policy_Settings](about_Group_Policy_Settings.md).
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -506,7 +506,7 @@ The following modules (or snap-ins) are installed with PowerShell.
 
 Beginning in PowerShell 3.0, you can record execution events for the cmdlets
 and functions in PowerShell modules and snap-ins by setting the
-**LogPipelineExecutionDetails** property of modules and snap-ins to `$True`. 
+**LogPipelineExecutionDetails** property of modules and snap-ins to `$True`.
 You can also use a Group Policy setting, Turn on Module Logging, to enable
 module logging in all PowerShell sessions. For more information, see
 [about_EventLogs](about_EventLogs.md) and

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -15,8 +15,9 @@ variables are created and maintained by PowerShell.
 
 ## LONG DESCRIPTION
 
-Conceptually, these variables are considered to be read-only.
-Even though they **can** be written to, for backward compatibility they **should not** be written to.
+Conceptually, these variables are considered to be read-only. Even though they
+**can** be written to, for backward compatibility they **should not** be
+written to.
 
 Here is a list of the automatic variables in  PowerShell:
 
@@ -35,7 +36,7 @@ Contains the first token in the last line received by the session.
 
 ### $_
 
-Same as $PSItem. Contains the current object in the pipeline object. You
+Same as `$PSItem`. Contains the current object in the pipeline object. You
 can use this variable in commands that perform an action on every object or
 on selected objects in a pipeline.
 
@@ -47,41 +48,40 @@ function, you can declare the parameters by using the param keyword or by
 adding a comma-separated list of parameters in parentheses after the
 function name.
 
-In an event action, the $Args variable contains objects that represent the
+In an event action, the `$Args` variable contains objects that represent the
 event arguments of the event that is being processed. This variable is
 populated only within the Action block of an event registration command.
 The value of this variable can also be found in the SourceArgs property of
-the PSEventArgs object (System.Management.Automation.PSEventArgs) that
-Get-Event returns.
+the **PSEventArgs** object that `Get-Event` returns.
 
 ### $CONSOLEFILENAME
 
 Contains the path of the console file (.psc1) that was most recently used
 in the session. This variable is populated when you start PowerShell with
-the PSConsoleFile parameter or when you use the Export-Console cmdlet to
+the PSConsoleFile parameter or when you use the `Export-Console` cmdlet to
 export snap-in names to a console file.
 
-When you use the Export-Console cmdlet without parameters, it automatically
+When you use the `Export-Console` cmdlet without parameters, it automatically
 updates the console file that was most recently used in the session. You
 can use this automatic variable to determine which file will be updated.
 
 ### $ERROR
 
 Contains an array of error objects that represent the most recent errors.
-The most recent error is the first error object in the array ($Error[0]).
+The most recent error is the first error object in the array `$Error[0]`.
 
-To prevent an error from being added to the $Error array, use the
-ErrorAction common parameter with a value of Ignore. For more information,
-see [about_CommonParameters](about_CommonParameters.md).
+To prevent an error from being added to the `$Error` array, use the
+**ErrorAction** common parameter with a value of **Ignore**. For more
+information, see [about_CommonParameters](about_CommonParameters.md).
 
 ### $EVENT
 
-Contains a PSEventArgs object that represents the event that is being
+Contains a **PSEventArgs** object that represents the event that is being
 processed. This variable is populated only within the Action block of an
-event registration command, such as Register-ObjectEvent. The value of this
-variable is the same object that the Get-Event cmdlet returns. Therefore,
-you can use the properties of the $Event variable, such as
-$Event.TimeGenerated , in an Action script block.
+event registration command, such as `Register-ObjectEvent`. The value of this
+variable is the same object that the `Get-Event` cmdlet returns. Therefore,
+you can use the properties of the `Event` variable, such as
+`$Event.TimeGenerated`, in an Action script block.
 
 ### $EVENTARGS
 
@@ -89,19 +89,18 @@ Contains an object that represents the first event argument that derives
 from EventArgs of the event that is being processed. This variable is
 populated only within the Action block of an event registration command.
 The value of this variable can also be found in the SourceEventArgs
-property of the PSEventArgs (System.Management.Automation.PSEventArgs)
-object that Get-Event returns.
+property of the **PSEventArgs** object that `Get-Event` returns.
 
 ### $EVENTSUBSCRIBER
 
-Contains a PSEventSubscriber object that represents the event subscriber of
+Contains a **PSEventSubscriber** object that represents the event subscriber of
 the event that is being processed. This variable is populated only within
 the Action block of an event registration command. The value of this
-variable is the same object that the Get-EventSubscriber cmdlet returns.
+variable is the same object that the `Get-EventSubscriber` cmdlet returns.
 
 ### $EXECUTIONCONTEXT
 
-Contains an EngineIntrinsics object that represents the execution context
+Contains an **EngineIntrinsics** object that represents the execution context
 of the PowerShell host. You can use this variable to find the execution
 objects that are available to cmdlets.
 
@@ -116,33 +115,33 @@ non-zero integer.
 
 Contains the enumerator (not the resulting values) of a ForEach loop. You
 can use the properties and methods of enumerators on the value of the
-$ForEach variable. This variable exists only while the ForEach loop is
+`$ForEach` variable. This variable exists only while the `ForEach` loop is
 running; it is deleted after the loop is completed. For detailed
 information, see [about_ForEach](about_ForEach.md).
 
 ### $HOME
 
 Contains the full path of the user's home directory. This variable is the
-equivalent of the `%homedrive%%homepath%` Windows environment variables,
-typically C:\\Users\\<UserName>.
+equivalent of the `"$env:homedrive$env:homepath"` Windows environment variables,
+typically `C:\Users\<UserName>`.
 
 ### $HOST
 
 Contains an object that represents the current host application for
 PowerShell. You can use this variable to represent the current host in
 commands or to display or change the properties of the host, such as
-$Host.version or $Host.CurrentCulture, or
-$host.ui.rawui.setbackgroundcolor("Red").
+`$Host.version` or `$Host.CurrentCulture`, or
+`$host.ui.rawui.setbackgroundcolor("Red")`.
 
 ### $INPUT
 
 Contains an enumerator that enumerates all input that is passed to a
-function. The $input variable is available only to functions and script
+function. The `$input` variable is available only to functions and script
 blocks (which are unnamed functions). In the Process block of a function,
-the $input variable enumerates the object that is currently in the
+the `$input` variable enumerates the object that is currently in the
 pipeline. When the Process block completes, there are no objects left in
-the pipeline, so the $input variable enumerates an empty collection. If the
-function does not have a Process block, then in the End block, the $input
+the pipeline, so the `$input` variable enumerates an empty collection. If the
+function does not have a Process block, then in the End block, the `$input`
 variable enumerates the collection of all input to the function.
 
 ### $LASTEXITCODE
@@ -151,11 +150,11 @@ Contains the exit code of the last Windows-based program that was run.
 
 ### $MATCHES
 
-The $Matches variable works with the `-match` and `-notmatch` operators.
+The `Matches` variable works with the `-match` and `-notmatch` operators.
 When you submit scalar input to the `-match` or `-notmatch` operator, and
 either one detects a match, they return a Boolean value and populate the
 $Matches automatic variable with a hash table of any string values that
-were matched. For more information about the -match operator, see
+were matched. For more information about the `-match` operator, see
 [about_comparison_operators](about_comparison_operators.md).
 
 ### $MYINVOCATION
@@ -165,14 +164,14 @@ parameters, parameter values, and information about how the command was
 started, called, or "invoked," such as the name of the script that called
 the current command.
 
-\$MyInvocation is populated only for scripts, function, and script blocks.
+`$MyInvocation` is populated only for scripts, function, and script blocks.
 You can use the information in the System.Management.Automation.InvocationInfo
-object that \$MyInvocation returns in the current script, such as the path and
-file name of the script (\$MyInvocation.MyCommand.Path) or the name of a
-function (\$MyInvocation.MyCommand.Name) to identify the current command. This
+object that `$MyInvocation` returns in the current script, such as the path and
+file name of the script (`$MyInvocation.MyCommand.Path`) or the name of a
+function (`$MyInvocation.MyCommand.Name`) to identify the current command. This
 is particularly useful for finding the name of the current script.
 
-Beginning in PowerShell 3.0, $MyInvocation has the following new
+Beginning in PowerShell 3.0, `MyInvocation` has the following new
 properties.
 
 | Property      | Description                                         |
@@ -185,10 +184,10 @@ properties.
 |               | property is populated only when the caller is a     |
 |               | script.                                             |
 
-Unlike the $PSScriptRoot and $PSCommandPath automatic variables, the
-PSScriptRoot and PSCommandPath properties of the $MyInvocation automatic
-variable contain information about the invoker or calling script, not the
-current script.
+Unlike the `$PSScriptRoot` and `$PSCommandPath` automatic variables, the
+**PSScriptRoot** and **PSCommandPath** properties of the `$MyInvocation`
+automatic variable contain information about the invoker or calling script,
+not the current script.
 
 ### $NESTEDPROMPTLEVEL
 
@@ -197,30 +196,30 @@ prompt level. The value is incremented when you enter a nested level and
 decremented when you exit it.
 
 For example, PowerShell presents a nested command prompt when you use the
-$Host.EnterNestedPrompt method. PowerShell also presents a nested command
+`$Host.EnterNestedPrompt` method. PowerShell also presents a nested command
 prompt when you reach a breakpoint in the PowerShell debugger.
 
 When you enter a nested prompt, PowerShell pauses the current command,
 saves the execution context, and increments the value of the
-$NestedPromptLevel variable. To create additional nested command prompts
+`$NestedPromptLevel` variable. To create additional nested command prompts
 (up to 128 levels) or to return to the original command prompt, complete
-the command, or type "exit".
+the command, or type `exit`.
 
-The $NestedPromptLevel variable helps you track the prompt level. You can
+The `$NestedPromptLevel` variable helps you track the prompt level. You can
 create an alternative PowerShell command prompt that includes this value so
 that it is always visible.
 
 ### $NULL
 
-$null is an automatic variable that contains a NULL or empty value. You can
+`$null` is an automatic variable that contains a NULL or empty value. You can
 use this variable to represent an absent or undefined value in commands and
 scripts.
 
-PowerShell treats $null as an object with a value, that is, as an explicit
-placeholder, so you can use $null to represent an empty value in a series
+PowerShell treats `$null` as an object with a value, that is, as an explicit
+placeholder, so you can use `$null` to represent an empty value in a series
 of values.
 
-For example, when $null is included in a collection, it is counted as one
+For example, when `$null` is included in a collection, it is counted as one
 of the objects.
 
 ```powershell
@@ -232,8 +231,8 @@ $a.count
 3
 ```
 
-If you pipe the $null variable to the ForEach-Object cmdlet, it generates a
-value for $null, just as it does for the other objects
+If you pipe the `$null` variable to the `ForEach-Object` cmdlet, it generates a
+value for `$null`, just as it does for the other objects
 
 ```powershell
 "one", $null, "three" | ForEach-Object { "Hello " + $_}
@@ -245,11 +244,11 @@ Hello
 Hello three
 ```
 
-As a result, you cannot use $null to mean "no parameter value." A parameter
-value of $null overrides the default parameter value.
+As a result, you cannot use `$null` to mean "no parameter value." A parameter
+value of `$null` overrides the default parameter value.
 
-However, because PowerShell treats the $null variable as a placeholder, you
-can use it in scripts like the following one, which would not work if $null
+However, because PowerShell treats the `$null` variable as a placeholder, you
+can use it in scripts like the following one, which would not work if `$null`
 were ignored.
 
 ```powershell
@@ -286,13 +285,13 @@ profile in commands. For example, you can use it in a command to determine
 whether a profile has been created:
 
 ```powershell
-test-path $profile
+Test-Path $PROFILE
 ```
 
 Or, you can use it in a command to create a profile:
 
 ```powershell
-new-item -type file -path $pshome -force
+New-Item -ItemType file -Path $PSHOME -Force
 ```
 
 You can also use it in a command to open the profile in Notepad:
@@ -330,11 +329,11 @@ being run.
 
 You can use the properties and methods of the object in your cmdlet or
 function code to respond to the conditions of use. For example, the
-ParameterSetName property contains the name of the parameter set that is
-being used, and the ShouldProcess method adds the WhatIf and Confirm
-parameters to the cmdlet dynamically.
+**ParameterSetName** property contains the name of the parameter set that is
+being used, and the **ShouldProcess** method adds the **WhatIf** and
+**Confirm** parameters to the cmdlet dynamically.
 
-For more information about the $PSCmdlet automatic variable, see
+For more information about the `$PSCmdlet` automatic variable, see
 [about_Functions_Advanced](about_Functions_Advanced.md).
 
 ### $PSCOMMANDPATH
@@ -347,24 +346,24 @@ variable is valid in all scripts.
 Contains the name of the culture currently in use in the operating system.
 The culture determines the display format of items such as numbers,
 currency, and dates. This is the value of the
-System.Globalization.CultureInfo.CurrentCulture.Name property of the
-system. To get the System.Globalization.CultureInfo object for the system,
-use the Get-Culture cmdlet.
+**System.Globalization.CultureInfo.CurrentCulture.Name** property of the
+system. To get the **System.Globalization.CultureInfo** object for the system,
+use the `Get-Culture` cmdlet.
 
 ### $PSDEBUGCONTEXT
 
 While debugging, this variable contains information about the debugging
-environment. Otherwise, it contains a NULL value. As a result, you can use
-it to indicate whether the debugger has control. When populated, it
-contains a PsDebugContext object that has Breakpoints and InvocationInfo
-properties. The InvocationInfo property has several useful properties,
-including the Location property. The Location property indicates the path
-of the script that is being debugged.
+environment. Otherwise, it contains a NULL value. As a result, you can use it
+to indicate whether the debugger has control. When populated, it contains a
+**PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
+properties. The **InvocationInfo** property has several useful properties,
+including the **Location** property. The **Location** property indicates the
+path of the script that is being debugged.
 
 ### $PSHOME
 
 Contains the full path of the installation directory for PowerShell,
-typically, `%windir%\System32\PowerShell\v1.0` in Windows systems. You can
+typically, `$env:windir\System32\PowerShell\v1.0` in Windows systems. You can
 use this variable in the paths of PowerShell files. For example, the
 following command searches the conceptual Help topics for the word
 "variable":
@@ -375,7 +374,7 @@ Select-String -Pattern Variable -Path $pshome\*.txt
 
 ### $PSITEM
 
-Same as $_. Contains the current object in the pipeline object. You can use
+Same as `$_`. Contains the current object in the pipeline object. You can use
 this variable in commands that perform an action on every object or on
 selected objects in a pipeline.
 
@@ -392,20 +391,20 @@ Contains information about the user who started the PSSession, including
 the user identity and the time zone of the originating computer. This
 variable is available only in PSSessions.
 
-The $PSSenderInfo variable includes a user-configurable property,
-ApplicationArguments, which, by default, contains only the $PSVersionTable
-from the originating session. To add data to the ApplicationArguments
-property, use the ApplicationArguments parameter of the New-PSSessionOption
-cmdlet.
+The `$PSSenderInfo` variable includes a user-configurable property,
+**ApplicationArguments**, which, by default, contains only the
+`$PSVersionTable` from the originating session. To add data to the
+**ApplicationArguments** property, use the **ApplicationArguments** parameter
+of the `New-PSSessionOption` cmdlet.
 
 ### $PSUICULTURE
 
-Contains the name of the user interface (UI) culture that is currently in
-use in the operating system. The UI culture determines which text strings
-are used for user interface elements, such as menus and messages. This is
-the value of the System.Globalization.CultureInfo.CurrentUICulture.Name
-property of the system. To get the System.Globalization.CultureInfo object
-for the system, use the Get-UICulture cmdlet.
+Contains the name of the user interface (UI) culture that is currently in use
+in the operating system. The UI culture determines which text strings are used
+for user interface elements, such as menus and messages. This is the value of
+the **System.Globalization.CultureInfo.CurrentUICulture.Name** property of the
+system. To get the **System.Globalization.CultureInfo** object for the system,
+use the `Get-UICulture` cmdlet.
 
 ### $PSVERSIONTABLE
 
@@ -435,13 +434,12 @@ following items:
 
 ### $PWD
 
-Contains a path object that represents the full path of the current
-directory.
+Contains a path object that represents the full path of the current directory.
 
 ### REPORTERRORSHOW VARIABLES
 
-The "ReportErrorShow" variables are defined in PowerShell, but they are not
-implemented. Get-Variable gets them, but they do not contain valid data.
+The **ReportErrorShow** variables are defined in PowerShell, but they are not
+implemented. `Get-Variable` gets them, but they do not contain valid data.
 
 - $REPORTERRORSHOWEXCEPTIONCLASS
 - $REPORTERRORSHOWINNEREXCEPTION
@@ -452,20 +450,21 @@ implemented. Get-Variable gets them, but they do not contain valid data.
 
 Contains the object that generated this event. This variable is populated
 only within the Action block of an event registration command. The value of
-this variable can also be found in the Sender property of the PSEventArgs
-(System.Management.Automation.PSEventArgs) object that Get-Event returns.
+this variable can also be found in the Sender property of the **PSEventArgs**
+object that `Get-Event` returns.
 
 ### $SHELLID
 
 Contains the identifier of the current shell.
 
 ### $STACKTRACE
+
 Contains a stack trace for the most recent error.
 
 ### $THIS
 
 In a script block that defines a script property or script method, the
-$This variable refers to the object that is being extended.
+`$This` variable refers to the object that is being extended.
 
 ### $TRUE
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -1,8 +1,10 @@
+---
 ms.date:  06/09/2017
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Language_Keywords
+---
 
 # About Language Keywords
 
@@ -66,12 +68,12 @@ objects are received from the pipeline.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
-DynamicParam {<statement list>}
-begin {<statement list>}
-process {<statement list>}
-end {<statement list>}
+    DynamicParam {<statement list>}
+    begin {<statement list>}
+    process {<statement list>}
+    end {<statement list>}
 }
 ```
 
@@ -81,7 +83,7 @@ Causes a script to exit a loop.
 
 Syntax:
 
-```powershell
+```Syntax
 while (<condition>) {
    <statements>
    ...
@@ -101,7 +103,7 @@ indicates that the error type is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [[<error type>]] {<statement list>}
 ```
@@ -112,7 +114,7 @@ Specifies a new class in PowerShell.
 
 Syntax:
 
-```powershell
+```Syntax
 class <class-name> {
     [[hidden] [static] <property-definition> ...]
     [<class-name>([argument-list>]) {<constructor-statement-list>} ...]
@@ -127,7 +129,7 @@ condition is met, the script begins the loop again.
 
 Syntax:
 
-```powershell
+```Syntax
 while (<condition>) {
    <statements>
    ...
@@ -142,40 +144,39 @@ while (<condition>) {
 ### Data
 
 In a script, defines a section that isolates data from the script logic. Can
-also include If statements and some limited commands.
+also include `If` statements and some limited commands.
 
 Syntax:
 
-```powershell
+```Syntax
 data <variable> [-supportedCommand <cmdlet-name>] {<permitted content>}
 ```
 
 ### Do
 
-Used with the While or Until keyword as a looping construct. Windows
-PowerShell runs the statement list at least one time, unlike a loop that uses
-While.
+Used with the `While` or `Until` keyword as a looping construct. PowerShell
+runs the statement list at least one time, unlike a loop that uses `While`.
 
-Syntax for _While_:
+Syntax for `While`:
 
-```powershell
+```Syntax
 do {<statement list>} while (<condition>)
 ```
 
-Syntax for _Until_:
+Syntax for `Until`:
 
-```powershell
+```Syntax
 do {<statement list>} until (<condition>)
 ```
 
 ### DynamicParam
 
-Specifies one part of the body of a function, along with the Begin, Process,
-and End keywords. Dynamic parameters are added at run time.
+Specifies one part of the body of a function, along with the `Begin`, `Process`,
+and `End` keywords. Dynamic parameters are added at run time.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -186,23 +187,23 @@ function <name> {
 
 ### Else
 
-Used with the If keyword to specify the default statement list.
+Used with the `If` keyword to specify the default statement list.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 else {<statement list>}
 ```
 
 ### Elseif
 
-Used with the If and Else keywords to specify additional conditionals. The
-Else keyword is optional.
+Used with the `If` and `Else` keywords to specify additional conditionals. The
+`Else` keyword is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 elseif (<condition>) {<statement list>}
 else {<statement list>}
@@ -210,13 +211,13 @@ else {<statement list>}
 
 ### End
 
-Specifies one part of the body of a function, along with the DynamicParam,
-Begin, and End keywords. The End statement list runs one time after all the
+Specifies one part of the body of a function, along with the `DynamicParam`,
+`Begin`, and `End` keywords. The `End` statement list runs one time after all the
 objects have been received from the pipeline.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -232,7 +233,7 @@ a set of named labels called the enumerator list.
 
 Syntax:
 
-```powershell
+```Syntax
 enum <enum-name> {
     <label> [= <int-value>]
     ...
@@ -245,7 +246,7 @@ Causes PowerShell to exit a script or a PowerShell instance.
 
 Syntax:
 
-```
+```Syntax
 exit
 exit <exitcode>
 ```
@@ -257,10 +258,10 @@ to indicate the post-execution status of the script.
 
 In PowerShell, the exit statement sets the value of the `$LASTEXITCODE`
 variable. In the Windows Command Shell (cmd.exe), the exit statement sets the
-value of the `%ERRORLEVEL% environment variable.
+value of the `%ERRORLEVEL%` environment variable.
 
 In the following example, the user sets the error level variable value to 4 by
-adding 'exit 4' to the script file _test.ps1_.
+adding `exit 4` to the script file _test.ps1_.
 
 ```cmd
 C:\scripts\test>type test.ps1
@@ -295,19 +296,19 @@ block.
 
 Syntax:
 
-```powershell
+```Syntax
 filter <name> {<statement list>}
 ```
 
 ### Finally
 
 Defines a statement list that runs after statements that are associated with
-Try and Catch. A Finally statement list runs even if you press CTRL+C to leave
+Try and Catch. A `Finally` statement list runs even if you press `CTRL+C` to leave
 a script or if you use the Exit keyword in the script.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [<error type>] {<statement list>}
 finally {<statement list>}
@@ -319,7 +320,7 @@ Defines a loop by using a condition.
 
 Syntax:
 
-```powershell
+```Syntax
 for (<initialize>; <condition>; <iterate>) { <statement list> }
 ```
 
@@ -329,7 +330,7 @@ Defines a loop by using each member of a collection.
 
 Syntax:
 
-```powershell
+```Syntax
 ForEach (<item> in <collection>) { <statement list> }
 ```
 
@@ -341,12 +342,12 @@ Reserved for future use.
 
 Creates a named statement list of reusable code. You can name the scope a
 function belongs to. And, you can specify one or more named parameters by
-using the Param keyword. Within the function statement list, you can include
-DynamicParam, Begin, Process, and End statement lists.
+using the `Param` keyword. Within the function statement list, you can include
+`DynamicParam`, `Begin`, `Process`, and `End` statement lists.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> {
    param ([type]<$pname1> [, [type]<$pname2>])
    DynamicParam {<statement list>}
@@ -361,7 +362,7 @@ statement list after the function name.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> [([type]<$pname1>, [[type]<$pname2>])] {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -376,29 +377,29 @@ Defines a conditional.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 ```
 
 ### Hidden
 
-Hides class members from the default results of the Get-Member cmdlet, and
+Hides class members from the default results of the `Get-Member` cmdlet, and
 from IntelliSense and tab completion results.
 
 Syntax:
 
-```powershell
+```Syntax
 Hidden [data type] $member_name
 ```
 
 ### In
 
-Used in a ForEach statement to create a loop that uses each member of a
+Used in a `ForEach` statement to create a loop that uses each member of a
 collection.
 
 Syntax:
 
-```powershell
+```Syntax
 ForEach (<item> in <collection>){<statement list>}
 ```
 
@@ -409,7 +410,7 @@ only in a PowerShell Workflow.
 
 Syntax:
 
-```powershell
+```Syntax
 workflow <verb>-<noun>
 {
    InlineScript
@@ -421,14 +422,13 @@ workflow <verb>-<noun>
 }
 ```
 
-The InlineScript keyword indicates an InlineScript activity, which runs
+The `InlineScript` keyword indicates an `InlineScript` activity, which runs
 commands in a shared standard (non-workflow) session. You can use the
-InlineScript keyword to run commands that are not otherwise valid in a
+`InlineScript` keyword to run commands that are not otherwise valid in a
 workflow, and to run commands that share data. By default, the commands in an
 InlineScript script block run in a separate process.
 
-For more information, see about_InlineScript and
-[Running PowerShell Commands in a Workflow](http://technet.microsoft.com/library/jj574197.aspx).
+For more information, see [Running PowerShell Commands in a Workflow](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/jj574197(v=ws.11)).
 
 ### Param
 
@@ -436,7 +436,7 @@ Defines the parameters in a function.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> {
    param ([type]<$pname1>[, [[type]<$pname2>]])
    <statement list>
@@ -445,16 +445,16 @@ function [<scope:>]<name> {
 
 ### Process
 
-Specifies a part of the body of a function, along with the DynamicParam,
-Begin, and End keywords. When a Process statement list receives input from the
-pipeline, the Process statement list runs one time for each element from the
-pipeline. If the pipeline provides no objects, the Process statement list does
-not run. If the command is the first command in the pipeline, the Process
-statement list runs one time.
+Specifies a part of the body of a function, along with the `DynamicParam`,
+`Begin`, and `End` keywords. When a `Process` statement list receives input
+from the pipeline, the `Process` statement list runs one time for each element
+from the pipeline. If the pipeline provides no objects, the `Process`
+statement list does not run. If the command is the first command in the
+pipeline, the `Process` statement list runs one time.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -470,7 +470,7 @@ and writes the optional expression to the output.
 
 Syntax:
 
-```powershell
+```Syntax
 return [<expression>]
 ```
 
@@ -479,19 +479,19 @@ return [<expression>]
 Specifies the property or method defined is common to all instances of the
 class in which is defined.
 
-See, in this topic, **Class**  for usage examples.
+See `Class` for usage examples.
 
 ### Switch
 
-To check multiple conditions, use a Switch statement. The Switch statement is
+To check multiple conditions, use a `Switch` statement. The `Switch` statement is
 equivalent to a series of If statements, but it is simpler.
 
-The Switch statement lists each condition and an optional action. If a
+The `Switch` statement lists each condition and an optional action. If a
 condition obtains, the action is performed.
 
 Syntax 1:
 
-```powershell
+```Syntax
 switch [-regex|-wildcard|-exact][-casesensitive] ( <value> )
 {
    <string>|<number>|<variable>|{ <expression> } {<statement list>}
@@ -504,7 +504,7 @@ switch [-regex|-wildcard|-exact][-casesensitive] ( <value> )
 
 Syntax 2:
 
-```powershell
+```Syntax
 switch [-regex|-wildcard|-exact][-casesensitive] -file <filename>
 {
    <string>|<number>|<variable>|{ <expression> } {<statement list>}
@@ -521,7 +521,7 @@ Throws an object as an error.
 
 Syntax:
 
-```powershell
+```Syntax
 throw [<object>]
 ```
 
@@ -533,20 +533,20 @@ is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 trap [[<error type>]] {<statement list>}
 ```
 
 ### Try
 
 Defines a statement list to be checked for errors while the statements run. If
-an error occurs, PowerShell continues running in a Catch or Finally statement.
-An error type requires brackets. The second pair of brackets indicates that
-the error type is optional.
+an error occurs, PowerShell continues running in a `Catch` or `Finally`
+statement. An error type requires brackets. The second pair of brackets
+indicates that the error type is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [[<error type>]] {<statement list>}
 finally {<statement list>}
@@ -554,12 +554,12 @@ finally {<statement list>}
 
 ### Until
 
-Used in a Do statement as a looping construct where the statement list is
+Used in a `Do` statement as a looping construct where the statement list is
 executed at least one time.
 
 Syntax:
 
-```powershell
+```Syntax
 do {<statement list>} until (<condition>)
 ```
 
@@ -570,23 +570,36 @@ members require less typing to mention them. You can also include classes from
 modules.
 
 Syntax #1:
-```
+
+```Syntax
 using namespace <.Net-framework-namespace>
 ```
 
 Syntax #2:
-```
+
+```Syntax
 using module <module-name>
 ```
 
 ### While
 
-Used in a Do statement as a looping construct where the statement list is
-executed at least one time.
+The `while` statement is a looping construct where the condition is tested
+before the statements are executed. If the condition is FALSE, then the
+statements do not execute.
 
-Syntax:
+Statement syntax:
 
-```powershell
+```Syntax
+while (<condition>) {
+   <statements>
+ }
+
+When used in a `Do` statement, `while` is part of a looping construct where
+the statement list is executed at least one time.
+
+Do loop Syntax:
+
+```Syntax
 do {<statement list>} while (<condition>)
 ```
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -62,8 +62,8 @@ Language Keywords
 
 ### Begin
 
-Specifies one part of the body of a function, along with the DynamicParam,
-Process, and End keywords. The Begin statement list runs one time before any
+Specifies one part of the body of a function, along with the `DynamicParam`,
+`Process`, and `End` keywords. The `Begin` statement list runs one time before any
 objects are received from the pipeline.
 
 Syntax:
@@ -593,6 +593,7 @@ Statement syntax:
 while (<condition>) {
    <statements>
  }
+```
 
 When used in a `Do` statement, `while` is part of a looping construct where
 the statement list is executed at least one time.

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -1,11 +1,10 @@
 ---
-ms.date:  11/29/2017
+ms.date:  01/04/2018
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Modules
 ---
-
 # About Modules
 
 ## Short Description
@@ -23,8 +22,8 @@ modules to their PowerShell sessions and use them just like the built-in
 commands.
 
 This topic explains how to use PowerShell modules. For information about how
-to write PowerShell modules, see [Writing a PowerShell Module](https://go.microsoft.com/fwlink/?LinkId=144916)
-in the MSDN library.
+to write PowerShell modules, see
+[Writing a PowerShell Module](/powershell/developer/module/writing-a-windows-powershell-module).
 
 ## What Is a Module?
 
@@ -43,6 +42,7 @@ gets all commands in all installed modules, even if they are not yet in the
 session, so you can find a command and use it without importing.
 
 Any of the following commands will import a module into your session.
+
 ### Run the Command
 
 ```powershell
@@ -68,14 +68,14 @@ Only modules that are stored in the location specified by the PSModulePath
 environment variable are automatically imported. Modules in other locations
 must be imported by running the `Import-Module` cmdlet.
 
-Also, commands that use PowerShell providers do not automatically
-import a module. For example, if you use a command that requires the WSMan:
-drive, such as the `Get-PSSessionConfiguration` cmdlet, you might need to
-run the `Import-Module` cmdlet to import the Microsoft.WSMan.Management
-module that includes the WSMan: drive.
+Also, commands that use PowerShell providers do not automatically import a
+module. For example, if you use a command that requires the WSMan: drive, such
+as the `Get-PSSessionConfiguration` cmdlet, you might need to run the
+`Import-Module` cmdlet to import the **Microsoft.WSMan.Management** module that
+includes the `WSMan:` drive.
 
 You can still run the `Import-Module` command to import a module and
-use the $PSModuleAutoloadingPreference variable to enable, disable and
+use the `$PSModuleAutoloadingPreference` variable to enable, disable and
 configure automatic importing of modules. For more information, see
 [about_Preference_Variables](about_Preference_Variables.md).
 
@@ -104,7 +104,6 @@ the Turn Windows features on or off dialog box in Control Panel, any
 PowerShell modules that are part of the feature are installed. Many other
 modules come in an installer or Setup program that installs the module.
 
-
 Create a Modules directory for the current user if one does not exist. To
 create a Modules directory, type:
 
@@ -115,7 +114,7 @@ New-Item -Type Directory -Path $HOME\Documents\WindowsPowerShell\Modules
 Copy the entire module folder into the Modules directory. You can use any
 method to copy the folder, including Windows Explorer and Cmd.exe, as well as
 PowerShell. In PowerShell use the `Copy-Item` cmdlet. For example, to copy the
-MyModule folder from C:\\ps-test\\MyModule to the Modules directory, type:
+MyModule folder from `C:\ps-test\MyModule` to the Modules directory, type:
 
 ```powershell
 Copy-Item -Path C:\ps-test\MyModule -Destination `
@@ -201,9 +200,9 @@ For more information, see [Get-Help](../Get-Help.md) and
 
 You might have to import a module or import a module file. Importing is
 required when a module is not installed in the locations specified by the
-PSModulePath environment variable ($env:PSModulePath), or the module consists
-of file, such as a .dll or .psm1 file, instead of typical module that is
-delivered as a folder.
+**PSModulePath** environment variable, `$env:PSModulePath`, or the module
+consists of file, such as a .dll or .psm1 file, instead of typical module that
+is delivered as a folder.
 
 You might also choose to import a module so that you can use the parameters of
 the `Import-Module` command, such as the Prefix parameter, which adds a
@@ -291,42 +290,43 @@ PowerShell 4.0, with the introduction of DSC, a new default module and DSC
 resource folder was introduced. For more information about DSC, see
 about_DesiredStateConfiguration.
 
-- System: $pshome\Modules (%windir%\System32\WindowsPowerShell\v1.0\Modules)
+- System: `$pshome\Modules` or
+  (`$env:windir\System32\WindowsPowerShell\v1.0\Modules`)
   System modules are those that ship with Windows and PowerShell.
 
   Starting in PowerShell 4.0, when PowerShell Desired State Configuration
   (DSC) was introduced, DSC resources that are included with PowerShell are
-  also stored in \$pshome\\Modules, in the
-  \$pshome\\Modules\\PSDesiredStateConfiguration\\DSCResources folder.
+  also stored in `$PSHOME\Modules`, in the
+  `$pshome\Modules\PSDesiredStateConfiguration\DSCResources` folder.
 
-- Current user: \$home\\Documents\\WindowsPowerShell\\Modules
-  (%UserProfile%\Documents\WindowsPowerShell\Modules)
+- Current user: `$home\Documents\WindowsPowerShell\Modules`
+  (`$env:UserProfile\Documents\WindowsPowerShell\Modules`)
 
   or
 
-  \$home\\My Documents\\WindowsPowerShell\\Modules
-  (%UserProfile%\My Documents\WindowsPowerShell\Modules)
+  `$home\My Documents\WindowsPowerShell\Modules`
+  (`$env:UserProfile\My Documents\WindowsPowerShell\Modules`)
   This is the location for user-added modules prior to PowerShell 4.0.
 
 In PowerShell 4.0 and later releases of PowerShell, user-added modules and DSC
-resources are stored in C:\\Program Files\\WindowsPowerShell\\Modules. Modules
+resources are stored in `C:\Program Files\WindowsPowerShell\Modules`. Modules
 and DSC resources in this location are accessible by all users of the
 computer. This change was required because the DSC engine runs as local
 system, and could not access user-specific paths, such as
-\$home\\Documents\\WindowsPowerShell\\Modules.
+`$home\Documents\WindowsPowerShell\Modules`.
 
 Starting in PowerShell 5.0, with the addition of the PowerShellGet module, and
-the [PowerShell Gallery](https://www.powershellgallery.com) of community- and
+the [PowerShell Gallery](https://www.powershellgallery.com) of community and
 Microsoft-created resources, the `Install-Module` command installs modules and
-DSC resources to C:\\Program Files\\WindowsPowerShell\\Modules by default.
+DSC resources to `C:\Program Files\WindowsPowerShell\Modules` by default.
 
-Note: To add or change files in the %Windir%\\System32 directory, start
+Note: To add or change files in the `$env:Windir\System32` directory, start
 PowerShell with the "Run as administrator" option.
 
 You can change the default module locations on your system by changing the
-value of the PSModulePath environment variable ($Env:PSModulePath). The
-PSModulePath environment variable is modeled on the Path environment variable
-and has the same format.
+value of the **PSModulePath** environment variable, `$Env:PSModulePath`. The
+**PSModulePath** environment variable is modeled on the Path environment
+variable and has the same format.
 
 To view the default module locations, type:
 
@@ -343,23 +343,23 @@ $Env:PSModulePath = $Env:PSModulePath + ";<path>"
 The semi-colon (;) in the command separates the new path from the
 path that precedes it in the list.
 
-For example, to add the "C:\ps-test\Modules" directory, type:
+For example, to add the `C:\ps-test\Modules` directory, type:
 
 ```powershell
 $Env:PSModulePath + ";C:\ps-test\Modules"
 ```
 
-When you add a path to PSModulePath, `Get-Module` and `Import-Module`
+When you add a path to **PSModulePath**, `Get-Module` and `Import-Module`
 commands include modules in that path.
 
 The value that you set affects only the current session. To make the
 change persistent, add the command to your PowerShell profile
-or use System in Control Panel to change the value of the PSModulePath
+or use System in Control Panel to change the value of the **PSModulePath**
 environment variable in the registry.
 
 Also, to make the change persistent, you can also use the
-SetEnvironmentVariable method of the System.Environment class to add
-a Path to the PSModulePath environment variable.
+**SetEnvironmentVariable** method of the **System.Environment** class to add a
+Path to the **PSModulePath** environment variable.
 
 For more information about the PSModulePath variable, see
 [about_Environment_Variables](about_Environment_Variables.md).
@@ -508,9 +508,9 @@ The following modules (or snap-ins) are installed with PowerShell.
 
 Beginning in PowerShell 3.0, you can record execution events for the cmdlets
 and functions in PowerShell modules and snap-ins by setting the
-LogPipelineExecutionDetails property of modules and snap-ins to \$True. You can
-also use a Group Policy setting, Turn on Module Logging, to enable module
-logging in all PowerShell sessions. For more information, see
+**LogPipelineExecutionDetails** property of modules and snap-ins to `$True`. 
+You can also use a Group Policy setting, Turn on Module Logging, to enable
+module logging in all PowerShell sessions. For more information, see
 [about_EventLogs](about_EventLogs.md) and
 [about_Group_Policy_Settings](about_Group_Policy_Settings.md).
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -508,7 +508,7 @@ The following modules (or snap-ins) are installed with PowerShell.
 
 Beginning in PowerShell 3.0, you can record execution events for the cmdlets
 and functions in PowerShell modules and snap-ins by setting the
-**LogPipelineExecutionDetails** property of modules and snap-ins to `$True`. 
+**LogPipelineExecutionDetails** property of modules and snap-ins to `$True`.
 You can also use a Group Policy setting, Turn on Module Logging, to enable
 module logging in all PowerShell sessions. For more information, see
 [about_EventLogs](about_EventLogs.md) and

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -15,8 +15,9 @@ variables are created and maintained by PowerShell.
 
 ## LONG DESCRIPTION
 
-Conceptually, these variables are considered to be read-only.
-Even though they **can** be written to, for backward compatibility they **should not** be written to.
+Conceptually, these variables are considered to be read-only. Even though they
+**can** be written to, for backward compatibility they **should not** be
+written to.
 
 Here is a list of the automatic variables in  PowerShell:
 
@@ -35,7 +36,7 @@ Contains the first token in the last line received by the session.
 
 ### $_
 
-Same as $PSItem. Contains the current object in the pipeline object. You
+Same as `$PSItem`. Contains the current object in the pipeline object. You
 can use this variable in commands that perform an action on every object or
 on selected objects in a pipeline.
 
@@ -47,41 +48,40 @@ function, you can declare the parameters by using the param keyword or by
 adding a comma-separated list of parameters in parentheses after the
 function name.
 
-In an event action, the $Args variable contains objects that represent the
+In an event action, the `$Args` variable contains objects that represent the
 event arguments of the event that is being processed. This variable is
 populated only within the Action block of an event registration command.
 The value of this variable can also be found in the SourceArgs property of
-the PSEventArgs object (System.Management.Automation.PSEventArgs) that
-Get-Event returns.
+the **PSEventArgs** object that `Get-Event` returns.
 
 ### $CONSOLEFILENAME
 
 Contains the path of the console file (.psc1) that was most recently used
 in the session. This variable is populated when you start PowerShell with
-the PSConsoleFile parameter or when you use the Export-Console cmdlet to
+the PSConsoleFile parameter or when you use the `Export-Console` cmdlet to
 export snap-in names to a console file.
 
-When you use the Export-Console cmdlet without parameters, it automatically
+When you use the `Export-Console` cmdlet without parameters, it automatically
 updates the console file that was most recently used in the session. You
 can use this automatic variable to determine which file will be updated.
 
 ### $ERROR
 
 Contains an array of error objects that represent the most recent errors.
-The most recent error is the first error object in the array ($Error[0]).
+The most recent error is the first error object in the array `$Error[0]`.
 
-To prevent an error from being added to the $Error array, use the
-ErrorAction common parameter with a value of Ignore. For more information,
-see [about_CommonParameters](about_CommonParameters.md).
+To prevent an error from being added to the `$Error` array, use the
+**ErrorAction** common parameter with a value of **Ignore**. For more
+information, see [about_CommonParameters](about_CommonParameters.md).
 
 ### $EVENT
 
-Contains a PSEventArgs object that represents the event that is being
+Contains a **PSEventArgs** object that represents the event that is being
 processed. This variable is populated only within the Action block of an
-event registration command, such as Register-ObjectEvent. The value of this
-variable is the same object that the Get-Event cmdlet returns. Therefore,
-you can use the properties of the $Event variable, such as
-$Event.TimeGenerated , in an Action script block.
+event registration command, such as `Register-ObjectEvent`. The value of this
+variable is the same object that the `Get-Event` cmdlet returns. Therefore,
+you can use the properties of the `Event` variable, such as
+`$Event.TimeGenerated`, in an Action script block.
 
 ### $EVENTARGS
 
@@ -89,19 +89,18 @@ Contains an object that represents the first event argument that derives
 from EventArgs of the event that is being processed. This variable is
 populated only within the Action block of an event registration command.
 The value of this variable can also be found in the SourceEventArgs
-property of the PSEventArgs (System.Management.Automation.PSEventArgs)
-object that Get-Event returns.
+property of the **PSEventArgs** object that `Get-Event` returns.
 
 ### $EVENTSUBSCRIBER
 
-Contains a PSEventSubscriber object that represents the event subscriber of
+Contains a **PSEventSubscriber** object that represents the event subscriber of
 the event that is being processed. This variable is populated only within
 the Action block of an event registration command. The value of this
-variable is the same object that the Get-EventSubscriber cmdlet returns.
+variable is the same object that the `Get-EventSubscriber` cmdlet returns.
 
 ### $EXECUTIONCONTEXT
 
-Contains an EngineIntrinsics object that represents the execution context
+Contains an **EngineIntrinsics** object that represents the execution context
 of the PowerShell host. You can use this variable to find the execution
 objects that are available to cmdlets.
 
@@ -116,33 +115,33 @@ non-zero integer.
 
 Contains the enumerator (not the resulting values) of a ForEach loop. You
 can use the properties and methods of enumerators on the value of the
-$ForEach variable. This variable exists only while the ForEach loop is
+`$ForEach` variable. This variable exists only while the `ForEach` loop is
 running; it is deleted after the loop is completed. For detailed
 information, see [about_ForEach](about_ForEach.md).
 
 ### $HOME
 
 Contains the full path of the user's home directory. This variable is the
-equivalent of the `%homedrive%%homepath%` Windows environment variables,
-typically C:\\Users\\<UserName>.
+equivalent of the `"$env:homedrive$env:homepath"` Windows environment variables,
+typically `C:\Users\<UserName>`.
 
 ### $HOST
 
 Contains an object that represents the current host application for
 PowerShell. You can use this variable to represent the current host in
 commands or to display or change the properties of the host, such as
-$Host.version or $Host.CurrentCulture, or
-$host.ui.rawui.setbackgroundcolor("Red").
+`$Host.version` or `$Host.CurrentCulture`, or
+`$host.ui.rawui.setbackgroundcolor("Red")`.
 
 ### $INPUT
 
 Contains an enumerator that enumerates all input that is passed to a
-function. The $input variable is available only to functions and script
+function. The `$input` variable is available only to functions and script
 blocks (which are unnamed functions). In the Process block of a function,
-the $input variable enumerates the object that is currently in the
+the `$input` variable enumerates the object that is currently in the
 pipeline. When the Process block completes, there are no objects left in
-the pipeline, so the $input variable enumerates an empty collection. If the
-function does not have a Process block, then in the End block, the $input
+the pipeline, so the `$input` variable enumerates an empty collection. If the
+function does not have a Process block, then in the End block, the `$input`
 variable enumerates the collection of all input to the function.
 
 ### $LASTEXITCODE
@@ -151,11 +150,11 @@ Contains the exit code of the last Windows-based program that was run.
 
 ### $MATCHES
 
-The $Matches variable works with the `-match` and `-notmatch` operators.
+The `Matches` variable works with the `-match` and `-notmatch` operators.
 When you submit scalar input to the `-match` or `-notmatch` operator, and
 either one detects a match, they return a Boolean value and populate the
 $Matches automatic variable with a hash table of any string values that
-were matched. For more information about the -match operator, see
+were matched. For more information about the `-match` operator, see
 [about_comparison_operators](about_comparison_operators.md).
 
 ### $MYINVOCATION
@@ -165,14 +164,14 @@ parameters, parameter values, and information about how the command was
 started, called, or "invoked," such as the name of the script that called
 the current command.
 
-\$MyInvocation is populated only for scripts, function, and script blocks.
+`$MyInvocation` is populated only for scripts, function, and script blocks.
 You can use the information in the System.Management.Automation.InvocationInfo
-object that \$MyInvocation returns in the current script, such as the path and
-file name of the script (\$MyInvocation.MyCommand.Path) or the name of a
-function (\$MyInvocation.MyCommand.Name) to identify the current command. This
+object that `$MyInvocation` returns in the current script, such as the path and
+file name of the script (`$MyInvocation.MyCommand.Path`) or the name of a
+function (`$MyInvocation.MyCommand.Name`) to identify the current command. This
 is particularly useful for finding the name of the current script.
 
-Beginning in PowerShell 3.0, $MyInvocation has the following new
+Beginning in PowerShell 3.0, `MyInvocation` has the following new
 properties.
 
 | Property      | Description                                         |
@@ -185,10 +184,10 @@ properties.
 |               | property is populated only when the caller is a     |
 |               | script.                                             |
 
-Unlike the $PSScriptRoot and $PSCommandPath automatic variables, the
-PSScriptRoot and PSCommandPath properties of the $MyInvocation automatic
-variable contain information about the invoker or calling script, not the
-current script.
+Unlike the `$PSScriptRoot` and `$PSCommandPath` automatic variables, the
+**PSScriptRoot** and **PSCommandPath** properties of the `$MyInvocation`
+automatic variable contain information about the invoker or calling script,
+not the current script.
 
 ### $NESTEDPROMPTLEVEL
 
@@ -197,30 +196,30 @@ prompt level. The value is incremented when you enter a nested level and
 decremented when you exit it.
 
 For example, PowerShell presents a nested command prompt when you use the
-$Host.EnterNestedPrompt method. PowerShell also presents a nested command
+`$Host.EnterNestedPrompt` method. PowerShell also presents a nested command
 prompt when you reach a breakpoint in the PowerShell debugger.
 
 When you enter a nested prompt, PowerShell pauses the current command,
 saves the execution context, and increments the value of the
-$NestedPromptLevel variable. To create additional nested command prompts
+`$NestedPromptLevel` variable. To create additional nested command prompts
 (up to 128 levels) or to return to the original command prompt, complete
-the command, or type "exit".
+the command, or type `exit`.
 
-The $NestedPromptLevel variable helps you track the prompt level. You can
+The `$NestedPromptLevel` variable helps you track the prompt level. You can
 create an alternative PowerShell command prompt that includes this value so
 that it is always visible.
 
 ### $NULL
 
-$null is an automatic variable that contains a NULL or empty value. You can
+`$null` is an automatic variable that contains a NULL or empty value. You can
 use this variable to represent an absent or undefined value in commands and
 scripts.
 
-PowerShell treats $null as an object with a value, that is, as an explicit
-placeholder, so you can use $null to represent an empty value in a series
+PowerShell treats `$null` as an object with a value, that is, as an explicit
+placeholder, so you can use `$null` to represent an empty value in a series
 of values.
 
-For example, when $null is included in a collection, it is counted as one
+For example, when `$null` is included in a collection, it is counted as one
 of the objects.
 
 ```powershell
@@ -232,8 +231,8 @@ $a.count
 3
 ```
 
-If you pipe the $null variable to the ForEach-Object cmdlet, it generates a
-value for $null, just as it does for the other objects
+If you pipe the `$null` variable to the `ForEach-Object` cmdlet, it generates a
+value for `$null`, just as it does for the other objects
 
 ```powershell
 "one", $null, "three" | ForEach-Object { "Hello " + $_}
@@ -245,11 +244,11 @@ Hello
 Hello three
 ```
 
-As a result, you cannot use $null to mean "no parameter value." A parameter
-value of $null overrides the default parameter value.
+As a result, you cannot use `$null` to mean "no parameter value." A parameter
+value of `$null` overrides the default parameter value.
 
-However, because PowerShell treats the $null variable as a placeholder, you
-can use it in scripts like the following one, which would not work if $null
+However, because PowerShell treats the `$null` variable as a placeholder, you
+can use it in scripts like the following one, which would not work if `$null`
 were ignored.
 
 ```powershell
@@ -286,13 +285,13 @@ profile in commands. For example, you can use it in a command to determine
 whether a profile has been created:
 
 ```powershell
-test-path $profile
+Test-Path $PROFILE
 ```
 
 Or, you can use it in a command to create a profile:
 
 ```powershell
-new-item -type file -path $pshome -force
+New-Item -ItemType file -Path $PSHOME -Force
 ```
 
 You can also use it in a command to open the profile in Notepad:
@@ -330,11 +329,11 @@ being run.
 
 You can use the properties and methods of the object in your cmdlet or
 function code to respond to the conditions of use. For example, the
-ParameterSetName property contains the name of the parameter set that is
-being used, and the ShouldProcess method adds the WhatIf and Confirm
-parameters to the cmdlet dynamically.
+**ParameterSetName** property contains the name of the parameter set that is
+being used, and the **ShouldProcess** method adds the **WhatIf** and
+**Confirm** parameters to the cmdlet dynamically.
 
-For more information about the $PSCmdlet automatic variable, see
+For more information about the `$PSCmdlet` automatic variable, see
 [about_Functions_Advanced](about_Functions_Advanced.md).
 
 ### $PSCOMMANDPATH
@@ -347,24 +346,24 @@ variable is valid in all scripts.
 Contains the name of the culture currently in use in the operating system.
 The culture determines the display format of items such as numbers,
 currency, and dates. This is the value of the
-System.Globalization.CultureInfo.CurrentCulture.Name property of the
-system. To get the System.Globalization.CultureInfo object for the system,
-use the Get-Culture cmdlet.
+**System.Globalization.CultureInfo.CurrentCulture.Name** property of the
+system. To get the **System.Globalization.CultureInfo** object for the system,
+use the `Get-Culture` cmdlet.
 
 ### $PSDEBUGCONTEXT
 
 While debugging, this variable contains information about the debugging
-environment. Otherwise, it contains a NULL value. As a result, you can use
-it to indicate whether the debugger has control. When populated, it
-contains a PsDebugContext object that has Breakpoints and InvocationInfo
-properties. The InvocationInfo property has several useful properties,
-including the Location property. The Location property indicates the path
-of the script that is being debugged.
+environment. Otherwise, it contains a NULL value. As a result, you can use it
+to indicate whether the debugger has control. When populated, it contains a
+**PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
+properties. The **InvocationInfo** property has several useful properties,
+including the **Location** property. The **Location** property indicates the
+path of the script that is being debugged.
 
 ### $PSHOME
 
 Contains the full path of the installation directory for PowerShell,
-typically, `%windir%\System32\PowerShell\v1.0` in Windows systems. You can
+typically, `$env:windir\System32\PowerShell\v1.0` in Windows systems. You can
 use this variable in the paths of PowerShell files. For example, the
 following command searches the conceptual Help topics for the word
 "variable":
@@ -375,7 +374,7 @@ Select-String -Pattern Variable -Path $pshome\*.txt
 
 ### $PSITEM
 
-Same as $_. Contains the current object in the pipeline object. You can use
+Same as `$_`. Contains the current object in the pipeline object. You can use
 this variable in commands that perform an action on every object or on
 selected objects in a pipeline.
 
@@ -392,20 +391,20 @@ Contains information about the user who started the PSSession, including
 the user identity and the time zone of the originating computer. This
 variable is available only in PSSessions.
 
-The $PSSenderInfo variable includes a user-configurable property,
-ApplicationArguments, which, by default, contains only the $PSVersionTable
-from the originating session. To add data to the ApplicationArguments
-property, use the ApplicationArguments parameter of the New-PSSessionOption
-cmdlet.
+The `$PSSenderInfo` variable includes a user-configurable property,
+**ApplicationArguments**, which, by default, contains only the
+`$PSVersionTable` from the originating session. To add data to the
+**ApplicationArguments** property, use the **ApplicationArguments** parameter
+of the `New-PSSessionOption` cmdlet.
 
 ### $PSUICULTURE
 
-Contains the name of the user interface (UI) culture that is currently in
-use in the operating system. The UI culture determines which text strings
-are used for user interface elements, such as menus and messages. This is
-the value of the System.Globalization.CultureInfo.CurrentUICulture.Name
-property of the system. To get the System.Globalization.CultureInfo object
-for the system, use the Get-UICulture cmdlet.
+Contains the name of the user interface (UI) culture that is currently in use
+in the operating system. The UI culture determines which text strings are used
+for user interface elements, such as menus and messages. This is the value of
+the **System.Globalization.CultureInfo.CurrentUICulture.Name** property of the
+system. To get the **System.Globalization.CultureInfo** object for the system,
+use the `Get-UICulture` cmdlet.
 
 ### $PSVERSIONTABLE
 
@@ -435,13 +434,12 @@ following items:
 
 ### $PWD
 
-Contains a path object that represents the full path of the current
-directory.
+Contains a path object that represents the full path of the current directory.
 
 ### REPORTERRORSHOW VARIABLES
 
-The "ReportErrorShow" variables are defined in PowerShell, but they are not
-implemented. Get-Variable gets them, but they do not contain valid data.
+The **ReportErrorShow** variables are defined in PowerShell, but they are not
+implemented. `Get-Variable` gets them, but they do not contain valid data.
 
 - $REPORTERRORSHOWEXCEPTIONCLASS
 - $REPORTERRORSHOWINNEREXCEPTION
@@ -452,20 +450,21 @@ implemented. Get-Variable gets them, but they do not contain valid data.
 
 Contains the object that generated this event. This variable is populated
 only within the Action block of an event registration command. The value of
-this variable can also be found in the Sender property of the PSEventArgs
-(System.Management.Automation.PSEventArgs) object that Get-Event returns.
+this variable can also be found in the Sender property of the **PSEventArgs**
+object that `Get-Event` returns.
 
 ### $SHELLID
 
 Contains the identifier of the current shell.
 
 ### $STACKTRACE
+
 Contains a stack trace for the most recent error.
 
 ### $THIS
 
 In a script block that defines a script property or script method, the
-$This variable refers to the object that is being extended.
+`$This` variable refers to the object that is being extended.
 
 ### $TRUE
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -1,8 +1,10 @@
+---
 ms.date:  06/09/2017
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Language_Keywords
+---
 
 # About Language Keywords
 
@@ -66,12 +68,12 @@ objects are received from the pipeline.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
-DynamicParam {<statement list>}
-begin {<statement list>}
-process {<statement list>}
-end {<statement list>}
+    DynamicParam {<statement list>}
+    begin {<statement list>}
+    process {<statement list>}
+    end {<statement list>}
 }
 ```
 
@@ -81,7 +83,7 @@ Causes a script to exit a loop.
 
 Syntax:
 
-```powershell
+```Syntax
 while (<condition>) {
    <statements>
    ...
@@ -101,7 +103,7 @@ indicates that the error type is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [[<error type>]] {<statement list>}
 ```
@@ -112,7 +114,7 @@ Specifies a new class in PowerShell.
 
 Syntax:
 
-```powershell
+```Syntax
 class <class-name> {
     [[hidden] [static] <property-definition> ...]
     [<class-name>([argument-list>]) {<constructor-statement-list>} ...]
@@ -127,7 +129,7 @@ condition is met, the script begins the loop again.
 
 Syntax:
 
-```powershell
+```Syntax
 while (<condition>) {
    <statements>
    ...
@@ -142,40 +144,39 @@ while (<condition>) {
 ### Data
 
 In a script, defines a section that isolates data from the script logic. Can
-also include If statements and some limited commands.
+also include `If` statements and some limited commands.
 
 Syntax:
 
-```powershell
+```Syntax
 data <variable> [-supportedCommand <cmdlet-name>] {<permitted content>}
 ```
 
 ### Do
 
-Used with the While or Until keyword as a looping construct. Windows
-PowerShell runs the statement list at least one time, unlike a loop that uses
-While.
+Used with the `While` or `Until` keyword as a looping construct. PowerShell
+runs the statement list at least one time, unlike a loop that uses `While`.
 
-Syntax for _While_:
+Syntax for `While`:
 
-```powershell
+```Syntax
 do {<statement list>} while (<condition>)
 ```
 
-Syntax for _Until_:
+Syntax for `Until`:
 
-```powershell
+```Syntax
 do {<statement list>} until (<condition>)
 ```
 
 ### DynamicParam
 
-Specifies one part of the body of a function, along with the Begin, Process,
-and End keywords. Dynamic parameters are added at run time.
+Specifies one part of the body of a function, along with the `Begin`, `Process`,
+and `End` keywords. Dynamic parameters are added at run time.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -186,23 +187,23 @@ function <name> {
 
 ### Else
 
-Used with the If keyword to specify the default statement list.
+Used with the `If` keyword to specify the default statement list.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 else {<statement list>}
 ```
 
 ### Elseif
 
-Used with the If and Else keywords to specify additional conditionals. The
-Else keyword is optional.
+Used with the `If` and `Else` keywords to specify additional conditionals. The
+`Else` keyword is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 elseif (<condition>) {<statement list>}
 else {<statement list>}
@@ -210,13 +211,13 @@ else {<statement list>}
 
 ### End
 
-Specifies one part of the body of a function, along with the DynamicParam,
-Begin, and End keywords. The End statement list runs one time after all the
+Specifies one part of the body of a function, along with the `DynamicParam`,
+`Begin`, and `End` keywords. The `End` statement list runs one time after all the
 objects have been received from the pipeline.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -232,7 +233,7 @@ a set of named labels called the enumerator list.
 
 Syntax:
 
-```powershell
+```Syntax
 enum <enum-name> {
     <label> [= <int-value>]
     ...
@@ -245,7 +246,7 @@ Causes PowerShell to exit a script or a PowerShell instance.
 
 Syntax:
 
-```
+```Syntax
 exit
 exit <exitcode>
 ```
@@ -257,10 +258,10 @@ to indicate the post-execution status of the script.
 
 In PowerShell, the exit statement sets the value of the `$LASTEXITCODE`
 variable. In the Windows Command Shell (cmd.exe), the exit statement sets the
-value of the `%ERRORLEVEL% environment variable.
+value of the `%ERRORLEVEL%` environment variable.
 
 In the following example, the user sets the error level variable value to 4 by
-adding 'exit 4' to the script file _test.ps1_.
+adding `exit 4` to the script file _test.ps1_.
 
 ```cmd
 C:\scripts\test>type test.ps1
@@ -295,19 +296,19 @@ block.
 
 Syntax:
 
-```powershell
+```Syntax
 filter <name> {<statement list>}
 ```
 
 ### Finally
 
 Defines a statement list that runs after statements that are associated with
-Try and Catch. A Finally statement list runs even if you press CTRL+C to leave
+Try and Catch. A `Finally` statement list runs even if you press `CTRL+C` to leave
 a script or if you use the Exit keyword in the script.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [<error type>] {<statement list>}
 finally {<statement list>}
@@ -319,7 +320,7 @@ Defines a loop by using a condition.
 
 Syntax:
 
-```powershell
+```Syntax
 for (<initialize>; <condition>; <iterate>) { <statement list> }
 ```
 
@@ -329,7 +330,7 @@ Defines a loop by using each member of a collection.
 
 Syntax:
 
-```powershell
+```Syntax
 ForEach (<item> in <collection>) { <statement list> }
 ```
 
@@ -341,12 +342,12 @@ Reserved for future use.
 
 Creates a named statement list of reusable code. You can name the scope a
 function belongs to. And, you can specify one or more named parameters by
-using the Param keyword. Within the function statement list, you can include
-DynamicParam, Begin, Process, and End statement lists.
+using the `Param` keyword. Within the function statement list, you can include
+`DynamicParam`, `Begin`, `Process`, and `End` statement lists.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> {
    param ([type]<$pname1> [, [type]<$pname2>])
    DynamicParam {<statement list>}
@@ -361,7 +362,7 @@ statement list after the function name.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> [([type]<$pname1>, [[type]<$pname2>])] {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -376,29 +377,29 @@ Defines a conditional.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 ```
 
 ### Hidden
 
-Hides class members from the default results of the Get-Member cmdlet, and
+Hides class members from the default results of the `Get-Member` cmdlet, and
 from IntelliSense and tab completion results.
 
 Syntax:
 
-```powershell
+```Syntax
 Hidden [data type] $member_name
 ```
 
 ### In
 
-Used in a ForEach statement to create a loop that uses each member of a
+Used in a `ForEach` statement to create a loop that uses each member of a
 collection.
 
 Syntax:
 
-```powershell
+```Syntax
 ForEach (<item> in <collection>){<statement list>}
 ```
 
@@ -409,7 +410,7 @@ only in a PowerShell Workflow.
 
 Syntax:
 
-```powershell
+```Syntax
 workflow <verb>-<noun>
 {
    InlineScript
@@ -421,14 +422,13 @@ workflow <verb>-<noun>
 }
 ```
 
-The InlineScript keyword indicates an InlineScript activity, which runs
+The `InlineScript` keyword indicates an `InlineScript` activity, which runs
 commands in a shared standard (non-workflow) session. You can use the
-InlineScript keyword to run commands that are not otherwise valid in a
+`InlineScript` keyword to run commands that are not otherwise valid in a
 workflow, and to run commands that share data. By default, the commands in an
 InlineScript script block run in a separate process.
 
-For more information, see about_InlineScript and
-[Running PowerShell Commands in a Workflow](http://technet.microsoft.com/library/jj574197.aspx).
+For more information, see [Running PowerShell Commands in a Workflow](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/jj574197(v=ws.11)).
 
 ### Param
 
@@ -436,7 +436,7 @@ Defines the parameters in a function.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> {
    param ([type]<$pname1>[, [[type]<$pname2>]])
    <statement list>
@@ -445,16 +445,16 @@ function [<scope:>]<name> {
 
 ### Process
 
-Specifies a part of the body of a function, along with the DynamicParam,
-Begin, and End keywords. When a Process statement list receives input from the
-pipeline, the Process statement list runs one time for each element from the
-pipeline. If the pipeline provides no objects, the Process statement list does
-not run. If the command is the first command in the pipeline, the Process
-statement list runs one time.
+Specifies a part of the body of a function, along with the `DynamicParam`,
+`Begin`, and `End` keywords. When a `Process` statement list receives input
+from the pipeline, the `Process` statement list runs one time for each element
+from the pipeline. If the pipeline provides no objects, the `Process`
+statement list does not run. If the command is the first command in the
+pipeline, the `Process` statement list runs one time.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -470,7 +470,7 @@ and writes the optional expression to the output.
 
 Syntax:
 
-```powershell
+```Syntax
 return [<expression>]
 ```
 
@@ -479,19 +479,19 @@ return [<expression>]
 Specifies the property or method defined is common to all instances of the
 class in which is defined.
 
-See, in this topic, **Class**  for usage examples.
+See `Class` for usage examples.
 
 ### Switch
 
-To check multiple conditions, use a Switch statement. The Switch statement is
+To check multiple conditions, use a `Switch` statement. The `Switch` statement is
 equivalent to a series of If statements, but it is simpler.
 
-The Switch statement lists each condition and an optional action. If a
+The `Switch` statement lists each condition and an optional action. If a
 condition obtains, the action is performed.
 
 Syntax 1:
 
-```powershell
+```Syntax
 switch [-regex|-wildcard|-exact][-casesensitive] ( <value> )
 {
    <string>|<number>|<variable>|{ <expression> } {<statement list>}
@@ -504,7 +504,7 @@ switch [-regex|-wildcard|-exact][-casesensitive] ( <value> )
 
 Syntax 2:
 
-```powershell
+```Syntax
 switch [-regex|-wildcard|-exact][-casesensitive] -file <filename>
 {
    <string>|<number>|<variable>|{ <expression> } {<statement list>}
@@ -521,7 +521,7 @@ Throws an object as an error.
 
 Syntax:
 
-```powershell
+```Syntax
 throw [<object>]
 ```
 
@@ -533,20 +533,20 @@ is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 trap [[<error type>]] {<statement list>}
 ```
 
 ### Try
 
 Defines a statement list to be checked for errors while the statements run. If
-an error occurs, PowerShell continues running in a Catch or Finally statement.
-An error type requires brackets. The second pair of brackets indicates that
-the error type is optional.
+an error occurs, PowerShell continues running in a `Catch` or `Finally`
+statement. An error type requires brackets. The second pair of brackets
+indicates that the error type is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [[<error type>]] {<statement list>}
 finally {<statement list>}
@@ -554,12 +554,12 @@ finally {<statement list>}
 
 ### Until
 
-Used in a Do statement as a looping construct where the statement list is
+Used in a `Do` statement as a looping construct where the statement list is
 executed at least one time.
 
 Syntax:
 
-```powershell
+```Syntax
 do {<statement list>} until (<condition>)
 ```
 
@@ -570,23 +570,36 @@ members require less typing to mention them. You can also include classes from
 modules.
 
 Syntax #1:
-```
+
+```Syntax
 using namespace <.Net-framework-namespace>
 ```
 
 Syntax #2:
-```
+
+```Syntax
 using module <module-name>
 ```
 
 ### While
 
-Used in a Do statement as a looping construct where the statement list is
-executed at least one time.
+The `while` statement is a looping construct where the condition is tested
+before the statements are executed. If the condition is FALSE, then the
+statements do not execute.
 
-Syntax:
+Statement syntax:
 
-```powershell
+```Syntax
+while (<condition>) {
+   <statements>
+ }
+
+When used in a `Do` statement, `while` is part of a looping construct where
+the statement list is executed at least one time.
+
+Do loop Syntax:
+
+```Syntax
 do {<statement list>} while (<condition>)
 ```
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -62,8 +62,8 @@ Language Keywords
 
 ### Begin
 
-Specifies one part of the body of a function, along with the DynamicParam,
-Process, and End keywords. The Begin statement list runs one time before any
+Specifies one part of the body of a function, along with the `DynamicParam`,
+`Process`, and `End` keywords. The `Begin` statement list runs one time before any
 objects are received from the pipeline.
 
 Syntax:
@@ -593,6 +593,7 @@ Statement syntax:
 while (<condition>) {
    <statements>
  }
+```
 
 When used in a `Do` statement, `while` is part of a looping construct where
 the statement list is executed at least one time.

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -5,7 +5,6 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Modules
 ---
-
 # About Modules
 
 ## Short Description
@@ -23,8 +22,8 @@ modules to their PowerShell sessions and use them just like the built-in
 commands.
 
 This topic explains how to use PowerShell modules. For information about how
-to write PowerShell modules, see [Writing a PowerShell Module](https://go.microsoft.com/fwlink/?LinkId=144916)
-in the MSDN library.
+to write PowerShell modules, see
+[Writing a PowerShell Module](/powershell/developer/module/writing-a-windows-powershell-module).
 
 ## What Is a Module?
 
@@ -43,6 +42,7 @@ gets all commands in all installed modules, even if they are not yet in the
 session, so you can find a command and use it without importing.
 
 Any of the following commands will import a module into your session.
+
 ### Run the Command
 
 ```powershell
@@ -68,14 +68,14 @@ Only modules that are stored in the location specified by the PSModulePath
 environment variable are automatically imported. Modules in other locations
 must be imported by running the `Import-Module` cmdlet.
 
-Also, commands that use PowerShell providers do not automatically
-import a module. For example, if you use a command that requires the WSMan:
-drive, such as the `Get-PSSessionConfiguration` cmdlet, you might need to
-run the `Import-Module` cmdlet to import the Microsoft.WSMan.Management
-module that includes the WSMan: drive.
+Also, commands that use PowerShell providers do not automatically import a
+module. For example, if you use a command that requires the WSMan: drive, such
+as the `Get-PSSessionConfiguration` cmdlet, you might need to run the
+`Import-Module` cmdlet to import the **Microsoft.WSMan.Management** module that
+includes the `WSMan:` drive.
 
 You can still run the `Import-Module` command to import a module and
-use the $PSModuleAutoloadingPreference variable to enable, disable and
+use the `$PSModuleAutoloadingPreference` variable to enable, disable and
 configure automatic importing of modules. For more information, see
 [about_Preference_Variables](about_Preference_Variables.md).
 
@@ -104,7 +104,6 @@ the Turn Windows features on or off dialog box in Control Panel, any
 PowerShell modules that are part of the feature are installed. Many other
 modules come in an installer or Setup program that installs the module.
 
-
 Create a Modules directory for the current user if one does not exist. To
 create a Modules directory, type:
 
@@ -115,7 +114,7 @@ New-Item -Type Directory -Path $HOME\Documents\WindowsPowerShell\Modules
 Copy the entire module folder into the Modules directory. You can use any
 method to copy the folder, including Windows Explorer and Cmd.exe, as well as
 PowerShell. In PowerShell use the `Copy-Item` cmdlet. For example, to copy the
-MyModule folder from C:\\ps-test\\MyModule to the Modules directory, type:
+MyModule folder from `C:\ps-test\MyModule` to the Modules directory, type:
 
 ```powershell
 Copy-Item -Path C:\ps-test\MyModule -Destination `
@@ -201,9 +200,9 @@ For more information, see [Get-Help](../Get-Help.md) and
 
 You might have to import a module or import a module file. Importing is
 required when a module is not installed in the locations specified by the
-PSModulePath environment variable ($env:PSModulePath), or the module consists
-of file, such as a .dll or .psm1 file, instead of typical module that is
-delivered as a folder.
+**PSModulePath** environment variable, `$env:PSModulePath`, or the module
+consists of file, such as a .dll or .psm1 file, instead of typical module that
+is delivered as a folder.
 
 You might also choose to import a module so that you can use the parameters of
 the `Import-Module` command, such as the Prefix parameter, which adds a
@@ -291,42 +290,43 @@ PowerShell 4.0, with the introduction of DSC, a new default module and DSC
 resource folder was introduced. For more information about DSC, see
 about_DesiredStateConfiguration.
 
-- System: $pshome\Modules (%windir%\System32\WindowsPowerShell\v1.0\Modules)
+- System: `$pshome\Modules` or
+  (`$env:windir\System32\WindowsPowerShell\v1.0\Modules`)
   System modules are those that ship with Windows and PowerShell.
 
   Starting in PowerShell 4.0, when PowerShell Desired State Configuration
   (DSC) was introduced, DSC resources that are included with PowerShell are
-  also stored in \$pshome\\Modules, in the
-  \$pshome\\Modules\\PSDesiredStateConfiguration\\DSCResources folder.
+  also stored in `$PSHOME\Modules`, in the
+  `$pshome\Modules\PSDesiredStateConfiguration\DSCResources` folder.
 
-- Current user: \$home\\Documents\\WindowsPowerShell\\Modules
-  (%UserProfile%\Documents\WindowsPowerShell\Modules)
+- Current user: `$home\Documents\WindowsPowerShell\Modules`
+  (`$env:UserProfile\Documents\WindowsPowerShell\Modules`)
 
   or
 
-  \$home\\My Documents\\WindowsPowerShell\\Modules
-  (%UserProfile%\My Documents\WindowsPowerShell\Modules)
+  `$home\My Documents\WindowsPowerShell\Modules`
+  (`$env:UserProfile\My Documents\WindowsPowerShell\Modules`)
   This is the location for user-added modules prior to PowerShell 4.0.
 
 In PowerShell 4.0 and later releases of PowerShell, user-added modules and DSC
-resources are stored in C:\\Program Files\\WindowsPowerShell\\Modules. Modules
+resources are stored in `C:\Program Files\WindowsPowerShell\Modules`. Modules
 and DSC resources in this location are accessible by all users of the
 computer. This change was required because the DSC engine runs as local
 system, and could not access user-specific paths, such as
-\$home\\Documents\\WindowsPowerShell\\Modules.
+`$home\Documents\WindowsPowerShell\Modules`.
 
 Starting in PowerShell 5.0, with the addition of the PowerShellGet module, and
-the [PowerShell Gallery](https://www.powershellgallery.com) of community- and
+the [PowerShell Gallery](https://www.powershellgallery.com) of community and
 Microsoft-created resources, the `Install-Module` command installs modules and
-DSC resources to C:\\Program Files\\WindowsPowerShell\\Modules by default.
+DSC resources to `C:\Program Files\WindowsPowerShell\Modules` by default.
 
-Note: To add or change files in the %Windir%\\System32 directory, start
+Note: To add or change files in the `$env:Windir\System32` directory, start
 PowerShell with the "Run as administrator" option.
 
 You can change the default module locations on your system by changing the
-value of the PSModulePath environment variable ($Env:PSModulePath). The
-PSModulePath environment variable is modeled on the Path environment variable
-and has the same format.
+value of the **PSModulePath** environment variable, `$Env:PSModulePath`. The
+**PSModulePath** environment variable is modeled on the Path environment
+variable and has the same format.
 
 To view the default module locations, type:
 
@@ -343,23 +343,23 @@ $Env:PSModulePath = $Env:PSModulePath + ";<path>"
 The semi-colon (;) in the command separates the new path from the
 path that precedes it in the list.
 
-For example, to add the "C:\ps-test\Modules" directory, type:
+For example, to add the `C:\ps-test\Modules` directory, type:
 
 ```powershell
 $Env:PSModulePath + ";C:\ps-test\Modules"
 ```
 
-When you add a path to PSModulePath, `Get-Module` and `Import-Module`
+When you add a path to **PSModulePath**, `Get-Module` and `Import-Module`
 commands include modules in that path.
 
 The value that you set affects only the current session. To make the
 change persistent, add the command to your PowerShell profile
-or use System in Control Panel to change the value of the PSModulePath
+or use System in Control Panel to change the value of the **PSModulePath**
 environment variable in the registry.
 
 Also, to make the change persistent, you can also use the
-SetEnvironmentVariable method of the System.Environment class to add
-a Path to the PSModulePath environment variable.
+**SetEnvironmentVariable** method of the **System.Environment** class to add a
+Path to the **PSModulePath** environment variable.
 
 For more information about the PSModulePath variable, see
 [about_Environment_Variables](about_Environment_Variables.md).
@@ -509,9 +509,9 @@ The following modules (or snap-ins) are installed with PowerShell.
 
 Beginning in PowerShell 3.0, you can record execution events for the cmdlets
 and functions in PowerShell modules and snap-ins by setting the
-LogPipelineExecutionDetails property of modules and snap-ins to \$True. You can
-also use a Group Policy setting, Turn on Module Logging, to enable module
-logging in all PowerShell sessions. For more information, see
+**LogPipelineExecutionDetails** property of modules and snap-ins to `$True`. 
+You can also use a Group Policy setting, Turn on Module Logging, to enable
+module logging in all PowerShell sessions. For more information, see
 [about_EventLogs](about_EventLogs.md) and
 [about_Group_Policy_Settings](about_Group_Policy_Settings.md).
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -509,7 +509,7 @@ The following modules (or snap-ins) are installed with PowerShell.
 
 Beginning in PowerShell 3.0, you can record execution events for the cmdlets
 and functions in PowerShell modules and snap-ins by setting the
-**LogPipelineExecutionDetails** property of modules and snap-ins to `$True`. 
+**LogPipelineExecutionDetails** property of modules and snap-ins to `$True`.
 You can also use a Group Policy setting, Turn on Module Logging, to enable
 module logging in all PowerShell sessions. For more information, see
 [about_EventLogs](about_EventLogs.md) and

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Automatic_Variables.md
@@ -15,8 +15,9 @@ variables are created and maintained by PowerShell.
 
 ## LONG DESCRIPTION
 
-Conceptually, these variables are considered to be read-only.
-Even though they **can** be written to, for backward compatibility they **should not** be written to.
+Conceptually, these variables are considered to be read-only. Even though they
+**can** be written to, for backward compatibility they **should not** be
+written to.
 
 Here is a list of the automatic variables in  PowerShell:
 
@@ -35,7 +36,7 @@ Contains the first token in the last line received by the session.
 
 ### $_
 
-Same as $PSItem. Contains the current object in the pipeline object. You
+Same as `$PSItem`. Contains the current object in the pipeline object. You
 can use this variable in commands that perform an action on every object or
 on selected objects in a pipeline.
 
@@ -47,41 +48,40 @@ function, you can declare the parameters by using the param keyword or by
 adding a comma-separated list of parameters in parentheses after the
 function name.
 
-In an event action, the $Args variable contains objects that represent the
+In an event action, the `$Args` variable contains objects that represent the
 event arguments of the event that is being processed. This variable is
 populated only within the Action block of an event registration command.
 The value of this variable can also be found in the SourceArgs property of
-the PSEventArgs object (System.Management.Automation.PSEventArgs) that
-Get-Event returns.
+the **PSEventArgs** object that `Get-Event` returns.
 
 ### $CONSOLEFILENAME
 
 Contains the path of the console file (.psc1) that was most recently used
 in the session. This variable is populated when you start PowerShell with
-the PSConsoleFile parameter or when you use the Export-Console cmdlet to
+the PSConsoleFile parameter or when you use the `Export-Console` cmdlet to
 export snap-in names to a console file.
 
-When you use the Export-Console cmdlet without parameters, it automatically
+When you use the `Export-Console` cmdlet without parameters, it automatically
 updates the console file that was most recently used in the session. You
 can use this automatic variable to determine which file will be updated.
 
 ### $ERROR
 
 Contains an array of error objects that represent the most recent errors.
-The most recent error is the first error object in the array ($Error[0]).
+The most recent error is the first error object in the array `$Error[0]`.
 
-To prevent an error from being added to the $Error array, use the
-ErrorAction common parameter with a value of Ignore. For more information,
-see [about_CommonParameters](about_CommonParameters.md).
+To prevent an error from being added to the `$Error` array, use the
+**ErrorAction** common parameter with a value of **Ignore**. For more
+information, see [about_CommonParameters](about_CommonParameters.md).
 
 ### $EVENT
 
-Contains a PSEventArgs object that represents the event that is being
+Contains a **PSEventArgs** object that represents the event that is being
 processed. This variable is populated only within the Action block of an
-event registration command, such as Register-ObjectEvent. The value of this
-variable is the same object that the Get-Event cmdlet returns. Therefore,
-you can use the properties of the $Event variable, such as
-$Event.TimeGenerated , in an Action script block.
+event registration command, such as `Register-ObjectEvent`. The value of this
+variable is the same object that the `Get-Event` cmdlet returns. Therefore,
+you can use the properties of the `Event` variable, such as
+`$Event.TimeGenerated`, in an Action script block.
 
 ### $EVENTARGS
 
@@ -89,19 +89,18 @@ Contains an object that represents the first event argument that derives
 from EventArgs of the event that is being processed. This variable is
 populated only within the Action block of an event registration command.
 The value of this variable can also be found in the SourceEventArgs
-property of the PSEventArgs (System.Management.Automation.PSEventArgs)
-object that Get-Event returns.
+property of the **PSEventArgs** object that `Get-Event` returns.
 
 ### $EVENTSUBSCRIBER
 
-Contains a PSEventSubscriber object that represents the event subscriber of
+Contains a **PSEventSubscriber** object that represents the event subscriber of
 the event that is being processed. This variable is populated only within
 the Action block of an event registration command. The value of this
-variable is the same object that the Get-EventSubscriber cmdlet returns.
+variable is the same object that the `Get-EventSubscriber` cmdlet returns.
 
 ### $EXECUTIONCONTEXT
 
-Contains an EngineIntrinsics object that represents the execution context
+Contains an **EngineIntrinsics** object that represents the execution context
 of the PowerShell host. You can use this variable to find the execution
 objects that are available to cmdlets.
 
@@ -116,54 +115,54 @@ non-zero integer.
 
 Contains the enumerator (not the resulting values) of a ForEach loop. You
 can use the properties and methods of enumerators on the value of the
-$ForEach variable. This variable exists only while the ForEach loop is
+`$ForEach` variable. This variable exists only while the `ForEach` loop is
 running; it is deleted after the loop is completed. For detailed
 information, see [about_ForEach](about_ForEach.md).
 
 ### $HOME
 
 Contains the full path of the user's home directory. This variable is the
-equivalent of the `%homedrive%%homepath%` Windows environment variables,
-typically C:\\Users\\<UserName>.
+equivalent of the `"$env:homedrive$env:homepath"` Windows environment variables,
+typically `C:\Users\<UserName>`.
 
 ### $HOST
 
 Contains an object that represents the current host application for
 PowerShell. You can use this variable to represent the current host in
 commands or to display or change the properties of the host, such as
-$Host.version or $Host.CurrentCulture, or
-$host.ui.rawui.setbackgroundcolor("Red").
+`$Host.version` or `$Host.CurrentCulture`, or
+`$host.ui.rawui.setbackgroundcolor("Red")`.
 
 ### $INPUT
 
 Contains an enumerator that enumerates all input that is passed to a
-function. The $input variable is available only to functions and script
+function. The `$input` variable is available only to functions and script
 blocks (which are unnamed functions). In the Process block of a function,
-the $input variable enumerates the object that is currently in the
+the `$input` variable enumerates the object that is currently in the
 pipeline. When the Process block completes, there are no objects left in
-the pipeline, so the $input variable enumerates an empty collection. If the
-function does not have a Process block, then in the End block, the $input
+the pipeline, so the `$input` variable enumerates an empty collection. If the
+function does not have a Process block, then in the End block, the `$input`
 variable enumerates the collection of all input to the function.
 
 ### $IsCoreCLR
 
-Contains $TRUE if the current session is running on the .NET Core Runtime
-(CoreCLR). Otherwise contains $FALSE.
+Contains `$TRUE` if the current session is running on the .NET Core Runtime
+(CoreCLR). Otherwise contains `$FALSE`.
 
 ### $IsLinux
 
-Contains $TRUE if the current session is running on a Linux operating system.
-Otherwise contains $FALSE.
+Contains `$TRUE` if the current session is running on a Linux operating system.
+Otherwise contains `$FALSE`.
 
 ### $IsMacOS
 
-Contains $TRUE if the current session is running on a MacOS operating system.
-Otherwise contains $FALSE.
+Contains `$TRUE` if the current session is running on a MacOS operating system.
+Otherwise contains `$FALSE`.
 
 ### $IsWindows
 
-Contains $TRUE if the current session is running on a Windows operationg system.
-Otherwise contains $FALSE.
+Contains `$TRUE` if the current session is running on a Windows operating
+system. Otherwise contains `$FALSE`.
 
 ### $LASTEXITCODE
 
@@ -171,28 +170,28 @@ Contains the exit code of the last Windows-based program that was run.
 
 ### $MATCHES
 
-The $Matches variable works with the `-match` and `-notmatch` operators.
+The `Matches` variable works with the `-match` and `-notmatch` operators.
 When you submit scalar input to the `-match` or `-notmatch` operator, and
 either one detects a match, they return a Boolean value and populate the
 $Matches automatic variable with a hash table of any string values that
-were matched. For more information about the -match operator, see
+were matched. For more information about the `-match` operator, see
 [about_comparison_operators](about_comparison_operators.md).
 
-### $MyInvocation
+### $MYINVOCATION
 
 Contains an information about the current command, such as the name,
 parameters, parameter values, and information about how the command was
 started, called, or "invoked," such as the name of the script that called
 the current command.
 
-\$MyInvocation is populated only for scripts, function, and script blocks.
+`$MyInvocation` is populated only for scripts, function, and script blocks.
 You can use the information in the System.Management.Automation.InvocationInfo
-object that \$MyInvocation returns in the current script, such as the path and
-file name of the script (\$MyInvocation.MyCommand.Path) or the name of a
-function (\$MyInvocation.MyCommand.Name) to identify the current command. This
+object that `$MyInvocation` returns in the current script, such as the path and
+file name of the script (`$MyInvocation.MyCommand.Path`) or the name of a
+function (`$MyInvocation.MyCommand.Name`) to identify the current command. This
 is particularly useful for finding the name of the current script.
 
-Beginning in PowerShell 3.0, $MyInvocation has the following new
+Beginning in PowerShell 3.0, `MyInvocation` has the following new
 properties.
 
 | Property      | Description                                         |
@@ -205,42 +204,42 @@ properties.
 |               | property is populated only when the caller is a     |
 |               | script.                                             |
 
-Unlike the $PSScriptRoot and $PSCommandPath automatic variables, the
-PSScriptRoot and PSCommandPath properties of the $MyInvocation automatic
-variable contain information about the invoker or calling script, not the
-current script.
+Unlike the `$PSScriptRoot` and `$PSCommandPath` automatic variables, the
+**PSScriptRoot** and **PSCommandPath** properties of the `$MyInvocation`
+automatic variable contain information about the invoker or calling script,
+not the current script.
 
-### $NestedPromptLevel
+### $NESTEDPROMPTLEVEL
 
 Contains the current prompt level. A value of 0 indicates the original
 prompt level. The value is incremented when you enter a nested level and
 decremented when you exit it.
 
 For example, PowerShell presents a nested command prompt when you use the
-$Host.EnterNestedPrompt method. PowerShell also presents a nested command
+`$Host.EnterNestedPrompt` method. PowerShell also presents a nested command
 prompt when you reach a breakpoint in the PowerShell debugger.
 
 When you enter a nested prompt, PowerShell pauses the current command,
 saves the execution context, and increments the value of the
-$NestedPromptLevel variable. To create additional nested command prompts
+`$NestedPromptLevel` variable. To create additional nested command prompts
 (up to 128 levels) or to return to the original command prompt, complete
-the command, or type "exit".
+the command, or type `exit`.
 
-The $NestedPromptLevel variable helps you track the prompt level. You can
+The `$NestedPromptLevel` variable helps you track the prompt level. You can
 create an alternative PowerShell command prompt that includes this value so
 that it is always visible.
 
-### $null
+### $NULL
 
-$null is an automatic variable that contains a NULL or empty value. You can
+`$null` is an automatic variable that contains a NULL or empty value. You can
 use this variable to represent an absent or undefined value in commands and
 scripts.
 
-PowerShell treats $null as an object with a value, that is, as an explicit
-placeholder, so you can use $null to represent an empty value in a series
+PowerShell treats `$null` as an object with a value, that is, as an explicit
+placeholder, so you can use `$null` to represent an empty value in a series
 of values.
 
-For example, when $null is included in a collection, it is counted as one
+For example, when `$null` is included in a collection, it is counted as one
 of the objects.
 
 ```powershell
@@ -252,8 +251,8 @@ $a.count
 3
 ```
 
-If you pipe the $null variable to the ForEach-Object cmdlet, it generates a
-value for $null, just as it does for the other objects
+If you pipe the `$null` variable to the `ForEach-Object` cmdlet, it generates a
+value for `$null`, just as it does for the other objects
 
 ```powershell
 "one", $null, "three" | ForEach-Object { "Hello " + $_}
@@ -265,11 +264,11 @@ Hello
 Hello three
 ```
 
-As a result, you cannot use $null to mean "no parameter value." A parameter
-value of $null overrides the default parameter value.
+As a result, you cannot use `$null` to mean "no parameter value." A parameter
+value of `$null` overrides the default parameter value.
 
-However, because PowerShell treats the $null variable as a placeholder, you
-can use it in scripts like the following one, which would not work if $null
+However, because PowerShell treats the `$null` variable as a placeholder, you
+can use it in scripts like the following one, which would not work if `$null`
 were ignored.
 
 ```powershell
@@ -306,13 +305,13 @@ profile in commands. For example, you can use it in a command to determine
 whether a profile has been created:
 
 ```powershell
-test-path $profile
+Test-Path $PROFILE
 ```
 
 Or, you can use it in a command to create a profile:
 
 ```powershell
-new-item -type file -path $pshome -force
+New-Item -ItemType file -Path $PSHOME -Force
 ```
 
 You can also use it in a command to open the profile in Notepad:
@@ -321,7 +320,7 @@ You can also use it in a command to open the profile in Notepad:
 notepad $profile
 ```
 
-### $PSBoundParameters
+### $PSBOUNDPARAMETERS
 
 Contains a dictionary of the parameters that are passed to a script or
 function and their current values. This variable has a value only in a
@@ -343,48 +342,48 @@ function Test {
 }
 ```
 
-### $PSCmdlet
+### $PSCMDLET
 
 Contains an object that represents the cmdlet or advanced function that is
 being run.
 
 You can use the properties and methods of the object in your cmdlet or
 function code to respond to the conditions of use. For example, the
-ParameterSetName property contains the name of the parameter set that is
-being used, and the ShouldProcess method adds the WhatIf and Confirm
-parameters to the cmdlet dynamically.
+**ParameterSetName** property contains the name of the parameter set that is
+being used, and the **ShouldProcess** method adds the **WhatIf** and
+**Confirm** parameters to the cmdlet dynamically.
 
-For more information about the $PSCmdlet automatic variable, see
-[about_Functions_Advanced_Methods](about_Functions_Advanced_Methods.md).
+For more information about the `$PSCmdlet` automatic variable, see
+[about_Functions_Advanced](about_Functions_Advanced.md).
 
-### $PSCommandPath
+### $PSCOMMANDPATH
 
 Contains the full path and file name of the script that is being run. This
 variable is valid in all scripts.
 
-### $PSCulture
+### $PSCULTURE
 
 Contains the name of the culture currently in use in the operating system.
 The culture determines the display format of items such as numbers,
 currency, and dates. This is the value of the
-System.Globalization.CultureInfo.CurrentCulture.Name property of the
-system. To get the System.Globalization.CultureInfo object for the system,
-use the Get-Culture cmdlet.
+**System.Globalization.CultureInfo.CurrentCulture.Name** property of the
+system. To get the **System.Globalization.CultureInfo** object for the system,
+use the `Get-Culture` cmdlet.
 
-### $PSDebugContext
+### $PSDEBUGCONTEXT
 
 While debugging, this variable contains information about the debugging
-environment. Otherwise, it contains a NULL value. As a result, you can use
-it to indicate whether the debugger has control. When populated, it
-contains a PSDebugContext object that has Breakpoints and InvocationInfo
-properties. The InvocationInfo property has several useful properties,
-including the Location property. The Location property indicates the path
-of the script that is being debugged.
+environment. Otherwise, it contains a NULL value. As a result, you can use it
+to indicate whether the debugger has control. When populated, it contains a
+**PsDebugContext** object that has **Breakpoints** and **InvocationInfo**
+properties. The **InvocationInfo** property has several useful properties,
+including the **Location** property. The **Location** property indicates the
+path of the script that is being debugged.
 
 ### $PSHOME
 
 Contains the full path of the installation directory for PowerShell,
-typically, `%windir%\System32\PowerShell\v1.0` in Windows systems. You can
+typically, `$env:windir\System32\PowerShell\v1.0` in Windows systems. You can
 use this variable in the paths of PowerShell files. For example, the
 following command searches the conceptual Help topics for the word
 "variable":
@@ -395,11 +394,11 @@ Select-String -Pattern Variable -Path $pshome\*.txt
 
 ### $PSITEM
 
-Same as $_. Contains the current object in the pipeline object. You can use
+Same as `$_`. Contains the current object in the pipeline object. You can use
 this variable in commands that perform an action on every object or on
 selected objects in a pipeline.
 
-### $PSScriptRoot
+### $PSSCRIPTROOT
 
 Contains the directory from which a script is being run.
 
@@ -412,22 +411,22 @@ Contains information about the user who started the PSSession, including
 the user identity and the time zone of the originating computer. This
 variable is available only in PSSessions.
 
-The $PSSenderInfo variable includes a user-configurable property,
-ApplicationArguments, which, by default, contains only the $PSVersionTable
-from the originating session. To add data to the ApplicationArguments
-property, use the ApplicationArguments parameter of the New-PSSessionOption
-cmdlet.
+The `$PSSenderInfo` variable includes a user-configurable property,
+**ApplicationArguments**, which, by default, contains only the
+`$PSVersionTable` from the originating session. To add data to the
+**ApplicationArguments** property, use the **ApplicationArguments** parameter
+of the `New-PSSessionOption` cmdlet.
 
-### $PSUICulture
+### $PSUICULTURE
 
-Contains the name of the user interface (UI) culture that is currently in
-use in the operating system. The UI culture determines which text strings
-are used for user interface elements, such as menus and messages. This is
-the value of the System.Globalization.CultureInfo.CurrentUICulture.Name
-property of the system. To get the System.Globalization.CultureInfo object
-for the system, use the Get-UICulture cmdlet.
+Contains the name of the user interface (UI) culture that is currently in use
+in the operating system. The UI culture determines which text strings are used
+for user interface elements, such as menus and messages. This is the value of
+the **System.Globalization.CultureInfo.CurrentUICulture.Name** property of the
+system. To get the **System.Globalization.CultureInfo** object for the system,
+use the `Get-UICulture` cmdlet.
 
-### $PSVersionTable
+### $PSVERSIONTABLE
 
 Contains a read-only hash table that displays details about the version of
 PowerShell that is running in the current session. The table includes the
@@ -456,13 +455,12 @@ following items:
 
 ### $PWD
 
-Contains a path object that represents the full path of the current
-directory.
+Contains a path object that represents the full path of the current directory.
 
 ### REPORTERRORSHOW VARIABLES
 
-The "ReportErrorShow" variables are defined in PowerShell, but they are not
-implemented. Get-Variable gets them, but they do not contain valid data.
+The **ReportErrorShow** variables are defined in PowerShell, but they are not
+implemented. `Get-Variable` gets them, but they do not contain valid data.
 
 - $REPORTERRORSHOWEXCEPTIONCLASS
 - $REPORTERRORSHOWINNEREXCEPTION
@@ -473,8 +471,8 @@ implemented. Get-Variable gets them, but they do not contain valid data.
 
 Contains the object that generated this event. This variable is populated
 only within the Action block of an event registration command. The value of
-this variable can also be found in the Sender property of the PSEventArgs
-(System.Management.Automation.PSEventArgs) object that Get-Event returns.
+this variable can also be found in the Sender property of the **PSEventArgs**
+object that `Get-Event` returns.
 
 ### $ShellId
 
@@ -486,9 +484,9 @@ Contains a stack trace for the most recent error.
 ### $THIS
 
 In a script block that defines a script property or script method, the
-$This variable refers to the object that is being extended.
+`$This` variable refers to the object that is being extended.
 
-### $true
+### $TRUE
 
 Contains TRUE. You can use this variable to represent TRUE in commands and
 scripts.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -67,12 +67,12 @@ objects are received from the pipeline.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
-DynamicParam {<statement list>}
-begin {<statement list>}
-process {<statement list>}
-end {<statement list>}
+    DynamicParam {<statement list>}
+    begin {<statement list>}
+    process {<statement list>}
+    end {<statement list>}
 }
 ```
 
@@ -82,7 +82,7 @@ Causes a script to exit a loop.
 
 Syntax:
 
-```powershell
+```Syntax
 while (<condition>) {
    <statements>
    ...
@@ -102,7 +102,7 @@ indicates that the error type is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [[<error type>]] {<statement list>}
 ```
@@ -113,7 +113,7 @@ Specifies a new class in PowerShell.
 
 Syntax:
 
-```powershell
+```Syntax
 class <class-name> {
     [[hidden] [static] <property-definition> ...]
     [<class-name>([argument-list>]) {<constructor-statement-list>} ...]
@@ -128,7 +128,7 @@ condition is met, the script begins the loop again.
 
 Syntax:
 
-```powershell
+```Syntax
 while (<condition>) {
    <statements>
    ...
@@ -143,40 +143,39 @@ while (<condition>) {
 ### Data
 
 In a script, defines a section that isolates data from the script logic. Can
-also include If statements and some limited commands.
+also include `If` statements and some limited commands.
 
 Syntax:
 
-```powershell
+```Syntax
 data <variable> [-supportedCommand <cmdlet-name>] {<permitted content>}
 ```
 
 ### Do
 
-Used with the While or Until keyword as a looping construct. Windows
-PowerShell runs the statement list at least one time, unlike a loop that uses
-While.
+Used with the `While` or `Until` keyword as a looping construct. PowerShell
+runs the statement list at least one time, unlike a loop that uses `While`.
 
-Syntax for _While_:
+Syntax for `While`:
 
-```powershell
+```Syntax
 do {<statement list>} while (<condition>)
 ```
 
-Syntax for _Until_:
+Syntax for `Until`:
 
-```powershell
+```Syntax
 do {<statement list>} until (<condition>)
 ```
 
 ### DynamicParam
 
-Specifies one part of the body of a function, along with the Begin, Process,
-and End keywords. Dynamic parameters are added at run time.
+Specifies one part of the body of a function, along with the `Begin`, `Process`,
+and `End` keywords. Dynamic parameters are added at run time.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -187,23 +186,23 @@ function <name> {
 
 ### Else
 
-Used with the If keyword to specify the default statement list.
+Used with the `If` keyword to specify the default statement list.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 else {<statement list>}
 ```
 
 ### Elseif
 
-Used with the If and Else keywords to specify additional conditionals. The
-Else keyword is optional.
+Used with the `If` and `Else` keywords to specify additional conditionals. The
+`Else` keyword is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 elseif (<condition>) {<statement list>}
 else {<statement list>}
@@ -211,13 +210,13 @@ else {<statement list>}
 
 ### End
 
-Specifies one part of the body of a function, along with the DynamicParam,
-Begin, and End keywords. The End statement list runs one time after all the
+Specifies one part of the body of a function, along with the `DynamicParam`,
+`Begin`, and `End` keywords. The `End` statement list runs one time after all the
 objects have been received from the pipeline.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -233,7 +232,7 @@ a set of named labels called the enumerator list.
 
 Syntax:
 
-```powershell
+```Syntax
 enum <enum-name> {
     <label> [= <int-value>]
     ...
@@ -246,7 +245,7 @@ Causes PowerShell to exit a script or a PowerShell instance.
 
 Syntax:
 
-```
+```Syntax
 exit
 exit <exitcode>
 ```
@@ -258,10 +257,10 @@ to indicate the post-execution status of the script.
 
 In PowerShell, the exit statement sets the value of the `$LASTEXITCODE`
 variable. In the Windows Command Shell (cmd.exe), the exit statement sets the
-value of the `%ERRORLEVEL% environment variable.
+value of the `%ERRORLEVEL%` environment variable.
 
 In the following example, the user sets the error level variable value to 4 by
-adding 'exit 4' to the script file _test.ps1_.
+adding `exit 4` to the script file _test.ps1_.
 
 ```cmd
 C:\scripts\test>type test.ps1
@@ -296,19 +295,19 @@ block.
 
 Syntax:
 
-```powershell
+```Syntax
 filter <name> {<statement list>}
 ```
 
 ### Finally
 
 Defines a statement list that runs after statements that are associated with
-Try and Catch. A Finally statement list runs even if you press CTRL+C to leave
+Try and Catch. A `Finally` statement list runs even if you press `CTRL+C` to leave
 a script or if you use the Exit keyword in the script.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [<error type>] {<statement list>}
 finally {<statement list>}
@@ -320,7 +319,7 @@ Defines a loop by using a condition.
 
 Syntax:
 
-```powershell
+```Syntax
 for (<initialize>; <condition>; <iterate>) { <statement list> }
 ```
 
@@ -330,7 +329,7 @@ Defines a loop by using each member of a collection.
 
 Syntax:
 
-```powershell
+```Syntax
 ForEach (<item> in <collection>) { <statement list> }
 ```
 
@@ -342,12 +341,12 @@ Reserved for future use.
 
 Creates a named statement list of reusable code. You can name the scope a
 function belongs to. And, you can specify one or more named parameters by
-using the Param keyword. Within the function statement list, you can include
-DynamicParam, Begin, Process, and End statement lists.
+using the `Param` keyword. Within the function statement list, you can include
+`DynamicParam`, `Begin`, `Process`, and `End` statement lists.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> {
    param ([type]<$pname1> [, [type]<$pname2>])
    DynamicParam {<statement list>}
@@ -362,7 +361,7 @@ statement list after the function name.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> [([type]<$pname1>, [[type]<$pname2>])] {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -377,29 +376,29 @@ Defines a conditional.
 
 Syntax:
 
-```powershell
+```Syntax
 if (<condition>) {<statement list>}
 ```
 
 ### Hidden
 
-Hides class members from the default results of the Get-Member cmdlet, and
+Hides class members from the default results of the `Get-Member` cmdlet, and
 from IntelliSense and tab completion results.
 
 Syntax:
 
-```powershell
+```Syntax
 Hidden [data type] $member_name
 ```
 
 ### In
 
-Used in a ForEach statement to create a loop that uses each member of a
+Used in a `ForEach` statement to create a loop that uses each member of a
 collection.
 
 Syntax:
 
-```powershell
+```Syntax
 ForEach (<item> in <collection>){<statement list>}
 ```
 
@@ -410,7 +409,7 @@ only in a PowerShell Workflow.
 
 Syntax:
 
-```powershell
+```Syntax
 workflow <verb>-<noun>
 {
    InlineScript
@@ -422,14 +421,13 @@ workflow <verb>-<noun>
 }
 ```
 
-The InlineScript keyword indicates an InlineScript activity, which runs
+The `InlineScript` keyword indicates an `InlineScript` activity, which runs
 commands in a shared standard (non-workflow) session. You can use the
-InlineScript keyword to run commands that are not otherwise valid in a
+`InlineScript` keyword to run commands that are not otherwise valid in a
 workflow, and to run commands that share data. By default, the commands in an
 InlineScript script block run in a separate process.
 
-For more information, see about_InlineScript and
-[Running PowerShell Commands in a Workflow](https://technet.microsoft.com/library/jj574197.aspx).
+For more information, see [Running PowerShell Commands in a Workflow](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/jj574197(v=ws.11)).
 
 ### Param
 
@@ -437,7 +435,7 @@ Defines the parameters in a function.
 
 Syntax:
 
-```powershell
+```Syntax
 function [<scope:>]<name> {
    param ([type]<$pname1>[, [[type]<$pname2>]])
    <statement list>
@@ -446,16 +444,16 @@ function [<scope:>]<name> {
 
 ### Process
 
-Specifies a part of the body of a function, along with the DynamicParam,
-Begin, and End keywords. When a Process statement list receives input from the
-pipeline, the Process statement list runs one time for each element from the
-pipeline. If the pipeline provides no objects, the Process statement list does
-not run. If the command is the first command in the pipeline, the Process
-statement list runs one time.
+Specifies a part of the body of a function, along with the `DynamicParam`,
+`Begin`, and `End` keywords. When a `Process` statement list receives input
+from the pipeline, the `Process` statement list runs one time for each element
+from the pipeline. If the pipeline provides no objects, the `Process`
+statement list does not run. If the command is the first command in the
+pipeline, the `Process` statement list runs one time.
 
 Syntax:
 
-```powershell
+```Syntax
 function <name> {
    DynamicParam {<statement list>}
    begin {<statement list>}
@@ -471,7 +469,7 @@ and writes the optional expression to the output.
 
 Syntax:
 
-```powershell
+```Syntax
 return [<expression>]
 ```
 
@@ -480,19 +478,19 @@ return [<expression>]
 Specifies the property or method defined is common to all instances of the
 class in which is defined.
 
-See, in this topic, **Class**  for usage examples.
+See `Class` for usage examples.
 
 ### Switch
 
-To check multiple conditions, use a Switch statement. The Switch statement is
+To check multiple conditions, use a `Switch` statement. The `Switch` statement is
 equivalent to a series of If statements, but it is simpler.
 
-The Switch statement lists each condition and an optional action. If a
+The `Switch` statement lists each condition and an optional action. If a
 condition obtains, the action is performed.
 
 Syntax 1:
 
-```powershell
+```Syntax
 switch [-regex|-wildcard|-exact][-casesensitive] ( <value> )
 {
    <string>|<number>|<variable>|{ <expression> } {<statement list>}
@@ -505,7 +503,7 @@ switch [-regex|-wildcard|-exact][-casesensitive] ( <value> )
 
 Syntax 2:
 
-```powershell
+```Syntax
 switch [-regex|-wildcard|-exact][-casesensitive] -file <filename>
 {
    <string>|<number>|<variable>|{ <expression> } {<statement list>}
@@ -522,7 +520,7 @@ Throws an object as an error.
 
 Syntax:
 
-```powershell
+```Syntax
 throw [<object>]
 ```
 
@@ -534,20 +532,20 @@ is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 trap [[<error type>]] {<statement list>}
 ```
 
 ### Try
 
 Defines a statement list to be checked for errors while the statements run. If
-an error occurs, PowerShell continues running in a Catch or Finally statement.
-An error type requires brackets. The second pair of brackets indicates that
-the error type is optional.
+an error occurs, PowerShell continues running in a `Catch` or `Finally`
+statement. An error type requires brackets. The second pair of brackets
+indicates that the error type is optional.
 
 Syntax:
 
-```powershell
+```Syntax
 try {<statement list>}
 catch [[<error type>]] {<statement list>}
 finally {<statement list>}
@@ -555,12 +553,12 @@ finally {<statement list>}
 
 ### Until
 
-Used in a Do statement as a looping construct where the statement list is
+Used in a `Do` statement as a looping construct where the statement list is
 executed at least one time.
 
 Syntax:
 
-```powershell
+```Syntax
 do {<statement list>} until (<condition>)
 ```
 
@@ -571,23 +569,36 @@ members require less typing to mention them. You can also include classes from
 modules.
 
 Syntax #1:
-```
+
+```Syntax
 using namespace <.Net-framework-namespace>
 ```
 
 Syntax #2:
-```
+
+```Syntax
 using module <module-name>
 ```
 
 ### While
 
-Used in a Do statement as a looping construct where the statement list is
-executed at least one time.
+The `while` statement is a looping construct where the condition is tested
+before the statements are executed. If the condition is FALSE, then the
+statements do not execute.
 
-Syntax:
+Statement syntax:
 
-```powershell
+```Syntax
+while (<condition>) {
+   <statements>
+ }
+
+When used in a `Do` statement, `while` is part of a looping construct where
+the statement list is executed at least one time.
+
+Do loop Syntax:
+
+```Syntax
 do {<statement list>} while (<condition>)
 ```
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Language_Keywords.md
@@ -61,8 +61,8 @@ Language Keywords
 
 ### Begin
 
-Specifies one part of the body of a function, along with the DynamicParam,
-Process, and End keywords. The Begin statement list runs one time before any
+Specifies one part of the body of a function, along with the `DynamicParam`,
+`Process`, and `End` keywords. The `Begin` statement list runs one time before any
 objects are received from the pipeline.
 
 Syntax:
@@ -592,6 +592,7 @@ Statement syntax:
 while (<condition>) {
    <statements>
  }
+```
 
 When used in a `Do` statement, `while` is part of a looping construct where
 the statement list is executed at least one time.

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Modules.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Modules.md
@@ -5,7 +5,6 @@ locale:  en-us
 keywords:  powershell,cmdlet
 title:  about_Modules
 ---
-
 # About Modules
 
 ## Short Description
@@ -23,8 +22,8 @@ modules to their PowerShell sessions and use them just like the built-in
 commands.
 
 This topic explains how to use PowerShell modules. For information about how
-to write PowerShell modules, see [Writing a Windows PowerShell Module](/developer/module/writing-a-windows-powershell-module.md)
-in Windows PowerShell SDK.
+to write PowerShell modules, see
+[Writing a PowerShell Module](/powershell/developer/module/writing-a-windows-powershell-module).
 
 ## What Is a Module?
 
@@ -43,6 +42,7 @@ gets all commands in all installed modules, even if they are not yet in the
 session, so you can find a command and use it without importing.
 
 Any of the following commands will import a module into your session.
+
 ### Run the Command
 
 ```powershell
@@ -68,14 +68,14 @@ Only modules that are stored in the location specified by the PSModulePath
 environment variable are automatically imported. Modules in other locations
 must be imported by running the `Import-Module` cmdlet.
 
-Also, commands that use PowerShell providers do not automatically
-import a module. For example, if you use a command that requires the WSMan:
-drive, such as the `Get-PSSessionConfiguration` cmdlet, you might need to
-run the `Import-Module` cmdlet to import the Microsoft.WSMan.Management
-module that includes the WSMan: drive.
+Also, commands that use PowerShell providers do not automatically import a
+module. For example, if you use a command that requires the WSMan: drive, such
+as the `Get-PSSessionConfiguration` cmdlet, you might need to run the
+`Import-Module` cmdlet to import the **Microsoft.WSMan.Management** module that
+includes the `WSMan:` drive.
 
 You can still run the `Import-Module` command to import a module and
-use the $PSModuleAutoloadingPreference variable to enable, disable and
+use the `$PSModuleAutoloadingPreference` variable to enable, disable and
 configure automatic importing of modules. For more information, see
 [about_Preference_Variables](about_Preference_Variables.md).
 
@@ -104,7 +104,6 @@ the Turn Windows features on or off dialog box in Control Panel, any
 PowerShell modules that are part of the feature are installed. Many other
 modules come in an installer or Setup program that installs the module.
 
-
 Create a Modules directory for the current user if one does not exist. To
 create a Modules directory, type:
 
@@ -115,7 +114,7 @@ New-Item -Type Directory -Path $HOME\Documents\WindowsPowerShell\Modules
 Copy the entire module folder into the Modules directory. You can use any
 method to copy the folder, including Windows Explorer and Cmd.exe, as well as
 PowerShell. In PowerShell use the `Copy-Item` cmdlet. For example, to copy the
-MyModule folder from C:\\ps-test\\MyModule to the Modules directory, type:
+MyModule folder from `C:\ps-test\MyModule` to the Modules directory, type:
 
 ```powershell
 Copy-Item -Path C:\ps-test\MyModule -Destination `
@@ -201,9 +200,9 @@ For more information, see [Get-Help](../Get-Help.md) and
 
 You might have to import a module or import a module file. Importing is
 required when a module is not installed in the locations specified by the
-PSModulePath environment variable ($env:PSModulePath), or the module consists
-of file, such as a .dll or .psm1 file, instead of typical module that is
-delivered as a folder.
+**PSModulePath** environment variable, `$env:PSModulePath`, or the module
+consists of file, such as a .dll or .psm1 file, instead of typical module that
+is delivered as a folder.
 
 You might also choose to import a module so that you can use the parameters of
 the `Import-Module` command, such as the Prefix parameter, which adds a
@@ -291,42 +290,43 @@ PowerShell 4.0, with the introduction of DSC, a new default module and DSC
 resource folder was introduced. For more information about DSC, see
 about_DesiredStateConfiguration.
 
-- System: $pshome\Modules (%windir%\System32\WindowsPowerShell\v1.0\Modules)
+- System: `$pshome\Modules` or
+  (`$env:windir\System32\WindowsPowerShell\v1.0\Modules`)
   System modules are those that ship with Windows and PowerShell.
 
   Starting in PowerShell 4.0, when PowerShell Desired State Configuration
   (DSC) was introduced, DSC resources that are included with PowerShell are
-  also stored in \$pshome\\Modules, in the
-  \$pshome\\Modules\\PSDesiredStateConfiguration\\DSCResources folder.
+  also stored in `$PSHOME\Modules`, in the
+  `$pshome\Modules\PSDesiredStateConfiguration\DSCResources` folder.
 
-- Current user: \$home\\Documents\\WindowsPowerShell\\Modules
-  (%UserProfile%\Documents\WindowsPowerShell\Modules)
+- Current user: `$home\Documents\WindowsPowerShell\Modules`
+  (`$env:UserProfile\Documents\WindowsPowerShell\Modules`)
 
   or
 
-  \$home\\My Documents\\WindowsPowerShell\\Modules
-  (%UserProfile%\My Documents\WindowsPowerShell\Modules)
+  `$home\My Documents\WindowsPowerShell\Modules`
+  (`$env:UserProfile\My Documents\WindowsPowerShell\Modules`)
   This is the location for user-added modules prior to PowerShell 4.0.
 
 In PowerShell 4.0 and later releases of PowerShell, user-added modules and DSC
-resources are stored in C:\\Program Files\\WindowsPowerShell\\Modules. Modules
+resources are stored in `C:\Program Files\WindowsPowerShell\Modules`. Modules
 and DSC resources in this location are accessible by all users of the
 computer. This change was required because the DSC engine runs as local
 system, and could not access user-specific paths, such as
-\$home\\Documents\\WindowsPowerShell\\Modules.
+`$home\Documents\WindowsPowerShell\Modules`.
 
 Starting in PowerShell 5.0, with the addition of the PowerShellGet module, and
-the [PowerShell Gallery](https://www.powershellgallery.com) of community- and
+the [PowerShell Gallery](https://www.powershellgallery.com) of community and
 Microsoft-created resources, the `Install-Module` command installs modules and
-DSC resources to C:\\Program Files\\WindowsPowerShell\\Modules by default.
+DSC resources to `C:\Program Files\WindowsPowerShell\Modules` by default.
 
-Note: To add or change files in the %Windir%\\System32 directory, start
+Note: To add or change files in the `$env:Windir\System32` directory, start
 PowerShell with the "Run as administrator" option.
 
 You can change the default module locations on your system by changing the
-value of the PSModulePath environment variable ($Env:PSModulePath). The
-PSModulePath environment variable is modeled on the Path environment variable
-and has the same format.
+value of the **PSModulePath** environment variable, `$Env:PSModulePath`. The
+**PSModulePath** environment variable is modeled on the Path environment
+variable and has the same format.
 
 To view the default module locations, type:
 
@@ -334,19 +334,19 @@ To view the default module locations, type:
 $Env:PSModulePath
 ```
 
-To add a default module location on Windows, use the following command format:
+To add a default module location, use the following command format.
 
 ```powershell
-$Env:PSModulePath += ";<path>"
+$Env:PSModulePath = $Env:PSModulePath + ";<path>"
 ```
 
-The semicolon (;) in the command separates the new path from the
+The semi-colon (;) in the command separates the new path from the
 path that precedes it in the list.
 
-For example, to add the "C:\ps-test\Modules" directory, type:
+For example, to add the `C:\ps-test\Modules` directory, type:
 
 ```powershell
-$Env:PSModulePath += ";C:\ps-test\Modules"
+$Env:PSModulePath + ";C:\ps-test\Modules"
 ```
 
 To add a default module location on Linux or MacOS, use the following command format:
@@ -365,15 +365,17 @@ $Env:PSModulePath += ":/usr/local/Fabrikam/Modules"
 On Linux or MacOS, the colon (:) in the command separates the new path from the path that
 precedes it in the list.
 
-When you add a path to PSModulePath, `Get-Module` and `Import-Module`
+When you add a path to **PSModulePath**, `Get-Module` and `Import-Module`
 commands include modules in that path.
 
-The value that you set affects only the current session. To make the change
-persistent, add the command to your PowerShell profile. Alternatively, on
-Windows, you can use System in Control Panel to change the value of the
-PSModulePath environment variable, or you can use the
-SetEnvironmentVariable method of the System.Environment class to add
-a path to the PSModulePath environment variable.
+The value that you set affects only the current session. To make the
+change persistent, add the command to your PowerShell profile
+or use System in Control Panel to change the value of the **PSModulePath**
+environment variable in the registry.
+
+Also, to make the change persistent, you can also use the
+**SetEnvironmentVariable** method of the **System.Environment** class to add a
+Path to the **PSModulePath** environment variable.
 
 For more information about the PSModulePath variable, see
 [about_Environment_Variables](about_Environment_Variables.md).

--- a/reference/docs-conceptual/components/web-access/authorization-rules-and-security-features-of-windows-powershell-web-access.md
+++ b/reference/docs-conceptual/components/web-access/authorization-rules-and-security-features-of-windows-powershell-web-access.md
@@ -341,10 +341,10 @@ authorization rule.
 ### Using a single set of authorization rules for multiple sites
 
 Authorization rules are stored in an XML file. By default, the path name of the XML file is
-`%windir%\Web\PowershellWebAccess\data\AuthorizationRules.xml`.
+`$env:windir\Web\PowershellWebAccess\data\AuthorizationRules.xml`.
 
 The path to the authorization rules XML file is stored in the **powwa.config** file, which is found
-in `%windir%\Web\PowershellWebAccess\data`. The administrator has the flexibility to change the
+in `$env:windir\Web\PowershellWebAccess\data`. The administrator has the flexibility to change the
 reference to the default path in **powwa.config** to suit preferences or requirements. Allowing the
 administrator to change the location of the file lets multiple Windows PowerShell Web Access
 gateways use the same authorization rules, if such a configuration is desired.
@@ -354,7 +354,7 @@ gateways use the same authorization rules, if such a configuration is desired.
 By default, Windows PowerShell Web Access limits a user to three sessions at one time. You can edit
 the web application's **web.config** file in IIS Manager to support a different number of sessions
 per user. The path to the **web.config** file is
-`$Env:Windir\Web\PowerShellWebAccess\wwwroot\Web.config`.
+`$env:windir\Web\PowerShellWebAccess\wwwroot\Web.config`.
 
 By default, IIS Web Server is configured to restart the application pool if any settings are
 edited. For example, the application pool is restarted if changes are made to the **web.config**

--- a/reference/docs-conceptual/components/web-access/install-and-use-windows-powershell-web-access.md
+++ b/reference/docs-conceptual/components/web-access/install-and-use-windows-powershell-web-access.md
@@ -211,7 +211,7 @@ the Secure Sockets Layer (SSL) certificate.
    - Path: /pswa
    - ApplicationPool: pswa_pool
    - EnabledProtocols: http
-   - PhysicalPath: `%*windir*%/Web/PowerShellWebAccess/wwwroot`
+   - PhysicalPath: %windir%/Web/PowerShellWebAccess/wwwroot
 
    **Example**: `Install-PswaWebApplication -webApplicationName myWebApp -useTestCertificate`
 
@@ -241,7 +241,7 @@ the Secure Sockets Layer (SSL) certificate.
    - Path: /pswa
    - ApplicationPool: pswa_pool
    - EnabledProtocols: http
-   - PhysicalPath: `%*windir*%/Web/PowerShellWebAccess/wwwroot`
+   - PhysicalPath: %windir%/Web/PowerShellWebAccess/wwwroot
 
 3. Open the IIS Manager console by doing one of the following.
 
@@ -411,7 +411,7 @@ gateway as a root website.
 7. In the **Application pool** field, select the application pool that you created in step 3.
 
 8. In the **Physical path** field, browse for the location of the application. You can use the
-  default location, `%windir%/Web/PowerShellWebAccess/wwwroot`. Click **OK**.
+  default location, `$env:windir/Web/PowerShellWebAccess/wwwroot`. Click **OK**.
 
 9. Follow the steps in the procedure
    [To configure an SSL certificate in IIS manager](#to-configure-an-ssl-certificate-in-iis-Manager)
@@ -480,7 +480,7 @@ gateway as a root website.
    the alternate application pool in the **Select Application Pool** dialog box, and then click
    **OK**.
 
-1. In the **Physical path** text box, navigate to %*windir*%/Web/PowerShellWebAccess/wwwroot.
+1. In the **Physical path** text box, navigate to %windir%/Web/PowerShellWebAccess/wwwroot.
 
 1. In the **Type** field of the **Binding** area, select **https**.
 

--- a/reference/docs-conceptual/learn/remoting/SSH-Remoting-in-PowerShell-Core.md
+++ b/reference/docs-conceptual/learn/remoting/SSH-Remoting-in-PowerShell-Core.md
@@ -56,7 +56,7 @@ password or key-based authentication.
 
 2. Install the latest Win32 OpenSSH. For installation instructions, see
    [Installation of OpenSSH](/windows-server/administration/openssh/openssh_install_firstuse).
-3. Edit the `sshd_config` file located at `%ProgramData%\ssh`.
+3. Edit the `sshd_config` file located at `$env:ProgramData\ssh`.
 
    - Make sure password authentication is enabled
 

--- a/reference/docs-conceptual/learn/remoting/WSMan-Remoting-in-PowerShell-Core.md
+++ b/reference/docs-conceptual/learn/remoting/WSMan-Remoting-in-PowerShell-Core.md
@@ -23,7 +23,7 @@ For more details, please see issue [#1193](https://github.com/PowerShell/PowerSh
 
 The script
 
-1. Creates a directory for the plug-in within %windir%\System32\PowerShell
+1. Creates a directory for the plug-in within `$env:windir\System32\PowerShell`
 1. Copies pwrshplugin.dll to that location
 1. Generates a configuration file
 1. Registers that plug-in with WinRM


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
This is the first of several PRs to change references to environment variables from `%variablename%` to `$env:variablename`.

Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [x] This PR partially fixes the issue, and issue #3559 tracks the remaining work
