### PR TITLE
Strip locale from docs links

### DIFF
--- a/dsc/managing-nodes/metaConfig.md
+++ b/dsc/managing-nodes/metaConfig.md
@@ -128,7 +128,7 @@ A **ConfigurationRepositoryWeb** defines the following properties.
 |ServerURL|string|The URL of the configuration service.|
 
 An example script to simplify configuring the ConfigurationRepositoryWeb value for on-premises nodes
-is available - see [Generating DSC metaconfigurations](https://docs.microsoft.com/en-us/azure/automation/automation-dsc-onboarding#generating-dsc-metaconfigurations)
+is available - see [Generating DSC metaconfigurations](https://docs.microsoft.com/azure/automation/automation-dsc-onboarding#generating-dsc-metaconfigurations)
 
 To define an SMB-based configuration server,
 you create a **ConfigurationRepositoryShare** block.
@@ -152,7 +152,7 @@ A **ResourceRepositoryWeb** defines the following properties.
 |ServerURL|string|The URL of the configuration server.|
 
 An example script to simplify configuring the ResourceRepositoryWeb value for on-premises nodes
-is available - see [Generating DSC metaconfigurations](https://docs.microsoft.com/en-us/azure/automation/automation-dsc-onboarding#generating-dsc-metaconfigurations)
+is available - see [Generating DSC metaconfigurations](https://docs.microsoft.com/azure/automation/automation-dsc-onboarding#generating-dsc-metaconfigurations)
 
 To define an SMB-based resource server,
 you create a **ResourceRepositoryShare** block.
@@ -177,7 +177,7 @@ The report server role is not compatible with SMB based pull service.
 |ServerURL|string|The URL of the configuration server.|
 
 An example script to simplify configuring the ReportServerWeb value for on-premises nodes
-is available - see [Generating DSC metaconfigurations](https://docs.microsoft.com/en-us/azure/automation/automation-dsc-onboarding#generating-dsc-metaconfigurations)
+is available - see [Generating DSC metaconfigurations](https://docs.microsoft.com/azure/automation/automation-dsc-onboarding#generating-dsc-metaconfigurations)
 
 ## Partial configurations
 
@@ -192,7 +192,7 @@ see [DSC Partial configurations](../pull-server/partialConfigs.md).
 |DependsOn|string{}|A list of names of other configurations that must be completed before this partial configuration is applied.|
 |Description|string|Text used to describe the partial configuration.|
 |ExclusiveResources|string[]|An array of resources exclusive to this partial configuration.|
-|RefreshMode|string|Specifies how the LCM gets this partial configuration. The possible values are __"Disabled"__, __"Push"__, and __"Pull"__. <ul><li>__Disabled__: This partial configuration is disabled.</li><li> __Push__: The partial configuration is pushed to the node by calling the [Publish-DscConfiguration](/powershell/module/PSDesiredStateConfiguration/Publish-DscConfiguration) cmdlet. After all partial configurations for the node are either pushed or pulled from a service, the configuration can be started by calling `Start-DscConfiguration –UseExisting`. This is the default value.</li><li>__Pull:__ The node is configured to regularly check for partial configuration from a pull service. If this property is set to __Pull__, you must specify a pull service in a __ConfigurationSource__ property. For more information about Azure Automation pull service, see [Azure Automation DSC Overview](https://docs.microsoft.com/en-us/azure/automation/automation-dsc-overview).</li></ul>|
+|RefreshMode|string|Specifies how the LCM gets this partial configuration. The possible values are __"Disabled"__, __"Push"__, and __"Pull"__. <ul><li>__Disabled__: This partial configuration is disabled.</li><li> __Push__: The partial configuration is pushed to the node by calling the [Publish-DscConfiguration](/powershell/module/PSDesiredStateConfiguration/Publish-DscConfiguration) cmdlet. After all partial configurations for the node are either pushed or pulled from a service, the configuration can be started by calling `Start-DscConfiguration –UseExisting`. This is the default value.</li><li>__Pull:__ The node is configured to regularly check for partial configuration from a pull service. If this property is set to __Pull__, you must specify a pull service in a __ConfigurationSource__ property. For more information about Azure Automation pull service, see [Azure Automation DSC Overview](https://docs.microsoft.com/azure/automation/automation-dsc-overview).</li></ul>|
 |ResourceModuleSource|string[]|An array of the names of resource servers from which to download required resources for this partial configuration. These names must refer to service endpoints previously defined in **ResourceRepositoryWeb** and **ResourceRepositoryShare** blocks.|
 
 __Note:__ partial configurations are supported with Azure Automation DSC, but only one configuration can be pulled from each automation account per node.
@@ -202,7 +202,7 @@ __Note:__ partial configurations are supported with Azure Automation DSC, but on
 ### Concepts
 [Desired State Configuration Overview](../overview/overview.md)
 
-[Getting started with Azure Automation DSC](https://docs.microsoft.com/en-us/azure/automation/automation-dsc-getting-started)
+[Getting started with Azure Automation DSC](https://docs.microsoft.com/azure/automation/automation-dsc-getting-started)
 
 ### Other Resources
 

--- a/dsc/pull-server/enactingConfigurations.md
+++ b/dsc/pull-server/enactingConfigurations.md
@@ -63,6 +63,6 @@ and does require some "do it yourself" integration.
 
 The following topics explain pull service and clients:
 
-- [Azure Automation DSC Overview](https://docs.microsoft.com/en-us/azure/automation/automation-dsc-overview)
+- [Azure Automation DSC Overview](https://docs.microsoft.com/azure/automation/automation-dsc-overview)
 - [Setting up an SMB pull server](pullServerSMB.md)
 - [Configuring a pull client](pullClientConfigID.md)

--- a/dsc/resources/get-test-set.md
+++ b/dsc/resources/get-test-set.md
@@ -232,6 +232,6 @@ VERBOSE: Time taken for configuration job to complete is 1.379 seconds
 
 ## See also
 
-- [Azure Automation DSC Overview](https://docs.microsoft.com/en-us/azure/automation/automation-dsc-overview)
+- [Azure Automation DSC Overview](https://docs.microsoft.com/azure/automation/automation-dsc-overview)
 - [Setting up an SMB pull server](../pull-server/pullServerSMB.md)
 - [Configuring a pull client](../pull-server/pullClientConfigID.md)

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -52,7 +52,7 @@ in this article.
 ## Types exposed by this provider
 
 Registry keys are represented as instances of the
-[Microsoft.Win32.RegistryKey](https://docs.microsoft.com/en-us/dotnet/api/microsoft.win32.registrykey)
+[Microsoft.Win32.RegistryKey](https://docs.microsoft.com/dotnet/api/microsoft.win32.registrykey)
 class. Registry entries are represented as instances of the
 [PSCustomObject](/dotnet/api/system.management.automation.pscustomobject)
 class.

--- a/reference/3.0/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Get-Module.md
@@ -423,7 +423,7 @@ Accept wildcard characters: True
 ### -CimSession
 
 Specifies a CIM session on the remote computer.
-Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) command.
+Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) command.
 
 `Get-Module` uses the CIM session connection to get modules from the remote computer.
 When you import the module (by using the `Import-Module` cmdlet) and use the commands from the imported module in the current session, the commands actually run on the remote computer.
@@ -531,9 +531,9 @@ When you create a CIM session on the local computer, Windows PowerShell uses DCO
 
 ## RELATED LINKS
 
-[Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession)
+[Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession)
 
-[New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession)
+[New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession)
 
 [about_Modules](About/about_Modules.md)
 

--- a/reference/3.0/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Import-Module.md
@@ -824,7 +824,7 @@ Accept wildcard characters: True
 ### -CimSession
 
 Specifies a CIM session on the remote computer.
-Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) command.
+Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) command.
 
 `Import-Module` uses the CIM session connection to import modules from the remote computer into the current session.
 When you use the commands from the imported module in the current session, the commands actually run on the remote computer.

--- a/reference/3.0/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Get-Process.md
@@ -325,7 +325,7 @@ If you use the Module parameter (without the FileVersionInfo parameter), it retu
 * You can also refer to Get-Process by its built-in aliases, "ps" and "gps". For more information, see about_Aliases.
 * On computers that are running a 64-bit version of Windows, the 64-bit version of Windows PowerShell gets only 64-bit process modules and the 32-bit version of Windows PowerShell gets only 32-bit process modules.
 * You can use the properties and methods of the WMI Win32_Process object in Windows PowerShell. For information, see T:Microsoft.PowerShell.Commands.Get-WmiObject and the Windows Management Instrumentation (WMI) SDK.
-* The default display of a process is a table that includes the following columns. For a description of all of the properties of process objects, see [Process Properties](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process#Properties) in the MSDN library.
+* The default display of a process is a table that includes the following columns. For a description of all of the properties of process objects, see [Process Properties](https://docs.microsoft.com/dotnet/api/system.diagnostics.process#Properties) in the MSDN library.
 
   - Handles: The number of handles that the process has opened.
 

--- a/reference/3.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
@@ -65,7 +65,7 @@ The created or updated instance is written to the WMI repository.
 
 New CIM cmdlets, introduced Windows PowerShell 3.0, perform the same tasks as the WMI cmdlets.
 The CIM cmdlets comply with WS-Management (WSMan) standards and with the Common Information Model (CIM) standard, which enables the cmdlets to use the same techniques to manage Windows computers and those running other operating systems.
-Instead of using `Set-WmiInstance`, consider using the [Set-CimInstance](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/set-ciminstance) or [New-CimInstance](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-ciminstance) cmdlets.
+Instead of using `Set-WmiInstance`, consider using the [Set-CimInstance](https://docs.microsoft.com/powershell/module/cimcmdlets/set-ciminstance) or [New-CimInstance](https://docs.microsoft.com/powershell/module/cimcmdlets/new-ciminstance) cmdlets.
 
 ## EXAMPLES
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -52,7 +52,7 @@ in this article.
 ## Types exposed by this provider
 
 Registry keys are represented as instances of the
-[Microsoft.Win32.RegistryKey](https://docs.microsoft.com/en-us/dotnet/api/microsoft.win32.registrykey)
+[Microsoft.Win32.RegistryKey](https://docs.microsoft.com/dotnet/api/microsoft.win32.registrykey)
 class. Registry entries are represented as instances of the
 [PSCustomObject](/dotnet/api/system.management.automation.pscustomobject)
 class.

--- a/reference/4.0/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Get-Module.md
@@ -392,7 +392,7 @@ Accept wildcard characters: False
 ### -CimSession
 
 Specifies a CIM session on the remote computer.
-Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) command.
+Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) command.
 
 `Get-Module` uses the CIM session connection to get modules from the remote computer.
 When you import the module (by using the `Import-Module` cmdlet) and use the commands from the imported module in the current session, the commands actually run on the remote computer.
@@ -576,9 +576,9 @@ When you create a CIM session on the local computer, Windows PowerShell uses DCO
 
 ## RELATED LINKS
 
-[Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession)
+[Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession)
 
-[New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession)
+[New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession)
 
 [about_Modules](About/about_Modules.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Import-Module.md
@@ -574,7 +574,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Specifies a CIM session on the remote computer.
-Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) command.
+Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) command.
 
 **Import-Module** uses the CIM session connection to import modules from the remote computer into the current session.
 When you use the commands from the imported module in the current session, the commands actually run on the remote computer.

--- a/reference/4.0/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Get-Process.md
@@ -375,7 +375,7 @@ If you use the Module parameter (without the FileVersionInfo parameter), it retu
 * You can also refer to Get-Process by its built-in aliases, "ps" and "gps". For more information, see about_Aliases.
 * On computers that are running a 64-bit version of Windows, the 64-bit version of Windows PowerShell gets only 64-bit process modules and the 32-bit version of Windows PowerShell gets only 32-bit process modules.
 * You can use the properties and methods of the WMI Win32_Process object in Windows PowerShell. For information, see T:Microsoft.PowerShell.Commands.Get-WmiObject and the Windows Management Instrumentation (WMI) SDK.
-* The default display of a process is a table that includes the following columns. For a description of all of the properties of process objects, see [Process Properties](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process#Properties) in the MSDN library.
+* The default display of a process is a table that includes the following columns. For a description of all of the properties of process objects, see [Process Properties](https://docs.microsoft.com/dotnet/api/system.diagnostics.process#Properties) in the MSDN library.
 
   - Handles: The number of handles that the process has opened.
 

--- a/reference/4.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
@@ -67,7 +67,7 @@ The created or updated instance is written to the WMI repository.
 
 New CIM cmdlets, introduced Windows PowerShell 3.0, perform the same tasks as the WMI cmdlets.
 The CIM cmdlets comply with WS-Management (WSMan) standards and with the Common Information Model (CIM) standard, which enables the cmdlets to use the same techniques to manage Windows computers and those running other operating systems.
-Instead of using `Set-WmiInstance`, consider using the [Set-CimInstance](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/set-ciminstance) or [New-CimInstance](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-ciminstance) cmdlets.
+Instead of using `Set-WmiInstance`, consider using the [Set-CimInstance](https://docs.microsoft.com/powershell/module/cimcmdlets/set-ciminstance) or [New-CimInstance](https://docs.microsoft.com/powershell/module/cimcmdlets/new-ciminstance) cmdlets.
 
 ## EXAMPLES
 

--- a/reference/4.0/PSDesiredStateConfiguration/Get-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Get-DscConfiguration.md
@@ -53,7 +53,7 @@ The second command gets the current configuration for the computers identified b
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/4.0/PSDesiredStateConfiguration/Get-DscLocalConfigurationManager.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Get-DscLocalConfigurationManager.md
@@ -54,7 +54,7 @@ The second command gets Local Configuration Manager settings for the computers i
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/4.0/PSDesiredStateConfiguration/Restore-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Restore-DscConfiguration.md
@@ -54,7 +54,7 @@ The second command restores the configuration for the computers identified by th
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/4.0/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
@@ -65,7 +65,7 @@ After the receiving the settings, Local Configuration Manager processes them.
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/4.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
@@ -46,7 +46,7 @@ The second command stops a currently running configuration job on the computer i
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/4.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -56,7 +56,7 @@ The second command tests configuration for the computers identified by the **Cim
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/4.0/PSDesiredStateConfiguration/Update-DscConfiguration.md
+++ b/reference/4.0/PSDesiredStateConfiguration/Update-DscConfiguration.md
@@ -53,7 +53,7 @@ The console does not accept additional commands until the current command finish
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -53,7 +53,7 @@ in this article.
 ## Types exposed by this provider
 
 Registry keys are represented as instances of the
-[Microsoft.Win32.RegistryKey](https://docs.microsoft.com/en-us/dotnet/api/microsoft.win32.registrykey)
+[Microsoft.Win32.RegistryKey](https://docs.microsoft.com/dotnet/api/microsoft.win32.registrykey)
 class. Registry entries are represented as instances of the
 [PSCustomObject](/dotnet/api/system.management.automation.pscustomobject)
 class.

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-Module.md
@@ -395,7 +395,7 @@ Accept wildcard characters: False
 ### -CimSession
 
 Specifies a CIM session on the remote computer.
-Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) command.
+Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) command.
 
 `Get-Module` uses the CIM session connection to get modules from the remote computer.
 When you import the module by using the `Import-Module` cmdlet and use the commands from the imported module in the current session, the commands actually run on the remote computer.
@@ -582,9 +582,9 @@ When you create a CIM session on the local computer, Windows PowerShell uses DCO
 
 ## RELATED LINKS
 
-[Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession)
+[Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession)
 
-[New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession)
+[New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession)
 
 [about_Modules](About/about_Modules.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Import-Module.md
@@ -590,7 +590,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Specifies a CIM session on the remote computer.
-Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) command.
+Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) command.
 
 **Import-Module** uses the CIM session connection to import modules from the remote computer into the current session.
 When you use the commands from the imported module in the current session, the commands actually run on the remote computer.

--- a/reference/5.0/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Get-Process.md
@@ -378,7 +378,7 @@ If you use the *Module* parameter, without the *FileVersionInfo* parameter, it r
 * You can also refer to this cmdlet by its built-in aliases, ps and gps. For more information, see about_Aliases.
 * On computers that are running a 64-bit version of Windows, the 64-bit version of Windows PowerShell gets only 64-bit process modules and the 32-bit version of Windows PowerShell gets only 32-bit process modules.
 * You can use the properties and methods of the Windows Management Instrumentation (WMI) Win32_Process object in Windows PowerShell. For information, see Get-WmiObject and the WMI SDK.
-* The default display of a process is a table that includes the following columns. For a description of all of the properties of process objects, see [Process Properties](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process#Properties) in the MSDN library.
+* The default display of a process is a table that includes the following columns. For a description of all of the properties of process objects, see [Process Properties](https://docs.microsoft.com/dotnet/api/system.diagnostics.process#Properties) in the MSDN library.
 
   - Handles: The number of handles that the process has opened.
 

--- a/reference/5.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Set-WmiInstance.md
@@ -68,7 +68,7 @@ The created or updated instance is written to the WMI repository.
 New CIM cmdlets, introduced Windows PowerShell 3.0, perform the same tasks as the WMI cmdlets.
 The CIM cmdlets comply with WS-Management (WSMan) standards and with the Common Information Model (CIM) standard.
 This enables cmdlets to use the same techniques to manage Windows-based computers and those running other operating systems.
-Instead of using `Set-WmiInstance`, consider using the [Set-CimInstance](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/set-ciminstance) or [New-CimInstance](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-ciminstance) cmdlets.
+Instead of using `Set-WmiInstance`, consider using the [Set-CimInstance](https://docs.microsoft.com/powershell/module/cimcmdlets/set-ciminstance) or [New-CimInstance](https://docs.microsoft.com/powershell/module/cimcmdlets/new-ciminstance) cmdlets.
 
 ## EXAMPLES
 

--- a/reference/5.0/PSDesiredStateConfiguration/About/about_Classes_and_DSC.md
+++ b/reference/5.0/PSDesiredStateConfiguration/About/about_Classes_and_DSC.md
@@ -981,4 +981,4 @@ function Html ([HTML] $doc) { return $doc }
 
 [about_Methods](../../Microsoft.PowerShell.Core/About/about_Methods.md)
 
-[Build Custom Windows PowerShell Desired State Configuration Resources](https://docs.microsoft.com/en-us/powershell/dsc/resources/authoringResource)
+[Build Custom Windows PowerShell Desired State Configuration Resources](https://docs.microsoft.com/powershell/dsc/resources/authoringResource)

--- a/reference/5.0/PSDesiredStateConfiguration/Disable-DscDebug.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Disable-DscDebug.md
@@ -70,7 +70,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Enable-DscDebug.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Enable-DscDebug.md
@@ -86,7 +86,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Get-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Get-DscConfiguration.md
@@ -79,7 +79,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Get-DscConfigurationStatus.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Get-DscConfigurationStatus.md
@@ -94,7 +94,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Get-DscLocalConfigurationManager.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Get-DscLocalConfigurationManager.md
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Publish-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Publish-DscConfiguration.md
@@ -50,7 +50,7 @@ The user who runs the cmdlet should be administrator on the remote computer.
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Remove-DscConfigurationDocument.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Remove-DscConfigurationDocument.md
@@ -72,7 +72,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Restore-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Restore-DscConfiguration.md
@@ -83,7 +83,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
@@ -65,7 +65,7 @@ After the receiving the settings, LCM processes them.
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Stop-DscConfiguration.md
@@ -74,7 +74,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -136,7 +136,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.0/PSDesiredStateConfiguration/Update-DscConfiguration.md
+++ b/reference/5.0/PSDesiredStateConfiguration/Update-DscConfiguration.md
@@ -53,7 +53,7 @@ The console does not accept additional commands until the current command finish
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](http://go.microsoft.com/fwlink/p/?LinkId=227967] or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](http://go.microsoft.com/fwlink/p/?LinkId=227967] or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -53,7 +53,7 @@ in this article.
 ## Types exposed by this provider
 
 Registry keys are represented as instances of the
-[Microsoft.Win32.RegistryKey](https://docs.microsoft.com/en-us/dotnet/api/microsoft.win32.registrykey)
+[Microsoft.Win32.RegistryKey](https://docs.microsoft.com/dotnet/api/microsoft.win32.registrykey)
 class. Registry entries are represented as instances of the
 [PSCustomObject](/dotnet/api/system.management.automation.pscustomobject)
 class.

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-Module.md
@@ -392,7 +392,7 @@ Accept wildcard characters: False
 ### -CimSession
 
 Specifies a CIM session on the remote computer.
-Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) command.
+Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) command.
 
 `Get-Module` uses the CIM session connection to get modules from the remote computer.
 When you import the module by using the `Import-Module` cmdlet and use the commands from the imported module in the current session, the commands actually run on the remote computer.
@@ -605,9 +605,9 @@ When you create a CIM session on the local computer, Windows PowerShell uses DCO
 
 ## RELATED LINKS
 
-[Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession)
+[Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession)
 
-[New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession)
+[New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession)
 
 [Get-PSSession](Get-PSSession.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Import-Module.md
@@ -592,7 +592,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Specifies a CIM session on the remote computer.
-Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) command.
+Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) command.
 
 **Import-Module** uses the CIM session connection to import modules from the remote computer into the current session.
 When you use the commands from the imported module in the current session, the commands actually run on the remote computer.

--- a/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Get-Process.md
@@ -379,7 +379,7 @@ If you use the *Module* parameter, without the *FileVersionInfo* parameter, it r
 * You can also refer to this cmdlet by its built-in aliases, ps and gps. For more information, see about_Aliases.
 * On computers that are running a 64-bit version of Windows, the 64-bit version of Windows PowerShell gets only 64-bit process modules and the 32-bit version of Windows PowerShell gets only 32-bit process modules.
 * You can use the properties and methods of the Windows Management Instrumentation (WMI) Win32_Process object in Windows PowerShell. For information, see Get-WmiObject and the WMI SDK.
-* The default display of a process is a table that includes the following columns. For a description of all of the properties of process objects, see [Process Properties](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process#Properties) in the MSDN library.
+* The default display of a process is a table that includes the following columns. For a description of all of the properties of process objects, see [Process Properties](https://docs.microsoft.com/dotnet/api/system.diagnostics.process#Properties) in the MSDN library.
 
   - Handles: The number of handles that the process has opened.
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Set-WmiInstance.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Set-WmiInstance.md
@@ -69,7 +69,7 @@ The created or updated instance is written to the WMI repository.
 New CIM cmdlets, introduced Windows PowerShell 3.0, perform the same tasks as the WMI cmdlets.
 The CIM cmdlets comply with WS-Management (WSMan) standards and with the Common Information Model (CIM) standard.
 this enables cmdlets to use the same techniques to manage Windows-based computers and those running other operating systems.
-Instead of using `Set-WmiInstance`, consider using the [Set-CimInstance](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/set-ciminstance) or [New-CimInstance](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-ciminstance) cmdlets.
+Instead of using `Set-WmiInstance`, consider using the [Set-CimInstance](https://docs.microsoft.com/powershell/module/cimcmdlets/set-ciminstance) or [New-CimInstance](https://docs.microsoft.com/powershell/module/cimcmdlets/new-ciminstance) cmdlets.
 
 ## EXAMPLES
 

--- a/reference/5.1/Microsoft.PowerShell.Security/New-FileCatalog.md
+++ b/reference/5.1/Microsoft.PowerShell.Security/New-FileCatalog.md
@@ -25,7 +25,7 @@ New-FileCatalog [-CatalogVersion <Int32>] [-CatalogFilePath] <String> [[-Path] <
 
 ## DESCRIPTION
 
-`New-FileCatalog` creates a [Windows catalog file](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/catalog-files)
+`New-FileCatalog` creates a [Windows catalog file](https://docs.microsoft.com/windows-hardware/drivers/install/catalog-files)
 for a set of folders and files.
 This catalog file contains hashes for all files in the provided paths.
 Users can then distribute the catalog with their files so that users can validate

--- a/reference/5.1/PSDesiredStateConfiguration/About/about_Classes_and_DSC.md
+++ b/reference/5.1/PSDesiredStateConfiguration/About/about_Classes_and_DSC.md
@@ -981,4 +981,4 @@ function Html ([HTML] $doc) { return $doc }
 
 [about_Methods](../../Microsoft.PowerShell.Core/About/about_Methods.md)
 
-[Build Custom Windows PowerShell Desired State Configuration Resources](https://docs.microsoft.com/en-us/powershell/dsc/resources/authoringResource)
+[Build Custom Windows PowerShell Desired State Configuration Resources](https://docs.microsoft.com/powershell/dsc/resources/authoringResource)

--- a/reference/5.1/PSDesiredStateConfiguration/Disable-DscDebug.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Disable-DscDebug.md
@@ -60,7 +60,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Enable-DscDebug.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Enable-DscDebug.md
@@ -76,7 +76,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Get-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Get-DscConfiguration.md
@@ -69,7 +69,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Get-DscConfigurationStatus.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Get-DscConfigurationStatus.md
@@ -84,7 +84,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Publish-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Publish-DscConfiguration.md
@@ -51,7 +51,7 @@ The user who runs the cmdlet should be administrator on the remote computer.
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Set-DscLocalConfigurationManager.md
@@ -66,7 +66,7 @@ After the receiving the settings, LCM processes them.
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Test-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Test-DscConfiguration.md
@@ -137,7 +137,7 @@ Accept wildcard characters: False
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/5.1/PSDesiredStateConfiguration/Update-DscConfiguration.md
+++ b/reference/5.1/PSDesiredStateConfiguration/Update-DscConfiguration.md
@@ -54,7 +54,7 @@ The console does not accept additional commands until the current command finish
 
 ### -CimSession
 Runs the cmdlet in a remote session or on a remote computer.
-Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) cmdlet.
+Enter a computer name or a session object, such as the output of a [New-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/new-cimsession) or [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) cmdlet.
 The default is the current session on the local computer.
 
 ```yaml

--- a/reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_PowerShell_Config.md
@@ -98,7 +98,7 @@ the configuration is for all users, sets the AllUser module path.
 
 > [!WARNING]
 > Configuring an AllUsers or CurrentUser module path here
-> will not change the scoped installation location for PowerShellGet modules like [Install-Module](https://docs.microsoft.com/en-us/powershell/module/powershellget/install-module).
+> will not change the scoped installation location for PowerShellGet modules like [Install-Module](https://docs.microsoft.com/powershell/module/powershellget/install-module).
 > These cmdlets always use the *default* module paths.
 
 If no value is set, the default value for the respective module path component

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -53,7 +53,7 @@ in this article.
 ## Types exposed by this provider
 
 Registry keys are represented as instances of the
-[Microsoft.Win32.RegistryKey](https://docs.microsoft.com/en-us/dotnet/api/microsoft.win32.registrykey)
+[Microsoft.Win32.RegistryKey](https://docs.microsoft.com/dotnet/api/microsoft.win32.registrykey)
 class. Registry entries are represented as instances of the
 [PSCustomObject](/dotnet/api/system.management.automation.pscustomobject)
 class.

--- a/reference/6/Microsoft.PowerShell.Core/Get-Module.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-Module.md
@@ -393,7 +393,7 @@ Accept wildcard characters: False
 ### -CimSession
 
 Specifies a CIM session on the remote computer.
-Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/get-cimsession) command.
+Enter a variable that contains the CIM session or a command that gets the CIM session, such as a [Get-CimSession](https://docs.microsoft.com/powershell/module/cimcmdlets/get-cimsession) command.
 
 `Get-Module` uses the CIM session connection to get modules from the remote computer.
 When you import the module by using the `Import-Module` cmdlet and use the commands from the imported module in the current session, the commands actually run on the remote computer.

--- a/reference/6/Microsoft.PowerShell.Management/Get-Process.md
+++ b/reference/6/Microsoft.PowerShell.Management/Get-Process.md
@@ -328,7 +328,7 @@ If you use the *Module* parameter, without the *FileVersionInfo* parameter, it r
 * You can also refer to this cmdlet by its built-in aliases, ps and gps. For more information, see about_Aliases.
 * On computers that are running a 64-bit version of Windows, the 64-bit version of PowerShell gets only 64-bit process modules and the 32-bit version of PowerShell gets only 32-bit process modules.
 * You can use the properties and methods of the Windows Management Instrumentation (WMI) Win32_Process object in PowerShell. For information, see Get-WmiObject and the WMI SDK.
-* The default display of a process is a table that includes the following columns. For a description of all of the properties of process objects, see [Process Properties](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process#Properties) in the MSDN library.
+* The default display of a process is a table that includes the following columns. For a description of all of the properties of process objects, see [Process Properties](https://docs.microsoft.com/dotnet/api/system.diagnostics.process#Properties) in the MSDN library.
 
   - Handles: The number of handles that the process has opened.
 

--- a/reference/6/Microsoft.PowerShell.Security/New-FileCatalog.md
+++ b/reference/6/Microsoft.PowerShell.Security/New-FileCatalog.md
@@ -25,7 +25,7 @@ New-FileCatalog [-CatalogVersion <Int32>] [-CatalogFilePath] <String> [[-Path] <
 
 ## DESCRIPTION
 
-`New-FileCatalog` creates a [Windows catalog file](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/catalog-files)
+`New-FileCatalog` creates a [Windows catalog file](https://docs.microsoft.com/windows-hardware/drivers/install/catalog-files)
 for a set of folders and files.
 This catalog file contains hashes for all files in the provided paths.
 Users can then distribute the catalog with their files so that users can validate

--- a/reference/6/PSDesiredStateConfiguration/About/about_Classes_and_DSC.md
+++ b/reference/6/PSDesiredStateConfiguration/About/about_Classes_and_DSC.md
@@ -981,4 +981,4 @@ function Html ([HTML] $doc) { return $doc }
 
 [about_Methods](../../Microsoft.PowerShell.Core/About/about_Methods.md)
 
-[Build Custom Windows PowerShell Desired State Configuration Resources](https://docs.microsoft.com/en-us/powershell/dsc/resources/authoringResource)
+[Build Custom Windows PowerShell Desired State Configuration Resources](https://docs.microsoft.com/powershell/dsc/resources/authoringResource)

--- a/reference/docs-conceptual/components/vscode/Using-VSCode-for-Remote-Editing-and-Debugging.md
+++ b/reference/docs-conceptual/components/vscode/Using-VSCode-for-Remote-Editing-and-Debugging.md
@@ -57,7 +57,7 @@ The watered down explanation of the cmdlet is:
 - `Enter-PSSession -ContainerId foo` and `Enter-PSSession -VmId foo` start a session via PowerShell Direct
 - `Enter-PSSession -HostName foo` starts a session via SSH
 
-For more info on `Enter-PSSession`, check out the docs [here](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/enter-pssession?view=powershell-6).
+For more info on `Enter-PSSession`, check out the docs [here](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/enter-pssession?view=powershell-6).
 
 I'll be using SSH for remoting since I'm going from macOS to an Ubuntu VM in Azure.
 

--- a/reference/docs-conceptual/components/web-access/troubleshooting-access-problems-in-windows-powershell-web-access.md
+++ b/reference/docs-conceptual/components/web-access/troubleshooting-access-problems-in-windows-powershell-web-access.md
@@ -162,4 +162,4 @@ For more information about IPv6 addresses, see [How IPv6 Works](https://technet.
 
 - [Authorization Rules and Security Features of Windows PowerShell Web Access](https://technet.microsoft.com/en-us/library/dn282394(v=ws.11).aspx)
 - [Use the Web-based Windows PowerShell Console](https://technet.microsoft.com/en-us/library/hh831417(v=ws.11).aspx)
-- [about_Remote_Requirements](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_remote_requirements)
+- [about_Remote_Requirements](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_remote_requirements)

--- a/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-61.md
+++ b/reference/docs-conceptual/whats-new/What-s-New-in-PowerShell-Core-61.md
@@ -39,8 +39,8 @@ The Windows Compatibility Pack enables PowerShell Core to use **more than 1900 c
 
 ## Support for Application Whitelisting
 
-PowerShell Core 6.1 has parity with Windows PowerShell 5.1 supporting [AppLocker](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/applocker/applocker-overview)
-and [Device Guard](https://docs.microsoft.com/en-us/windows/security/threat-protection/device-guard/introduction-to-device-guard-virtualization-based-security-and-windows-defender-application-control) application whitelisting.
+PowerShell Core 6.1 has parity with Windows PowerShell 5.1 supporting [AppLocker](https://docs.microsoft.com/windows/security/threat-protection/windows-defender-application-control/applocker/applocker-overview)
+and [Device Guard](https://docs.microsoft.com/windows/security/threat-protection/device-guard/introduction-to-device-guard-virtualization-based-security-and-windows-defender-application-control) application whitelisting.
 Application whitelisting allows granular control of what binaries are allowed to be executed used with PowerShell [Constrained Language mode](https://blogs.msdn.microsoft.com/powershell/2017/11/02/powershell-constrained-language-mode/).
 
 ## Performance improvements


### PR DESCRIPTION
Remove `en-us/` from any links to docs.microsoft.com. This allows the reader to stay on their preferred locale rather than being unexpectedly kicked over to en-us.

Version(s) of document impacted
------------------------------
- [x] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document