### PR TITLE
removing %-style environment variables and other cleanup

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -89,7 +89,7 @@ PS C:\> cd HKLM:\Software
 > PowerShell uses aliases to allow you a familiar way to work with provider
 > paths. Commands such as `dir` and `ls` are now aliases for
 > [Get-ChildItem](../../Microsoft.PowerShell.Management/Get-ChildItem.md),
-> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md)
+> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md),
 > and `pwd` is an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
 
 This last example shows another path syntax you can use to navigate the
@@ -136,8 +136,7 @@ Spooler     DependOnService    : {RPCSS, http}
             Group              : SpoolerGroup
             ImagePath          : C:\WINDOWS\System32\spoolsv.exe
             ObjectName         : LocalSystem
-            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege,
-            SeAuditPrivilege, SeChangeNotifyPrivilege...}
+            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege, ...
             ServiceSidType     : 1
             Start              : 2
             Type               : 27
@@ -194,7 +193,7 @@ articles.
 
 Registry key values are stored as properties of each registry key. The
 `Get-ItemProperty` cmdlet views registry key properties using the name you
-specify. The result is a **PSCustom** object containing the properties you
+specify. The result is a **PSCustomObject** containing the properties you
 specify.
 
 The Following example uses the `Get-ItemProperty` cmdlet to view all
@@ -309,9 +308,9 @@ Name                           Property
 ContosoCompany
 ```
 
-You can use the `New-ItemProperty` cmdlet to create to **Item Properties** on
-a registry key that you specify. The following example creates a new DWORD
-value on the ContosoCompany registry key.
+You can use the `New-ItemProperty` cmdlet to create values in a registry key
+that you specify. The following example creates a new DWORD value on the
+ContosoCompany registry key.
 
 ```powershell
 $path = "HKLM:\SOFTWARE\ContosoCompany"
@@ -541,7 +540,7 @@ Beginning in Windows PowerShell 3.0, you can get customized help topics for
 provider cmdlets that explain how those cmdlets behave in a file system drive.
 
 To get the help topics that are customized for the file system drive, run a
-`Get-Help` command in a file system drive or use the `-Path` parameter to
+`Get-Help` command in a file system drive or use the **Path** parameter to
 specify a file system drive.
 
 ```powershell

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -28,8 +28,10 @@ Provides access to the registry keys, entries, and values in PowerShell.
 The PowerShell **Registry** provider lets you get, add, change,
 clear, and delete registry keys, entries, and values in PowerShell.
 
-The **Registry** drives are a hierarchical namespace containing the registry keys and subkeys on your computer. Registry entries and values are not
-components of that hierarchy. Instead, they are properties of each of the keys.
+The **Registry** drives are a hierarchical namespace containing the registry
+keys and subkeys on your computer. Registry entries and values are not
+components of that hierarchy. Instead, they are properties of each of the
+keys.
 
 The **Registry** provider supports the following cmdlets, which are covered
 in this article.
@@ -76,7 +78,8 @@ Set-Location C:
 
 You can also work with the **Registry** provider from any other PowerShell
 drive. To reference a registry key from another location, use the drive name
-(`HKLM:`, `HKCU:`) in the path. Use a backslash (\\) or a forward slash (/) to indicate a level of the **Registry** drive.
+(`HKLM:`, `HKCU:`) in the path. Use a backslash (\\) or a forward slash (/) to
+indicate a level of the **Registry** drive.
 
 ```powershell
 PS C:\> cd HKLM:\Software
@@ -86,13 +89,13 @@ PS C:\> cd HKLM:\Software
 > PowerShell uses aliases to allow you a familiar way to work with provider
 > paths. Commands such as `dir` and `ls` are now aliases for
 > [Get-ChildItem](../../Microsoft.PowerShell.Management/Get-ChildItem.md),
-> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md). and `pwd` is
-> an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
+> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md)
+> and `pwd` is an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
 
 This last example shows another path syntax you can use to navigate the
 **Registry** provider. This syntax uses the provider name, followed by two
-colons `::`.  This syntax allows you to use the full HIVE name, instead
-of the mapped drive name `HKLM`.
+colons `::`. This syntax allows you to use the full HIVE name, instead of the
+mapped drive name `HKLM`.
 
 ```powershell
 cd "Registry::HKEY_LOCAL_MACHINE\Software"
@@ -100,7 +103,8 @@ cd "Registry::HKEY_LOCAL_MACHINE\Software"
 
 ## Displaying the contents of registry keys
 
-The registry is divided into keys, subkeys, and entries.  For more information about registry structure, see [Structure of the Registry](/windows/desktop/sysinfo/structure-of-the-registry.md).
+The registry is divided into keys, subkeys, and entries. For more information
+about registry structure, see [Structure of the Registry](/windows/desktop/sysinfo/structure-of-the-registry.md).
 
 In a **Registry** drive, each key is a container. A key can contain any number
 of keys. A registry key that has a parent key is called a subkey. You can
@@ -112,7 +116,8 @@ they are called **Item Properties**. A registry key can have both children
 keys and item properties.
 
 In this example, the difference between `Get-Item` and `Get-ChildItem` is
-shown. When you use `Get-Item` on the "Spooler" registry key, you can view its properties.
+shown. When you use `Get-Item` on the "Spooler" registry key, you can view its
+properties.
 
 ```
 PS C:\ > Get-Item -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
@@ -121,21 +126,21 @@ PS C:\ > Get-Item -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services
 
 
-Name                           Property
-----                           --------
-Spooler                        DependOnService    : {RPCSS, http}
-                               Description        : @%systemroot%\system32\spoolsv.exe,-2
-                               DisplayName        : @%systemroot%\system32\spoolsv.exe,-1
-                               ErrorControl       : 1
-                               FailureActions     : {16, 14, 0, 0...}
-                               Group              : SpoolerGroup
-                               ImagePath          : C:\WINDOWS\System32\spoolsv.exe
-                               ObjectName         : LocalSystem
-                               RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege, SeAuditPrivilege,
-                               SeChangeNotifyPrivilege...}
-                               ServiceSidType     : 1
-                               Start              : 2
-                               Type               : 272
+Name        Property
+----        --------
+Spooler     DependOnService    : {RPCSS, http}
+            Description        : @%systemroot%\system32\spoolsv.exe,-2
+            DisplayName        : @%systemroot%\system32\spoolsv.exe,-1
+            ErrorControl       : 1
+            FailureActions     : {16, 14, 0, 0...}
+            Group              : SpoolerGroup
+            ImagePath          : C:\WINDOWS\System32\spoolsv.exe
+            ObjectName         : LocalSystem
+            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege,
+            SeAuditPrivilege, SeChangeNotifyPrivilege...}
+            ServiceSidType     : 1
+            Start              : 2
+            Type               : 27
 ```
 
 Each registry key can also have subkeys. When you use `Get-Item` on a registry
@@ -150,16 +155,16 @@ PS C:\> Get-ChildItem -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Spooler
 
 
-Name                           Property
-----                           --------
-Performance                    Close           : PerfClose
-                               Collect         : PerfCollect
-                               Collect Timeout : 2000
-                               Library         : C:\Windows\System32\winspool.drv
-                               Object List     : 1450
-                               Open            : PerfOpen
-                               Open Timeout    : 4000
-Security                       Security : {1, 0, 20, 128...}
+Name             Property
+----             --------
+Performance      Close           : PerfClose
+                 Collect         : PerfCollect
+                 Collect Timeout : 2000
+                 Library         : C:\Windows\System32\winspool.drv
+                 Object List     : 1450
+                 Open            : PerfOpen
+                 Open Timeout    : 4000
+Security         Security : {1, 0, 20, 128...}
 ```
 
 The `Get-Item` cmdlet can also be used on the current location. The following
@@ -172,10 +177,10 @@ PS HKLM:\SYSTEM\CurrentControlSet\Services\Spooler> Get-Item .
 
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services
 
-Name                           Property
-----                           --------
-Spooler                        DependOnService    : {RPCSS, http}
-                               Description        : @%systemroot%\system32\spoolsv.exe,-2
+Name             Property
+----             --------
+Spooler          DependOnService    : {RPCSS, http}
+                 Description        : @%systemroot%\system32\spoolsv.exe,-2
 ...
 ```
 
@@ -187,8 +192,10 @@ articles.
 
 ## Viewing registry key values
 
-Registry key values are stored as properties of each registry key. The `Get-ItemProperty` cmdlet views registry key properties using the name you specify. The result is a **PSCustom** object containing the
-properties you specify.
+Registry key values are stored as properties of each registry key. The
+`Get-ItemProperty` cmdlet views registry key properties using the name you
+specify. The result is a **PSCustom** object containing the properties you
+specify.
 
 The Following example uses the `Get-ItemProperty` cmdlet to view all
 properties. Storing the resulting object in a variable allows you to access
@@ -249,7 +256,10 @@ articles.
 
 ## Changing registry key values
 
-The `Set-ItemProperty` cmdlet will set attributes for registry keys. The following example uses `Set-ItemProperty` to change the spooler service start type to manual. The example changes the **StartType** back to *Automatic* using the `Set-Service` cmdlet.
+The `Set-ItemProperty` cmdlet will set attributes for registry keys. The
+following example uses `Set-ItemProperty` to change the spooler service start
+type to manual. The example changes the **StartType** back to *Automatic*
+using the `Set-Service` cmdlet.
 
 ```
 PS C:\> Get-Service spooler | Select-Object Name, StartMode
@@ -273,7 +283,8 @@ Each registry key has a *default* value. You can change the *default* value
 for a registry key with either `Set-Item` or `Set-ItemProperty`.
 
 ```powershell
-Set-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name "(default)" -Value "one" Set-Item -Path HKLM:\SOFTWARE\Contoso -Value "two"
+Set-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name "(default)" -Value "one"
+Set-Item -Path HKLM:\SOFTWARE\Contoso -Value "two"
 ```
 
 For more information on the cmdlets used in this section, see the following
@@ -298,9 +309,9 @@ Name                           Property
 ContosoCompany
 ```
 
-You can use the `New-ItemProperty` cmdlet to create to **Item Properties**
-on a registry key that you specify. The following example creates a new
-DWORD value on the ContosoCompany registry key.
+You can use the `New-ItemProperty` cmdlet to create to **Item Properties** on
+a registry key that you specify. The following example creates a new DWORD
+value on the ContosoCompany registry key.
 
 ```powershell
 $path = "HKLM:\SOFTWARE\ContosoCompany"
@@ -315,7 +326,10 @@ For detailed cmdlet usage, see [New-ItemProperty](../../Microsoft.PowerShell.Man
 
 ## Copying registry keys and values
 
-In the **Registry** provider, use the `Copy-Item` cmdlet copies registry keys and values. Use the `Copy-ItemProperty` cmdlet to copy registry values only. The following command copies the "Contoso" registry key, and its properties to the specified location "HKLM:\Software\Fabrikam".
+In the **Registry** provider, use the `Copy-Item` cmdlet copies registry keys
+and values. Use the `Copy-ItemProperty` cmdlet to copy registry values only.
+The following command copies the "Contoso" registry key, and its properties to
+the specified location "HKLM:\Software\Fabrikam".
 
 `Copy-Item` creates the destination key if it does not exist. If the
 destination key exists, `Copy-Item` creates a duplicate of the source key
@@ -343,9 +357,9 @@ articles.
 ## Moving registry keys and values
 
 The `Move-Item` and `Move-ItemProperty` cmdlets behave like their "Copy"
-counterparts. If the destination exists, `Move-Item` moves the source
-key underneath the destination key. If the destination key does not exist,
-the source key is moved to the destination path.
+counterparts. If the destination exists, `Move-Item` moves the source key
+underneath the destination key. If the destination key does not exist, the
+source key is moved to the destination path.
 
 The following command moves the "Contoso" key to the path
 "HKLM:\SOFTWARE\Fabrikam".
@@ -402,7 +416,8 @@ For more examples and cmdlet usage details see the following articles.
 
 ## Removing and clearing registry keys and values
 
-You can remove contained items by using **Remove-Item**, but you will be prompted to confirm the removal if the item contains anything else. The
+You can remove contained items by using **Remove-Item**, but you will be
+prompted to confirm the removal if the item contains anything else. The
 following example attempts to delete a key "HKLM:\SOFTWARE\Contoso".
 
 ```
@@ -418,8 +433,8 @@ PS C:\> Remove-Item -Path HKLM:\SOFTWARE\Contoso
 
 Confirm
 The item at HKLM:\SOFTWARE\Contoso has children and the -Recurse
-parameter was not specified. If you continue, all children will be removed with
- the item. Are you sure you want to continue?
+parameter was not specified. If you continue, all children will be removed
+with the item. Are you sure you want to continue?
 [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help
 (default is "Y"):
 ```
@@ -430,14 +445,16 @@ To delete contained items without prompting, specify the `-Recurse` parameter.
 Remove-Item -Path HKLM:\SOFTWARE\Contoso -Recurse
 ```
 
-If you wanted to remove all items within "HKLM:\SOFTWARE\Contoso" but not "HKLM:\SOFTWARE\Contoso" itself, use a trailing backslash `\` followed by a
+If you wanted to remove all items within "HKLM:\SOFTWARE\Contoso" but not
+"HKLM:\SOFTWARE\Contoso" itself, use a trailing backslash `\` followed by a
 wildcard.
 
 ```powershell
 Remove-Item -Path HKLM:\SOFTWARE\Contoso\* -Recurse
 ```
 
-This command deletes the "ContosoTest" registry value from the "HKLM:\SOFTWARE\Contoso" registry key.
+This command deletes the "ContosoTest" registry value from the
+"HKLM:\SOFTWARE\Contoso" registry key.
 
 ```powershell
 Remove-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name ContosoTest
@@ -452,12 +469,12 @@ PS HKLM:\SOFTWARE\> Get-Item .\Contoso\
 
     Hive: HKEY_LOCAL_MACHINE\SOFTWARE
 
-Name                           Property
-----                           --------
-Contoso                        Server     : {a, b, c}
-                               HereString : {This is text which contains
-                                            newlines. It also contains "quoted" strings}
-                               (default)  : 1
+Name           Property
+----           --------
+Contoso        Server     : {a, b, c}
+               HereString : {This is text which contains
+               newlines. It also contains "quoted" strings}
+               (default)  : 1
 
 PS HKLM:\SOFTWARE\> Clear-Item .\Contoso\
 PS HKLM:\SOFTWARE\> Get-Item .\Contoso\
@@ -478,23 +495,33 @@ For more examples and cmdlet usage details see the following articles.
 
 ## Dynamic parameters
 
-Dynamic parameters are cmdlet parameters that are added by a PowerShell provider and are available only when the cmdlet is being used in the provider-enabled drive.
+Dynamic parameters are cmdlet parameters that are added by a PowerShell
+provider and are available only when the cmdlet is being used in the
+provider-enabled drive.
 
 ### Type <Microsoft.Win32.RegistryValueKind>
 
 Establishes or changes the data type of a registry value. The default is `String` (REG_SZ).
 
-This parameter works as designed on the [Set-ItemProperty](../../Microsoft.PowerShell.Management/Set-ItemProperty.md) cmdlet. It is also available on the [Set-Item](../../Microsoft.PowerShell.Management/Set-Item.md) cmdlet in the registry drives, but it has no effect.
+This parameter works as designed on the
+[Set-ItemProperty](../../Microsoft.PowerShell.Management/Set-ItemProperty.md)
+cmdlet. It is also available on the
+[Set-Item](../../Microsoft.PowerShell.Management/Set-Item.md) cmdlet in the
+registry drives, but it has no effect.
 
-|Value|Description|
-|-----------|-----------------|
-|  `String` | Specifies a null-terminated string. Equivalent to REG_SZ. |
-|  `ExpandString` | Specifies a null-terminated string that contains unexpanded references to environment variables that are expanded when the value is retrieved. Equivalent to REG_EXPAND_SZ. |
-|  `Binary` | Specifies binary data in any form. Equivalent to REG_BINARY. |
-|  `DWord` | Specifies a 32-bit binary number. Equivalent to REG_DWORD. |
-|  `MultiString` | Specifies an array of null-terminated strings terminated by two null characters. Equivalent to REG_MULTI_SZ. |
-|  `QWord` | Specifies a 64-bit binary number. Equivalent to REG_QWORD. |
-|  `Unknown` | Indicates an unsupported registry data type, such as REG_RESOURCE_LIST. |
+|Value | Description |
+| ---- | ----------- |
+| `String` | Specifies a null-terminated string. Equivalent to REG_SZ. |
+| `ExpandString` | Specifies a null-terminated string that contains unexpanded |
+|                | references to environment variables that are expanded when |
+|                | the value is retrieved. Equivalent to REG_EXPAND_SZ. |
+| `Binary` | Specifies binary data in any form. Equivalent to REG_BINARY. |
+| `DWord` | Specifies a 32-bit binary number. Equivalent to REG_DWORD. |
+| `MultiString` | Specifies an array of null-terminated strings terminated by |
+|               | two null characters. Equivalent to REG_MULTI_SZ. |
+| `QWord` | Specifies a 64-bit binary number. Equivalent to REG_QWORD. |
+| `Unknown` | Indicates an unsupported registry data type, such as |
+|           | REG_RESOURCE_LIST. |
 
 #### Cmdlets supported
 
@@ -504,9 +531,9 @@ This parameter works as designed on the [Set-ItemProperty](../../Microsoft.Power
 ## Using the pipeline
 
 Provider cmdlets accept pipeline input. You can use the pipeline to simplify
-task by sending provider data from one cmdlet to another provider cmdlet.
-To read more about how to use the pipeline with provider cmdlets, see the
-cmdlet references provided throughout this article.
+task by sending provider data from one cmdlet to another provider cmdlet. To
+read more about how to use the pipeline with provider cmdlets, see the cmdlet
+references provided throughout this article.
 
 ## Getting help
 
@@ -514,8 +541,8 @@ Beginning in Windows PowerShell 3.0, you can get customized help topics for
 provider cmdlets that explain how those cmdlets behave in a file system drive.
 
 To get the help topics that are customized for the file system drive, run a
-[Get-Help](../Get-Help.md) command in a file system drive or use the `-Path`
-parameter of [Get-Help](../Get-Help.md) to specify a file system drive.
+`Get-Help` command in a file system drive or use the `-Path` parameter to
+specify a file system drive.
 
 ```powershell
 Get-Help Get-ChildItem

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -166,7 +166,7 @@ creates firewall rules that allows remote access from the same local subnet.
 
 On client versions of Windows, `Enable-PSRemoting` succeeds on private and
 domain networks. By default, it fails on public networks, but if
-you use the SkipNetworkProfileCheck parameter, `Enable-PSRemoting` succeeds
+you use the **SkipNetworkProfileCheck** parameter, `Enable-PSRemoting` succeeds
 and creates a firewall rule that allows traffic from the same local subnet.
 
 To remove the local subnet restriction on public networks and allow
@@ -279,8 +279,8 @@ Get-Item wsman:\localhost\Service\RootSDDL
 
 To change the RootSDDL, use the `Set-Item` cmdlet in the WSMan: drive. To
 change the security descriptor of a session configuration, use the
-`Set-PSSessionConfiguration` cmdlet with the SecurityDescriptorSDDL or
-ShowSecurityDescriptorUI parameters.
+`Set-PSSessionConfiguration` cmdlet with the **SecurityDescriptorSDDL** or
+**ShowSecurityDescriptorUI** parameters.
 
 For more information about the WSMan: drive, see the Help topic for the
 WSMan provider ("Get-Help wsman").
@@ -308,8 +308,8 @@ Administrator.
 Invoke-Command -ComputerName Server01 -Credential Domain01\Admin01
 ```
 
-For more information about the Credential parameter, see `New-PSSession`,
-`Enter-PSSession` or `Invoke-Command`.
+For more information about the **Credential** parameter, see [New-PSSession](../New-PSSession.md),
+[Enter-PSSession](../Enter-PSSession.md) or [Invoke-Command](../Invoke-Command.md).
 
 ### HOW TO ENABLE REMOTING FOR NON-ADMINISTRATIVE USERS
 
@@ -737,8 +737,8 @@ Set-PSSessionConfiguration -Name microsoft.PowerShell `
 For more information about the `New-PSSessionOption` cmdlet, see
 `New-PSSessionOption`.
 
-For more information about the WS-Management quotas, see the Help topic for
-the WSMan provider (type `Get-Help WSMan`).
+For more information about the WS-Management quotas, see
+[about_WSMan_Provider](../../Microsoft.WsMan.Management/About/about_WSMan_Provider.md).
 
 ### HOW TO RESOLVE TIMEOUT ERRORS
 

--- a/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -18,15 +18,16 @@ This section describes some of the problems that you might encounter when
 using the remoting features of PowerShell that are based on
 WS-Management technology and it suggests solutions to these problems.
 
-Before using PowerShell remoting, see about_Remote and
-about_Remote_Requirements for guidance on configuration and basic use Also,
-the Help topics for each of the remoting cmdlets, particularly the parameter
-descriptions, have useful information that is designed to help you avoid
-problems.
+Before using PowerShell remoting, see [about_Remote](about_remote.md) and
+[about_Remote_Requirements](about_Remote_Requirements.md) for guidance on
+configuration and basic use. Also, the Help topics for each of the remoting
+cmdlets, particularly the parameter descriptions, have useful information that
+is designed to help you avoid problems.
 
-NOTE: To view or change settings for the local computer in the WSMan: drive,
-including changes to the session configurations, trusted hosts, ports, or
-listeners, start PowerShell with the "Run as administrator" option.
+> [!NOTE]
+> To view or change settings for the local computer in the WSMan: drive,
+> including changes to the session configurations, trusted hosts, ports, or
+> listeners, start PowerShell with the "Run as administrator" option.
 
 ## TROUBLESHOOTING PERMISSION AND AUTHENTICATION ISSUES
 
@@ -54,11 +55,12 @@ To start Windows PowerShell with the "Run as administrator option:
 - In the Windows taskbar, right-click the Windows PowerShell icon, and then
   click "Run as Administrator."
 
-  Note: In Windows Server 2008 R2, the Windows PowerShell icon is pinned
-  to the taskbar by default.
+  In Windows Server 2008 R2, the Windows PowerShell icon is pinned to the
+  taskbar by default.
 
 ### HOW TO ENABLE REMOTING
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -66,6 +68,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 No configuration is required to enable a computer to send remote
 commands. However, to receive remote commands, PowerShell remoting
@@ -76,25 +79,26 @@ session configurations.
 
 Windows PowerShell remoting is enabled on Windows Server 2012 and newer
 releases of Windows Server by default. On all other systems, run the
-Enable-PSRemoting cmdlet to enable remoting. You can also run the
-Enable-PSRemoting cmdlet to re-enable remoting on Windows Server 2012 and
+`Enable-PSRemoting` cmdlet to enable remoting. You can also run the
+`Enable-PSRemoting` cmdlet to re-enable remoting on Windows Server 2012 and
 newer releases of Windows Server if remoting is disabled.
 
 To configure a computer to receive remote commands, use the
-Enable-PSRemoting cmdlet. The following command enables all required
+`Enable-PSRemoting` cmdlet. The following command enables all required
 remote settings, enables the session configurations, and restarts the
 WinRM service to make the changes effective.
 
-Enable-PSRemoting
+`Enable-PSRemoting`
 
 To suppress all user prompts, type:
 
-Enable-PSRemoting -Force
+`Enable-PSRemoting -Force`
 
-For more information, see Enable-PSRemoting.
+For more information, see [Enable-PSRemoting](../Enable-PSRemoting.md).
 
 ### HOW TO ENABLE REMOTING IN AN ENTERPRISE
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -102,9 +106,10 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 To enable a single computer to receive remote PowerShell commands
-and accept connections, use the Enable-PSRemoting cmdlet.
+and accept connections, use the `Enable-PSRemoting` cmdlet.
 
 To enable remoting for multiple computers in an enterprise, you can use the
 following scaled options.
@@ -114,7 +119,7 @@ following scaled options.
   Enable Listeners by Using a Group Policy" (below).
 
 - To set the startup type of the Windows Remote Management (WinRM)
-  to Automatic on multiple computers, use the Set-Service cmdlet. For
+  to Automatic on multiple computers, use the `Set-Service` cmdlet. For
   instructions, see "How to Set the Startup Type of the WinrM Service"
   (below).
 
@@ -124,6 +129,7 @@ following scaled options.
 
 ### HOW TO ENABLE LISTENERS BY USING A GROUP POLICY
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -131,6 +137,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to listen
 for requests on the correct port and HTTP URL.
+```
 
 To configure the listeners for all computers in a domain, enable the "Allow
 automatic configuration of listeners" policy in the following Group Policy
@@ -144,20 +151,22 @@ permitted.
 
 ### HOW TO ENABLE REMOTING ON PUBLIC NETWORKS
 
+```
 ERROR:  Unable to check the status of the firewall
+```
 
-The Enable-PSRemoting cmdlet returns this error when the local network
+The `Enable-PSRemoting` cmdlet returns this error when the local network
 is public and the SkipNetworkProfileCheck parameter is not used in the
 command.
 
-On server versions of Windows, Enable-PSRemoting succeeds on all network
+On server versions of Windows, `Enable-PSRemoting` succeeds on all network
 location types. It creates firewall rules that allow remote access to
 private and domain ("Home" and "Work") networks. For public networks, it
 creates firewall rules that allows remote access from the same local subnet.
 
-On client versions of Windows, Enable-PSRemoting succeeds on private and
+On client versions of Windows, `Enable-PSRemoting` succeeds on private and
 domain networks. By default, it fails on public networks, but if
-you use the SkipNetworkProfileCheck parameter, Enable-PSRemoting succeeds
+you use the SkipNetworkProfileCheck parameter, `Enable-PSRemoting` succeeds
 and creates a firewall rule that allows traffic from the same local subnet.
 
 To remove the local subnet restriction on public networks and allow
@@ -167,16 +176,18 @@ remote access from any location, run the following command:
 Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP-PUBLIC" -RemoteAddress Any
 ```
 
-The Set-NetFirewallRule cmdlet is exported by the NetSecurity module.
+The `Set-NetFirewallRule` cmdlet is exported by the NetSecurity module.
 
-NOTE: In Windows PowerShell 2.0, on computers running server versions
-of Windows, Enable-PSRemoting creates firewall rules that allow remote
-access on private, domain and public networks. On computers running
-client versions of Windows, Enable-PSRemoting creates firewall rules
-that allow remote access only on private and domain networks.
+> [!NOTE]
+> In Windows PowerShell 2.0, on computers running server versions
+> of Windows, `Enable-PSRemoting` creates firewall rules that allow remote
+> access on private, domain and public networks. On computers running
+> client versions of Windows, `Enable-PSRemoting` creates firewall rules
+> that allow remote access only on private and domain networks.
 
 ### HOW TO ENABLE A FIREWALL EXCEPTION BY USING A GROUP POLICY
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -184,6 +195,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 To enable a firewall exception for in all computers in a domain, enable the
 "Windows Firewall: Allow local port exceptions" policy in the following
@@ -198,7 +210,9 @@ the Windows Remote Management service.
 
 ### HOW TO SET THE STARTUP TYPE OF THE WINRM SERVICE
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 PowerShell remoting depends upon the Windows Remote Management
 (WinRM) service. The service must be running to support remote commands.
@@ -210,7 +224,7 @@ However, on client versions of Windows, the WinRM service is disabled
 by default.
 
 To set the startup type of a service on a remote computer, use the
-Set-Service cmdlet.
+`Set-Service` cmdlet.
 
 To run the command on multiple computers, you can create a text file or
 CSV file of the computer names.
@@ -220,38 +234,42 @@ Servers.txt file and then sets the startup type of the WinRM service on all
 of the computers to Automatic.
 
 ```powershell
-C:\PS> $servers = Get-Content servers.txt
-C:\PS> Set-Service WinRM -ComputerName $servers -startuptype Automatic
+$servers = Get-Content servers.txt
+Set-Service WinRM -ComputerName $servers -startuptype Automatic
 ```
 
-To see the results use the Get-WMIObject cmdlet with the Win32_Service object.
-For more information, see Set-Service.
+To see the results use the `Get-WMIObject` cmdlet with the **Win32_Service**
+object. For more information, see
+[Set-Service](../../Microsoft.PowerShell.Management/Set-Service.md).
 
 ### HOW TO RECREATE THE DEFAULT SESSION CONFIGURATIONS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To connect to the local computer and run commands remotely, the local
 computer must include session configurations for remote commands.
 
-When you use Enable-PSRemoting, it creates default session configurations
+When you use `Enable-PSRemoting`, it creates default session configurations
 on the local computer. Remote users use these session configurations
 whenever a remote command does not include the ConfigurationName parameter.
 
 If the default configurations on a computer are unregistered or deleted,
-use the Enable-PSRemoting cmdlet to recreate them. You can use this cmdlet
+use the `Enable-PSRemoting` cmdlet to recreate them. You can use this cmdlet
 repeatedly. It does not generate errors if a feature is already configured.
 
 If you change the default session configurations and want to restore the
 original default session configurations, use the
-Unregister-PSSessionConfiguration cmdlet to delete the changed session
-configurations and then use the Enable-PSRemoting cmdlet to restore them.
-Enable-PSRemoting does not change existing session configurations.
+`Unregister-PSSessionConfiguration` cmdlet to delete the changed session
+configurations and then use the `Enable-PSRemoting` cmdlet to restore them.
+`Enable-PSRemoting` does not change existing session configurations.
 
-Note: When Enable-PSRemoting restores the default session configuration, it
-does not create explicit security descriptors for the configurations.
-Instead, the configurations inherit the security descriptor of the RootSDDL,
-which is secure by default.
+> [!NOTE]
+> When `Enable-PSRemoting` restores the default session configuration, it
+> does not create explicit security descriptors for the configurations.
+> Instead, the configurations inherit the security descriptor of the
+> RootSDDL, which is secure by default.
 
 To see the RootSDDL security descriptor, type:
 
@@ -259,9 +277,9 @@ To see the RootSDDL security descriptor, type:
 Get-Item wsman:\localhost\Service\RootSDDL
 ```
 
-To change the RootSDDL, use the Set-Item cmdlet in the WSMan: drive. To
+To change the RootSDDL, use the `Set-Item` cmdlet in the WSMan: drive. To
 change the security descriptor of a session configuration, use the
-Set-PSSessionConfiguration cmdlet with the SecurityDescriptorSDDL or
+`Set-PSSessionConfiguration` cmdlet with the SecurityDescriptorSDDL or
 ShowSecurityDescriptorUI parameters.
 
 For more information about the WSMan: drive, see the Help topic for the
@@ -269,7 +287,9 @@ WSMan provider ("Get-Help wsman").
 
 ### HOW TO PROVIDE ADMINISTRATOR CREDENTIALS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To create a PSSession or run commands on a remote computer, by default, the
 current user must be a member of the Administrators group on the remote
@@ -278,8 +298,8 @@ logged on to an account that is a member of the Administrators group.
 
 If the current user is a member of the Administrators group on the remote
 computer, or can provide the credentials of a member of the Administrators
-group, use the Credential parameter of the New-PSSession, Enter-PSSession
-or Invoke-Command cmdlets to connect remotely.
+group, use the Credential parameter of the `New-PSSession`, `Enter-PSSession`
+or `Invoke-Command` cmdlets to connect remotely.
 
 For example, the following command provides the credentials of an
 Administrator.
@@ -288,12 +308,14 @@ Administrator.
 Invoke-Command -ComputerName Server01 -Credential Domain01\Admin01
 ```
 
-For more information about the Credential parameter, see New-PSSession,
-Enter-PSSession or Invoke-Command.
+For more information about the Credential parameter, see `New-PSSession`,
+`Enter-PSSession` or `Invoke-Command`.
 
 ### HOW TO ENABLE REMOTING FOR NON-ADMINISTRATIVE USERS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To establish a PSSession or run a command on a remote computer, the user
 must have permission to use the session configurations on the remote
@@ -319,7 +341,9 @@ For more information, see [about_Session_Configurations](about_Session_Configura
 
 ### HOW TO ENABLE REMOTING FOR ADMINISTRATORS IN OTHER DOMAINS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 When a user in another domain is a member of the Administrators group on
 the local computer, the user cannot connect to the local computer remotely
@@ -330,30 +354,33 @@ However, you can use the LocalAccountTokenFilterPolicy registry entry to
 change the default behavior and allow remote users who are members of the
 Administrators group to run with Administrator privileges.
 
-Caution: The LocalAccountTokenFilterPolicy entry disables user account
-control (UAC) remote restrictions for all users of all affected
-computers. Consider the implications of this setting carefully
-before changing the policy.
+> [!CAUTION]
+> The LocalAccountTokenFilterPolicy entry disables user account
+> control (UAC) remote restrictions for all users of all affected
+> computers. Consider the implications of this setting carefully
+> before changing the policy.
 
 To change the policy, use the following command to set the value of the
 LocalAccountTokenFilterPolicy registry entry to 1.
 
 ```powershell
-C:\PS> New-ItemProperty -Name LocalAccountTokenFilterPolicy -Path `
-HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System `
--PropertyType DWord -Value 1
+New-ItemProperty -Name LocalAccountTokenFilterPolicy `
+  -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System `
+  -PropertyType DWord -Value 1
 ```
 
 ### HOW TO USE AN IP ADDRESS IN A REMOTE COMMAND
 
+```
 ERROR:  The WinRM client cannot process the request. If the
 authentication scheme is different from Kerberos, or if the client
 computer is not joined to a domain, then HTTPS transport must be used
 or the destination machine must be added to the TrustedHosts
 configuration setting.
+```
 
-The ComputerName parameters of the New-PSSession, Enter-PSSession and
-Invoke-Command cmdlets accept an IP address as a valid value. However,
+The ComputerName parameters of the `New-PSSession`, `Enter-PSSession` and
+`Invoke-Command` cmdlets accept an IP address as a valid value. However,
 because Kerberos authentication does not support IP addresses, NTLM
 authentication is used by default whenever you specify an IP address.
 
@@ -374,11 +401,13 @@ for remoting.
 
 ### HOW TO CONNECT REMOTELY FROM A WORKGROUP-BASED COMPUTER
 
+```
 ERROR:  The WinRM client cannot process the request. If the
 authentication scheme is different from Kerberos, or if the client
 computer is not joined to a domain, then HTTPS transport must be used
 or the destination machine must be added to the TrustedHosts
 configuration setting.
+```
 
 When the local computer is not in a domain, the following procedure is required
 for remoting.
@@ -422,7 +451,7 @@ To view the list of trusted hosts, use the following command:
 Get-Item wsman:\localhost\Client\TrustedHosts
 ```
 
-You can also use the Set-Location cmdlet (alias = cd) to navigate
+You can also use the `Set-Location` cmdlet (alias = cd) to navigate
 though the WSMan: drive to the location.
 For example:
 
@@ -453,7 +482,7 @@ the following command format:
 Set-Item wsman:\localhost\Client\TrustedHosts -Value <ComputerName>
 ```
 
-where each value <ComputerName> must have the following format:
+where each value `<ComputerName>` must have the following format:
 
 ```
 <Computer>.<Domain>.<Company>.<top-level-domain>
@@ -494,10 +523,12 @@ Set-Item wsman:\localhost\Client\TrustedHosts -Value 172.16.0.0
 ```
 
 To add a computer to the TrustedHosts list of a remote computer, use the
-Connect-WSMan cmdlet to add a node for the remote computer to the WSMan: drive
-on the local computer. Then use a Set-Item command to add the computer.
+`Connect-WSMan` cmdlet to add a node for the remote computer to the WSMan:
+drive on the local computer. Then use a `Set-Item` command to add the
+computer.
 
-For more information about the Connect-WSMan cmdlet, see Connect-WSMan.
+For more information about the `Connect-WSMan` cmdlet, see
+[Connect-WSMan](../../Microsoft.WSMan.Management/Connect-WSMan.md).
 
 ## TROUBLESHOOTING COMPUTER CONFIGURATION ISSUES
 
@@ -506,15 +537,17 @@ configurations of a computer, domain, or enterprise.
 
 ### HOW TO CONFIGURE REMOTING ON ALTERNATE PORTS
 
+```
 ERROR:  The connection to the specified remote host was refused. Verify
 that the WS-Management service is running on the remote host and
 configured to listen for requests on the correct port and HTTP URL.
+```
 
 Windows PowerShell remoting uses port 80 for HTTP transport by default. The
 default port is used whenever the user does not specify the ConnectionURI
 or Port parameters in a remote command.
 
-To change the default port that Windows PowerShell uses, use Set-Item cmdlet
+To change the default port that Windows PowerShell uses, use `Set-Item` cmdlet
 in the WSMan: drive to change the Port value in the  listener leaf node.
 
 For example, the following command changes the default port to 8080.
@@ -525,9 +558,11 @@ Set-Item wsman:\localhost\listener\listener*\port -Value 8080
 
 ### HOW TO CONFIGURE REMOTING WITH A PROXY SERVER
 
+```
 ERROR: The client cannot connect to the destination specified in the
 request. Verify that the service on the destination is running and is
 accepting requests.
+```
 
 Because PowerShell remoting uses the HTTP protocol, it is affected
 by HTTP proxy settings. In enterprises that have proxy servers, users
@@ -543,29 +578,29 @@ The following settings are available:
 To set these options for a particular command, use the following procedure:
 
 1. Use the ProxyAccessType, ProxyAuthentication, and ProxyCredential
-   parameters of the New-PSSessionOption cmdlet to create a session
+   parameters of the `New-PSSessionOption` cmdlet to create a session
    option object with the proxy settings for your enterprise. Save the
    option object is a variable.
 
 2. Use the variable that contains the option object as the value of the
-   SessionOption parameter of a New-PSSession, Enter-PSSession, or
-   Invoke-Command command.
+   SessionOption parameter of a `New-PSSession`, `Enter-PSSession`, or
+   `Invoke-Command` command.
 
 For example, the following command creates a session option object with
 proxy session options and then uses the object to create a remote session.
 
 ```powershell
-C:\PS> $SessionOption = New-PSSessionOption -ProxyAccessType IEConfig `
+$SessionOption = New-PSSessionOption -ProxyAccessType IEConfig `
 -ProxyAuthentication Negotiate -ProxyCredential Domain01\User01
 
-C:\PS> New-PSSession -ConnectionURI https://www.fabrikam.com
+New-PSSession -ConnectionURI https://www.fabrikam.com
 ```
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+[New-PSSessionOption](../New-PSSessionOption.md).
 
 To set these options for all remote commands in the current session, use
-the option object that New-PSSessionOption creates in the value of the
+the option object that `New-PSSessionOption` creates in the value of the
 $PSSessionOption preference variable. For more information about the
 $PSSessionOption preference variable, see about_Preference_Variables.
 
@@ -576,19 +611,21 @@ profiles, see about_Profiles.
 
 ### HOW TO DETECT A 32-BIT SESSION ON A 64-BIT COMPUTER
 
+```
 ERROR: The term "<tool-Name>" is not recognized as the name of a cmdlet,
 function, script file, or operable program. Check the spelling of the
 name, or if a path was included, verify that the path is correct and try
 again.
+```
 
 If the remote computer is running a 64-bit version of Windows, and the
 remote command is using a 32-bit session configuration, such as
 Microsoft.PowerShell32, Windows Remote Management (WinRM) loads a WOW64
 process and Windows automatically redirects all references to the
-%Windir%\\System32 directory to the %windir%\\SysWOW64 directory.
+`$env:Windir\System32` directory to the `$env:Windir\SysWOW64` directory.
 
 As a result, if you try to use tools in the System32 directory that do
-not have counterparts in the SysWow64 directory, such as Defrag.exe,
+not have counterparts in the SysWow64 directory, such as **Defrag.exe**,
 the tools cannot be found in the directory.
 
 To find the processor architecture that is being used in the session,
@@ -599,10 +636,14 @@ following command finds the processor architecture of the session in the
 ```powershell
 $s = New-PSSession -ComputerName Server01 -ConfigurationName CustomShell
 Invoke-Command -Session $s {$env:PROCESSOR_ARCHITECTURE}
+```
+
+```Output
 x86
 ```
 
-For more information about session configurations, see [about_Session_Configurations](about_Session_Configurations.md).
+For more information about session configurations, see
+[about_Session_Configurations](about_Session_Configurations.md).
 
 ## TROUBLESHOOTING POLICY AND PREFERENCE ISSUES
 
@@ -611,20 +652,22 @@ preferences set on the local and remote computers.
 
 ### HOW TO CHANGE THE EXECUTION POLICY FOR IMPORT-PSSESSION AND IMPORT-MODULE
 
+```
 ERROR: Import-Module: File <filename> cannot be loaded because the
 execution of scripts is disabled on this system.
+```
 
-The Import-PSSession and Export-PSSession cmdlets create modules that
+The `Import-PSSession` and `Export-PSSession` cmdlets create modules that
 contains unsigned script files and formatting files.
 
 To import the modules that are created by these cmdlets, either by using
-Import-PSSession or Import-Module, the execution policy in the current
+`Import-PSSession` or `Import-Module`, the execution policy in the current
 session cannot be Restricted or AllSigned. (For information about Windows
 PowerShell execution policies, see about_Execution_Policies.
 
 To import the modules without changing the execution policy for the local
 computer that is set in the registry, use the Scope parameter of
-Set-ExecutionPolicy to set a less restrictive execution policy for a single
+`Set-ExecutionPolicy` to set a less restrictive execution policy for a single
 process.
 
 For example, the following command starts a process with the RemoteSigned
@@ -636,22 +679,24 @@ setting.
 Set-ExecutionPolicy -Scope process -ExecutionPolicy RemoteSigned
 ```
 
-You can also use the ExecutionPolicy parameter of PowerShell.exe to start
+You can also use the ExecutionPolicy parameter of **PowerShell.exe** to start
 a single session with a less restrictive execution policy.
 
 ```powershell
 PowerShell.exe -ExecutionPolicy RemoteSigned
 ```
 
-For more information about the cmdlets, see Import-PSSession,
-Export-PSSession, and Import-Module. For more information about
+For more information about the cmdlets, see `Import-PSSession`,
+`Export-PSSession`, and `Import-Module`. For more information about
 execution policies, see about_Execution_Policies. For more information
 about the PowerShell.exe console help options, type "PowerShell.exe -?".
 
 ### HOW TO SET AND CHANGE QUOTAS
 
+```
 ERROR: The total data received from the remote client exceeded allowed
 maximum.
+```
 
 You can use quotas to protect the local computer and the remote computer
 from excessive resource use, both accidental and malicious.
@@ -659,19 +704,20 @@ from excessive resource use, both accidental and malicious.
 The following quotas are available in the basic configuration.
 
 - The WSMan provider (WSMan:) provides several quota settings, such as the
-  MaxEnvelopeSizeKB and MaxProviderRequests settings in the
-  WSMan:\<ComputerName\> node and the MaxConcurrentOperations,
-  MaxConcurrentOperationsPerUser, and MaxConnections settings in the
-  WSMan:\<ComputerName\>\\Service node.
+  **MaxEnvelopeSizeKB** and **MaxProviderRequests** settings in the
+  `WSMan:<ComputerName>` node and the **MaxConcurrentOperations**,
+  **MaxConcurrentOperationsPerUser**, and **MaxConnections** settings in the
+  `WSMan:<ComputerName>\Service` node.
 
 - You can protect the local computer by using the
-  MaximumReceivedDataSizePerCommand and MaximumReceivedObjectSize parameters of
-  the New-PSSessionOption cmdlet and the \$PSSessionOption preference variable.
+  MaximumReceivedDataSizePerCommand and MaximumReceivedObjectSize parameters
+  of the `New-PSSessionOption` cmdlet and the \$PSSessionOption preference
+  variable.
 
 - You can protect the remote computer by adding restrictions to the session
-  configurations, such as by using the MaximumReceivedDataSizePerCommandMB and
-  MaximumReceivedObjectSizeMB parameters of the Register-PSSessionConfiguration
-  cmdlet.
+  configurations, such as by using the **MaximumReceivedDataSizePerCommandMB**
+  and **MaximumReceivedObjectSizeMB** parameters of the
+  `Register-PSSessionConfiguration` cmdlet.
 
 When quotas conflict with a command, PowerShell generates an error.
 
@@ -685,19 +731,21 @@ Microsoft.PowerShell session configuration on the remote computer from 10 MB
 
 ```powershell
 Set-PSSessionConfiguration -Name microsoft.PowerShell `
--MaximumReceivedObjectSizeMB 11 -Force
+  -MaximumReceivedObjectSizeMB 11 -Force
 ```
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+`New-PSSessionOption`.
 
 For more information about the WS-Management quotas, see the Help topic for
-the WSMan provider (type "Get-Help WSMan").
+the WSMan provider (type `Get-Help WSMan`).
 
 ### HOW TO RESOLVE TIMEOUT ERRORS
 
+```
 ERROR: The WS-Management service cannot complete the operation within
 the time specified in OperationTimeout.
+```
 
 You can use timeouts to protect the local computer and the remote computer
 from excessive resource use, both accidental and malicious. When timeouts
@@ -707,14 +755,14 @@ shortest timeout settings.
 The following timeouts are available in the basic configuration.
 
 - The WSMan provider (WSMan:) provides several client-side and service-side
-  timeout settings, such as the MaxTimeoutms setting in the
-  WSMan:\<ComputerName\> node and the EnumerationTimeoutms and
-  MaxPacketRetrievalTimeSeconds settings in the WSMan:\<ComputerName\>\\Service
-  node.
+  timeout settings, such as the **MaxTimeoutms** setting in the
+  `WSMan:<ComputerName>` node and the **EnumerationTimeoutms** and
+  **MaxPacketRetrievalTimeSeconds** settings in the
+  `WSMan:<ComputerName>\Service` node.
 
-- You can protect the local computer by using the CancelTimeout, IdleTimeout,
-  OpenTimeout, and OperationTimeout parameters of the New-PSSessionOption
-  cmdlet and the $PSSessionOption preference variable.
+- You can protect the local computer by using the **CancelTimeout**,
+  **IdleTimeout**, **OpenTimeout**, and **OperationTimeout** parameters of the
+  `New-PSSessionOption` cmdlet and the $PSSessionOption preference variable.
 
 - You can also protect the remote computer by setting timeout values
   programmatically in the session configuration for the session.
@@ -726,21 +774,21 @@ To resolve the error, change the command to complete within the timeout
 interval or determine the source of the timeout limit and increase the
 timeout interval to allow the command to complete.
 
-For example, the following commans use the New-PSSessionOption cmdlet to
-create a session option object with an OperationTimeout value of 4 minutes
+For example, the following commands use the `New-PSSessionOption` cmdlet to
+create a session option object with an **OperationTimeout** value of 4 minutes
 (in MS) and then use the session option object to create a remote session.
 
 ```powershell
-C:\PS> $pso = New-PSSessionoption -OperationTimeout 240000
+$pso = New-PSSessionoption -OperationTimeout 240000
 
-C:\PS> New-PSSession -ComputerName Server01 -sessionOption $pso
+New-PSSession -ComputerName Server01 -sessionOption $pso
 ```
 
 For more information about the WS-Management timeouts, see the Help topic for
 the WSMan provider (type "Get-Help WSMan").
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+[New-PSSessionOption](../New-PSSessionOption.md).
 
 ## TROUBLESHOOTING UNRESPONSIVE BEHAVIOR
 
@@ -756,13 +804,15 @@ Win32 console API, do not work correctly in the PowerShell remote host.
 When you use these programs, you might see unexpected behavior, such as no
 output, partial output, or a remote command that does not complete.
 
-To end an unresponsive program, type CTRL + C. To view any errors that might
-have been reported, type "$error" in the local host and the remote session.
+To end an unresponsive program, type `CTRL+C`. To view any errors that might
+have been reported, type `$error` in the local host and the remote session.
 
 ## HOW TO RECOVER FROM AN OPERATION FAILURE
 
+```
 ERROR: The I/O operation has been aborted because of either a thread exit
 or an  application request.
+```
 
 This error is returned when an operation is terminated before it completes.
 Typically, it occurs when the WinRM service stops or restarts while other
@@ -774,7 +824,7 @@ the command again.
 1. Start PowerShell with the "Run as administrator" option.
 2. Run the following command:
 
-   Start-Service WinRM
+   `Start-Service WinRM`
 
 3. Re-run the command that generated the error.
 

--- a/reference/3.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -46,26 +46,36 @@ Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBuff
 
 ## DESCRIPTION
 
-The **Disconnect-PSSession** cmdlet disconnects a Windows PowerShell session ("PSSession"), such as one started by using the New-PSSession cmdlet, from the current session.
-As a result, the PSSession is in a disconnected state.
-You can connect to the disconnected PSSession from the current session or from another session on the local computer or a different computer.
+The `Disconnect-PSSession` cmdlet disconnects a Windows PowerShell session ("PSSession"), such as
+one started by using the `New-PSSession` cmdlet, from the current session. As a result, the PSSession
+is in a disconnected state. You can connect to the disconnected PSSession from the current session
+or from another session on the local computer or a different computer.
 
-The **Disconnect-PSSession** cmdlet disconnects only open PSSessions that are connected to the current session.
-**Disconnect-PSSession** cannot disconnect broken or closed PSSessions, or interactive PSSessions started by using the Enter-PSSession cmdlet,  and it cannot disconnect PSSessions that are connected to other sessions.
+The `Disconnect-PSSession` cmdlet disconnects only open PSSessions that are connected to the
+current session. `Disconnect-PSSession` cannot disconnect broken or closed PSSessions, or
+interactive PSSessions started by using the `Enter-PSSession` cmdlet, and it cannot disconnect
+PSSessions that are connected to other sessions.
 
-To reconnect to a disconnected PSSession, use the Connect-PSSession or Receive-PSSession cmdlets.
+To reconnect to a disconnected PSSession, use the `Connect-PSSession` or `Receive-PSSession` cmdlets.
 
-When a PSSession is disconnected, the commands in the PSSession continue to run until they complete, unless the PSSession times out or the commands in the PSSession are blocked by a full output buffer.
-To change the idle timeout, use the **IdleTimeoutSec** parameter.
-To change the output buffering mode, use the **OutputBufferingMode** parameter You can also use the **InDisconnectedSession** parameter of the Invoke-Command cmdlet to run a command in a disconnected session.
+When a PSSession is disconnected, the commands in the PSSession continue to run until they
+complete, unless the PSSession times out or the commands in the PSSession are blocked by a full
+output buffer. To change the idle timeout, use the **IdleTimeoutSec** parameter. To change the
+output buffering mode, use the **OutputBufferingMode** parameter You can also use the
+**InDisconnectedSession** parameter of the `Invoke-Command` cmdlet to run a command in a disconnected
+session.
 
-For more information about the Disconnected Sessions feature, see [about_Remote_Disconnected_Sessions](./About/about_Remote_Disconnected_Sessions.md).
+For more information about the Disconnected Sessions feature, see
+[about_Remote_Disconnected_Sessions](./About/about_Remote_Disconnected_Sessions.md).
 
 This cmdlet is introduced in Windows PowerShell 3.0.
 
 ## EXAMPLES
 
-### Example 1
+### Example 1 - Disconnect a session by name
+
+This command disconnects the UpdateSession PSSession on the Server01 computer from the current
+session. The command uses the **Name** parameter to identify the PSSession.
 
 ```
 PS> Disconnect-PSSession -Name UpdateSession
@@ -74,47 +84,48 @@ Id Name            ComputerName    State         ConfigurationName     Availabil
 1  UpdateSession   Server01        Disconnected  Microsoft.PowerShell          None
 ```
 
-This command disconnects the UpdateSession PSSession on the Server01 computer from the current session.
-The command uses the **Name** parameter to identify the PSSession.
+The output shows that the attempt to disconnect was successful. The session state is Disconnected
+and the Availability is None, which indicates that the session is not busy and can be reconnected.
 
-The output shows that the attempt to disconnect was successful.
-The session state is Disconnected and the Availability is None, which indicates that the session is not busy and can be reconnected.
+### Example 2 - Disconnect a session from a specific computer
 
-### Example 2
+This command disconnects the ITTask PSSession on the Server12 computer from the current session.
+The ITTask session was created in the current session and connects to the Server12 computer. The
+command uses the `Get-PSSession` cmdlet to get the session and the `Disconnect-PSSession` cmdlet to
+disconnect it.
 
 ```
-PS> Get-PSSession -ComputerName Server12 -Name ITTask | Disconnect-PSSession -OutputBufferingMode Drop -IdleTimeoutSec 86400
+PS> Get-PSSession -ComputerName Server12 -Name ITTask |
+  Disconnect-PSSession -OutputBufferingMode Drop -IdleTimeoutSec 86400
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
 1  ITTask          Server12        Disconnected  ITTasks               None
 ```
 
-This command disconnects the ITTask PSSession on the Server12 computer from the current session.
-The ITTask session was created in the current session and connects to the Server12 computer.
-The command uses the Get-PSSession cmdlet to get the session and the **Disconnect-PSSession** cmdlet to disconnect it.
+The `Disconnect-PSSession` command uses the **OutputBufferingMode** parameter to set the output
+mode to **Drop**. This setting ensures that the script that is running in the session can continue
+to run even if the session output buffer is full. Because the script writes its output to a report
+on a file share, other output can be lost without consequence.
 
-The **Disconnect-PSSession** command uses the **OutputBufferingMode** parameter to set the output mode to **Drop**.
-This setting ensures that the script that is running in the session can continue to run even if the session output buffer is full.
-Because the script writes its output to a report on a file share, other output can be lost without consequence.
+The command also uses the **IdleTimeoutSec** parameter to extend the idle timeout of the session to
+24 hours. This setting allows time for this administrator or other administrators to reconnect to
+the session to verify that the script ran and troubleshoot if needed.
 
-The command also uses the **IdleTimeoutSec** parameter to extend the idle timeout of the session to 24 hours.
-This setting allows time for this administrator or other administrators to reconnect to the session to verify that the script ran and troubleshoot if needed.
+### Example 3 - Using multiple PSSessions on multiple computers
 
-### Example 3
+This series of commands shows how the `Disconnect-PSSession` cmdlet might be used in an enterprise
+scenario. In this case, a new technician starts a script in a session on a remote computer and runs
+into a problem. The technician disconnects from the session so that a more experienced manager can
+connect to the session and resolve the problem.
 
 ```
-The technician begins by creating sessions on several remote computers and running a script in each session.The first command uses the New-PSSession cmdlet to create the ITTask session on three remote computers. The command saves the sessions in the $s variable. The second command uses the **FilePath** parameter of the Invoke-Command cmdlet to run a script in the sessions in the $s variable.
 PS> $s = New-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
-
 PS> Invoke-Command $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
-
-The script running on the Srv1 computer generates unexpected errors. The technician contacts his manager and asks for assistance. The manager directs the technician to disconnect from the session so he can investigate.The second command uses the Get-PSSession cmdlet to get the ITTask session on the Srv1 computer and the **Disconnect-PSSession** cmdlet to disconnect it. This command does not affect the ITTask sessions on  the other computers.
 PS> Get-PSSession -Name ITTask -ComputerName Srv1 | Disconnect-PSSession
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
 1 ITTask           Srv1            Disconnected  Microsoft.PowerShell          None
 
-The third  command uses the **Get-PSSession** cmdlet to get the ITTask sessions. The output shows that the ITTask sessions on the Srv2 and Srv30 computers were not affected by the command to disconnect.
 PS> Get-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
@@ -122,47 +133,73 @@ Id Name            ComputerName    State         ConfigurationName     Availabil
  2 ITTask          Srv2            Opened        Microsoft.PowerShell     Available
  3 ITTask          Srv30           Opened        Microsoft.PowerShell     Available
 
-The manager logs on to his home computer, connects to his corporate network, starts Windows PowerShell, and uses the Get-PSSession cmdlet to get the ITTask session on the Srv1 computer. He uses the credentials of the technician to access the session.
 PS> Get-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
  1 ITTask          Srv1            Disconnected  Microsoft.PowerShell          None
 
-Next, the manager uses the  Connect-PSSession cmdlet to connect to the ITTask session on the Srv1 computer. The command saves the session in the $s variable.
 PS> $s = Connect-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
-
-The manager uses the Invoke-Command cmdlet to run some diagnostic commands in the session in the $s variable. He recognizes that the script failed because it did not find a required directory. The manager uses the MkDir function to create the directory, and then he restarts the Get-PatchStatus.ps1 script and disconnects from the session.The manager reports his findings to the technician, suggests that he reconnect to the session to complete the tasks, and asks him to add a command to the Get-PatchStatus.ps1 script that creates the required directory if it does not exist.
 PS> Invoke-Command -Session $s {dir $home\Scripts\PatchStatusOutput.ps1}
-
 PS> Invoke-Command -Session $s {mkdir $home\Scripts\PatchStatusOutput}
-
 PS> Invoke-Command -Session $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
-
 PS> Disconnect-PSSession -Session $s
 ```
 
-This series of commands shows how the **Disconnect-PSSession** cmdlet might be used in an enterprise scenario.
-In this case, a new technician starts a script in a session on a remote computer and runs into a problem.
-The technician disconnects from the session so that a more experienced manager can connect to the session and resolve the problem.
+The technician begins by creating sessions on several remote computers and running a script in each
+session. The first command uses the `New-PSSession` cmdlet to create the ITTask session on three
+remote computers. The command saves the sessions in the $s variable. The second command uses the
+**FilePath** parameter of the `Invoke-Command` cmdlet to run a script in the sessions in the $s
+variable.
 
-### Example 4
+The script running on the Srv1 computer generates unexpected errors. The technician contacts his
+manager and asks for assistance. The manager directs the technician to disconnect from the session
+so he can investigate.The second command uses the `Get-PSSession` cmdlet to get the ITTask session on
+the Srv1 computer and the `Disconnect-PSSession` cmdlet to disconnect it. This command does not
+affect the ITTask sessions on the other computers.
+
+The third command uses the `Get-PSSession` cmdlet to get the ITTask sessions. The output shows that
+the ITTask sessions on the Srv2 and Srv30 computers were not affected by the command to disconnect.
+
+The manager logs on to his home computer, connects to his corporate network, starts Windows
+PowerShell, and uses the `Get-PSSession` cmdlet to get the ITTask session on the Srv1 computer. He
+uses the credentials of the technician to access the session.
+
+Next, the manager uses the `Connect-PSSession` cmdlet to connect to the ITTask session on the Srv1
+computer. The command saves the session in the $s variable.
+
+The manager uses the `Invoke-Command` cmdlet to run some diagnostic commands in the session in the
+`$s` variable. He recognizes that the script failed because it did not find a required directory.
+The manager uses the `MkDir` function to create the directory, and then he restarts the
+`Get-PatchStatus.ps1` script and disconnects from the session.The manager reports his findings to
+the technician, suggests that he reconnect to the session to complete the tasks, and asks him to
+add a command to the `Get-PatchStatus.ps1` script that creates the required directory if it does
+not exist.
+
+### Example 4 - Change the timeout value for a PSSession
+
+This example shows how to correct the value of the **IdleTimeout** property of a session so that it
+can be disconnected.
+
+The idle timeout property of a session is critical to disconnected sessions, because it determines
+how long a disconnected session is maintained before it is deleted. You can set the idle timeout
+option when you create a session and when you disconnect it. The default values for the idle
+timeout of a session are set in the `$PSSessionOption` preference variable on the local computer
+and in the session configuration on the remote computer. Values set for the session take precedence
+over values set in the session configuration, but session values cannot exceed quotas set in the
+session configuration, such as the **MaxIdleTimeoutMs** value.
 
 ```
-The first command uses the New-PSSessionOption cmdlet to create a session option object. It uses the **IdleTimeout** parameter to set an idle timeout of 48 hours (172800000 milliseconds). The command saves the session option object in the $Timeout variable.
 PS> $Timeout = New-PSSessionOption -IdleTimeout 172800000
-
-The second command uses the New-PSSession cmdlet to create the ITTask session on the Server01 computer. The command save the session in the $s variable. The value of the **SessionOption** parameter is the 48-hour idle timeout in the $Timeout variable.
 PS> $s = New-PSSession -Computer Server01 -Name ITTask -SessionOption $Timeout
-
-The third command disconnects the ITTask session in the $s variable. The command fails because the idle timeout value of the session exceeds the **MaxIdleTimeoutMs** quota in the session configuration. Because the idle timeout is not used until the session is disconnected, this violation can go undetected while the session is in use.
 PS> Disconnect-PSSession -Session $s
 Disconnect-PSSession : The session ITTask cannot be disconnected because the specified
 idle timeout value 172800(seconds) is either greater than the server maximum allowed
 43200 (seconds) or less that the minimum allowed60(seconds).  Choose an idle time out
 value that is within the allowed range and try again.
 
-The fourth command uses the Invoke-Command cmdlet to run a Get-PSSessionConfiguration command for the Microsoft.PowerShell session configuration on the Server01 computer. The command uses the Format-List cmdlet to display all properties of the session configuration in a list.The output shows that the  **MaxIdleTimeoutMS** property, which establishes the maximum permitted **IdleTimeout** value for sessions that use the session configuration, is 43200000 milliseconds (12 hours).
-PS> Invoke-Command -ComputerName Server01 {Get-PSSessionConfiguration Microsoft.PowerShell} | Format-List -Property *
+PS> Invoke-Command -ComputerName Server01 {Get-PSSessionConfiguration Microsoft.PowerShell} |
+ Format-List -Property *
+
 Architecture                  : 64
 Filename                      : %windir%\system32\pwrshplugin.dll
 ResourceUri                   : http://schemas.microsoft.com/powershell/microsoft.powershell
@@ -199,7 +236,6 @@ RunspaceId                    : aea84310-6dbf-4c21-90ac-13980039925a
 PSShowComputerName            : True
 
 
-The fifth command gets the session option values of the session in the $s variable. The values of many session options are properties of the **ConnectionInfo** property of the **Runspace** property of the session.The output shows that the value of the **IdleTimeout** property of the session is 172800000 milliseconds (48 hours), which violates the **MaxIdleTimeoutMs** quota of 12 hours in the session configuration.To resolve this conflict, you can use the **ConfigurationName** parameter to select a different session configuration or use the **IdleTimeout** parameter to reduce the idle timeout of the session.
 PS> $s.Runspace.ConnectionInfo
 ConnectionUri                     : http://Server01/wsman
 ComputerName                      : Server01
@@ -232,33 +268,58 @@ CancelTimeout                     : 60000
 OperationTimeout                  : 180000
 IdleTimeout                       : 172800000
 
-The sixth command disconnects the session. It uses the **IdleTimeoutSec** parameter to set the idle timeout to the 12-hour maximum.
 PS> Disconnect-PSSession $s -IdleTimeoutSec 43200
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
  4 ITTask          Server01        Disconnected  Microsoft.PowerShell          None
 
-The seventh command gets the value of the **IdleTimeout** property of the disconnected session, which is measured in milliseconds. The output confirms that the command was successful.
 PS> $s.Runspace.ConnectionInfo.IdleTimeout
 43200000
 ```
 
-This example shows how to correct the value of the **IdleTimeout** property of a session so that it can be disconnected.
+The first command uses the `New-PSSessionOption` cmdlet to create a session option object. It uses
+the **IdleTimeout** parameter to set an idle timeout of 48 hours (172800000 milliseconds). The
+command saves the session option object in the $Timeout variable.
 
-The idle timeout property of a session is critical to disconnected sessions, because it determines how long a disconnected session is maintained before it is deleted.
-You can set the idle timeout option when you create a session and when you disconnect it.
-The default values for the idle timeout of a session are set in the **$PSSessionOption** preference variable on the local computer and in the session configuration on the remote computer.
-Values set for the session take precedence over values set in the session configuration, but session values cannot exceed quotas set in the session configuration, such as the **MaxIdleTimeoutMs** value.
+The second command uses the `New-PSSession` cmdlet to create the ITTask session on the Server01
+computer. The command save the session in the $s variable. The value of the **SessionOption**
+parameter is the 48-hour idle timeout in the $Timeout variable.
+
+The third command disconnects the ITTask session in the $s variable. The command fails because the
+idle timeout value of the session exceeds the **MaxIdleTimeoutMs** quota in the session
+configuration. Because the idle timeout is not used until the session is disconnected, this
+violation can go undetected while the session is in use.
+
+The fourth command uses the `Invoke-Command` cmdlet to run a `Get-PSSessionConfiguration` command
+for the Microsoft.PowerShell session configuration on the Server01 computer. The command uses the
+`Format-List` cmdlet to display all properties of the session configuration in a list.The output
+shows that the **MaxIdleTimeoutMS** property, which establishes the maximum permitted
+**IdleTimeout** value for sessions that use the session configuration, is 43200000 milliseconds (12
+hours).
+
+The fifth command gets the session option values of the session in the $s variable. The values of
+many session options are properties of the **ConnectionInfo** property of the **Runspace** property
+of the session.The output shows that the value of the **IdleTimeout** property of the session is
+172800000 milliseconds (48 hours), which violates the **MaxIdleTimeoutMs** quota of 12 hours in the
+session configuration.To resolve this conflict, you can use the **ConfigurationName** parameter to
+select a different session configuration or use the **IdleTimeout** parameter to reduce the idle
+timeout of the session.
+
+The sixth command disconnects the session. It uses the **IdleTimeoutSec** parameter to set the idle
+timeout to the 12-hour maximum.
+
+The seventh command gets the value of the **IdleTimeout** property of the disconnected session,
+which is measured in milliseconds. The output confirms that the command was successful.
 
 ## PARAMETERS
 
 ### -Id
 
-Disconnects from sessions with the specified session ID.
-Type one or more IDs (separated by commas), or use the range operator (..) to specify a range of IDs.
+Disconnects from sessions with the specified session ID. Type one or more IDs (separated by
+commas), or use the range operator (..) to specify a range of IDs.
 
-To get the ID of a session, use the Get-PSSession cmdlet.
-The instance ID is stored in the **ID** property of the session.
+To get the ID of a session, use the `Get-PSSession` cmdlet. The instance ID is stored in the **ID**
+property of the session.
 
 ```yaml
 Type: Int32[]
@@ -274,21 +335,23 @@ Accept wildcard characters: False
 
 ### -IdleTimeoutSec
 
-Changes the idle timeout value of the disconnected PSSession.
-Enter a value in seconds.
-The minimum value is 60 (1 minute).
+Changes the idle timeout value of the disconnected PSSession. Enter a value in seconds. The minimum
+value is 60 (1 minute).
 
-The idle timeout determines how long the disconnected PSSession is maintained on the remote computer.
-When the timeout expires, the PSSession is deleted.
+The idle timeout determines how long the disconnected PSSession is maintained on the remote
+computer. When the timeout expires, the PSSession is deleted.
 
-Disconnected PSSessions are considered to be idle from the moment that they are disconnected, even if commands are running in the disconnected session.
+Disconnected PSSessions are considered to be idle from the moment that they are disconnected, even
+if commands are running in the disconnected session.
 
-The default value for the idle timeout of a session is set by the value of the **IdleTimeoutMs** property of the session configuration.
-The default value is 7200000 milliseconds (2 hours).
+The default value for the idle timeout of a session is set by the value of the **IdleTimeoutMs**
+property of the session configuration. The default value is 7200000 milliseconds (2 hours).
 
-The value of this parameter takes precedence over the value of the **IdleTimeout** property of the $PSSessionOption preference variable and the default idle timeout value in the session configuration.
-However, this value cannot exceed the value of the **MaxIdleTimeoutMs** property of the session configuration.
-The default value of **MaxIdleTimeoutMs** is 12 hours (43200000 milliseconds).
+The value of this parameter takes precedence over the value of the **IdleTimeout** property of the
+$PSSessionOption preference variable and the default idle timeout value in the session
+configuration. However, this value cannot exceed the value of the **MaxIdleTimeoutMs** property of
+the session configuration. The default value of **MaxIdleTimeoutMs** is 12 hours (43200000
+milliseconds).
 
 ```yaml
 Type: Int32
@@ -306,11 +369,11 @@ Accept wildcard characters: False
 
 Disconnects from sessions with the specified instance IDs.
 
-The instance ID is a GUID that uniquely identifies a session on a local or remote computer.
-The instance ID is unique, even across multiple sessions on multiple computers.
+The instance ID is a GUID that uniquely identifies a session on a local or remote computer. The
+instance ID is unique, even across multiple sessions on multiple computers.
 
-To get the instance ID of a session, use the Get-PSSession cmdlet.
-The instance ID is stored in the **InstanceID** property of the session.
+To get the instance ID of a session, use the `Get-PSSession` cmdlet. The instance ID is stored in
+the **InstanceID** property of the session.
 
 ```yaml
 Type: Guid[]
@@ -326,11 +389,10 @@ Accept wildcard characters: False
 
 ### -Name
 
-Disconnects from sessions with the specified friendly names.
-Wildcards are permitted.
+Disconnects from sessions with the specified friendly names. Wildcards are permitted.
 
-To get the friendly name of a session, use the Get-PSSession cmdlet.
-The friendly name is stored in the **Name** property of the session.
+To get the friendly name of a session, use the `Get-PSSession` cmdlet. The friendly name is stored
+in the **Name** property of the session.
 
 ```yaml
 Type: String[]
@@ -346,13 +408,14 @@ Accept wildcard characters: False
 
 ### -Session
 
-Disconnects from the specified PSSessions.
-Enter PSSession objects, such as those that the New-PSSession cmdlet returns.
-You can also pipe a PSSession object to Disconnect-PSSession.
+Disconnects from the specified PSSessions. Enter PSSession objects, such as those that the
+`New-PSSession` cmdlet returns. You can also pipe a PSSession object to `Disconnect-PSSession`.
 
-The **Get-PSSession** cmdlet can get all PSSessions that terminate at a remote computer, including PSSessions that are disconnected and PSSessions that are connected to other sessions on other computers.
-**Disconnect-PSSession** disconnects only PSSession that are connected to the current session.
-If you pipe other PSSessions to **Disconnect-PSSession**, the **Disconnect-PSSession** command fails.
+The `Get-PSSession` cmdlet can get all PSSessions that terminate at a remote computer, including
+PSSessions that are disconnected and PSSessions that are connected to other sessions on other
+computers. `Disconnect-PSSession` disconnects only PSSession that are connected to the current
+session. If you pipe other PSSessions to `Disconnect-PSSession`, the `Disconnect-PSSession` command
+fails.
 
 ```yaml
 Type: PSSession[]
@@ -368,10 +431,10 @@ Accept wildcard characters: False
 
 ### -ThrottleLimit
 
-Sets the throttle limit for the **Disconnect-PSSession** command.
+Sets the throttle limit for the `Disconnect-PSSession` command.
 
-The throttle limit is the maximum number of concurrent connections that can be established to run this command.
-If you omit this parameter or enter a value of 0, the default value, 32, is used.
+The throttle limit is the maximum number of concurrent connections that can be established to run
+this command. If you omit this parameter or enter a value of 0, the default value, 32, is used.
 
 The throttle limit applies only to the current command, not to the session or to the computer.
 
@@ -389,19 +452,22 @@ Accept wildcard characters: False
 
 ### -OutputBufferingMode
 
-Determines how command output is managed in the disconnected session when the output buffer is full.
-The default value is **Block**.
+Determines how command output is managed in the disconnected session when the output buffer is
+full. The default value is **Block**.
 
-If the command in the disconnected session is returning output and the output buffer fills, the value of this parameter effectively determines whether the command continues to run while the session is disconnected.
-A value of **Block** suspends the command until the session is reconnected.
-A value of **Drop** allows the command to complete, although data might be lost.
-When using the **Drop** value, redirect the command output to a file on disk.
+If the command in the disconnected session is returning output and the output buffer fills, the
+value of this parameter effectively determines whether the command continues to run while the
+session is disconnected. A value of **Block** suspends the command until the session is
+reconnected. A value of **Drop** allows the command to complete, although data might be lost. When
+using the **Drop** value, redirect the command output to a file on disk.
 
 Valid values are:
 
 - **Block**: When the output buffer is full, execution is suspended until the buffer is clear.
-- **Drop**: When the output buffer is full, execution continues. As new output is saved, the oldest output is discarded.
-- **None**: No output buffering mode is specified. The value of the **OutputBufferingMode** property of the session configuration is used for the disconnected session.
+- **Drop**: When the output buffer is full, execution continues. As new output is saved, the oldest
+  output is discarded.
+- **None**: No output buffering mode is specified. The value of the **OutputBufferingMode** property
+  of the session configuration is used for the disconnected session.
 
 ```yaml
 Type: OutputBufferingMode
@@ -450,39 +516,50 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](./About/about_CommonParameters.md).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### System.Management.Automation.Runspaces.PSSession
 
-You can pipe a session to **Disconnect-PSSession**.
+You can pipe a session to `Disconnect-PSSession`.
 
 ## OUTPUTS
 
 ### System.Management.Automation.Runspaces.PSSession
 
-**Disconnect-PSSession** returns an object that represents the session that it disconnected.
+`Disconnect-PSSession` returns an object that represents the session that it disconnected.
 
 ## NOTES
 
-- The **Disconnect-PSSession** cmdlet works only when the local and remote computers are running Windows PowerShell 3.0 or later versions of Windows PowerShell.
-- If you use the **Disconnect-PSSession** cmdlet on a disconnected session, the command has no effect on the session and it does not generate errors.
-- Disconnected loopback sessions with interactive security tokens (those created with the **EnableNetworkAccess** parameter) can be reconnected only from the computer on which the session was created. This restriction protects the computer from malicious access.
-- When you disconnect a PSSession, the session state is **Disconnected** and the availability is **None**.
+- The `Disconnect-PSSession` cmdlet works only when the local and remote computers are running
+  PowerShell 3.0 or later.
+- If you use the `Disconnect-PSSession` cmdlet on a disconnected session, the command has no effect
+  on the session and it does not generate errors.
+- Disconnected loopback sessions with interactive security tokens (those created with the
+  **EnableNetworkAccess** parameter) can be reconnected only from the computer on which the session
+  was created. This restriction protects the computer from malicious access.
+- When you disconnect a PSSession, the session state is **Disconnected** and the availability is
+  **None**.
 
-  The value of the **State** property is relative to the current session.
-Therefore, a value of **Disconnected** means that the PSSession is not connected to the current session.
-However, it does not mean that the PSSession is disconnected from all sessions.
-It might be connected to a different session.
-To determine whether you can connect or reconnect to the session, use the **Availability** property.
+  The value of the **State** property is relative to the current session. Therefore, a value of
+  **Disconnected** means that the PSSession is not connected to the current session. However, it
+  does not mean that the PSSession is disconnected from all sessions. It might be connected to a
+  different session. To determine whether you can connect or reconnect to the session, use the
+  **Availability** property.
 
-  An **Availability** value of **None** indicates that you can connect to the session.
-A value of **Busy** indicates that you cannot connect to the PSSession because it is connected to another session.
+  An **Availability** value of **None** indicates that you can connect to the session. A value of
+  **Busy** indicates that you cannot connect to the PSSession because it is connected to another
+  session.
 
-  For more information about the values of the **State** property of sessions, see [RunspaceState Enumeration](/dotnet/api/system.management.automation.runspaces.runspacestate) in the MSDN library.
+  For more information about the values of the **State** property of sessions, see
+  [RunspaceState Enumeration](/dotnet/api/system.management.automation.runspaces.runspacestate).
 
-  For more information about the values of the **Availability** property of sessions, see [RunspaceAvailability Enumeration](/dotnet/api/system.management.automation.runspaces.runspaceavailability) in the MSDN library.
+  For more information about the values of the **Availability** property of sessions, see
+  [RunspaceAvailability Enumeration](/dotnet/api/system.management.automation.runspaces.runspaceavailability).
 
 ## RELATED LINKS
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -89,7 +89,7 @@ PS C:\> cd HKLM:\Software
 > PowerShell uses aliases to allow you a familiar way to work with provider
 > paths. Commands such as `dir` and `ls` are now aliases for
 > [Get-ChildItem](../../Microsoft.PowerShell.Management/Get-ChildItem.md),
-> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md)
+> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md),
 > and `pwd` is an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
 
 This last example shows another path syntax you can use to navigate the
@@ -136,8 +136,7 @@ Spooler     DependOnService    : {RPCSS, http}
             Group              : SpoolerGroup
             ImagePath          : C:\WINDOWS\System32\spoolsv.exe
             ObjectName         : LocalSystem
-            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege,
-            SeAuditPrivilege, SeChangeNotifyPrivilege...}
+            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege, ...
             ServiceSidType     : 1
             Start              : 2
             Type               : 27
@@ -194,7 +193,7 @@ articles.
 
 Registry key values are stored as properties of each registry key. The
 `Get-ItemProperty` cmdlet views registry key properties using the name you
-specify. The result is a **PSCustom** object containing the properties you
+specify. The result is a **PSCustomObject** containing the properties you
 specify.
 
 The Following example uses the `Get-ItemProperty` cmdlet to view all
@@ -309,9 +308,9 @@ Name                           Property
 ContosoCompany
 ```
 
-You can use the `New-ItemProperty` cmdlet to create to **Item Properties** on
-a registry key that you specify. The following example creates a new DWORD
-value on the ContosoCompany registry key.
+You can use the `New-ItemProperty` cmdlet to create values in a registry key
+that you specify. The following example creates a new DWORD value on the
+ContosoCompany registry key.
 
 ```powershell
 $path = "HKLM:\SOFTWARE\ContosoCompany"
@@ -541,7 +540,7 @@ Beginning in Windows PowerShell 3.0, you can get customized help topics for
 provider cmdlets that explain how those cmdlets behave in a file system drive.
 
 To get the help topics that are customized for the file system drive, run a
-`Get-Help` command in a file system drive or use the `-Path` parameter to
+`Get-Help` command in a file system drive or use the **Path** parameter to
 specify a file system drive.
 
 ```powershell

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -28,8 +28,10 @@ Provides access to the registry keys, entries, and values in PowerShell.
 The PowerShell **Registry** provider lets you get, add, change,
 clear, and delete registry keys, entries, and values in PowerShell.
 
-The **Registry** drives are a hierarchical namespace containing the registry keys and subkeys on your computer. Registry entries and values are not
-components of that hierarchy. Instead, they are properties of each of the keys.
+The **Registry** drives are a hierarchical namespace containing the registry
+keys and subkeys on your computer. Registry entries and values are not
+components of that hierarchy. Instead, they are properties of each of the
+keys.
 
 The **Registry** provider supports the following cmdlets, which are covered
 in this article.
@@ -76,7 +78,8 @@ Set-Location C:
 
 You can also work with the **Registry** provider from any other PowerShell
 drive. To reference a registry key from another location, use the drive name
-(`HKLM:`, `HKCU:`) in the path. Use a backslash (\\) or a forward slash (/) to indicate a level of the **Registry** drive.
+(`HKLM:`, `HKCU:`) in the path. Use a backslash (\\) or a forward slash (/) to
+indicate a level of the **Registry** drive.
 
 ```powershell
 PS C:\> cd HKLM:\Software
@@ -86,13 +89,13 @@ PS C:\> cd HKLM:\Software
 > PowerShell uses aliases to allow you a familiar way to work with provider
 > paths. Commands such as `dir` and `ls` are now aliases for
 > [Get-ChildItem](../../Microsoft.PowerShell.Management/Get-ChildItem.md),
-> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md). and `pwd` is
-> an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
+> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md)
+> and `pwd` is an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
 
 This last example shows another path syntax you can use to navigate the
 **Registry** provider. This syntax uses the provider name, followed by two
-colons `::`.  This syntax allows you to use the full HIVE name, instead
-of the mapped drive name `HKLM`.
+colons `::`. This syntax allows you to use the full HIVE name, instead of the
+mapped drive name `HKLM`.
 
 ```powershell
 cd "Registry::HKEY_LOCAL_MACHINE\Software"
@@ -100,7 +103,8 @@ cd "Registry::HKEY_LOCAL_MACHINE\Software"
 
 ## Displaying the contents of registry keys
 
-The registry is divided into keys, subkeys, and entries.  For more information about registry structure, see [Structure of the Registry](/windows/desktop/sysinfo/structure-of-the-registry.md).
+The registry is divided into keys, subkeys, and entries. For more information
+about registry structure, see [Structure of the Registry](/windows/desktop/sysinfo/structure-of-the-registry.md).
 
 In a **Registry** drive, each key is a container. A key can contain any number
 of keys. A registry key that has a parent key is called a subkey. You can
@@ -112,7 +116,8 @@ they are called **Item Properties**. A registry key can have both children
 keys and item properties.
 
 In this example, the difference between `Get-Item` and `Get-ChildItem` is
-shown. When you use `Get-Item` on the "Spooler" registry key, you can view its properties.
+shown. When you use `Get-Item` on the "Spooler" registry key, you can view its
+properties.
 
 ```
 PS C:\ > Get-Item -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
@@ -121,21 +126,21 @@ PS C:\ > Get-Item -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services
 
 
-Name                           Property
-----                           --------
-Spooler                        DependOnService    : {RPCSS, http}
-                               Description        : @%systemroot%\system32\spoolsv.exe,-2
-                               DisplayName        : @%systemroot%\system32\spoolsv.exe,-1
-                               ErrorControl       : 1
-                               FailureActions     : {16, 14, 0, 0...}
-                               Group              : SpoolerGroup
-                               ImagePath          : C:\WINDOWS\System32\spoolsv.exe
-                               ObjectName         : LocalSystem
-                               RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege, SeAuditPrivilege,
-                               SeChangeNotifyPrivilege...}
-                               ServiceSidType     : 1
-                               Start              : 2
-                               Type               : 272
+Name        Property
+----        --------
+Spooler     DependOnService    : {RPCSS, http}
+            Description        : @%systemroot%\system32\spoolsv.exe,-2
+            DisplayName        : @%systemroot%\system32\spoolsv.exe,-1
+            ErrorControl       : 1
+            FailureActions     : {16, 14, 0, 0...}
+            Group              : SpoolerGroup
+            ImagePath          : C:\WINDOWS\System32\spoolsv.exe
+            ObjectName         : LocalSystem
+            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege,
+            SeAuditPrivilege, SeChangeNotifyPrivilege...}
+            ServiceSidType     : 1
+            Start              : 2
+            Type               : 27
 ```
 
 Each registry key can also have subkeys. When you use `Get-Item` on a registry
@@ -150,16 +155,16 @@ PS C:\> Get-ChildItem -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Spooler
 
 
-Name                           Property
-----                           --------
-Performance                    Close           : PerfClose
-                               Collect         : PerfCollect
-                               Collect Timeout : 2000
-                               Library         : C:\Windows\System32\winspool.drv
-                               Object List     : 1450
-                               Open            : PerfOpen
-                               Open Timeout    : 4000
-Security                       Security : {1, 0, 20, 128...}
+Name             Property
+----             --------
+Performance      Close           : PerfClose
+                 Collect         : PerfCollect
+                 Collect Timeout : 2000
+                 Library         : C:\Windows\System32\winspool.drv
+                 Object List     : 1450
+                 Open            : PerfOpen
+                 Open Timeout    : 4000
+Security         Security : {1, 0, 20, 128...}
 ```
 
 The `Get-Item` cmdlet can also be used on the current location. The following
@@ -172,10 +177,10 @@ PS HKLM:\SYSTEM\CurrentControlSet\Services\Spooler> Get-Item .
 
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services
 
-Name                           Property
-----                           --------
-Spooler                        DependOnService    : {RPCSS, http}
-                               Description        : @%systemroot%\system32\spoolsv.exe,-2
+Name             Property
+----             --------
+Spooler          DependOnService    : {RPCSS, http}
+                 Description        : @%systemroot%\system32\spoolsv.exe,-2
 ...
 ```
 
@@ -187,8 +192,10 @@ articles.
 
 ## Viewing registry key values
 
-Registry key values are stored as properties of each registry key. The `Get-ItemProperty` cmdlet views registry key properties using the name you specify. The result is a **PSCustom** object containing the
-properties you specify.
+Registry key values are stored as properties of each registry key. The
+`Get-ItemProperty` cmdlet views registry key properties using the name you
+specify. The result is a **PSCustom** object containing the properties you
+specify.
 
 The Following example uses the `Get-ItemProperty` cmdlet to view all
 properties. Storing the resulting object in a variable allows you to access
@@ -249,7 +256,10 @@ articles.
 
 ## Changing registry key values
 
-The `Set-ItemProperty` cmdlet will set attributes for registry keys. The following example uses `Set-ItemProperty` to change the spooler service start type to manual. The example changes the **StartType** back to *Automatic* using the `Set-Service` cmdlet.
+The `Set-ItemProperty` cmdlet will set attributes for registry keys. The
+following example uses `Set-ItemProperty` to change the spooler service start
+type to manual. The example changes the **StartType** back to *Automatic*
+using the `Set-Service` cmdlet.
 
 ```
 PS C:\> Get-Service spooler | Select-Object Name, StartMode
@@ -273,7 +283,8 @@ Each registry key has a *default* value. You can change the *default* value
 for a registry key with either `Set-Item` or `Set-ItemProperty`.
 
 ```powershell
-Set-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name "(default)" -Value "one" Set-Item -Path HKLM:\SOFTWARE\Contoso -Value "two"
+Set-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name "(default)" -Value "one"
+Set-Item -Path HKLM:\SOFTWARE\Contoso -Value "two"
 ```
 
 For more information on the cmdlets used in this section, see the following
@@ -298,9 +309,9 @@ Name                           Property
 ContosoCompany
 ```
 
-You can use the `New-ItemProperty` cmdlet to create to **Item Properties**
-on a registry key that you specify. The following example creates a new
-DWORD value on the ContosoCompany registry key.
+You can use the `New-ItemProperty` cmdlet to create to **Item Properties** on
+a registry key that you specify. The following example creates a new DWORD
+value on the ContosoCompany registry key.
 
 ```powershell
 $path = "HKLM:\SOFTWARE\ContosoCompany"
@@ -315,7 +326,10 @@ For detailed cmdlet usage, see [New-ItemProperty](../../Microsoft.PowerShell.Man
 
 ## Copying registry keys and values
 
-In the **Registry** provider, use the `Copy-Item` cmdlet copies registry keys and values. Use the `Copy-ItemProperty` cmdlet to copy registry values only. The following command copies the "Contoso" registry key, and its properties to the specified location "HKLM:\Software\Fabrikam".
+In the **Registry** provider, use the `Copy-Item` cmdlet copies registry keys
+and values. Use the `Copy-ItemProperty` cmdlet to copy registry values only.
+The following command copies the "Contoso" registry key, and its properties to
+the specified location "HKLM:\Software\Fabrikam".
 
 `Copy-Item` creates the destination key if it does not exist. If the
 destination key exists, `Copy-Item` creates a duplicate of the source key
@@ -343,9 +357,9 @@ articles.
 ## Moving registry keys and values
 
 The `Move-Item` and `Move-ItemProperty` cmdlets behave like their "Copy"
-counterparts. If the destination exists, `Move-Item` moves the source
-key underneath the destination key. If the destination key does not exist,
-the source key is moved to the destination path.
+counterparts. If the destination exists, `Move-Item` moves the source key
+underneath the destination key. If the destination key does not exist, the
+source key is moved to the destination path.
 
 The following command moves the "Contoso" key to the path
 "HKLM:\SOFTWARE\Fabrikam".
@@ -402,7 +416,8 @@ For more examples and cmdlet usage details see the following articles.
 
 ## Removing and clearing registry keys and values
 
-You can remove contained items by using **Remove-Item**, but you will be prompted to confirm the removal if the item contains anything else. The
+You can remove contained items by using **Remove-Item**, but you will be
+prompted to confirm the removal if the item contains anything else. The
 following example attempts to delete a key "HKLM:\SOFTWARE\Contoso".
 
 ```
@@ -418,8 +433,8 @@ PS C:\> Remove-Item -Path HKLM:\SOFTWARE\Contoso
 
 Confirm
 The item at HKLM:\SOFTWARE\Contoso has children and the -Recurse
-parameter was not specified. If you continue, all children will be removed with
- the item. Are you sure you want to continue?
+parameter was not specified. If you continue, all children will be removed
+with the item. Are you sure you want to continue?
 [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help
 (default is "Y"):
 ```
@@ -430,14 +445,16 @@ To delete contained items without prompting, specify the `-Recurse` parameter.
 Remove-Item -Path HKLM:\SOFTWARE\Contoso -Recurse
 ```
 
-If you wanted to remove all items within "HKLM:\SOFTWARE\Contoso" but not "HKLM:\SOFTWARE\Contoso" itself, use a trailing backslash `\` followed by a
+If you wanted to remove all items within "HKLM:\SOFTWARE\Contoso" but not
+"HKLM:\SOFTWARE\Contoso" itself, use a trailing backslash `\` followed by a
 wildcard.
 
 ```powershell
 Remove-Item -Path HKLM:\SOFTWARE\Contoso\* -Recurse
 ```
 
-This command deletes the "ContosoTest" registry value from the "HKLM:\SOFTWARE\Contoso" registry key.
+This command deletes the "ContosoTest" registry value from the
+"HKLM:\SOFTWARE\Contoso" registry key.
 
 ```powershell
 Remove-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name ContosoTest
@@ -452,12 +469,12 @@ PS HKLM:\SOFTWARE\> Get-Item .\Contoso\
 
     Hive: HKEY_LOCAL_MACHINE\SOFTWARE
 
-Name                           Property
-----                           --------
-Contoso                        Server     : {a, b, c}
-                               HereString : {This is text which contains
-                                            newlines. It also contains "quoted" strings}
-                               (default)  : 1
+Name           Property
+----           --------
+Contoso        Server     : {a, b, c}
+               HereString : {This is text which contains
+               newlines. It also contains "quoted" strings}
+               (default)  : 1
 
 PS HKLM:\SOFTWARE\> Clear-Item .\Contoso\
 PS HKLM:\SOFTWARE\> Get-Item .\Contoso\
@@ -478,23 +495,33 @@ For more examples and cmdlet usage details see the following articles.
 
 ## Dynamic parameters
 
-Dynamic parameters are cmdlet parameters that are added by a PowerShell provider and are available only when the cmdlet is being used in the provider-enabled drive.
+Dynamic parameters are cmdlet parameters that are added by a PowerShell
+provider and are available only when the cmdlet is being used in the
+provider-enabled drive.
 
 ### Type <Microsoft.Win32.RegistryValueKind>
 
 Establishes or changes the data type of a registry value. The default is `String` (REG_SZ).
 
-This parameter works as designed on the [Set-ItemProperty](../../Microsoft.PowerShell.Management/Set-ItemProperty.md) cmdlet. It is also available on the [Set-Item](../../Microsoft.PowerShell.Management/Set-Item.md) cmdlet in the registry drives, but it has no effect.
+This parameter works as designed on the
+[Set-ItemProperty](../../Microsoft.PowerShell.Management/Set-ItemProperty.md)
+cmdlet. It is also available on the
+[Set-Item](../../Microsoft.PowerShell.Management/Set-Item.md) cmdlet in the
+registry drives, but it has no effect.
 
-|Value|Description|
-|-----------|-----------------|
-|  `String` | Specifies a null-terminated string. Equivalent to REG_SZ. |
-|  `ExpandString` | Specifies a null-terminated string that contains unexpanded references to environment variables that are expanded when the value is retrieved. Equivalent to REG_EXPAND_SZ. |
-|  `Binary` | Specifies binary data in any form. Equivalent to REG_BINARY. |
-|  `DWord` | Specifies a 32-bit binary number. Equivalent to REG_DWORD. |
-|  `MultiString` | Specifies an array of null-terminated strings terminated by two null characters. Equivalent to REG_MULTI_SZ. |
-|  `QWord` | Specifies a 64-bit binary number. Equivalent to REG_QWORD. |
-|  `Unknown` | Indicates an unsupported registry data type, such as REG_RESOURCE_LIST. |
+|Value | Description |
+| ---- | ----------- |
+| `String` | Specifies a null-terminated string. Equivalent to REG_SZ. |
+| `ExpandString` | Specifies a null-terminated string that contains unexpanded |
+|                | references to environment variables that are expanded when |
+|                | the value is retrieved. Equivalent to REG_EXPAND_SZ. |
+| `Binary` | Specifies binary data in any form. Equivalent to REG_BINARY. |
+| `DWord` | Specifies a 32-bit binary number. Equivalent to REG_DWORD. |
+| `MultiString` | Specifies an array of null-terminated strings terminated by |
+|               | two null characters. Equivalent to REG_MULTI_SZ. |
+| `QWord` | Specifies a 64-bit binary number. Equivalent to REG_QWORD. |
+| `Unknown` | Indicates an unsupported registry data type, such as |
+|           | REG_RESOURCE_LIST. |
 
 #### Cmdlets supported
 
@@ -504,9 +531,9 @@ This parameter works as designed on the [Set-ItemProperty](../../Microsoft.Power
 ## Using the pipeline
 
 Provider cmdlets accept pipeline input. You can use the pipeline to simplify
-task by sending provider data from one cmdlet to another provider cmdlet.
-To read more about how to use the pipeline with provider cmdlets, see the
-cmdlet references provided throughout this article.
+task by sending provider data from one cmdlet to another provider cmdlet. To
+read more about how to use the pipeline with provider cmdlets, see the cmdlet
+references provided throughout this article.
 
 ## Getting help
 
@@ -514,8 +541,8 @@ Beginning in Windows PowerShell 3.0, you can get customized help topics for
 provider cmdlets that explain how those cmdlets behave in a file system drive.
 
 To get the help topics that are customized for the file system drive, run a
-[Get-Help](../Get-Help.md) command in a file system drive or use the `-Path`
-parameter of [Get-Help](../Get-Help.md) to specify a file system drive.
+`Get-Help` command in a file system drive or use the `-Path` parameter to
+specify a file system drive.
 
 ```powershell
 Get-Help Get-ChildItem

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -166,7 +166,7 @@ creates firewall rules that allows remote access from the same local subnet.
 
 On client versions of Windows, `Enable-PSRemoting` succeeds on private and
 domain networks. By default, it fails on public networks, but if
-you use the SkipNetworkProfileCheck parameter, `Enable-PSRemoting` succeeds
+you use the **SkipNetworkProfileCheck** parameter, `Enable-PSRemoting` succeeds
 and creates a firewall rule that allows traffic from the same local subnet.
 
 To remove the local subnet restriction on public networks and allow
@@ -279,8 +279,8 @@ Get-Item wsman:\localhost\Service\RootSDDL
 
 To change the RootSDDL, use the `Set-Item` cmdlet in the WSMan: drive. To
 change the security descriptor of a session configuration, use the
-`Set-PSSessionConfiguration` cmdlet with the SecurityDescriptorSDDL or
-ShowSecurityDescriptorUI parameters.
+`Set-PSSessionConfiguration` cmdlet with the **SecurityDescriptorSDDL** or
+**ShowSecurityDescriptorUI** parameters.
 
 For more information about the WSMan: drive, see the Help topic for the
 WSMan provider ("Get-Help wsman").
@@ -308,8 +308,8 @@ Administrator.
 Invoke-Command -ComputerName Server01 -Credential Domain01\Admin01
 ```
 
-For more information about the Credential parameter, see `New-PSSession`,
-`Enter-PSSession` or `Invoke-Command`.
+For more information about the **Credential** parameter, see [New-PSSession](../New-PSSession.md),
+[Enter-PSSession](../Enter-PSSession.md) or [Invoke-Command](../Invoke-Command.md).
 
 ### HOW TO ENABLE REMOTING FOR NON-ADMINISTRATIVE USERS
 
@@ -737,8 +737,8 @@ Set-PSSessionConfiguration -Name microsoft.PowerShell `
 For more information about the `New-PSSessionOption` cmdlet, see
 `New-PSSessionOption`.
 
-For more information about the WS-Management quotas, see the Help topic for
-the WSMan provider (type `Get-Help WSMan`).
+For more information about the WS-Management quotas, see
+[about_WSMan_Provider](../../Microsoft.WsMan.Management/About/about_WSMan_Provider.md).
 
 ### HOW TO RESOLVE TIMEOUT ERRORS
 

--- a/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -18,15 +18,16 @@ This section describes some of the problems that you might encounter when
 using the remoting features of PowerShell that are based on
 WS-Management technology and it suggests solutions to these problems.
 
-Before using PowerShell remoting, see about_Remote and
-about_Remote_Requirements for guidance on configuration and basic use Also,
-the Help topics for each of the remoting cmdlets, particularly the parameter
-descriptions, have useful information that is designed to help you avoid
-problems.
+Before using PowerShell remoting, see [about_Remote](about_remote.md) and
+[about_Remote_Requirements](about_Remote_Requirements.md) for guidance on
+configuration and basic use. Also, the Help topics for each of the remoting
+cmdlets, particularly the parameter descriptions, have useful information that
+is designed to help you avoid problems.
 
-NOTE: To view or change settings for the local computer in the WSMan: drive,
-including changes to the session configurations, trusted hosts, ports, or
-listeners, start PowerShell with the "Run as administrator" option.
+> [!NOTE]
+> To view or change settings for the local computer in the WSMan: drive,
+> including changes to the session configurations, trusted hosts, ports, or
+> listeners, start PowerShell with the "Run as administrator" option.
 
 ## TROUBLESHOOTING PERMISSION AND AUTHENTICATION ISSUES
 
@@ -54,11 +55,12 @@ To start Windows PowerShell with the "Run as administrator option:
 - In the Windows taskbar, right-click the Windows PowerShell icon, and then
   click "Run as Administrator."
 
-  Note: In Windows Server 2008 R2, the Windows PowerShell icon is pinned
-  to the taskbar by default.
+  In Windows Server 2008 R2, the Windows PowerShell icon is pinned to the
+  taskbar by default.
 
 ### HOW TO ENABLE REMOTING
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -66,6 +68,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 No configuration is required to enable a computer to send remote
 commands. However, to receive remote commands, PowerShell remoting
@@ -76,25 +79,26 @@ session configurations.
 
 Windows PowerShell remoting is enabled on Windows Server 2012 and newer
 releases of Windows Server by default. On all other systems, run the
-Enable-PSRemoting cmdlet to enable remoting. You can also run the
-Enable-PSRemoting cmdlet to re-enable remoting on Windows Server 2012 and
+`Enable-PSRemoting` cmdlet to enable remoting. You can also run the
+`Enable-PSRemoting` cmdlet to re-enable remoting on Windows Server 2012 and
 newer releases of Windows Server if remoting is disabled.
 
 To configure a computer to receive remote commands, use the
-Enable-PSRemoting cmdlet. The following command enables all required
+`Enable-PSRemoting` cmdlet. The following command enables all required
 remote settings, enables the session configurations, and restarts the
 WinRM service to make the changes effective.
 
-Enable-PSRemoting
+`Enable-PSRemoting`
 
 To suppress all user prompts, type:
 
-Enable-PSRemoting -Force
+`Enable-PSRemoting -Force`
 
-For more information, see Enable-PSRemoting.
+For more information, see [Enable-PSRemoting](../Enable-PSRemoting.md).
 
 ### HOW TO ENABLE REMOTING IN AN ENTERPRISE
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -102,9 +106,10 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 To enable a single computer to receive remote PowerShell commands
-and accept connections, use the Enable-PSRemoting cmdlet.
+and accept connections, use the `Enable-PSRemoting` cmdlet.
 
 To enable remoting for multiple computers in an enterprise, you can use the
 following scaled options.
@@ -114,7 +119,7 @@ following scaled options.
   Enable Listeners by Using a Group Policy" (below).
 
 - To set the startup type of the Windows Remote Management (WinRM)
-  to Automatic on multiple computers, use the Set-Service cmdlet. For
+  to Automatic on multiple computers, use the `Set-Service` cmdlet. For
   instructions, see "How to Set the Startup Type of the WinrM Service"
   (below).
 
@@ -124,6 +129,7 @@ following scaled options.
 
 ### HOW TO ENABLE LISTENERS BY USING A GROUP POLICY
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -131,6 +137,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to listen
 for requests on the correct port and HTTP URL.
+```
 
 To configure the listeners for all computers in a domain, enable the "Allow
 automatic configuration of listeners" policy in the following Group Policy
@@ -144,20 +151,22 @@ permitted.
 
 ### HOW TO ENABLE REMOTING ON PUBLIC NETWORKS
 
+```
 ERROR:  Unable to check the status of the firewall
+```
 
-The Enable-PSRemoting cmdlet returns this error when the local network
+The `Enable-PSRemoting` cmdlet returns this error when the local network
 is public and the SkipNetworkProfileCheck parameter is not used in the
 command.
 
-On server versions of Windows, Enable-PSRemoting succeeds on all network
+On server versions of Windows, `Enable-PSRemoting` succeeds on all network
 location types. It creates firewall rules that allow remote access to
 private and domain ("Home" and "Work") networks. For public networks, it
 creates firewall rules that allows remote access from the same local subnet.
 
-On client versions of Windows, Enable-PSRemoting succeeds on private and
+On client versions of Windows, `Enable-PSRemoting` succeeds on private and
 domain networks. By default, it fails on public networks, but if
-you use the SkipNetworkProfileCheck parameter, Enable-PSRemoting succeeds
+you use the SkipNetworkProfileCheck parameter, `Enable-PSRemoting` succeeds
 and creates a firewall rule that allows traffic from the same local subnet.
 
 To remove the local subnet restriction on public networks and allow
@@ -167,16 +176,18 @@ remote access from any location, run the following command:
 Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP-PUBLIC" -RemoteAddress Any
 ```
 
-The Set-NetFirewallRule cmdlet is exported by the NetSecurity module.
+The `Set-NetFirewallRule` cmdlet is exported by the NetSecurity module.
 
-NOTE: In Windows PowerShell 2.0, on computers running server versions
-of Windows, Enable-PSRemoting creates firewall rules that allow remote
-access on private, domain and public networks. On computers running
-client versions of Windows, Enable-PSRemoting creates firewall rules
-that allow remote access only on private and domain networks.
+> [!NOTE]
+> In Windows PowerShell 2.0, on computers running server versions
+> of Windows, `Enable-PSRemoting` creates firewall rules that allow remote
+> access on private, domain and public networks. On computers running
+> client versions of Windows, `Enable-PSRemoting` creates firewall rules
+> that allow remote access only on private and domain networks.
 
 ### HOW TO ENABLE A FIREWALL EXCEPTION BY USING A GROUP POLICY
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -184,6 +195,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 To enable a firewall exception for in all computers in a domain, enable the
 "Windows Firewall: Allow local port exceptions" policy in the following
@@ -198,7 +210,9 @@ the Windows Remote Management service.
 
 ### HOW TO SET THE STARTUP TYPE OF THE WINRM SERVICE
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 PowerShell remoting depends upon the Windows Remote Management
 (WinRM) service. The service must be running to support remote commands.
@@ -210,7 +224,7 @@ However, on client versions of Windows, the WinRM service is disabled
 by default.
 
 To set the startup type of a service on a remote computer, use the
-Set-Service cmdlet.
+`Set-Service` cmdlet.
 
 To run the command on multiple computers, you can create a text file or
 CSV file of the computer names.
@@ -220,38 +234,42 @@ Servers.txt file and then sets the startup type of the WinRM service on all
 of the computers to Automatic.
 
 ```powershell
-C:\PS> $servers = Get-Content servers.txt
-C:\PS> Set-Service WinRM -ComputerName $servers -startuptype Automatic
+$servers = Get-Content servers.txt
+Set-Service WinRM -ComputerName $servers -startuptype Automatic
 ```
 
-To see the results use the Get-WMIObject cmdlet with the Win32_Service object.
-For more information, see Set-Service.
+To see the results use the `Get-WMIObject` cmdlet with the **Win32_Service**
+object. For more information, see
+[Set-Service](../../Microsoft.PowerShell.Management/Set-Service.md).
 
 ### HOW TO RECREATE THE DEFAULT SESSION CONFIGURATIONS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To connect to the local computer and run commands remotely, the local
 computer must include session configurations for remote commands.
 
-When you use Enable-PSRemoting, it creates default session configurations
+When you use `Enable-PSRemoting`, it creates default session configurations
 on the local computer. Remote users use these session configurations
 whenever a remote command does not include the ConfigurationName parameter.
 
 If the default configurations on a computer are unregistered or deleted,
-use the Enable-PSRemoting cmdlet to recreate them. You can use this cmdlet
+use the `Enable-PSRemoting` cmdlet to recreate them. You can use this cmdlet
 repeatedly. It does not generate errors if a feature is already configured.
 
 If you change the default session configurations and want to restore the
 original default session configurations, use the
-Unregister-PSSessionConfiguration cmdlet to delete the changed session
-configurations and then use the Enable-PSRemoting cmdlet to restore them.
-Enable-PSRemoting does not change existing session configurations.
+`Unregister-PSSessionConfiguration` cmdlet to delete the changed session
+configurations and then use the `Enable-PSRemoting` cmdlet to restore them.
+`Enable-PSRemoting` does not change existing session configurations.
 
-Note: When Enable-PSRemoting restores the default session configuration, it
-does not create explicit security descriptors for the configurations.
-Instead, the configurations inherit the security descriptor of the RootSDDL,
-which is secure by default.
+> [!NOTE]
+> When `Enable-PSRemoting` restores the default session configuration, it
+> does not create explicit security descriptors for the configurations.
+> Instead, the configurations inherit the security descriptor of the
+> RootSDDL, which is secure by default.
 
 To see the RootSDDL security descriptor, type:
 
@@ -259,9 +277,9 @@ To see the RootSDDL security descriptor, type:
 Get-Item wsman:\localhost\Service\RootSDDL
 ```
 
-To change the RootSDDL, use the Set-Item cmdlet in the WSMan: drive. To
+To change the RootSDDL, use the `Set-Item` cmdlet in the WSMan: drive. To
 change the security descriptor of a session configuration, use the
-Set-PSSessionConfiguration cmdlet with the SecurityDescriptorSDDL or
+`Set-PSSessionConfiguration` cmdlet with the SecurityDescriptorSDDL or
 ShowSecurityDescriptorUI parameters.
 
 For more information about the WSMan: drive, see the Help topic for the
@@ -269,7 +287,9 @@ WSMan provider ("Get-Help wsman").
 
 ### HOW TO PROVIDE ADMINISTRATOR CREDENTIALS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To create a PSSession or run commands on a remote computer, by default, the
 current user must be a member of the Administrators group on the remote
@@ -278,8 +298,8 @@ logged on to an account that is a member of the Administrators group.
 
 If the current user is a member of the Administrators group on the remote
 computer, or can provide the credentials of a member of the Administrators
-group, use the Credential parameter of the New-PSSession, Enter-PSSession
-or Invoke-Command cmdlets to connect remotely.
+group, use the Credential parameter of the `New-PSSession`, `Enter-PSSession`
+or `Invoke-Command` cmdlets to connect remotely.
 
 For example, the following command provides the credentials of an
 Administrator.
@@ -288,12 +308,14 @@ Administrator.
 Invoke-Command -ComputerName Server01 -Credential Domain01\Admin01
 ```
 
-For more information about the Credential parameter, see New-PSSession,
-Enter-PSSession or Invoke-Command.
+For more information about the Credential parameter, see `New-PSSession`,
+`Enter-PSSession` or `Invoke-Command`.
 
 ### HOW TO ENABLE REMOTING FOR NON-ADMINISTRATIVE USERS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To establish a PSSession or run a command on a remote computer, the user
 must have permission to use the session configurations on the remote
@@ -319,7 +341,9 @@ For more information, see [about_Session_Configurations](about_Session_Configura
 
 ### HOW TO ENABLE REMOTING FOR ADMINISTRATORS IN OTHER DOMAINS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 When a user in another domain is a member of the Administrators group on
 the local computer, the user cannot connect to the local computer remotely
@@ -330,30 +354,33 @@ However, you can use the LocalAccountTokenFilterPolicy registry entry to
 change the default behavior and allow remote users who are members of the
 Administrators group to run with Administrator privileges.
 
-Caution: The LocalAccountTokenFilterPolicy entry disables user account
-control (UAC) remote restrictions for all users of all affected
-computers. Consider the implications of this setting carefully
-before changing the policy.
+> [!CAUTION]
+> The LocalAccountTokenFilterPolicy entry disables user account
+> control (UAC) remote restrictions for all users of all affected
+> computers. Consider the implications of this setting carefully
+> before changing the policy.
 
 To change the policy, use the following command to set the value of the
 LocalAccountTokenFilterPolicy registry entry to 1.
 
 ```powershell
-C:\PS> New-ItemProperty -Name LocalAccountTokenFilterPolicy -Path `
-HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System `
--PropertyType DWord -Value 1
+New-ItemProperty -Name LocalAccountTokenFilterPolicy `
+  -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System `
+  -PropertyType DWord -Value 1
 ```
 
 ### HOW TO USE AN IP ADDRESS IN A REMOTE COMMAND
 
+```
 ERROR:  The WinRM client cannot process the request. If the
 authentication scheme is different from Kerberos, or if the client
 computer is not joined to a domain, then HTTPS transport must be used
 or the destination machine must be added to the TrustedHosts
 configuration setting.
+```
 
-The ComputerName parameters of the New-PSSession, Enter-PSSession and
-Invoke-Command cmdlets accept an IP address as a valid value. However,
+The ComputerName parameters of the `New-PSSession`, `Enter-PSSession` and
+`Invoke-Command` cmdlets accept an IP address as a valid value. However,
 because Kerberos authentication does not support IP addresses, NTLM
 authentication is used by default whenever you specify an IP address.
 
@@ -374,11 +401,13 @@ for remoting.
 
 ### HOW TO CONNECT REMOTELY FROM A WORKGROUP-BASED COMPUTER
 
+```
 ERROR:  The WinRM client cannot process the request. If the
 authentication scheme is different from Kerberos, or if the client
 computer is not joined to a domain, then HTTPS transport must be used
 or the destination machine must be added to the TrustedHosts
 configuration setting.
+```
 
 When the local computer is not in a domain, the following procedure is required
 for remoting.
@@ -422,7 +451,7 @@ To view the list of trusted hosts, use the following command:
 Get-Item wsman:\localhost\Client\TrustedHosts
 ```
 
-You can also use the Set-Location cmdlet (alias = cd) to navigate
+You can also use the `Set-Location` cmdlet (alias = cd) to navigate
 though the WSMan: drive to the location.
 For example:
 
@@ -453,7 +482,7 @@ the following command format:
 Set-Item wsman:\localhost\Client\TrustedHosts -Value <ComputerName>
 ```
 
-where each value <ComputerName> must have the following format:
+where each value `<ComputerName>` must have the following format:
 
 ```
 <Computer>.<Domain>.<Company>.<top-level-domain>
@@ -494,10 +523,12 @@ Set-Item wsman:\localhost\Client\TrustedHosts -Value 172.16.0.0
 ```
 
 To add a computer to the TrustedHosts list of a remote computer, use the
-Connect-WSMan cmdlet to add a node for the remote computer to the WSMan: drive
-on the local computer. Then use a Set-Item command to add the computer.
+`Connect-WSMan` cmdlet to add a node for the remote computer to the WSMan:
+drive on the local computer. Then use a `Set-Item` command to add the
+computer.
 
-For more information about the Connect-WSMan cmdlet, see Connect-WSMan.
+For more information about the `Connect-WSMan` cmdlet, see
+[Connect-WSMan](../../Microsoft.WSMan.Management/Connect-WSMan.md).
 
 ## TROUBLESHOOTING COMPUTER CONFIGURATION ISSUES
 
@@ -506,15 +537,17 @@ configurations of a computer, domain, or enterprise.
 
 ### HOW TO CONFIGURE REMOTING ON ALTERNATE PORTS
 
+```
 ERROR:  The connection to the specified remote host was refused. Verify
 that the WS-Management service is running on the remote host and
 configured to listen for requests on the correct port and HTTP URL.
+```
 
 Windows PowerShell remoting uses port 80 for HTTP transport by default. The
 default port is used whenever the user does not specify the ConnectionURI
 or Port parameters in a remote command.
 
-To change the default port that Windows PowerShell uses, use Set-Item cmdlet
+To change the default port that Windows PowerShell uses, use `Set-Item` cmdlet
 in the WSMan: drive to change the Port value in the  listener leaf node.
 
 For example, the following command changes the default port to 8080.
@@ -525,9 +558,11 @@ Set-Item wsman:\localhost\listener\listener*\port -Value 8080
 
 ### HOW TO CONFIGURE REMOTING WITH A PROXY SERVER
 
+```
 ERROR: The client cannot connect to the destination specified in the
 request. Verify that the service on the destination is running and is
 accepting requests.
+```
 
 Because PowerShell remoting uses the HTTP protocol, it is affected
 by HTTP proxy settings. In enterprises that have proxy servers, users
@@ -543,29 +578,29 @@ The following settings are available:
 To set these options for a particular command, use the following procedure:
 
 1. Use the ProxyAccessType, ProxyAuthentication, and ProxyCredential
-   parameters of the New-PSSessionOption cmdlet to create a session
+   parameters of the `New-PSSessionOption` cmdlet to create a session
    option object with the proxy settings for your enterprise. Save the
    option object is a variable.
 
 2. Use the variable that contains the option object as the value of the
-   SessionOption parameter of a New-PSSession, Enter-PSSession, or
-   Invoke-Command command.
+   SessionOption parameter of a `New-PSSession`, `Enter-PSSession`, or
+   `Invoke-Command` command.
 
 For example, the following command creates a session option object with
 proxy session options and then uses the object to create a remote session.
 
 ```powershell
-C:\PS> $SessionOption = New-PSSessionOption -ProxyAccessType IEConfig `
+$SessionOption = New-PSSessionOption -ProxyAccessType IEConfig `
 -ProxyAuthentication Negotiate -ProxyCredential Domain01\User01
 
-C:\PS> New-PSSession -ConnectionURI https://www.fabrikam.com
+New-PSSession -ConnectionURI https://www.fabrikam.com
 ```
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+[New-PSSessionOption](../New-PSSessionOption.md).
 
 To set these options for all remote commands in the current session, use
-the option object that New-PSSessionOption creates in the value of the
+the option object that `New-PSSessionOption` creates in the value of the
 $PSSessionOption preference variable. For more information about the
 $PSSessionOption preference variable, see about_Preference_Variables.
 
@@ -576,19 +611,21 @@ profiles, see about_Profiles.
 
 ### HOW TO DETECT A 32-BIT SESSION ON A 64-BIT COMPUTER
 
+```
 ERROR: The term "<tool-Name>" is not recognized as the name of a cmdlet,
 function, script file, or operable program. Check the spelling of the
 name, or if a path was included, verify that the path is correct and try
 again.
+```
 
 If the remote computer is running a 64-bit version of Windows, and the
 remote command is using a 32-bit session configuration, such as
 Microsoft.PowerShell32, Windows Remote Management (WinRM) loads a WOW64
 process and Windows automatically redirects all references to the
-%Windir%\\System32 directory to the %windir%\\SysWOW64 directory.
+`$env:Windir\System32` directory to the `$env:Windir\SysWOW64` directory.
 
 As a result, if you try to use tools in the System32 directory that do
-not have counterparts in the SysWow64 directory, such as Defrag.exe,
+not have counterparts in the SysWow64 directory, such as **Defrag.exe**,
 the tools cannot be found in the directory.
 
 To find the processor architecture that is being used in the session,
@@ -599,10 +636,14 @@ following command finds the processor architecture of the session in the
 ```powershell
 $s = New-PSSession -ComputerName Server01 -ConfigurationName CustomShell
 Invoke-Command -Session $s {$env:PROCESSOR_ARCHITECTURE}
+```
+
+```Output
 x86
 ```
 
-For more information about session configurations, see [about_Session_Configurations](about_Session_Configurations.md).
+For more information about session configurations, see
+[about_Session_Configurations](about_Session_Configurations.md).
 
 ## TROUBLESHOOTING POLICY AND PREFERENCE ISSUES
 
@@ -611,20 +652,22 @@ preferences set on the local and remote computers.
 
 ### HOW TO CHANGE THE EXECUTION POLICY FOR IMPORT-PSSESSION AND IMPORT-MODULE
 
+```
 ERROR: Import-Module: File <filename> cannot be loaded because the
 execution of scripts is disabled on this system.
+```
 
-The Import-PSSession and Export-PSSession cmdlets create modules that
+The `Import-PSSession` and `Export-PSSession` cmdlets create modules that
 contains unsigned script files and formatting files.
 
 To import the modules that are created by these cmdlets, either by using
-Import-PSSession or Import-Module, the execution policy in the current
+`Import-PSSession` or `Import-Module`, the execution policy in the current
 session cannot be Restricted or AllSigned. (For information about Windows
 PowerShell execution policies, see about_Execution_Policies.
 
 To import the modules without changing the execution policy for the local
 computer that is set in the registry, use the Scope parameter of
-Set-ExecutionPolicy to set a less restrictive execution policy for a single
+`Set-ExecutionPolicy` to set a less restrictive execution policy for a single
 process.
 
 For example, the following command starts a process with the RemoteSigned
@@ -636,22 +679,24 @@ setting.
 Set-ExecutionPolicy -Scope process -ExecutionPolicy RemoteSigned
 ```
 
-You can also use the ExecutionPolicy parameter of PowerShell.exe to start
+You can also use the ExecutionPolicy parameter of **PowerShell.exe** to start
 a single session with a less restrictive execution policy.
 
 ```powershell
 PowerShell.exe -ExecutionPolicy RemoteSigned
 ```
 
-For more information about the cmdlets, see Import-PSSession,
-Export-PSSession, and Import-Module. For more information about
+For more information about the cmdlets, see `Import-PSSession`,
+`Export-PSSession`, and `Import-Module`. For more information about
 execution policies, see about_Execution_Policies. For more information
 about the PowerShell.exe console help options, type "PowerShell.exe -?".
 
 ### HOW TO SET AND CHANGE QUOTAS
 
+```
 ERROR: The total data received from the remote client exceeded allowed
 maximum.
+```
 
 You can use quotas to protect the local computer and the remote computer
 from excessive resource use, both accidental and malicious.
@@ -659,19 +704,20 @@ from excessive resource use, both accidental and malicious.
 The following quotas are available in the basic configuration.
 
 - The WSMan provider (WSMan:) provides several quota settings, such as the
-  MaxEnvelopeSizeKB and MaxProviderRequests settings in the
-  WSMan:\<ComputerName\> node and the MaxConcurrentOperations,
-  MaxConcurrentOperationsPerUser, and MaxConnections settings in the
-  WSMan:\<ComputerName\>\\Service node.
+  **MaxEnvelopeSizeKB** and **MaxProviderRequests** settings in the
+  `WSMan:<ComputerName>` node and the **MaxConcurrentOperations**,
+  **MaxConcurrentOperationsPerUser**, and **MaxConnections** settings in the
+  `WSMan:<ComputerName>\Service` node.
 
 - You can protect the local computer by using the
-  MaximumReceivedDataSizePerCommand and MaximumReceivedObjectSize parameters of
-  the New-PSSessionOption cmdlet and the \$PSSessionOption preference variable.
+  MaximumReceivedDataSizePerCommand and MaximumReceivedObjectSize parameters
+  of the `New-PSSessionOption` cmdlet and the \$PSSessionOption preference
+  variable.
 
 - You can protect the remote computer by adding restrictions to the session
-  configurations, such as by using the MaximumReceivedDataSizePerCommandMB and
-  MaximumReceivedObjectSizeMB parameters of the Register-PSSessionConfiguration
-  cmdlet.
+  configurations, such as by using the **MaximumReceivedDataSizePerCommandMB**
+  and **MaximumReceivedObjectSizeMB** parameters of the
+  `Register-PSSessionConfiguration` cmdlet.
 
 When quotas conflict with a command, PowerShell generates an error.
 
@@ -685,19 +731,21 @@ Microsoft.PowerShell session configuration on the remote computer from 10 MB
 
 ```powershell
 Set-PSSessionConfiguration -Name microsoft.PowerShell `
--MaximumReceivedObjectSizeMB 11 -Force
+  -MaximumReceivedObjectSizeMB 11 -Force
 ```
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+`New-PSSessionOption`.
 
 For more information about the WS-Management quotas, see the Help topic for
-the WSMan provider (type "Get-Help WSMan").
+the WSMan provider (type `Get-Help WSMan`).
 
 ### HOW TO RESOLVE TIMEOUT ERRORS
 
+```
 ERROR: The WS-Management service cannot complete the operation within
 the time specified in OperationTimeout.
+```
 
 You can use timeouts to protect the local computer and the remote computer
 from excessive resource use, both accidental and malicious. When timeouts
@@ -707,14 +755,14 @@ shortest timeout settings.
 The following timeouts are available in the basic configuration.
 
 - The WSMan provider (WSMan:) provides several client-side and service-side
-  timeout settings, such as the MaxTimeoutms setting in the
-  WSMan:\<ComputerName\> node and the EnumerationTimeoutms and
-  MaxPacketRetrievalTimeSeconds settings in the WSMan:\<ComputerName\>\\Service
-  node.
+  timeout settings, such as the **MaxTimeoutms** setting in the
+  `WSMan:<ComputerName>` node and the **EnumerationTimeoutms** and
+  **MaxPacketRetrievalTimeSeconds** settings in the
+  `WSMan:<ComputerName>\Service` node.
 
-- You can protect the local computer by using the CancelTimeout, IdleTimeout,
-  OpenTimeout, and OperationTimeout parameters of the New-PSSessionOption
-  cmdlet and the $PSSessionOption preference variable.
+- You can protect the local computer by using the **CancelTimeout**,
+  **IdleTimeout**, **OpenTimeout**, and **OperationTimeout** parameters of the
+  `New-PSSessionOption` cmdlet and the $PSSessionOption preference variable.
 
 - You can also protect the remote computer by setting timeout values
   programmatically in the session configuration for the session.
@@ -726,21 +774,21 @@ To resolve the error, change the command to complete within the timeout
 interval or determine the source of the timeout limit and increase the
 timeout interval to allow the command to complete.
 
-For example, the following commans use the New-PSSessionOption cmdlet to
-create a session option object with an OperationTimeout value of 4 minutes
+For example, the following commands use the `New-PSSessionOption` cmdlet to
+create a session option object with an **OperationTimeout** value of 4 minutes
 (in MS) and then use the session option object to create a remote session.
 
 ```powershell
-C:\PS> $pso = New-PSSessionoption -OperationTimeout 240000
+$pso = New-PSSessionoption -OperationTimeout 240000
 
-C:\PS> New-PSSession -ComputerName Server01 -sessionOption $pso
+New-PSSession -ComputerName Server01 -sessionOption $pso
 ```
 
 For more information about the WS-Management timeouts, see the Help topic for
 the WSMan provider (type "Get-Help WSMan").
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+[New-PSSessionOption](../New-PSSessionOption.md).
 
 ## TROUBLESHOOTING UNRESPONSIVE BEHAVIOR
 
@@ -756,13 +804,15 @@ Win32 console API, do not work correctly in the PowerShell remote host.
 When you use these programs, you might see unexpected behavior, such as no
 output, partial output, or a remote command that does not complete.
 
-To end an unresponsive program, type CTRL + C. To view any errors that might
-have been reported, type "$error" in the local host and the remote session.
+To end an unresponsive program, type `CTRL+C`. To view any errors that might
+have been reported, type `$error` in the local host and the remote session.
 
 ## HOW TO RECOVER FROM AN OPERATION FAILURE
 
+```
 ERROR: The I/O operation has been aborted because of either a thread exit
 or an  application request.
+```
 
 This error is returned when an operation is terminated before it completes.
 Typically, it occurs when the WinRM service stops or restarts while other
@@ -774,7 +824,7 @@ the command again.
 1. Start PowerShell with the "Run as administrator" option.
 2. Run the following command:
 
-   Start-Service WinRM
+   `Start-Service WinRM`
 
 3. Re-run the command that generated the error.
 

--- a/reference/4.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -30,13 +30,6 @@ Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBuff
  [-ThrottleLimit <Int32>] -Name <String[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### Id
-
-```
-Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBufferingMode>]
- [-ThrottleLimit <Int32>] [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
 ### InstanceId
 
 ```
@@ -44,157 +37,169 @@ Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBuff
  [-ThrottleLimit <Int32>] -InstanceId <Guid[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
+### Id
+
+```
+Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBufferingMode>]
+ [-ThrottleLimit <Int32>] [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
 ## DESCRIPTION
 
-The **Disconnect-PSSession** cmdlet disconnects a Windows PowerShell session ("PSSession"), such as one started by using the New-PSSession cmdlet, from the current session.
-As a result, the PSSession is in a disconnected state.
-You can connect to the disconnected PSSession from the current session or from another session on the local computer or a different computer.
+The `Disconnect-PSSession` cmdlet disconnects a Windows PowerShell session ("PSSession"), such as
+one started by using the `New-PSSession` cmdlet, from the current session. As a result, the PSSession
+is in a disconnected state. You can connect to the disconnected PSSession from the current session
+or from another session on the local computer or a different computer.
 
-The **Disconnect-PSSession** cmdlet disconnects only open PSSessions that are connected to the current session.
-**Disconnect-PSSession** cannot disconnect broken or closed PSSessions, or interactive PSSessions started by using the Enter-PSSession cmdlet,  and it cannot disconnect PSSessions that are connected to other sessions.
+The `Disconnect-PSSession` cmdlet disconnects only open PSSessions that are connected to the
+current session. `Disconnect-PSSession` cannot disconnect broken or closed PSSessions, or
+interactive PSSessions started by using the `Enter-PSSession` cmdlet, and it cannot disconnect
+PSSessions that are connected to other sessions.
 
-To reconnect to a disconnected PSSession, use the Connect-PSSession or Receive-PSSession cmdlets.
+To reconnect to a disconnected PSSession, use the `Connect-PSSession` or `Receive-PSSession` cmdlets.
 
-When a PSSession is disconnected, the commands in the PSSession continue to run until they complete, unless the PSSession times out or the commands in the PSSession are blocked by a full output buffer.
-To change the idle timeout, use the **IdleTimeoutSec** parameter.
-To change the output buffering mode, use the **OutputBufferingMode** parameter You can also use the **InDisconnectedSession** parameter of the Invoke-Command cmdlet to run a command in a disconnected session.
+When a PSSession is disconnected, the commands in the PSSession continue to run until they
+complete, unless the PSSession times out or the commands in the PSSession are blocked by a full
+output buffer. To change the idle timeout, use the **IdleTimeoutSec** parameter. To change the
+output buffering mode, use the **OutputBufferingMode** parameter You can also use the
+**InDisconnectedSession** parameter of the `Invoke-Command` cmdlet to run a command in a disconnected
+session.
 
-For more information about the Disconnected Sessions feature, see about_Remote_Disconnected_Sessions.
+For more information about the Disconnected Sessions feature, see
+[about_Remote_Disconnected_Sessions](./About/about_Remote_Disconnected_Sessions.md).
 
 This cmdlet is introduced in Windows PowerShell 3.0.
 
 ## EXAMPLES
 
-### Example 1
+### Example 1 - Disconnect a session by name
 
-```powershell
-Disconnect-PSSession -Name UpdateSession
+This command disconnects the UpdateSession PSSession on the Server01 computer from the current
+session. The command uses the **Name** parameter to identify the PSSession.
+
 ```
-
-```output
+PS> Disconnect-PSSession -Name UpdateSession
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
 1  UpdateSession   Server01        Disconnected  Microsoft.PowerShell          None
 ```
 
-This command disconnects the UpdateSession PSSession on the Server01 computer from the current session.
-The command uses the **Name** parameter to identify the PSSession.
+The output shows that the attempt to disconnect was successful. The session state is Disconnected
+and the Availability is None, which indicates that the session is not busy and can be reconnected.
 
-The output shows that the attempt to disconnect was successful.
-The session state is Disconnected and the Availability is None, which indicates that the session is not busy and can be reconnected.
+### Example 2 - Disconnect a session from a specific computer
 
-### Example 2
+This command disconnects the ITTask PSSession on the Server12 computer from the current session.
+The ITTask session was created in the current session and connects to the Server12 computer. The
+command uses the `Get-PSSession` cmdlet to get the session and the `Disconnect-PSSession` cmdlet to
+disconnect it.
 
-```powershell
-Get-PSSession -ComputerName Server12 -Name ITTask | Disconnect-PSSession -OutputBufferingMode Drop -IdleTimeoutSec 86400
 ```
-
-```output
+PS> Get-PSSession -ComputerName Server12 -Name ITTask |
+  Disconnect-PSSession -OutputBufferingMode Drop -IdleTimeoutSec 86400
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
 1  ITTask          Server12        Disconnected  ITTasks               None
 ```
 
-This command disconnects the ITTask PSSession on the Server12 computer from the current session.
-The ITTask session was created in the current session and connects to the Server12 computer.
-The command uses the Get-PSSession cmdlet to get the session and the **Disconnect-PSSession** cmdlet to disconnect it.
+The `Disconnect-PSSession` command uses the **OutputBufferingMode** parameter to set the output
+mode to **Drop**. This setting ensures that the script that is running in the session can continue
+to run even if the session output buffer is full. Because the script writes its output to a report
+on a file share, other output can be lost without consequence.
 
-The **Disconnect-PSSession** command uses the **OutputBufferingMode** parameter to set the output mode to **Drop**.
-This setting ensures that the script that is running in the session can continue to run even if the session output buffer is full.
-Because the script writes its output to a report on a file share, other output can be lost without consequence.
+The command also uses the **IdleTimeoutSec** parameter to extend the idle timeout of the session to
+24 hours. This setting allows time for this administrator or other administrators to reconnect to
+the session to verify that the script ran and troubleshoot if needed.
 
-The command also uses the **IdleTimeoutSec** parameter to extend the idle timeout of the session to 24 hours.
-This setting allows time for this administrator or other administrators to reconnect to the session to verify that the script ran and troubleshoot if needed.
+### Example 3 - Using multiple PSSessions on multiple computers
 
-### Example 3
+This series of commands shows how the `Disconnect-PSSession` cmdlet might be used in an enterprise
+scenario. In this case, a new technician starts a script in a session on a remote computer and runs
+into a problem. The technician disconnects from the session so that a more experienced manager can
+connect to the session and resolve the problem.
 
-The technician begins by creating sessions on several remote computers and running a script in each session.The first command uses the New-PSSession cmdlet to create the ITTask session on three remote computers. The command saves the sessions in the $s variable. The second command uses the **FilePath** parameter of the Invoke-Command cmdlet to run a script in the sessions in the $s variable.
-
-The script running on the Srv1 computer generates unexpected errors. The technician contacts his manager and asks for assistance. The manager directs the technician to disconnect from the session so he can investigate.The second command uses the Get-PSSession cmdlet to get the ITTask session on the Srv1 computer and the **Disconnect-PSSession** cmdlet to disconnect it. This command does not affect the ITTask sessions on  the other computers.
-
-```powershell
-$s = New-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
-Invoke-Command $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
 ```
-
-```powershell
-Get-PSSession -Name ITTask -ComputerName Srv1 | Disconnect-PSSession
-```
-
-```output
+PS> $s = New-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
+PS> Invoke-Command $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
+PS> Get-PSSession -Name ITTask -ComputerName Srv1 | Disconnect-PSSession
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
 1 ITTask           Srv1            Disconnected  Microsoft.PowerShell          None
-```
 
-### Reconnecting to a Disconnected Session
-
-The manager logs on to his home computer, connects to his corporate network, starts Windows PowerShell, and uses the Get-PSSession cmdlet to get the ITTask session on the Srv1 computer. He uses the credentials of the technician to access the session.
-
-Next, the manager uses the  Connect-PSSession cmdlet to connect to the ITTask session on the Srv1 computer. The command saves the session in the $s variable.
-
-```powershell
-Get-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
-```
-
-```output
+PS> Get-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
  1 ITTask          Srv1            Disconnected  Microsoft.PowerShell          None
+ 2 ITTask          Srv2            Opened        Microsoft.PowerShell     Available
+ 3 ITTask          Srv30           Opened        Microsoft.PowerShell     Available
+
+PS> Get-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
+Id Name            ComputerName    State         ConfigurationName     Availability
+-- ----            ------------    -----         -----------------     ------------
+ 1 ITTask          Srv1            Disconnected  Microsoft.PowerShell          None
+
+PS> $s = Connect-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
+PS> Invoke-Command -Session $s {dir $home\Scripts\PatchStatusOutput.ps1}
+PS> Invoke-Command -Session $s {mkdir $home\Scripts\PatchStatusOutput}
+PS> Invoke-Command -Session $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
+PS> Disconnect-PSSession -Session $s
 ```
 
-```powershell
-$s = Connect-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
+The technician begins by creating sessions on several remote computers and running a script in each
+session. The first command uses the `New-PSSession` cmdlet to create the ITTask session on three
+remote computers. The command saves the sessions in the $s variable. The second command uses the
+**FilePath** parameter of the `Invoke-Command` cmdlet to run a script in the sessions in the $s
+variable.
+
+The script running on the Srv1 computer generates unexpected errors. The technician contacts his
+manager and asks for assistance. The manager directs the technician to disconnect from the session
+so he can investigate.The second command uses the `Get-PSSession` cmdlet to get the ITTask session on
+the Srv1 computer and the `Disconnect-PSSession` cmdlet to disconnect it. This command does not
+affect the ITTask sessions on the other computers.
+
+The third command uses the `Get-PSSession` cmdlet to get the ITTask sessions. The output shows that
+the ITTask sessions on the Srv2 and Srv30 computers were not affected by the command to disconnect.
+
+The manager logs on to his home computer, connects to his corporate network, starts Windows
+PowerShell, and uses the `Get-PSSession` cmdlet to get the ITTask session on the Srv1 computer. He
+uses the credentials of the technician to access the session.
+
+Next, the manager uses the `Connect-PSSession` cmdlet to connect to the ITTask session on the Srv1
+computer. The command saves the session in the $s variable.
+
+The manager uses the `Invoke-Command` cmdlet to run some diagnostic commands in the session in the
+`$s` variable. He recognizes that the script failed because it did not find a required directory.
+The manager uses the `MkDir` function to create the directory, and then he restarts the
+`Get-PatchStatus.ps1` script and disconnects from the session.The manager reports his findings to
+the technician, suggests that he reconnect to the session to complete the tasks, and asks him to
+add a command to the `Get-PatchStatus.ps1` script that creates the required directory if it does
+not exist.
+
+### Example 4 - Change the timeout value for a PSSession
+
+This example shows how to correct the value of the **IdleTimeout** property of a session so that it
+can be disconnected.
+
+The idle timeout property of a session is critical to disconnected sessions, because it determines
+how long a disconnected session is maintained before it is deleted. You can set the idle timeout
+option when you create a session and when you disconnect it. The default values for the idle
+timeout of a session are set in the `$PSSessionOption` preference variable on the local computer
+and in the session configuration on the remote computer. Values set for the session take precedence
+over values set in the session configuration, but session values cannot exceed quotas set in the
+session configuration, such as the **MaxIdleTimeoutMs** value.
+
 ```
-
-### Invoking Commands against a Session
-
-```powershell
-Invoke-Command -Session $s {dir $home\Scripts\PatchStatusOutput.ps1}
-Invoke-Command -Session $s {mkdir $home\Scripts\PatchStatusOutput}
-Invoke-Command -Session $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
-Disconnect-PSSession -Session $s
-```
-
-The manager uses the Invoke-Command cmdlet to run some diagnostic commands in the session in the $s variable. He recognizes that the script failed because it did not find a required directory. The manager uses the MkDir function to create the directory, and then he restarts the Get-PatchStatus.ps1 script and disconnects from the session.The manager reports his findings to the technician, suggests that he reconnect to the session to complete the tasks, and asks him to add a command to the Get-PatchStatus.ps1 script that creates the required directory if it does not exist.
-
-This series of commands shows how the **Disconnect-PSSession** cmdlet might be used in an enterprise scenario.
-In this case, a new technician starts a script in a session on a remote computer and runs into a problem.
-The technician disconnects from the session so that a more experienced manager can connect to the session and resolve the problem.
-
-### Example 4
-
-```powershell
-# Create a Session Option object with an IdleTimeout
-$Timeout = New-PSSessionOption -IdleTimeout 172800000
-# Use the Session Option object to create a new session with New-PSSession
-$s = New-PSSession -ComputerName Server01 -Name ITTask -SessionOption $Timeout
-```
-
-### Attempting to Disconnect the Session
-
-```powershell
-Disconnect-PSSession -Session $s
-```
-
-```output
+PS> $Timeout = New-PSSessionOption -IdleTimeout 172800000
+PS> $s = New-PSSession -Computer Server01 -Name ITTask -SessionOption $Timeout
+PS> Disconnect-PSSession -Session $s
 Disconnect-PSSession : The session ITTask cannot be disconnected because the specified
 idle timeout value 172800(seconds) is either greater than the server maximum allowed
 43200 (seconds) or less that the minimum allowed60(seconds).  Choose an idle time out
 value that is within the allowed range and try again.
-```
 
-The third command disconnects the ITTask session in the $s variable. The command fails because the idle timeout value of the session exceeds the **MaxIdleTimeoutMs** quota in the session configuration. Because the idle timeout is not used until the session is disconnected, this violation can go undetected while the session is in use.
+PS> Invoke-Command -ComputerName Server01 {Get-PSSessionConfiguration Microsoft.PowerShell} |
+ Format-List -Property *
 
-### View the Session Configuration properties
-
-The fourth command uses the Invoke-Command cmdlet to run a Get-PSSessionConfiguration command for the Microsoft.PowerShell session configuration on the Server01 computer. The command uses the Format-List cmdlet to display all properties of the session configuration in a list.The output shows that the  **MaxIdleTimeoutMS** property, which establishes the maximum permitted **IdleTimeout** value for sessions that use the session configuration, is 43200000 milliseconds (12 hours).
-
-```powershell
-Invoke-Command -ComputerName Server01 {Get-PSSessionConfiguration Microsoft.PowerShell} | Format-List -Property *
-```
-
-```output
 Architecture                  : 64
 Filename                      : %windir%\system32\pwrshplugin.dll
 ResourceUri                   : http://schemas.microsoft.com/powershell/microsoft.powershell
@@ -229,15 +234,9 @@ Permission                    : BUILTIN\Administrators AccessAllowed
 PSComputerName                : localhost
 RunspaceId                    : aea84310-6dbf-4c21-90ac-13980039925a
 PSShowComputerName            : True
-```
 
-### Modifying Session Options through the Session object
 
-```powershell
-$s.Runspace.ConnectionInfo
-```
-
-```output
+PS> $s.Runspace.ConnectionInfo
 ConnectionUri                     : http://Server01/wsman
 ComputerName                      : Server01
 Scheme                            : http
@@ -268,62 +267,59 @@ OpenTimeout                       : 180000
 CancelTimeout                     : 60000
 OperationTimeout                  : 180000
 IdleTimeout                       : 172800000
-```
 
-```powershell
-# Disconnect the Session using the IdleTimoutSec parameter set to the 12-hour maximum.
-Disconnect-PSSession $s -IdleTimeoutSec 43200
-```
-
-```output
+PS> Disconnect-PSSession $s -IdleTimeoutSec 43200
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
  4 ITTask          Server01        Disconnected  Microsoft.PowerShell          None
-```
 
-```powershell
-# Verify the new IdleTimeout
-$s.Runspace.ConnectionInfo.IdleTimeout
-```
-
-```output
+PS> $s.Runspace.ConnectionInfo.IdleTimeout
 43200000
 ```
 
-The values of many session options are properties of the **ConnectionInfo** property of the **Runspace** property of the session.The output shows that the value of the **IdleTimeout** property of the session is 172800000 milliseconds (48 hours), which violates the **MaxIdleTimeoutMs** quota of 12 hours in the session configuration.To resolve this conflict, you can use the **ConfigurationName** parameter to select a different session configuration or use the **IdleTimeout** parameter to reduce the idle timeout of the session.
+The first command uses the `New-PSSessionOption` cmdlet to create a session option object. It uses
+the **IdleTimeout** parameter to set an idle timeout of 48 hours (172800000 milliseconds). The
+command saves the session option object in the $Timeout variable.
 
-This example shows how to correct the value of the **IdleTimeout** property of a session so that it can be disconnected.
+The second command uses the `New-PSSession` cmdlet to create the ITTask session on the Server01
+computer. The command save the session in the $s variable. The value of the **SessionOption**
+parameter is the 48-hour idle timeout in the $Timeout variable.
 
-The idle timeout property of a session is critical to disconnected sessions, because it determines how long a disconnected session is maintained before it is deleted.
-You can set the idle timeout option when you create a session and when you disconnect it.
-The default values for the idle timeout of a session are set in the **$PSSessionOption** preference variable on the local computer and in the session configuration on the remote computer.
-Values set for the session take precedence over values set in the session configuration, but session values cannot exceed quotas set in the session configuration, such as the **MaxIdleTimeoutMs** value.
+The third command disconnects the ITTask session in the $s variable. The command fails because the
+idle timeout value of the session exceeds the **MaxIdleTimeoutMs** quota in the session
+configuration. Because the idle timeout is not used until the session is disconnected, this
+violation can go undetected while the session is in use.
+
+The fourth command uses the `Invoke-Command` cmdlet to run a `Get-PSSessionConfiguration` command
+for the Microsoft.PowerShell session configuration on the Server01 computer. The command uses the
+`Format-List` cmdlet to display all properties of the session configuration in a list.The output
+shows that the **MaxIdleTimeoutMS** property, which establishes the maximum permitted
+**IdleTimeout** value for sessions that use the session configuration, is 43200000 milliseconds (12
+hours).
+
+The fifth command gets the session option values of the session in the $s variable. The values of
+many session options are properties of the **ConnectionInfo** property of the **Runspace** property
+of the session.The output shows that the value of the **IdleTimeout** property of the session is
+172800000 milliseconds (48 hours), which violates the **MaxIdleTimeoutMs** quota of 12 hours in the
+session configuration.To resolve this conflict, you can use the **ConfigurationName** parameter to
+select a different session configuration or use the **IdleTimeout** parameter to reduce the idle
+timeout of the session.
+
+The sixth command disconnects the session. It uses the **IdleTimeoutSec** parameter to set the idle
+timeout to the 12-hour maximum.
+
+The seventh command gets the value of the **IdleTimeout** property of the disconnected session,
+which is measured in milliseconds. The output confirms that the command was successful.
 
 ## PARAMETERS
 
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Id
 
-Disconnects from sessions with the specified session ID.
-Type one or more IDs (separated by commas), or use the range operator (..) to specify a range of IDs.
+Disconnects from sessions with the specified session ID. Type one or more IDs (separated by
+commas), or use the range operator (..) to specify a range of IDs.
 
-To get the ID of a session, use the Get-PSSession cmdlet.
-The instance ID is stored in the **ID** property of the session.
+To get the ID of a session, use the `Get-PSSession` cmdlet. The instance ID is stored in the **ID**
+property of the session.
 
 ```yaml
 Type: Int32[]
@@ -331,7 +327,7 @@ Parameter Sets: Id
 Aliases:
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
@@ -339,21 +335,23 @@ Accept wildcard characters: False
 
 ### -IdleTimeoutSec
 
-Changes the idle timeout value of the disconnected PSSession.
-Enter a value in seconds.
-The minimum value is 60 (1 minute).
+Changes the idle timeout value of the disconnected PSSession. Enter a value in seconds. The minimum
+value is 60 (1 minute).
 
-The idle timeout determines how long the disconnected PSSession is maintained on the remote computer.
-When the timeout expires, the PSSession is deleted.
+The idle timeout determines how long the disconnected PSSession is maintained on the remote
+computer. When the timeout expires, the PSSession is deleted.
 
-Disconnected PSSessions are considered to be idle from the moment that they are disconnected, even if commands are running in the disconnected session.
+Disconnected PSSessions are considered to be idle from the moment that they are disconnected, even
+if commands are running in the disconnected session.
 
-The default value for the idle timeout of a session is set by the value of the **IdleTimeoutMs** property of the session configuration.
-The default value is 7200000 milliseconds (2 hours).
+The default value for the idle timeout of a session is set by the value of the **IdleTimeoutMs**
+property of the session configuration. The default value is 7200000 milliseconds (2 hours).
 
-The value of this parameter takes precedence over the value of the **IdleTimeout** property of the $PSSessionOption preference variable and the default idle timeout value in the session configuration.
-However, this value cannot exceed the value of the **MaxIdleTimeoutMs** property of the session configuration.
-The default value of **MaxIdleTimeoutMs** is 12 hours (43200000 milliseconds).
+The value of this parameter takes precedence over the value of the **IdleTimeout** property of the
+$PSSessionOption preference variable and the default idle timeout value in the session
+configuration. However, this value cannot exceed the value of the **MaxIdleTimeoutMs** property of
+the session configuration. The default value of **MaxIdleTimeoutMs** is 12 hours (43200000
+milliseconds).
 
 ```yaml
 Type: Int32
@@ -371,11 +369,11 @@ Accept wildcard characters: False
 
 Disconnects from sessions with the specified instance IDs.
 
-The instance ID is a GUID that uniquely identifies a session on a local or remote computer.
-The instance ID is unique, even across multiple sessions on multiple computers.
+The instance ID is a GUID that uniquely identifies a session on a local or remote computer. The
+instance ID is unique, even across multiple sessions on multiple computers.
 
-To get the instance ID of a session, use the Get-PSSession cmdlet.
-The instance ID is stored in the **InstanceID** property of the session.
+To get the instance ID of a session, use the `Get-PSSession` cmdlet. The instance ID is stored in
+the **InstanceID** property of the session.
 
 ```yaml
 Type: Guid[]
@@ -391,11 +389,10 @@ Accept wildcard characters: False
 
 ### -Name
 
-Disconnects from sessions with the specified friendly names.
-Wildcards are permitted.
+Disconnects from sessions with the specified friendly names. Wildcards are permitted.
 
-To get the friendly name of a session, use the Get-PSSession cmdlet.
-The friendly name is stored in the **Name** property of the session.
+To get the friendly name of a session, use the `Get-PSSession` cmdlet. The friendly name is stored
+in the **Name** property of the session.
 
 ```yaml
 Type: String[]
@@ -409,44 +406,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -OutputBufferingMode
-
-Determines how command output is managed in the disconnected session when the output buffer is full.
-The default value is **Block**.
-
-If the command in the disconnected session is returning output and the output buffer fills, the value of this parameter effectively determines whether the command continues to run while the session is disconnected.
-A value of **Block** suspends the command until the session is reconnected.
-A value of **Drop** allows the command to complete, although data might be lost.
-When using the **Drop** value, redirect the command output to a file on disk.
-
-Valid values are:
-
-- **Block**: When the output buffer is full, execution is suspended until the buffer is clear.
-- **Drop**: When the output buffer is full, execution continues. As new output is saved, the oldest output is discarded.
-- **None**: No output buffering mode is specified. The value of the **OutputBufferingMode** property of the session configuration is used for the disconnected session.
-
-```yaml
-Type: OutputBufferingMode
-Parameter Sets: (All)
-Aliases:
-Accepted values: None, Drop, Block
-
-Required: False
-Position: Named
-Default value: Block
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Session
 
-Disconnects from the specified PSSessions.
-Enter PSSession objects, such as those that the New-PSSession cmdlet returns.
-You can also pipe a PSSession object to Disconnect-PSSession.
+Disconnects from the specified PSSessions. Enter PSSession objects, such as those that the
+`New-PSSession` cmdlet returns. You can also pipe a PSSession object to `Disconnect-PSSession`.
 
-The **Get-PSSession** cmdlet can get all PSSessions that terminate at a remote computer, including PSSessions that are disconnected and PSSessions that are connected to other sessions on other computers.
-**Disconnect-PSSession** disconnects only PSSession that are connected to the current session.
-If you pipe other PSSessions to **Disconnect-PSSession**, the **Disconnect-PSSession** command fails.
+The `Get-PSSession` cmdlet can get all PSSessions that terminate at a remote computer, including
+PSSessions that are disconnected and PSSessions that are connected to other sessions on other
+computers. `Disconnect-PSSession` disconnects only PSSession that are connected to the current
+session. If you pipe other PSSessions to `Disconnect-PSSession`, the `Disconnect-PSSession` command
+fails.
 
 ```yaml
 Type: PSSession[]
@@ -454,7 +423,7 @@ Parameter Sets: Session
 Aliases:
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
@@ -462,10 +431,10 @@ Accept wildcard characters: False
 
 ### -ThrottleLimit
 
-Sets the throttle limit for the **Disconnect-PSSession** command.
+Sets the throttle limit for the `Disconnect-PSSession` command.
 
-The throttle limit is the maximum number of concurrent connections that can be established to run this command.
-If you omit this parameter or enter a value of 0, the default value, 32, is used.
+The throttle limit is the maximum number of concurrent connections that can be established to run
+this command. If you omit this parameter or enter a value of 0, the default value, 32, is used.
 
 The throttle limit applies only to the current command, not to the session or to the computer.
 
@@ -477,6 +446,53 @@ Aliases:
 Required: False
 Position: Named
 Default value: 32
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputBufferingMode
+
+Determines how command output is managed in the disconnected session when the output buffer is
+full. The default value is **Block**.
+
+If the command in the disconnected session is returning output and the output buffer fills, the
+value of this parameter effectively determines whether the command continues to run while the
+session is disconnected. A value of **Block** suspends the command until the session is
+reconnected. A value of **Drop** allows the command to complete, although data might be lost. When
+using the **Drop** value, redirect the command output to a file on disk.
+
+Valid values are:
+
+- **Block**: When the output buffer is full, execution is suspended until the buffer is clear.
+- **Drop**: When the output buffer is full, execution continues. As new output is saved, the oldest
+  output is discarded.
+- **None**: No output buffering mode is specified. The value of the **OutputBufferingMode** property
+  of the session configuration is used for the disconnected session.
+
+```yaml
+Type: OutputBufferingMode
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Block
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -500,39 +516,50 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### System.Management.Automation.Runspaces.PSSession
 
-You can pipe a session to **Disconnect-PSSession**.
+You can pipe a session to `Disconnect-PSSession`.
 
 ## OUTPUTS
 
 ### System.Management.Automation.Runspaces.PSSession
 
-**Disconnect-PSSession** returns an object that represents the session that it disconnected.
+`Disconnect-PSSession` returns an object that represents the session that it disconnected.
 
 ## NOTES
 
-- The **Disconnect-PSSession** cmdlet works only when the local and remote computers are running Windows PowerShell 3.0 or later versions of Windows PowerShell.
-- If you use the **Disconnect-PSSession** cmdlet on a disconnected session, the command has no effect on the session and it does not generate errors.
-- Disconnected loopback sessions with interactive security tokens (those created with the **EnableNetworkAccess** parameter) can be reconnected only from the computer on which the session was created. This restriction protects the computer from malicious access.
-- When you disconnect a PSSession, the session state is **Disconnected** and the availability is **None**.
+- The `Disconnect-PSSession` cmdlet works only when the local and remote computers are running
+  PowerShell 3.0 or later.
+- If you use the `Disconnect-PSSession` cmdlet on a disconnected session, the command has no effect
+  on the session and it does not generate errors.
+- Disconnected loopback sessions with interactive security tokens (those created with the
+  **EnableNetworkAccess** parameter) can be reconnected only from the computer on which the session
+  was created. This restriction protects the computer from malicious access.
+- When you disconnect a PSSession, the session state is **Disconnected** and the availability is
+  **None**.
 
-  The value of the **State** property is relative to the current session.
-Therefore, a value of **Disconnected** means that the PSSession is not connected to the current session.
-However, it does not mean that the PSSession is disconnected from all sessions.
-It might be connected to a different session.
-To determine whether you can connect or reconnect to the session, use the **Availability** property.
+  The value of the **State** property is relative to the current session. Therefore, a value of
+  **Disconnected** means that the PSSession is not connected to the current session. However, it
+  does not mean that the PSSession is disconnected from all sessions. It might be connected to a
+  different session. To determine whether you can connect or reconnect to the session, use the
+  **Availability** property.
 
-  An **Availability** value of **None** indicates that you can connect to the session.
-A value of **Busy** indicates that you cannot connect to the PSSession because it is connected to another session.
+  An **Availability** value of **None** indicates that you can connect to the session. A value of
+  **Busy** indicates that you cannot connect to the PSSession because it is connected to another
+  session.
 
-  For more information about the values of the **State** property of sessions, see [RunspaceState Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspacestate) in the MSDN library.
+  For more information about the values of the **State** property of sessions, see
+  [RunspaceState Enumeration](/dotnet/api/system.management.automation.runspaces.runspacestate).
 
-  For more information about the values of the **Availability** property of sessions, see [RunspaceAvailability Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspaceavailability) in the MSDN library.
+  For more information about the values of the **Availability** property of sessions, see
+  [RunspaceAvailability Enumeration](/dotnet/api/system.management.automation.runspaces.runspaceavailability).
 
 ## RELATED LINKS
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -29,8 +29,10 @@ Provides access to the registry keys, entries, and values in PowerShell.
 The PowerShell **Registry** provider lets you get, add, change,
 clear, and delete registry keys, entries, and values in PowerShell.
 
-The **Registry** drives are a hierarchical namespace containing the registry keys and subkeys on your computer. Registry entries and values are not
-components of that hierarchy. Instead, they are properties of each of the keys.
+The **Registry** drives are a hierarchical namespace containing the registry
+keys and subkeys on your computer. Registry entries and values are not
+components of that hierarchy. Instead, they are properties of each of the
+keys.
 
 The **Registry** provider supports the following cmdlets, which are covered
 in this article.
@@ -77,7 +79,8 @@ Set-Location C:
 
 You can also work with the **Registry** provider from any other PowerShell
 drive. To reference a registry key from another location, use the drive name
-(`HKLM:`, `HKCU:`) in the path. Use a backslash (\\) or a forward slash (/) to indicate a level of the **Registry** drive.
+(`HKLM:`, `HKCU:`) in the path. Use a backslash (\\) or a forward slash (/) to
+indicate a level of the **Registry** drive.
 
 ```powershell
 PS C:\> cd HKLM:\Software
@@ -87,13 +90,13 @@ PS C:\> cd HKLM:\Software
 > PowerShell uses aliases to allow you a familiar way to work with provider
 > paths. Commands such as `dir` and `ls` are now aliases for
 > [Get-ChildItem](../../Microsoft.PowerShell.Management/Get-ChildItem.md),
-> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md). and `pwd` is
-> an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
+> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md)
+> and `pwd` is an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
 
 This last example shows another path syntax you can use to navigate the
 **Registry** provider. This syntax uses the provider name, followed by two
-colons `::`.  This syntax allows you to use the full HIVE name, instead
-of the mapped drive name `HKLM`.
+colons `::`. This syntax allows you to use the full HIVE name, instead of the
+mapped drive name `HKLM`.
 
 ```powershell
 cd "Registry::HKEY_LOCAL_MACHINE\Software"
@@ -101,7 +104,8 @@ cd "Registry::HKEY_LOCAL_MACHINE\Software"
 
 ## Displaying the contents of registry keys
 
-The registry is divided into keys, subkeys, and entries.  For more information about registry structure, see [Structure of the Registry](/windows/desktop/sysinfo/structure-of-the-registry.md).
+The registry is divided into keys, subkeys, and entries. For more information
+about registry structure, see [Structure of the Registry](/windows/desktop/sysinfo/structure-of-the-registry.md).
 
 In a **Registry** drive, each key is a container. A key can contain any number
 of keys. A registry key that has a parent key is called a subkey. You can
@@ -113,7 +117,8 @@ they are called **Item Properties**. A registry key can have both children
 keys and item properties.
 
 In this example, the difference between `Get-Item` and `Get-ChildItem` is
-shown. When you use `Get-Item` on the "Spooler" registry key, you can view its properties.
+shown. When you use `Get-Item` on the "Spooler" registry key, you can view its
+properties.
 
 ```
 PS C:\ > Get-Item -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
@@ -122,21 +127,21 @@ PS C:\ > Get-Item -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services
 
 
-Name                           Property
-----                           --------
-Spooler                        DependOnService    : {RPCSS, http}
-                               Description        : @%systemroot%\system32\spoolsv.exe,-2
-                               DisplayName        : @%systemroot%\system32\spoolsv.exe,-1
-                               ErrorControl       : 1
-                               FailureActions     : {16, 14, 0, 0...}
-                               Group              : SpoolerGroup
-                               ImagePath          : C:\WINDOWS\System32\spoolsv.exe
-                               ObjectName         : LocalSystem
-                               RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege, SeAuditPrivilege,
-                               SeChangeNotifyPrivilege...}
-                               ServiceSidType     : 1
-                               Start              : 2
-                               Type               : 272
+Name        Property
+----        --------
+Spooler     DependOnService    : {RPCSS, http}
+            Description        : @%systemroot%\system32\spoolsv.exe,-2
+            DisplayName        : @%systemroot%\system32\spoolsv.exe,-1
+            ErrorControl       : 1
+            FailureActions     : {16, 14, 0, 0...}
+            Group              : SpoolerGroup
+            ImagePath          : C:\WINDOWS\System32\spoolsv.exe
+            ObjectName         : LocalSystem
+            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege,
+            SeAuditPrivilege, SeChangeNotifyPrivilege...}
+            ServiceSidType     : 1
+            Start              : 2
+            Type               : 27
 ```
 
 Each registry key can also have subkeys. When you use `Get-Item` on a registry
@@ -151,16 +156,16 @@ PS C:\> Get-ChildItem -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Spooler
 
 
-Name                           Property
-----                           --------
-Performance                    Close           : PerfClose
-                               Collect         : PerfCollect
-                               Collect Timeout : 2000
-                               Library         : C:\Windows\System32\winspool.drv
-                               Object List     : 1450
-                               Open            : PerfOpen
-                               Open Timeout    : 4000
-Security                       Security : {1, 0, 20, 128...}
+Name             Property
+----             --------
+Performance      Close           : PerfClose
+                 Collect         : PerfCollect
+                 Collect Timeout : 2000
+                 Library         : C:\Windows\System32\winspool.drv
+                 Object List     : 1450
+                 Open            : PerfOpen
+                 Open Timeout    : 4000
+Security         Security : {1, 0, 20, 128...}
 ```
 
 The `Get-Item` cmdlet can also be used on the current location. The following
@@ -173,10 +178,10 @@ PS HKLM:\SYSTEM\CurrentControlSet\Services\Spooler> Get-Item .
 
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services
 
-Name                           Property
-----                           --------
-Spooler                        DependOnService    : {RPCSS, http}
-                               Description        : @%systemroot%\system32\spoolsv.exe,-2
+Name             Property
+----             --------
+Spooler          DependOnService    : {RPCSS, http}
+                 Description        : @%systemroot%\system32\spoolsv.exe,-2
 ...
 ```
 
@@ -188,8 +193,10 @@ articles.
 
 ## Viewing registry key values
 
-Registry key values are stored as properties of each registry key. The `Get-ItemProperty` cmdlet views registry key properties using the name you specify. The result is a **PSCustom** object containing the
-properties you specify.
+Registry key values are stored as properties of each registry key. The
+`Get-ItemProperty` cmdlet views registry key properties using the name you
+specify. The result is a **PSCustom** object containing the properties you
+specify.
 
 The Following example uses the `Get-ItemProperty` cmdlet to view all
 properties. Storing the resulting object in a variable allows you to access
@@ -250,7 +257,10 @@ articles.
 
 ## Changing registry key values
 
-The `Set-ItemProperty` cmdlet will set attributes for registry keys. The following example uses `Set-ItemProperty` to change the spooler service start type to manual. The example changes the **StartType** back to *Automatic* using the `Set-Service` cmdlet.
+The `Set-ItemProperty` cmdlet will set attributes for registry keys. The
+following example uses `Set-ItemProperty` to change the spooler service start
+type to manual. The example changes the **StartType** back to *Automatic*
+using the `Set-Service` cmdlet.
 
 ```
 PS C:\> Get-Service spooler | Select-Object Name, StartMode
@@ -274,7 +284,8 @@ Each registry key has a *default* value. You can change the *default* value
 for a registry key with either `Set-Item` or `Set-ItemProperty`.
 
 ```powershell
-Set-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name "(default)" -Value "one" Set-Item -Path HKLM:\SOFTWARE\Contoso -Value "two"
+Set-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name "(default)" -Value "one"
+Set-Item -Path HKLM:\SOFTWARE\Contoso -Value "two"
 ```
 
 For more information on the cmdlets used in this section, see the following
@@ -299,9 +310,9 @@ Name                           Property
 ContosoCompany
 ```
 
-You can use the `New-ItemProperty` cmdlet to create to **Item Properties**
-on a registry key that you specify. The following example creates a new
-DWORD value on the ContosoCompany registry key.
+You can use the `New-ItemProperty` cmdlet to create to **Item Properties** on
+a registry key that you specify. The following example creates a new DWORD
+value on the ContosoCompany registry key.
 
 ```powershell
 $path = "HKLM:\SOFTWARE\ContosoCompany"
@@ -316,7 +327,10 @@ For detailed cmdlet usage, see [New-ItemProperty](../../Microsoft.PowerShell.Man
 
 ## Copying registry keys and values
 
-In the **Registry** provider, use the `Copy-Item` cmdlet copies registry keys and values. Use the `Copy-ItemProperty` cmdlet to copy registry values only. The following command copies the "Contoso" registry key, and its properties to the specified location "HKLM:\Software\Fabrikam".
+In the **Registry** provider, use the `Copy-Item` cmdlet copies registry keys
+and values. Use the `Copy-ItemProperty` cmdlet to copy registry values only.
+The following command copies the "Contoso" registry key, and its properties to
+the specified location "HKLM:\Software\Fabrikam".
 
 `Copy-Item` creates the destination key if it does not exist. If the
 destination key exists, `Copy-Item` creates a duplicate of the source key
@@ -344,9 +358,9 @@ articles.
 ## Moving registry keys and values
 
 The `Move-Item` and `Move-ItemProperty` cmdlets behave like their "Copy"
-counterparts. If the destination exists, `Move-Item` moves the source
-key underneath the destination key. If the destination key does not exist,
-the source key is moved to the destination path.
+counterparts. If the destination exists, `Move-Item` moves the source key
+underneath the destination key. If the destination key does not exist, the
+source key is moved to the destination path.
 
 The following command moves the "Contoso" key to the path
 "HKLM:\SOFTWARE\Fabrikam".
@@ -403,7 +417,8 @@ For more examples and cmdlet usage details see the following articles.
 
 ## Removing and clearing registry keys and values
 
-You can remove contained items by using **Remove-Item**, but you will be prompted to confirm the removal if the item contains anything else. The
+You can remove contained items by using **Remove-Item**, but you will be
+prompted to confirm the removal if the item contains anything else. The
 following example attempts to delete a key "HKLM:\SOFTWARE\Contoso".
 
 ```
@@ -419,8 +434,8 @@ PS C:\> Remove-Item -Path HKLM:\SOFTWARE\Contoso
 
 Confirm
 The item at HKLM:\SOFTWARE\Contoso has children and the -Recurse
-parameter was not specified. If you continue, all children will be removed with
- the item. Are you sure you want to continue?
+parameter was not specified. If you continue, all children will be removed
+with the item. Are you sure you want to continue?
 [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help
 (default is "Y"):
 ```
@@ -431,14 +446,16 @@ To delete contained items without prompting, specify the `-Recurse` parameter.
 Remove-Item -Path HKLM:\SOFTWARE\Contoso -Recurse
 ```
 
-If you wanted to remove all items within "HKLM:\SOFTWARE\Contoso" but not "HKLM:\SOFTWARE\Contoso" itself, use a trailing backslash `\` followed by a
+If you wanted to remove all items within "HKLM:\SOFTWARE\Contoso" but not
+"HKLM:\SOFTWARE\Contoso" itself, use a trailing backslash `\` followed by a
 wildcard.
 
 ```powershell
 Remove-Item -Path HKLM:\SOFTWARE\Contoso\* -Recurse
 ```
 
-This command deletes the "ContosoTest" registry value from the "HKLM:\SOFTWARE\Contoso" registry key.
+This command deletes the "ContosoTest" registry value from the
+"HKLM:\SOFTWARE\Contoso" registry key.
 
 ```powershell
 Remove-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name ContosoTest
@@ -453,12 +470,12 @@ PS HKLM:\SOFTWARE\> Get-Item .\Contoso\
 
     Hive: HKEY_LOCAL_MACHINE\SOFTWARE
 
-Name                           Property
-----                           --------
-Contoso                        Server     : {a, b, c}
-                               HereString : {This is text which contains
-                                            newlines. It also contains "quoted" strings}
-                               (default)  : 1
+Name           Property
+----           --------
+Contoso        Server     : {a, b, c}
+               HereString : {This is text which contains
+               newlines. It also contains "quoted" strings}
+               (default)  : 1
 
 PS HKLM:\SOFTWARE\> Clear-Item .\Contoso\
 PS HKLM:\SOFTWARE\> Get-Item .\Contoso\
@@ -479,23 +496,33 @@ For more examples and cmdlet usage details see the following articles.
 
 ## Dynamic parameters
 
-Dynamic parameters are cmdlet parameters that are added by a PowerShell provider and are available only when the cmdlet is being used in the provider-enabled drive.
+Dynamic parameters are cmdlet parameters that are added by a PowerShell
+provider and are available only when the cmdlet is being used in the
+provider-enabled drive.
 
 ### Type <Microsoft.Win32.RegistryValueKind>
 
 Establishes or changes the data type of a registry value. The default is `String` (REG_SZ).
 
-This parameter works as designed on the [Set-ItemProperty](../../Microsoft.PowerShell.Management/Set-ItemProperty.md) cmdlet. It is also available on the [Set-Item](../../Microsoft.PowerShell.Management/Set-Item.md) cmdlet in the registry drives, but it has no effect.
+This parameter works as designed on the
+[Set-ItemProperty](../../Microsoft.PowerShell.Management/Set-ItemProperty.md)
+cmdlet. It is also available on the
+[Set-Item](../../Microsoft.PowerShell.Management/Set-Item.md) cmdlet in the
+registry drives, but it has no effect.
 
-|Value|Description|
-|-----------|-----------------|
-|  `String` | Specifies a null-terminated string. Equivalent to REG_SZ. |
-|  `ExpandString` | Specifies a null-terminated string that contains unexpanded references to environment variables that are expanded when the value is retrieved. Equivalent to REG_EXPAND_SZ. |
-|  `Binary` | Specifies binary data in any form. Equivalent to REG_BINARY. |
-|  `DWord` | Specifies a 32-bit binary number. Equivalent to REG_DWORD. |
-|  `MultiString` | Specifies an array of null-terminated strings terminated by two null characters. Equivalent to REG_MULTI_SZ. |
-|  `QWord` | Specifies a 64-bit binary number. Equivalent to REG_QWORD. |
-|  `Unknown` | Indicates an unsupported registry data type, such as REG_RESOURCE_LIST. |
+|Value | Description |
+| ---- | ----------- |
+| `String` | Specifies a null-terminated string. Equivalent to REG_SZ. |
+| `ExpandString` | Specifies a null-terminated string that contains unexpanded |
+|                | references to environment variables that are expanded when |
+|                | the value is retrieved. Equivalent to REG_EXPAND_SZ. |
+| `Binary` | Specifies binary data in any form. Equivalent to REG_BINARY. |
+| `DWord` | Specifies a 32-bit binary number. Equivalent to REG_DWORD. |
+| `MultiString` | Specifies an array of null-terminated strings terminated by |
+|               | two null characters. Equivalent to REG_MULTI_SZ. |
+| `QWord` | Specifies a 64-bit binary number. Equivalent to REG_QWORD. |
+| `Unknown` | Indicates an unsupported registry data type, such as |
+|           | REG_RESOURCE_LIST. |
 
 #### Cmdlets supported
 
@@ -505,9 +532,9 @@ This parameter works as designed on the [Set-ItemProperty](../../Microsoft.Power
 ## Using the pipeline
 
 Provider cmdlets accept pipeline input. You can use the pipeline to simplify
-task by sending provider data from one cmdlet to another provider cmdlet.
-To read more about how to use the pipeline with provider cmdlets, see the
-cmdlet references provided throughout this article.
+task by sending provider data from one cmdlet to another provider cmdlet. To
+read more about how to use the pipeline with provider cmdlets, see the cmdlet
+references provided throughout this article.
 
 ## Getting help
 
@@ -515,8 +542,8 @@ Beginning in Windows PowerShell 3.0, you can get customized help topics for
 provider cmdlets that explain how those cmdlets behave in a file system drive.
 
 To get the help topics that are customized for the file system drive, run a
-[Get-Help](../Get-Help.md) command in a file system drive or use the `-Path`
-parameter of [Get-Help](../Get-Help.md) to specify a file system drive.
+`Get-Help` command in a file system drive or use the `-Path` parameter to
+specify a file system drive.
 
 ```powershell
 Get-Help Get-ChildItem

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -90,7 +90,7 @@ PS C:\> cd HKLM:\Software
 > PowerShell uses aliases to allow you a familiar way to work with provider
 > paths. Commands such as `dir` and `ls` are now aliases for
 > [Get-ChildItem](../../Microsoft.PowerShell.Management/Get-ChildItem.md),
-> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md)
+> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md),
 > and `pwd` is an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
 
 This last example shows another path syntax you can use to navigate the
@@ -137,8 +137,7 @@ Spooler     DependOnService    : {RPCSS, http}
             Group              : SpoolerGroup
             ImagePath          : C:\WINDOWS\System32\spoolsv.exe
             ObjectName         : LocalSystem
-            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege,
-            SeAuditPrivilege, SeChangeNotifyPrivilege...}
+            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege, ...
             ServiceSidType     : 1
             Start              : 2
             Type               : 27
@@ -195,7 +194,7 @@ articles.
 
 Registry key values are stored as properties of each registry key. The
 `Get-ItemProperty` cmdlet views registry key properties using the name you
-specify. The result is a **PSCustom** object containing the properties you
+specify. The result is a **PSCustomObject** containing the properties you
 specify.
 
 The Following example uses the `Get-ItemProperty` cmdlet to view all
@@ -310,9 +309,9 @@ Name                           Property
 ContosoCompany
 ```
 
-You can use the `New-ItemProperty` cmdlet to create to **Item Properties** on
-a registry key that you specify. The following example creates a new DWORD
-value on the ContosoCompany registry key.
+You can use the `New-ItemProperty` cmdlet to create values in a registry key
+that you specify. The following example creates a new DWORD value on the
+ContosoCompany registry key.
 
 ```powershell
 $path = "HKLM:\SOFTWARE\ContosoCompany"
@@ -542,7 +541,7 @@ Beginning in Windows PowerShell 3.0, you can get customized help topics for
 provider cmdlets that explain how those cmdlets behave in a file system drive.
 
 To get the help topics that are customized for the file system drive, run a
-`Get-Help` command in a file system drive or use the `-Path` parameter to
+`Get-Help` command in a file system drive or use the **Path** parameter to
 specify a file system drive.
 
 ```powershell

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -166,7 +166,7 @@ creates firewall rules that allows remote access from the same local subnet.
 
 On client versions of Windows, `Enable-PSRemoting` succeeds on private and
 domain networks. By default, it fails on public networks, but if
-you use the SkipNetworkProfileCheck parameter, `Enable-PSRemoting` succeeds
+you use the **SkipNetworkProfileCheck** parameter, `Enable-PSRemoting` succeeds
 and creates a firewall rule that allows traffic from the same local subnet.
 
 To remove the local subnet restriction on public networks and allow
@@ -279,8 +279,8 @@ Get-Item wsman:\localhost\Service\RootSDDL
 
 To change the RootSDDL, use the `Set-Item` cmdlet in the WSMan: drive. To
 change the security descriptor of a session configuration, use the
-`Set-PSSessionConfiguration` cmdlet with the SecurityDescriptorSDDL or
-ShowSecurityDescriptorUI parameters.
+`Set-PSSessionConfiguration` cmdlet with the **SecurityDescriptorSDDL** or
+**ShowSecurityDescriptorUI** parameters.
 
 For more information about the WSMan: drive, see the Help topic for the
 WSMan provider ("Get-Help wsman").
@@ -308,8 +308,8 @@ Administrator.
 Invoke-Command -ComputerName Server01 -Credential Domain01\Admin01
 ```
 
-For more information about the Credential parameter, see `New-PSSession`,
-`Enter-PSSession` or `Invoke-Command`.
+For more information about the **Credential** parameter, see [New-PSSession](../New-PSSession.md),
+[Enter-PSSession](../Enter-PSSession.md) or [Invoke-Command](../Invoke-Command.md).
 
 ### HOW TO ENABLE REMOTING FOR NON-ADMINISTRATIVE USERS
 
@@ -737,8 +737,8 @@ Set-PSSessionConfiguration -Name microsoft.PowerShell `
 For more information about the `New-PSSessionOption` cmdlet, see
 `New-PSSessionOption`.
 
-For more information about the WS-Management quotas, see the Help topic for
-the WSMan provider (type `Get-Help WSMan`).
+For more information about the WS-Management quotas, see
+[about_WSMan_Provider](../../Microsoft.WsMan.Management/About/about_WSMan_Provider.md).
 
 ### HOW TO RESOLVE TIMEOUT ERRORS
 

--- a/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -18,15 +18,16 @@ This section describes some of the problems that you might encounter when
 using the remoting features of PowerShell that are based on
 WS-Management technology and it suggests solutions to these problems.
 
-Before using PowerShell remoting, see about_Remote and
-about_Remote_Requirements for guidance on configuration and basic use Also,
-the Help topics for each of the remoting cmdlets, particularly the parameter
-descriptions, have useful information that is designed to help you avoid
-problems.
+Before using PowerShell remoting, see [about_Remote](about_remote.md) and
+[about_Remote_Requirements](about_Remote_Requirements.md) for guidance on
+configuration and basic use. Also, the Help topics for each of the remoting
+cmdlets, particularly the parameter descriptions, have useful information that
+is designed to help you avoid problems.
 
-NOTE: To view or change settings for the local computer in the WSMan: drive,
-including changes to the session configurations, trusted hosts, ports, or
-listeners, start PowerShell with the "Run as administrator" option.
+> [!NOTE]
+> To view or change settings for the local computer in the WSMan: drive,
+> including changes to the session configurations, trusted hosts, ports, or
+> listeners, start PowerShell with the "Run as administrator" option.
 
 ## TROUBLESHOOTING PERMISSION AND AUTHENTICATION ISSUES
 
@@ -54,11 +55,12 @@ To start Windows PowerShell with the "Run as administrator option:
 - In the Windows taskbar, right-click the Windows PowerShell icon, and then
   click "Run as Administrator."
 
-  Note: In Windows Server 2008 R2, the Windows PowerShell icon is pinned
-  to the taskbar by default.
+  In Windows Server 2008 R2, the Windows PowerShell icon is pinned to the
+  taskbar by default.
 
 ### HOW TO ENABLE REMOTING
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -66,6 +68,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 No configuration is required to enable a computer to send remote
 commands. However, to receive remote commands, PowerShell remoting
@@ -76,25 +79,26 @@ session configurations.
 
 Windows PowerShell remoting is enabled on Windows Server 2012 and newer
 releases of Windows Server by default. On all other systems, run the
-Enable-PSRemoting cmdlet to enable remoting. You can also run the
-Enable-PSRemoting cmdlet to re-enable remoting on Windows Server 2012 and
+`Enable-PSRemoting` cmdlet to enable remoting. You can also run the
+`Enable-PSRemoting` cmdlet to re-enable remoting on Windows Server 2012 and
 newer releases of Windows Server if remoting is disabled.
 
 To configure a computer to receive remote commands, use the
-Enable-PSRemoting cmdlet. The following command enables all required
+`Enable-PSRemoting` cmdlet. The following command enables all required
 remote settings, enables the session configurations, and restarts the
 WinRM service to make the changes effective.
 
-Enable-PSRemoting
+`Enable-PSRemoting`
 
 To suppress all user prompts, type:
 
-Enable-PSRemoting -Force
+`Enable-PSRemoting -Force`
 
-For more information, see Enable-PSRemoting.
+For more information, see [Enable-PSRemoting](../Enable-PSRemoting.md).
 
 ### HOW TO ENABLE REMOTING IN AN ENTERPRISE
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -102,9 +106,10 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 To enable a single computer to receive remote PowerShell commands
-and accept connections, use the Enable-PSRemoting cmdlet.
+and accept connections, use the `Enable-PSRemoting` cmdlet.
 
 To enable remoting for multiple computers in an enterprise, you can use the
 following scaled options.
@@ -114,7 +119,7 @@ following scaled options.
   Enable Listeners by Using a Group Policy" (below).
 
 - To set the startup type of the Windows Remote Management (WinRM)
-  to Automatic on multiple computers, use the Set-Service cmdlet. For
+  to Automatic on multiple computers, use the `Set-Service` cmdlet. For
   instructions, see "How to Set the Startup Type of the WinrM Service"
   (below).
 
@@ -124,6 +129,7 @@ following scaled options.
 
 ### HOW TO ENABLE LISTENERS BY USING A GROUP POLICY
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -131,6 +137,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to listen
 for requests on the correct port and HTTP URL.
+```
 
 To configure the listeners for all computers in a domain, enable the "Allow
 automatic configuration of listeners" policy in the following Group Policy
@@ -144,20 +151,22 @@ permitted.
 
 ### HOW TO ENABLE REMOTING ON PUBLIC NETWORKS
 
+```
 ERROR:  Unable to check the status of the firewall
+```
 
-The Enable-PSRemoting cmdlet returns this error when the local network
+The `Enable-PSRemoting` cmdlet returns this error when the local network
 is public and the SkipNetworkProfileCheck parameter is not used in the
 command.
 
-On server versions of Windows, Enable-PSRemoting succeeds on all network
+On server versions of Windows, `Enable-PSRemoting` succeeds on all network
 location types. It creates firewall rules that allow remote access to
 private and domain ("Home" and "Work") networks. For public networks, it
 creates firewall rules that allows remote access from the same local subnet.
 
-On client versions of Windows, Enable-PSRemoting succeeds on private and
+On client versions of Windows, `Enable-PSRemoting` succeeds on private and
 domain networks. By default, it fails on public networks, but if
-you use the SkipNetworkProfileCheck parameter, Enable-PSRemoting succeeds
+you use the SkipNetworkProfileCheck parameter, `Enable-PSRemoting` succeeds
 and creates a firewall rule that allows traffic from the same local subnet.
 
 To remove the local subnet restriction on public networks and allow
@@ -167,16 +176,18 @@ remote access from any location, run the following command:
 Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP-PUBLIC" -RemoteAddress Any
 ```
 
-The Set-NetFirewallRule cmdlet is exported by the NetSecurity module.
+The `Set-NetFirewallRule` cmdlet is exported by the NetSecurity module.
 
-NOTE: In Windows PowerShell 2.0, on computers running server versions
-of Windows, Enable-PSRemoting creates firewall rules that allow remote
-access on private, domain and public networks. On computers running
-client versions of Windows, Enable-PSRemoting creates firewall rules
-that allow remote access only on private and domain networks.
+> [!NOTE]
+> In Windows PowerShell 2.0, on computers running server versions
+> of Windows, `Enable-PSRemoting` creates firewall rules that allow remote
+> access on private, domain and public networks. On computers running
+> client versions of Windows, `Enable-PSRemoting` creates firewall rules
+> that allow remote access only on private and domain networks.
 
 ### HOW TO ENABLE A FIREWALL EXCEPTION BY USING A GROUP POLICY
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -184,6 +195,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 To enable a firewall exception for in all computers in a domain, enable the
 "Windows Firewall: Allow local port exceptions" policy in the following
@@ -198,7 +210,9 @@ the Windows Remote Management service.
 
 ### HOW TO SET THE STARTUP TYPE OF THE WINRM SERVICE
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 PowerShell remoting depends upon the Windows Remote Management
 (WinRM) service. The service must be running to support remote commands.
@@ -210,7 +224,7 @@ However, on client versions of Windows, the WinRM service is disabled
 by default.
 
 To set the startup type of a service on a remote computer, use the
-Set-Service cmdlet.
+`Set-Service` cmdlet.
 
 To run the command on multiple computers, you can create a text file or
 CSV file of the computer names.
@@ -220,38 +234,42 @@ Servers.txt file and then sets the startup type of the WinRM service on all
 of the computers to Automatic.
 
 ```powershell
-C:\PS> $servers = Get-Content servers.txt
-C:\PS> Set-Service WinRM -ComputerName $servers -startuptype Automatic
+$servers = Get-Content servers.txt
+Set-Service WinRM -ComputerName $servers -startuptype Automatic
 ```
 
-To see the results use the Get-WMIObject cmdlet with the Win32_Service object.
-For more information, see Set-Service.
+To see the results use the `Get-WMIObject` cmdlet with the **Win32_Service**
+object. For more information, see
+[Set-Service](../../Microsoft.PowerShell.Management/Set-Service.md).
 
 ### HOW TO RECREATE THE DEFAULT SESSION CONFIGURATIONS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To connect to the local computer and run commands remotely, the local
 computer must include session configurations for remote commands.
 
-When you use Enable-PSRemoting, it creates default session configurations
+When you use `Enable-PSRemoting`, it creates default session configurations
 on the local computer. Remote users use these session configurations
 whenever a remote command does not include the ConfigurationName parameter.
 
 If the default configurations on a computer are unregistered or deleted,
-use the Enable-PSRemoting cmdlet to recreate them. You can use this cmdlet
+use the `Enable-PSRemoting` cmdlet to recreate them. You can use this cmdlet
 repeatedly. It does not generate errors if a feature is already configured.
 
 If you change the default session configurations and want to restore the
 original default session configurations, use the
-Unregister-PSSessionConfiguration cmdlet to delete the changed session
-configurations and then use the Enable-PSRemoting cmdlet to restore them.
-Enable-PSRemoting does not change existing session configurations.
+`Unregister-PSSessionConfiguration` cmdlet to delete the changed session
+configurations and then use the `Enable-PSRemoting` cmdlet to restore them.
+`Enable-PSRemoting` does not change existing session configurations.
 
-Note: When Enable-PSRemoting restores the default session configuration, it
-does not create explicit security descriptors for the configurations.
-Instead, the configurations inherit the security descriptor of the RootSDDL,
-which is secure by default.
+> [!NOTE]
+> When `Enable-PSRemoting` restores the default session configuration, it
+> does not create explicit security descriptors for the configurations.
+> Instead, the configurations inherit the security descriptor of the
+> RootSDDL, which is secure by default.
 
 To see the RootSDDL security descriptor, type:
 
@@ -259,9 +277,9 @@ To see the RootSDDL security descriptor, type:
 Get-Item wsman:\localhost\Service\RootSDDL
 ```
 
-To change the RootSDDL, use the Set-Item cmdlet in the WSMan: drive. To
+To change the RootSDDL, use the `Set-Item` cmdlet in the WSMan: drive. To
 change the security descriptor of a session configuration, use the
-Set-PSSessionConfiguration cmdlet with the SecurityDescriptorSDDL or
+`Set-PSSessionConfiguration` cmdlet with the SecurityDescriptorSDDL or
 ShowSecurityDescriptorUI parameters.
 
 For more information about the WSMan: drive, see the Help topic for the
@@ -269,7 +287,9 @@ WSMan provider ("Get-Help wsman").
 
 ### HOW TO PROVIDE ADMINISTRATOR CREDENTIALS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To create a PSSession or run commands on a remote computer, by default, the
 current user must be a member of the Administrators group on the remote
@@ -278,8 +298,8 @@ logged on to an account that is a member of the Administrators group.
 
 If the current user is a member of the Administrators group on the remote
 computer, or can provide the credentials of a member of the Administrators
-group, use the Credential parameter of the New-PSSession, Enter-PSSession
-or Invoke-Command cmdlets to connect remotely.
+group, use the Credential parameter of the `New-PSSession`, `Enter-PSSession`
+or `Invoke-Command` cmdlets to connect remotely.
 
 For example, the following command provides the credentials of an
 Administrator.
@@ -288,12 +308,14 @@ Administrator.
 Invoke-Command -ComputerName Server01 -Credential Domain01\Admin01
 ```
 
-For more information about the Credential parameter, see New-PSSession,
-Enter-PSSession or Invoke-Command.
+For more information about the Credential parameter, see `New-PSSession`,
+`Enter-PSSession` or `Invoke-Command`.
 
 ### HOW TO ENABLE REMOTING FOR NON-ADMINISTRATIVE USERS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To establish a PSSession or run a command on a remote computer, the user
 must have permission to use the session configurations on the remote
@@ -319,7 +341,9 @@ For more information, see [about_Session_Configurations](about_Session_Configura
 
 ### HOW TO ENABLE REMOTING FOR ADMINISTRATORS IN OTHER DOMAINS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 When a user in another domain is a member of the Administrators group on
 the local computer, the user cannot connect to the local computer remotely
@@ -330,30 +354,33 @@ However, you can use the LocalAccountTokenFilterPolicy registry entry to
 change the default behavior and allow remote users who are members of the
 Administrators group to run with Administrator privileges.
 
-Caution: The LocalAccountTokenFilterPolicy entry disables user account
-control (UAC) remote restrictions for all users of all affected
-computers. Consider the implications of this setting carefully
-before changing the policy.
+> [!CAUTION]
+> The LocalAccountTokenFilterPolicy entry disables user account
+> control (UAC) remote restrictions for all users of all affected
+> computers. Consider the implications of this setting carefully
+> before changing the policy.
 
 To change the policy, use the following command to set the value of the
 LocalAccountTokenFilterPolicy registry entry to 1.
 
 ```powershell
-C:\PS> New-ItemProperty -Name LocalAccountTokenFilterPolicy -Path `
-HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System `
--PropertyType DWord -Value 1
+New-ItemProperty -Name LocalAccountTokenFilterPolicy `
+  -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System `
+  -PropertyType DWord -Value 1
 ```
 
 ### HOW TO USE AN IP ADDRESS IN A REMOTE COMMAND
 
+```
 ERROR:  The WinRM client cannot process the request. If the
 authentication scheme is different from Kerberos, or if the client
 computer is not joined to a domain, then HTTPS transport must be used
 or the destination machine must be added to the TrustedHosts
 configuration setting.
+```
 
-The ComputerName parameters of the New-PSSession, Enter-PSSession and
-Invoke-Command cmdlets accept an IP address as a valid value. However,
+The ComputerName parameters of the `New-PSSession`, `Enter-PSSession` and
+`Invoke-Command` cmdlets accept an IP address as a valid value. However,
 because Kerberos authentication does not support IP addresses, NTLM
 authentication is used by default whenever you specify an IP address.
 
@@ -374,11 +401,13 @@ for remoting.
 
 ### HOW TO CONNECT REMOTELY FROM A WORKGROUP-BASED COMPUTER
 
+```
 ERROR:  The WinRM client cannot process the request. If the
 authentication scheme is different from Kerberos, or if the client
 computer is not joined to a domain, then HTTPS transport must be used
 or the destination machine must be added to the TrustedHosts
 configuration setting.
+```
 
 When the local computer is not in a domain, the following procedure is required
 for remoting.
@@ -422,7 +451,7 @@ To view the list of trusted hosts, use the following command:
 Get-Item wsman:\localhost\Client\TrustedHosts
 ```
 
-You can also use the Set-Location cmdlet (alias = cd) to navigate
+You can also use the `Set-Location` cmdlet (alias = cd) to navigate
 though the WSMan: drive to the location.
 For example:
 
@@ -453,7 +482,7 @@ the following command format:
 Set-Item wsman:\localhost\Client\TrustedHosts -Value <ComputerName>
 ```
 
-where each value <ComputerName> must have the following format:
+where each value `<ComputerName>` must have the following format:
 
 ```
 <Computer>.<Domain>.<Company>.<top-level-domain>
@@ -494,10 +523,12 @@ Set-Item wsman:\localhost\Client\TrustedHosts -Value 172.16.0.0
 ```
 
 To add a computer to the TrustedHosts list of a remote computer, use the
-Connect-WSMan cmdlet to add a node for the remote computer to the WSMan: drive
-on the local computer. Then use a Set-Item command to add the computer.
+`Connect-WSMan` cmdlet to add a node for the remote computer to the WSMan:
+drive on the local computer. Then use a `Set-Item` command to add the
+computer.
 
-For more information about the Connect-WSMan cmdlet, see Connect-WSMan.
+For more information about the `Connect-WSMan` cmdlet, see
+[Connect-WSMan](../../Microsoft.WSMan.Management/Connect-WSMan.md).
 
 ## TROUBLESHOOTING COMPUTER CONFIGURATION ISSUES
 
@@ -506,15 +537,17 @@ configurations of a computer, domain, or enterprise.
 
 ### HOW TO CONFIGURE REMOTING ON ALTERNATE PORTS
 
+```
 ERROR:  The connection to the specified remote host was refused. Verify
 that the WS-Management service is running on the remote host and
 configured to listen for requests on the correct port and HTTP URL.
+```
 
 Windows PowerShell remoting uses port 80 for HTTP transport by default. The
 default port is used whenever the user does not specify the ConnectionURI
 or Port parameters in a remote command.
 
-To change the default port that Windows PowerShell uses, use Set-Item cmdlet
+To change the default port that Windows PowerShell uses, use `Set-Item` cmdlet
 in the WSMan: drive to change the Port value in the  listener leaf node.
 
 For example, the following command changes the default port to 8080.
@@ -525,9 +558,11 @@ Set-Item wsman:\localhost\listener\listener*\port -Value 8080
 
 ### HOW TO CONFIGURE REMOTING WITH A PROXY SERVER
 
+```
 ERROR: The client cannot connect to the destination specified in the
 request. Verify that the service on the destination is running and is
 accepting requests.
+```
 
 Because PowerShell remoting uses the HTTP protocol, it is affected
 by HTTP proxy settings. In enterprises that have proxy servers, users
@@ -543,29 +578,29 @@ The following settings are available:
 To set these options for a particular command, use the following procedure:
 
 1. Use the ProxyAccessType, ProxyAuthentication, and ProxyCredential
-   parameters of the New-PSSessionOption cmdlet to create a session
+   parameters of the `New-PSSessionOption` cmdlet to create a session
    option object with the proxy settings for your enterprise. Save the
    option object is a variable.
 
 2. Use the variable that contains the option object as the value of the
-   SessionOption parameter of a New-PSSession, Enter-PSSession, or
-   Invoke-Command command.
+   SessionOption parameter of a `New-PSSession`, `Enter-PSSession`, or
+   `Invoke-Command` command.
 
 For example, the following command creates a session option object with
 proxy session options and then uses the object to create a remote session.
 
 ```powershell
-C:\PS> $SessionOption = New-PSSessionOption -ProxyAccessType IEConfig `
+$SessionOption = New-PSSessionOption -ProxyAccessType IEConfig `
 -ProxyAuthentication Negotiate -ProxyCredential Domain01\User01
 
-C:\PS> New-PSSession -ConnectionURI https://www.fabrikam.com
+New-PSSession -ConnectionURI https://www.fabrikam.com
 ```
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+[New-PSSessionOption](../New-PSSessionOption.md).
 
 To set these options for all remote commands in the current session, use
-the option object that New-PSSessionOption creates in the value of the
+the option object that `New-PSSessionOption` creates in the value of the
 $PSSessionOption preference variable. For more information about the
 $PSSessionOption preference variable, see about_Preference_Variables.
 
@@ -576,19 +611,21 @@ profiles, see about_Profiles.
 
 ### HOW TO DETECT A 32-BIT SESSION ON A 64-BIT COMPUTER
 
+```
 ERROR: The term "<tool-Name>" is not recognized as the name of a cmdlet,
 function, script file, or operable program. Check the spelling of the
 name, or if a path was included, verify that the path is correct and try
 again.
+```
 
 If the remote computer is running a 64-bit version of Windows, and the
 remote command is using a 32-bit session configuration, such as
 Microsoft.PowerShell32, Windows Remote Management (WinRM) loads a WOW64
 process and Windows automatically redirects all references to the
-%Windir%\\System32 directory to the %windir%\\SysWOW64 directory.
+`$env:Windir\System32` directory to the `$env:Windir\SysWOW64` directory.
 
 As a result, if you try to use tools in the System32 directory that do
-not have counterparts in the SysWow64 directory, such as Defrag.exe,
+not have counterparts in the SysWow64 directory, such as **Defrag.exe**,
 the tools cannot be found in the directory.
 
 To find the processor architecture that is being used in the session,
@@ -599,10 +636,14 @@ following command finds the processor architecture of the session in the
 ```powershell
 $s = New-PSSession -ComputerName Server01 -ConfigurationName CustomShell
 Invoke-Command -Session $s {$env:PROCESSOR_ARCHITECTURE}
+```
+
+```Output
 x86
 ```
 
-For more information about session configurations, see [about_Session_Configurations](about_Session_Configurations.md).
+For more information about session configurations, see
+[about_Session_Configurations](about_Session_Configurations.md).
 
 ## TROUBLESHOOTING POLICY AND PREFERENCE ISSUES
 
@@ -611,20 +652,22 @@ preferences set on the local and remote computers.
 
 ### HOW TO CHANGE THE EXECUTION POLICY FOR IMPORT-PSSESSION AND IMPORT-MODULE
 
+```
 ERROR: Import-Module: File <filename> cannot be loaded because the
 execution of scripts is disabled on this system.
+```
 
-The Import-PSSession and Export-PSSession cmdlets create modules that
+The `Import-PSSession` and `Export-PSSession` cmdlets create modules that
 contains unsigned script files and formatting files.
 
 To import the modules that are created by these cmdlets, either by using
-Import-PSSession or Import-Module, the execution policy in the current
+`Import-PSSession` or `Import-Module`, the execution policy in the current
 session cannot be Restricted or AllSigned. (For information about Windows
 PowerShell execution policies, see about_Execution_Policies.
 
 To import the modules without changing the execution policy for the local
 computer that is set in the registry, use the Scope parameter of
-Set-ExecutionPolicy to set a less restrictive execution policy for a single
+`Set-ExecutionPolicy` to set a less restrictive execution policy for a single
 process.
 
 For example, the following command starts a process with the RemoteSigned
@@ -636,22 +679,24 @@ setting.
 Set-ExecutionPolicy -Scope process -ExecutionPolicy RemoteSigned
 ```
 
-You can also use the ExecutionPolicy parameter of PowerShell.exe to start
+You can also use the ExecutionPolicy parameter of **PowerShell.exe** to start
 a single session with a less restrictive execution policy.
 
 ```powershell
 PowerShell.exe -ExecutionPolicy RemoteSigned
 ```
 
-For more information about the cmdlets, see Import-PSSession,
-Export-PSSession, and Import-Module. For more information about
+For more information about the cmdlets, see `Import-PSSession`,
+`Export-PSSession`, and `Import-Module`. For more information about
 execution policies, see about_Execution_Policies. For more information
 about the PowerShell.exe console help options, type "PowerShell.exe -?".
 
 ### HOW TO SET AND CHANGE QUOTAS
 
+```
 ERROR: The total data received from the remote client exceeded allowed
 maximum.
+```
 
 You can use quotas to protect the local computer and the remote computer
 from excessive resource use, both accidental and malicious.
@@ -659,19 +704,20 @@ from excessive resource use, both accidental and malicious.
 The following quotas are available in the basic configuration.
 
 - The WSMan provider (WSMan:) provides several quota settings, such as the
-  MaxEnvelopeSizeKB and MaxProviderRequests settings in the
-  WSMan:\<ComputerName\> node and the MaxConcurrentOperations,
-  MaxConcurrentOperationsPerUser, and MaxConnections settings in the
-  WSMan:\<ComputerName\>\\Service node.
+  **MaxEnvelopeSizeKB** and **MaxProviderRequests** settings in the
+  `WSMan:<ComputerName>` node and the **MaxConcurrentOperations**,
+  **MaxConcurrentOperationsPerUser**, and **MaxConnections** settings in the
+  `WSMan:<ComputerName>\Service` node.
 
 - You can protect the local computer by using the
-  MaximumReceivedDataSizePerCommand and MaximumReceivedObjectSize parameters of
-  the New-PSSessionOption cmdlet and the \$PSSessionOption preference variable.
+  MaximumReceivedDataSizePerCommand and MaximumReceivedObjectSize parameters
+  of the `New-PSSessionOption` cmdlet and the \$PSSessionOption preference
+  variable.
 
 - You can protect the remote computer by adding restrictions to the session
-  configurations, such as by using the MaximumReceivedDataSizePerCommandMB and
-  MaximumReceivedObjectSizeMB parameters of the Register-PSSessionConfiguration
-  cmdlet.
+  configurations, such as by using the **MaximumReceivedDataSizePerCommandMB**
+  and **MaximumReceivedObjectSizeMB** parameters of the
+  `Register-PSSessionConfiguration` cmdlet.
 
 When quotas conflict with a command, PowerShell generates an error.
 
@@ -685,19 +731,21 @@ Microsoft.PowerShell session configuration on the remote computer from 10 MB
 
 ```powershell
 Set-PSSessionConfiguration -Name microsoft.PowerShell `
--MaximumReceivedObjectSizeMB 11 -Force
+  -MaximumReceivedObjectSizeMB 11 -Force
 ```
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+`New-PSSessionOption`.
 
 For more information about the WS-Management quotas, see the Help topic for
-the WSMan provider (type "Get-Help WSMan").
+the WSMan provider (type `Get-Help WSMan`).
 
 ### HOW TO RESOLVE TIMEOUT ERRORS
 
+```
 ERROR: The WS-Management service cannot complete the operation within
 the time specified in OperationTimeout.
+```
 
 You can use timeouts to protect the local computer and the remote computer
 from excessive resource use, both accidental and malicious. When timeouts
@@ -707,14 +755,14 @@ shortest timeout settings.
 The following timeouts are available in the basic configuration.
 
 - The WSMan provider (WSMan:) provides several client-side and service-side
-  timeout settings, such as the MaxTimeoutms setting in the
-  WSMan:\<ComputerName\> node and the EnumerationTimeoutms and
-  MaxPacketRetrievalTimeSeconds settings in the WSMan:\<ComputerName\>\\Service
-  node.
+  timeout settings, such as the **MaxTimeoutms** setting in the
+  `WSMan:<ComputerName>` node and the **EnumerationTimeoutms** and
+  **MaxPacketRetrievalTimeSeconds** settings in the
+  `WSMan:<ComputerName>\Service` node.
 
-- You can protect the local computer by using the CancelTimeout, IdleTimeout,
-  OpenTimeout, and OperationTimeout parameters of the New-PSSessionOption
-  cmdlet and the $PSSessionOption preference variable.
+- You can protect the local computer by using the **CancelTimeout**,
+  **IdleTimeout**, **OpenTimeout**, and **OperationTimeout** parameters of the
+  `New-PSSessionOption` cmdlet and the $PSSessionOption preference variable.
 
 - You can also protect the remote computer by setting timeout values
   programmatically in the session configuration for the session.
@@ -726,21 +774,21 @@ To resolve the error, change the command to complete within the timeout
 interval or determine the source of the timeout limit and increase the
 timeout interval to allow the command to complete.
 
-For example, the following commans use the New-PSSessionOption cmdlet to
-create a session option object with an OperationTimeout value of 4 minutes
+For example, the following commands use the `New-PSSessionOption` cmdlet to
+create a session option object with an **OperationTimeout** value of 4 minutes
 (in MS) and then use the session option object to create a remote session.
 
 ```powershell
-C:\PS> $pso = New-PSSessionoption -OperationTimeout 240000
+$pso = New-PSSessionoption -OperationTimeout 240000
 
-C:\PS> New-PSSession -ComputerName Server01 -sessionOption $pso
+New-PSSession -ComputerName Server01 -sessionOption $pso
 ```
 
 For more information about the WS-Management timeouts, see the Help topic for
 the WSMan provider (type "Get-Help WSMan").
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+[New-PSSessionOption](../New-PSSessionOption.md).
 
 ## TROUBLESHOOTING UNRESPONSIVE BEHAVIOR
 
@@ -756,13 +804,15 @@ Win32 console API, do not work correctly in the PowerShell remote host.
 When you use these programs, you might see unexpected behavior, such as no
 output, partial output, or a remote command that does not complete.
 
-To end an unresponsive program, type CTRL + C. To view any errors that might
-have been reported, type "$error" in the local host and the remote session.
+To end an unresponsive program, type `CTRL+C`. To view any errors that might
+have been reported, type `$error` in the local host and the remote session.
 
 ## HOW TO RECOVER FROM AN OPERATION FAILURE
 
+```
 ERROR: The I/O operation has been aborted because of either a thread exit
 or an  application request.
+```
 
 This error is returned when an operation is terminated before it completes.
 Typically, it occurs when the WinRM service stops or restarts while other
@@ -774,7 +824,7 @@ the command again.
 1. Start PowerShell with the "Run as administrator" option.
 2. Run the following command:
 
-   Start-Service WinRM
+   `Start-Service WinRM`
 
 3. Re-run the command that generated the error.
 

--- a/reference/5.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -11,11 +11,13 @@ title:  Disconnect-PSSession
 # Disconnect-PSSession
 
 ## SYNOPSIS
+
 Disconnects from a session.
 
 ## SYNTAX
 
 ### Session (Default)
+
 ```
 Disconnect-PSSession [-Session] <PSSession[]> [-IdleTimeoutSec <Int32>]
  [-OutputBufferingMode <OutputBufferingMode>] [-ThrottleLimit <Int32>] [-WhatIf] [-Confirm]
@@ -23,138 +25,182 @@ Disconnect-PSSession [-Session] <PSSession[]> [-IdleTimeoutSec <Int32>]
 ```
 
 ### Name
+
 ```
 Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBufferingMode>]
  [-ThrottleLimit <Int32>] -Name <String[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### Id
-```
-Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBufferingMode>]
- [-ThrottleLimit <Int32>] [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
 ### InstanceId
+
 ```
 Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBufferingMode>]
  [-ThrottleLimit <Int32>] -InstanceId <Guid[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
+### Id
+
+```
+Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBufferingMode>]
+ [-ThrottleLimit <Int32>] [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
 ## DESCRIPTION
-The **Disconnect-PSSession** cmdlet disconnects a Windows PowerShell session (**PSSession**), such as one started by using the New-PSSession cmdlet, from the current session.
-As a result, the **PSSession** is in a disconnected state.
-You can connect to the disconnected **PSSession** from the current session or from another session on the local computer or a different computer.
 
-The **Disconnect-PSSession** cmdlet disconnects only open **PSSessions** that are connected to the current session.
-**Disconnect-PSSession** cannot disconnect broken or closed **PSSession** objects, or interactive **PSSession** objects started by using the Enter-PSSession cmdlet, and it cannot disconnect **PSSession** objects that are connected to other sessions.
+The `Disconnect-PSSession` cmdlet disconnects a Windows PowerShell session ("PSSession"), such as
+one started by using the `New-PSSession` cmdlet, from the current session. As a result, the PSSession
+is in a disconnected state. You can connect to the disconnected PSSession from the current session
+or from another session on the local computer or a different computer.
 
-To reconnect to a disconnected **PSSession**, use the Connect-PSSession or Receive-PSSession cmdlets.
+The `Disconnect-PSSession` cmdlet disconnects only open PSSessions that are connected to the
+current session. `Disconnect-PSSession` cannot disconnect broken or closed PSSessions, or
+interactive PSSessions started by using the `Enter-PSSession` cmdlet, and it cannot disconnect
+PSSessions that are connected to other sessions.
 
-When a **PSSession** is disconnected, the commands in the **PSSession** continue to run until they finish, unless the PSSession times out or the commands in the **PSSession** are blocked by a full output buffer.
-To change the idle time-out, use the *IdleTimeoutSec* parameter.
-To change the output buffering mode, use the *OutputBufferingMode* parameter.
-You can also use the *InDisconnectedSession* parameter of the Invoke-Command cmdlet to run a command in a disconnected session.
+To reconnect to a disconnected PSSession, use the `Connect-PSSession` or `Receive-PSSession` cmdlets.
 
-For more information about the Disconnected Sessions feature, see about_Remote_Disconnected_Sessions.
+When a PSSession is disconnected, the commands in the PSSession continue to run until they
+complete, unless the PSSession times out or the commands in the PSSession are blocked by a full
+output buffer. To change the idle timeout, use the **IdleTimeoutSec** parameter. To change the
+output buffering mode, use the **OutputBufferingMode** parameter You can also use the
+**InDisconnectedSession** parameter of the `Invoke-Command` cmdlet to run a command in a disconnected
+session.
 
-This cmdlet was introduced in Windows PowerShell 3.0.
+For more information about the Disconnected Sessions feature, see
+[about_Remote_Disconnected_Sessions](./About/about_Remote_Disconnected_Sessions.md).
+
+This cmdlet is introduced in Windows PowerShell 3.0.
 
 ## EXAMPLES
 
-### Example 1: Disconnect a session
+### Example 1 - Disconnect a session by name
+
+This command disconnects the UpdateSession PSSession on the Server01 computer from the current
+session. The command uses the **Name** parameter to identify the PSSession.
+
 ```
-PS C:\> Disconnect-PSSession -Name UpdateSession
+PS> Disconnect-PSSession -Name UpdateSession
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
 1  UpdateSession   Server01        Disconnected  Microsoft.PowerShell          None
 ```
 
-This command disconnects the UpdateSession **PSSession** on the Server01 computer from the current session.
-The command uses the *Name* parameter to identify the **PSSession**.
+The output shows that the attempt to disconnect was successful. The session state is Disconnected
+and the Availability is None, which indicates that the session is not busy and can be reconnected.
 
-The output shows that the attempt to disconnect was successful.
-The session state is **Disconnected** and the **Availability** is None, which indicates that the session is not busy and can be reconnected.
+### Example 2 - Disconnect a session from a specific computer
 
-### Example 2: Disconnect a session created in the current session
+This command disconnects the ITTask PSSession on the Server12 computer from the current session.
+The ITTask session was created in the current session and connects to the Server12 computer. The
+command uses the `Get-PSSession` cmdlet to get the session and the `Disconnect-PSSession` cmdlet to
+disconnect it.
+
 ```
-PS C:\> Get-PSSession -ComputerName Server12 -Name ITTask | Disconnect-PSSession -OutputBufferingMode Drop -IdleTimeoutSec 86400
+PS> Get-PSSession -ComputerName Server12 -Name ITTask |
+  Disconnect-PSSession -OutputBufferingMode Drop -IdleTimeoutSec 86400
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
 1  ITTask          Server12        Disconnected  ITTasks               None
 ```
 
-This command disconnects the ITTask **PSSession** on the Server12 computer from the current session.
-The ITTask session was created in the current session and connects to the Server12 computer.
-The command uses the Get-PSSession cmdlet to get the session and **Disconnect-PSSession** to disconnect it.
+The `Disconnect-PSSession` command uses the **OutputBufferingMode** parameter to set the output
+mode to **Drop**. This setting ensures that the script that is running in the session can continue
+to run even if the session output buffer is full. Because the script writes its output to a report
+on a file share, other output can be lost without consequence.
 
-The **Disconnect-PSSession** command uses the *OutputBufferingMode* parameter to set the output mode to Drop.
-This setting makes sure that the script that is running in the session can continue to run even if the session output buffer is full.
-Because the script writes its output to a report on a file share, other output can be lost without consequence.
+The command also uses the **IdleTimeoutSec** parameter to extend the idle timeout of the session to
+24 hours. This setting allows time for this administrator or other administrators to reconnect to
+the session to verify that the script ran and troubleshoot if needed.
 
-The command also uses the *IdleTimeoutSec* parameter to extend the idle time-out of the session to 24 hours.
-This setting allows time for this administrator or other administrators to reconnect to the session to verify that the script ran and troubleshoot if needed.
+### Example 3 - Using multiple PSSessions on multiple computers
 
-### Example 3: Disconnecting sessions in an enterprise scenario
+This series of commands shows how the `Disconnect-PSSession` cmdlet might be used in an enterprise
+scenario. In this case, a new technician starts a script in a session on a remote computer and runs
+into a problem. The technician disconnects from the session so that a more experienced manager can
+connect to the session and resolve the problem.
+
 ```
-The technician starts by creating sessions on several remote computers and running a script in each session.The first command uses the New-PSSession cmdlet to create the ITTask session on three remote computers. The command saves the sessions in the $s variable. The second command uses the *FilePath* parameter of the Invoke-Command cmdlet to run a script in the sessions in the $s variable.
-PS C:\> $s = New-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
-
-PS C:\> Invoke-Command $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
-
-The script running on the Srv1 computer generates unexpected errors. The technician contacts his manager and asks for assistance. The manager directs the technician to disconnect from the session so he can investigate.The second command uses the Get-PSSession cmdlet to get the ITTask session on the Srv1 computer and **Disconnect-PSSession** to disconnect it. This command does not affect the ITTask sessions on  the other computers.
-PS C:\> Get-PSSession -Name ITTask -ComputerName Srv1 | Disconnect-PSSession
+PS> $s = New-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
+PS> Invoke-Command $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
+PS> Get-PSSession -Name ITTask -ComputerName Srv1 | Disconnect-PSSession
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
 1 ITTask           Srv1            Disconnected  Microsoft.PowerShell          None
 
-The third command uses the **Get-PSSession** cmdlet to get the ITTask sessions. The output shows that the ITTask sessions on the Srv2 and Srv30 computers were not affected by the command to disconnect.
-PS C:\> Get-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
+PS> Get-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
  1 ITTask          Srv1            Disconnected  Microsoft.PowerShell          None
  2 ITTask          Srv2            Opened        Microsoft.PowerShell     Available
  3 ITTask          Srv30           Opened        Microsoft.PowerShell     Available
 
-The manager logs on to his home computer, connects to his corporate network, starts Windows PowerShell, and uses the Get-PSSession cmdlet to get the ITTask session on the Srv1 computer. He uses the credentials of the technician to access the session.
-PS C:\> Get-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
+PS> Get-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
  1 ITTask          Srv1            Disconnected  Microsoft.PowerShell          None
 
-Next, the manager uses the Connect-PSSession cmdlet to connect to the ITTask session on the Srv1 computer. The command saves the session in the $s variable.
-PS C:\> $s = Connect-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
-
-The manager uses the Invoke-Command cmdlet to run some diagnostic commands in the session in the $s variable. He recognizes that the script failed because it did not find a required directory. The manager uses the MkDir function to create the directory, and then he restarts the Get-PatchStatus.ps1 script and disconnects from the session.The manager reports his findings to the technician, suggests that he reconnect to the session to complete the tasks, and asks him to add a command to the Get-PatchStatus.ps1 script that creates the required directory if it does not exist.
-PS C:\> Invoke-Command -Session $s {dir $home\Scripts\PatchStatusOutput.ps1}
-
-PS C:\> Invoke-Command -Session $s {mkdir $home\Scripts\PatchStatusOutput}
-
-PS C:\> Invoke-Command -Session $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
-
-PS C:\> Disconnect-PSSession -Session $s
+PS> $s = Connect-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
+PS> Invoke-Command -Session $s {dir $home\Scripts\PatchStatusOutput.ps1}
+PS> Invoke-Command -Session $s {mkdir $home\Scripts\PatchStatusOutput}
+PS> Invoke-Command -Session $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
+PS> Disconnect-PSSession -Session $s
 ```
 
-This series of commands shows how **Disconnect-PSSession** might be used in an enterprise scenario.
-In this case, a new technician starts a script in a session on a remote computer and runs into a problem.
-The technician disconnects from the session so that a more experienced manager can connect to the session and resolve the problem.
+The technician begins by creating sessions on several remote computers and running a script in each
+session. The first command uses the `New-PSSession` cmdlet to create the ITTask session on three
+remote computers. The command saves the sessions in the $s variable. The second command uses the
+**FilePath** parameter of the `Invoke-Command` cmdlet to run a script in the sessions in the $s
+variable.
 
-### Example 4: Correct the value of an idle time-out so it can be disconnected
+The script running on the Srv1 computer generates unexpected errors. The technician contacts his
+manager and asks for assistance. The manager directs the technician to disconnect from the session
+so he can investigate.The second command uses the `Get-PSSession` cmdlet to get the ITTask session on
+the Srv1 computer and the `Disconnect-PSSession` cmdlet to disconnect it. This command does not
+affect the ITTask sessions on the other computers.
+
+The third command uses the `Get-PSSession` cmdlet to get the ITTask sessions. The output shows that
+the ITTask sessions on the Srv2 and Srv30 computers were not affected by the command to disconnect.
+
+The manager logs on to his home computer, connects to his corporate network, starts Windows
+PowerShell, and uses the `Get-PSSession` cmdlet to get the ITTask session on the Srv1 computer. He
+uses the credentials of the technician to access the session.
+
+Next, the manager uses the `Connect-PSSession` cmdlet to connect to the ITTask session on the Srv1
+computer. The command saves the session in the $s variable.
+
+The manager uses the `Invoke-Command` cmdlet to run some diagnostic commands in the session in the
+`$s` variable. He recognizes that the script failed because it did not find a required directory.
+The manager uses the `MkDir` function to create the directory, and then he restarts the
+`Get-PatchStatus.ps1` script and disconnects from the session.The manager reports his findings to
+the technician, suggests that he reconnect to the session to complete the tasks, and asks him to
+add a command to the `Get-PatchStatus.ps1` script that creates the required directory if it does
+not exist.
+
+### Example 4 - Change the timeout value for a PSSession
+
+This example shows how to correct the value of the **IdleTimeout** property of a session so that it
+can be disconnected.
+
+The idle timeout property of a session is critical to disconnected sessions, because it determines
+how long a disconnected session is maintained before it is deleted. You can set the idle timeout
+option when you create a session and when you disconnect it. The default values for the idle
+timeout of a session are set in the `$PSSessionOption` preference variable on the local computer
+and in the session configuration on the remote computer. Values set for the session take precedence
+over values set in the session configuration, but session values cannot exceed quotas set in the
+session configuration, such as the **MaxIdleTimeoutMs** value.
+
 ```
-The first command uses the New-PSSessionOption cmdlet to create a session option object. It uses the *IdleTimeout* parameter to set an idle time-out of 48 hours (172800000 milliseconds). The command saves the session option object in the $Timeout variable.
-PS C:\> $Timeout = New-PSSessionOption -IdleTimeout 172800000
-
-The second command uses the New-PSSession cmdlet to create the ITTask session on the Server01 computer. The command saves the session in the $s variable. The value of the *SessionOption* parameter is the 48-hour idle time-out in the $Timeout variable.
-PS C:\> $s = New-PSSession -Computer Server01 -Name ITTask -SessionOption $Timeout
-
-The third command disconnects the ITTask session in the $s variable. The command fails because the idle time-out value of the session exceeds the **MaxIdleTimeoutMs** quota in the session configuration. Because the idle time-out is not used until the session is disconnected, this violation can go undetected while the session is being used.
-PS C:\> Disconnect-PSSession -Session $s
+PS> $Timeout = New-PSSessionOption -IdleTimeout 172800000
+PS> $s = New-PSSession -Computer Server01 -Name ITTask -SessionOption $Timeout
+PS> Disconnect-PSSession -Session $s
 Disconnect-PSSession : The session ITTask cannot be disconnected because the specified
 idle timeout value 172800(seconds) is either greater than the server maximum allowed
 43200 (seconds) or less that the minimum allowed60(seconds).  Choose an idle time out
 value that is within the allowed range and try again.
 
-The fourth command uses the Invoke-Command cmdlet to run a Get-PSSessionConfiguration command for the Microsoft.PowerShell session configuration on the Server01 computer. The command uses the Format-List cmdlet to display all properties of the session configuration in a list.The output shows that the **MaxIdleTimeoutMS** property, which establishes the maximum permitted **IdleTimeout** value for sessions that use the session configuration, is 43200000 milliseconds (12 hours).
-PS C:\> Invoke-Command -ComputerName Server01 {Get-PSSessionConfiguration Microsoft.PowerShell} | Format-List -Property *
+PS> Invoke-Command -ComputerName Server01 {Get-PSSessionConfiguration Microsoft.PowerShell} |
+ Format-List -Property *
+
 Architecture                  : 64
 Filename                      : %windir%\system32\pwrshplugin.dll
 ResourceUri                   : http://schemas.microsoft.com/powershell/microsoft.powershell
@@ -191,8 +237,7 @@ RunspaceId                    : aea84310-6dbf-4c21-90ac-13980039925a
 PSShowComputerName            : True
 
 
-The fifth command gets the session option values of the session in the $s variable. The values of many session options are properties of the **ConnectionInfo** property of the **Runspace** property of the session.The output shows that the value of the **IdleTimeout** property of the session is 172800000 milliseconds (48 hours), which violates the **MaxIdleTimeoutMs** quota of 12 hours in the session configuration.To resolve this conflict, you can use the *ConfigurationName* parameter to select a different session configuration or use the *IdleTimeout* parameter to reduce the idle time-out of the session.
-PS C:\> $s.Runspace.ConnectionInfo
+PS> $s.Runspace.ConnectionInfo
 ConnectionUri                     : http://Server01/wsman
 ComputerName                      : Server01
 Scheme                            : http
@@ -224,47 +269,58 @@ CancelTimeout                     : 60000
 OperationTimeout                  : 180000
 IdleTimeout                       : 172800000
 
-The sixth command disconnects the session. It uses the *IdleTimeoutSec* parameter to set the idle time-out to the 12-hour maximum.
-PS C:\> Disconnect-PSSession $s -IdleTimeoutSec 43200
+PS> Disconnect-PSSession $s -IdleTimeoutSec 43200
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
  4 ITTask          Server01        Disconnected  Microsoft.PowerShell          None
 
-The seventh command gets the value of the **IdleTimeout** property of the disconnected session, which is measured in milliseconds. The output confirms that the command was successful.
-PS C:\> $s.Runspace.ConnectionInfo.IdleTimeout
+PS> $s.Runspace.ConnectionInfo.IdleTimeout
 43200000
 ```
 
-This example shows how to correct the value of the **IdleTimeout** property of a session so that it can be disconnected.
+The first command uses the `New-PSSessionOption` cmdlet to create a session option object. It uses
+the **IdleTimeout** parameter to set an idle timeout of 48 hours (172800000 milliseconds). The
+command saves the session option object in the $Timeout variable.
 
-The idle time-out property of a session is critical to disconnected sessions, because it determines how long a disconnected session is maintained before it is deleted.
-You can set the idle time-out option when you create a session and when you disconnect it.
-The default values for the idle time-out of a session are set in the **$PSSessionOption** preference variable on the local computer and in the session configuration on the remote computer.
-Values set for the session take precedence over values set in the session configuration, but session values cannot exceed quotas set in the session configuration, such as the **MaxIdleTimeoutMs** value.
+The second command uses the `New-PSSession` cmdlet to create the ITTask session on the Server01
+computer. The command save the session in the $s variable. The value of the **SessionOption**
+parameter is the 48-hour idle timeout in the $Timeout variable.
+
+The third command disconnects the ITTask session in the $s variable. The command fails because the
+idle timeout value of the session exceeds the **MaxIdleTimeoutMs** quota in the session
+configuration. Because the idle timeout is not used until the session is disconnected, this
+violation can go undetected while the session is in use.
+
+The fourth command uses the `Invoke-Command` cmdlet to run a `Get-PSSessionConfiguration` command
+for the Microsoft.PowerShell session configuration on the Server01 computer. The command uses the
+`Format-List` cmdlet to display all properties of the session configuration in a list.The output
+shows that the **MaxIdleTimeoutMS** property, which establishes the maximum permitted
+**IdleTimeout** value for sessions that use the session configuration, is 43200000 milliseconds (12
+hours).
+
+The fifth command gets the session option values of the session in the $s variable. The values of
+many session options are properties of the **ConnectionInfo** property of the **Runspace** property
+of the session.The output shows that the value of the **IdleTimeout** property of the session is
+172800000 milliseconds (48 hours), which violates the **MaxIdleTimeoutMs** quota of 12 hours in the
+session configuration.To resolve this conflict, you can use the **ConfigurationName** parameter to
+select a different session configuration or use the **IdleTimeout** parameter to reduce the idle
+timeout of the session.
+
+The sixth command disconnects the session. It uses the **IdleTimeoutSec** parameter to set the idle
+timeout to the 12-hour maximum.
+
+The seventh command gets the value of the **IdleTimeout** property of the disconnected session,
+which is measured in milliseconds. The output confirms that the command was successful.
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Id
-Specifies an array of IDs of sessions that this cmdlet disconnects.
-Type one or more IDs, separated by commas, or use the range operator (..) to specify a range of IDs.
 
-To get the ID of a session, use the Get-PSSession cmdlet.
-The instance ID is stored in the **ID** property of the session.
+Disconnects from sessions with the specified session ID. Type one or more IDs (separated by
+commas), or use the range operator (..) to specify a range of IDs.
+
+To get the ID of a session, use the `Get-PSSession` cmdlet. The instance ID is stored in the **ID**
+property of the session.
 
 ```yaml
 Type: Int32[]
@@ -272,28 +328,31 @@ Parameter Sets: Id
 Aliases:
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
 ### -IdleTimeoutSec
-Changes the idle time-out value of the disconnected **PSSession**.
-Enter a value in seconds.
-The minimum value is 60 (1 minute).
 
-The idle time-out determines how long the disconnected **PSSession** is maintained on the remote computer.
-When the time-out expires, the **PSSession** is deleted.
+Changes the idle timeout value of the disconnected PSSession. Enter a value in seconds. The minimum
+value is 60 (1 minute).
 
-Disconnected **PSSession** objects are considered to be idle from the moment that they are disconnected, even if commands are running in the disconnected session.
+The idle timeout determines how long the disconnected PSSession is maintained on the remote
+computer. When the timeout expires, the PSSession is deleted.
 
-The default value for the idle time-out of a session is set by the value of the **IdleTimeoutMs** property of the session configuration.
-The default value is 7200000 milliseconds (2 hours).
+Disconnected PSSessions are considered to be idle from the moment that they are disconnected, even
+if commands are running in the disconnected session.
 
-The value of this parameter takes precedence over the value of the **IdleTimeout** property of the $PSSessionOption preference variable and the default idle time-out value in the session configuration.
-However, this value cannot exceed the value of the **MaxIdleTimeoutMs** property of the session configuration.
-The default value of **MaxIdleTimeoutMs** is 12 hours (43200000 milliseconds).
+The default value for the idle timeout of a session is set by the value of the **IdleTimeoutMs**
+property of the session configuration. The default value is 7200000 milliseconds (2 hours).
+
+The value of this parameter takes precedence over the value of the **IdleTimeout** property of the
+$PSSessionOption preference variable and the default idle timeout value in the session
+configuration. However, this value cannot exceed the value of the **MaxIdleTimeoutMs** property of
+the session configuration. The default value of **MaxIdleTimeoutMs** is 12 hours (43200000
+milliseconds).
 
 ```yaml
 Type: Int32
@@ -302,19 +361,20 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 60
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -InstanceId
-Specifies an array of GUIDs of sessions that this cmdlet disconnects.
 
-The instance ID is a GUID that uniquely identifies a session on a local or remote computer.
-The instance ID is unique, even across multiple sessions on multiple computers.
+Disconnects from sessions with the specified instance IDs.
 
-To get the instance ID of a session, use **Get-PSSession**.
-The instance ID is stored in the **InstanceID** property of the session.
+The instance ID is a GUID that uniquely identifies a session on a local or remote computer. The
+instance ID is unique, even across multiple sessions on multiple computers.
+
+To get the instance ID of a session, use the `Get-PSSession` cmdlet. The instance ID is stored in
+the **InstanceID** property of the session.
 
 ```yaml
 Type: Guid[]
@@ -329,11 +389,11 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of friendly names of sessions that this cmdlet disconnects.
-Wildcard characters are permitted.
 
-To get the friendly name of a session, use **Get-PSSession**.
-The friendly name is stored in the **Name** property of the session.
+Disconnects from sessions with the specified friendly names. Wildcards are permitted.
+
+To get the friendly name of a session, use the `Get-PSSession` cmdlet. The friendly name is stored
+in the **Name** property of the session.
 
 ```yaml
 Type: String[]
@@ -347,43 +407,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -OutputBufferingMode
-Specifies how command output is managed in the disconnected session when the output buffer is full.
-The default value is Block.
-
-If the command in the disconnected session is returning output and the output buffer fills, the value of this parameter effectively determines whether the command continues to run while the session is disconnected.
-A value of Block suspends the command until the session is reconnected.
-A value of Drop allows the command to complete, although data might be lost.
-When using the Drop value, redirect the command output to a file on disk.
-
-The acceptable values for this parameter are:
-
-- Block. When the output buffer is full, execution is suspended until the buffer is clear.
-- Drop. When the output buffer is full, execution continues. As new output is saved, the oldest output is discarded.
-- None. No output buffering mode is specified. The value of the *OutputBufferingMode* property of the session configuration is used for the disconnected session.
-
-```yaml
-Type: OutputBufferingMode
-Parameter Sets: (All)
-Aliases:
-Accepted values: None, Drop, Block
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Session
-Specifies an array of sessions.
-Enter **PSSession** objects, such as those that the **New-PSSession** cmdlet returns.
-You can also pipe a **PSSession** object to Disconnect-PSSession.
 
-**Get-PSSession** can get all **PSSession** objects that end at a remote computer.
-These include **PSSession** objects that are disconnected and **PSSession** objects that are connected to other sessions on other computers.
-**Disconnect-PSSession** disconnects only **PSSession** that are connected to the current session.
-If you pipe other **PSSession** objects to **Disconnect-PSSession**, the **Disconnect-PSSession** command fails.
+Disconnects from the specified PSSessions. Enter PSSession objects, such as those that the
+`New-PSSession` cmdlet returns. You can also pipe a PSSession object to `Disconnect-PSSession`.
+
+The `Get-PSSession` cmdlet can get all PSSessions that terminate at a remote computer, including
+PSSessions that are disconnected and PSSessions that are connected to other sessions on other
+computers. `Disconnect-PSSession` disconnects only PSSession that are connected to the current
+session. If you pipe other PSSessions to `Disconnect-PSSession`, the `Disconnect-PSSession` command
+fails.
 
 ```yaml
 Type: PSSession[]
@@ -391,17 +424,18 @@ Parameter Sets: Session
 Aliases:
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Sets the throttle limit for the **Disconnect-PSSession** command.
 
-The throttle limit is the maximum number of concurrent connections that can be established to run this command.
-If you omit this parameter or enter a value of 0, the default value, 32, is used.
+Sets the throttle limit for the `Disconnect-PSSession` command.
+
+The throttle limit is the maximum number of concurrent connections that can be established to run
+this command. If you omit this parameter or enter a value of 0, the default value, 32, is used.
 
 The throttle limit applies only to the current command, not to the session or to the computer.
 
@@ -412,12 +446,60 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 32
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputBufferingMode
+
+Determines how command output is managed in the disconnected session when the output buffer is
+full. The default value is **Block**.
+
+If the command in the disconnected session is returning output and the output buffer fills, the
+value of this parameter effectively determines whether the command continues to run while the
+session is disconnected. A value of **Block** suspends the command until the session is
+reconnected. A value of **Drop** allows the command to complete, although data might be lost. When
+using the **Drop** value, redirect the command output to a file on disk.
+
+Valid values are:
+
+- **Block**: When the output buffer is full, execution is suspended until the buffer is clear.
+- **Drop**: When the output buffer is full, execution continues. As new output is saved, the oldest
+  output is discarded.
+- **None**: No output buffering mode is specified. The value of the **OutputBufferingMode** property
+  of the session configuration is used for the disconnected session.
+
+```yaml
+Type: OutputBufferingMode
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Block
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -434,36 +516,51 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### System.Management.Automation.Runspaces.PSSession
-You can pipe a session to this cmdlet.
+
+You can pipe a session to `Disconnect-PSSession`.
 
 ## OUTPUTS
 
 ### System.Management.Automation.Runspaces.PSSession
-This cmdlet returns an object that represents the session that it disconnected.
+
+`Disconnect-PSSession` returns an object that represents the session that it disconnected.
 
 ## NOTES
-* The **Disconnect-PSSession** cmdlet works only when the local and remote computers are running Windows PowerShell 3.0 or later versions of Windows PowerShell.
-* If you use **Disconnect-PSSession** on a disconnected session, the command does not affect the session and it does not generate errors.
-* Disconnected loopback sessions with interactive security tokens, which are created by using the *EnableNetworkAccess* parameter, can be reconnected only from the computer on which the session was created. This restriction protects the computer from malicious access.
-* When you disconnect a **PSSession**, the session state is **Disconnected** and the availability is **None**.
 
-  The value of the **State** property is relative to the current session.
-Therefore, a value of **Disconnected** means that the **PSSession** is not connected to the current session.
-However, it does not mean that the **PSSession** is disconnected from all sessions.
-It might be connected to a different session.
-To determine whether you can connect or reconnect to the session, use the **Availability** property.
+- The `Disconnect-PSSession` cmdlet works only when the local and remote computers are running
+  PowerShell 3.0 or later.
+- If you use the `Disconnect-PSSession` cmdlet on a disconnected session, the command has no effect
+  on the session and it does not generate errors.
+- Disconnected loopback sessions with interactive security tokens (those created with the
+  **EnableNetworkAccess** parameter) can be reconnected only from the computer on which the session
+  was created. This restriction protects the computer from malicious access.
+- When you disconnect a PSSession, the session state is **Disconnected** and the availability is
+  **None**.
 
-  An **Availability** value of **None** indicates that you can connect to the session.
-A value of **Busy** indicates that you cannot connect to the **PSSession** because it is connected to another session.
+  The value of the **State** property is relative to the current session. Therefore, a value of
+  **Disconnected** means that the PSSession is not connected to the current session. However, it
+  does not mean that the PSSession is disconnected from all sessions. It might be connected to a
+  different session. To determine whether you can connect or reconnect to the session, use the
+  **Availability** property.
 
-  For more information about the values of the **State** property of sessions, see [RunspaceState Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspacestate) in the MSDN library.
+  An **Availability** value of **None** indicates that you can connect to the session. A value of
+  **Busy** indicates that you cannot connect to the PSSession because it is connected to another
+  session.
 
-  For more information about the values of the **Availability** property of sessions, see [RunspaceAvailability Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspaceavailability) in the MSDN library.
+  For more information about the values of the **State** property of sessions, see
+  [RunspaceState Enumeration](/dotnet/api/system.management.automation.runspaces.runspacestate).
+
+  For more information about the values of the **Availability** property of sessions, see
+  [RunspaceAvailability Enumeration](/dotnet/api/system.management.automation.runspaces.runspaceavailability).
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -29,8 +29,10 @@ Provides access to the registry keys, entries, and values in PowerShell.
 The PowerShell **Registry** provider lets you get, add, change,
 clear, and delete registry keys, entries, and values in PowerShell.
 
-The **Registry** drives are a hierarchical namespace containing the registry keys and subkeys on your computer. Registry entries and values are not
-components of that hierarchy. Instead, they are properties of each of the keys.
+The **Registry** drives are a hierarchical namespace containing the registry
+keys and subkeys on your computer. Registry entries and values are not
+components of that hierarchy. Instead, they are properties of each of the
+keys.
 
 The **Registry** provider supports the following cmdlets, which are covered
 in this article.
@@ -77,7 +79,8 @@ Set-Location C:
 
 You can also work with the **Registry** provider from any other PowerShell
 drive. To reference a registry key from another location, use the drive name
-(`HKLM:`, `HKCU:`) in the path. Use a backslash (\\) or a forward slash (/) to indicate a level of the **Registry** drive.
+(`HKLM:`, `HKCU:`) in the path. Use a backslash (\\) or a forward slash (/) to
+indicate a level of the **Registry** drive.
 
 ```powershell
 PS C:\> cd HKLM:\Software
@@ -87,13 +90,13 @@ PS C:\> cd HKLM:\Software
 > PowerShell uses aliases to allow you a familiar way to work with provider
 > paths. Commands such as `dir` and `ls` are now aliases for
 > [Get-ChildItem](../../Microsoft.PowerShell.Management/Get-ChildItem.md),
-> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md). and `pwd` is
-> an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
+> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md)
+> and `pwd` is an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
 
 This last example shows another path syntax you can use to navigate the
 **Registry** provider. This syntax uses the provider name, followed by two
-colons `::`.  This syntax allows you to use the full HIVE name, instead
-of the mapped drive name `HKLM`.
+colons `::`. This syntax allows you to use the full HIVE name, instead of the
+mapped drive name `HKLM`.
 
 ```powershell
 cd "Registry::HKEY_LOCAL_MACHINE\Software"
@@ -101,7 +104,8 @@ cd "Registry::HKEY_LOCAL_MACHINE\Software"
 
 ## Displaying the contents of registry keys
 
-The registry is divided into keys, subkeys, and entries.  For more information about registry structure, see [Structure of the Registry](/windows/desktop/sysinfo/structure-of-the-registry.md).
+The registry is divided into keys, subkeys, and entries. For more information
+about registry structure, see [Structure of the Registry](/windows/desktop/sysinfo/structure-of-the-registry.md).
 
 In a **Registry** drive, each key is a container. A key can contain any number
 of keys. A registry key that has a parent key is called a subkey. You can
@@ -113,7 +117,8 @@ they are called **Item Properties**. A registry key can have both children
 keys and item properties.
 
 In this example, the difference between `Get-Item` and `Get-ChildItem` is
-shown. When you use `Get-Item` on the "Spooler" registry key, you can view its properties.
+shown. When you use `Get-Item` on the "Spooler" registry key, you can view its
+properties.
 
 ```
 PS C:\ > Get-Item -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
@@ -122,21 +127,21 @@ PS C:\ > Get-Item -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services
 
 
-Name                           Property
-----                           --------
-Spooler                        DependOnService    : {RPCSS, http}
-                               Description        : @%systemroot%\system32\spoolsv.exe,-2
-                               DisplayName        : @%systemroot%\system32\spoolsv.exe,-1
-                               ErrorControl       : 1
-                               FailureActions     : {16, 14, 0, 0...}
-                               Group              : SpoolerGroup
-                               ImagePath          : C:\WINDOWS\System32\spoolsv.exe
-                               ObjectName         : LocalSystem
-                               RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege, SeAuditPrivilege,
-                               SeChangeNotifyPrivilege...}
-                               ServiceSidType     : 1
-                               Start              : 2
-                               Type               : 272
+Name        Property
+----        --------
+Spooler     DependOnService    : {RPCSS, http}
+            Description        : @%systemroot%\system32\spoolsv.exe,-2
+            DisplayName        : @%systemroot%\system32\spoolsv.exe,-1
+            ErrorControl       : 1
+            FailureActions     : {16, 14, 0, 0...}
+            Group              : SpoolerGroup
+            ImagePath          : C:\WINDOWS\System32\spoolsv.exe
+            ObjectName         : LocalSystem
+            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege,
+            SeAuditPrivilege, SeChangeNotifyPrivilege...}
+            ServiceSidType     : 1
+            Start              : 2
+            Type               : 27
 ```
 
 Each registry key can also have subkeys. When you use `Get-Item` on a registry
@@ -151,16 +156,16 @@ PS C:\> Get-ChildItem -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Spooler
 
 
-Name                           Property
-----                           --------
-Performance                    Close           : PerfClose
-                               Collect         : PerfCollect
-                               Collect Timeout : 2000
-                               Library         : C:\Windows\System32\winspool.drv
-                               Object List     : 1450
-                               Open            : PerfOpen
-                               Open Timeout    : 4000
-Security                       Security : {1, 0, 20, 128...}
+Name             Property
+----             --------
+Performance      Close           : PerfClose
+                 Collect         : PerfCollect
+                 Collect Timeout : 2000
+                 Library         : C:\Windows\System32\winspool.drv
+                 Object List     : 1450
+                 Open            : PerfOpen
+                 Open Timeout    : 4000
+Security         Security : {1, 0, 20, 128...}
 ```
 
 The `Get-Item` cmdlet can also be used on the current location. The following
@@ -173,10 +178,10 @@ PS HKLM:\SYSTEM\CurrentControlSet\Services\Spooler> Get-Item .
 
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services
 
-Name                           Property
-----                           --------
-Spooler                        DependOnService    : {RPCSS, http}
-                               Description        : @%systemroot%\system32\spoolsv.exe,-2
+Name             Property
+----             --------
+Spooler          DependOnService    : {RPCSS, http}
+                 Description        : @%systemroot%\system32\spoolsv.exe,-2
 ...
 ```
 
@@ -188,8 +193,10 @@ articles.
 
 ## Viewing registry key values
 
-Registry key values are stored as properties of each registry key. The `Get-ItemProperty` cmdlet views registry key properties using the name you specify. The result is a **PSCustom** object containing the
-properties you specify.
+Registry key values are stored as properties of each registry key. The
+`Get-ItemProperty` cmdlet views registry key properties using the name you
+specify. The result is a **PSCustom** object containing the properties you
+specify.
 
 The Following example uses the `Get-ItemProperty` cmdlet to view all
 properties. Storing the resulting object in a variable allows you to access
@@ -250,7 +257,10 @@ articles.
 
 ## Changing registry key values
 
-The `Set-ItemProperty` cmdlet will set attributes for registry keys. The following example uses `Set-ItemProperty` to change the spooler service start type to manual. The example changes the **StartType** back to *Automatic* using the `Set-Service` cmdlet.
+The `Set-ItemProperty` cmdlet will set attributes for registry keys. The
+following example uses `Set-ItemProperty` to change the spooler service start
+type to manual. The example changes the **StartType** back to *Automatic*
+using the `Set-Service` cmdlet.
 
 ```
 PS C:\> Get-Service spooler | Select-Object Name, StartMode
@@ -274,7 +284,8 @@ Each registry key has a *default* value. You can change the *default* value
 for a registry key with either `Set-Item` or `Set-ItemProperty`.
 
 ```powershell
-Set-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name "(default)" -Value "one" Set-Item -Path HKLM:\SOFTWARE\Contoso -Value "two"
+Set-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name "(default)" -Value "one"
+Set-Item -Path HKLM:\SOFTWARE\Contoso -Value "two"
 ```
 
 For more information on the cmdlets used in this section, see the following
@@ -299,9 +310,9 @@ Name                           Property
 ContosoCompany
 ```
 
-You can use the `New-ItemProperty` cmdlet to create to **Item Properties**
-on a registry key that you specify. The following example creates a new
-DWORD value on the ContosoCompany registry key.
+You can use the `New-ItemProperty` cmdlet to create to **Item Properties** on
+a registry key that you specify. The following example creates a new DWORD
+value on the ContosoCompany registry key.
 
 ```powershell
 $path = "HKLM:\SOFTWARE\ContosoCompany"
@@ -316,7 +327,10 @@ For detailed cmdlet usage, see [New-ItemProperty](../../Microsoft.PowerShell.Man
 
 ## Copying registry keys and values
 
-In the **Registry** provider, use the `Copy-Item` cmdlet copies registry keys and values. Use the `Copy-ItemProperty` cmdlet to copy registry values only. The following command copies the "Contoso" registry key, and its properties to the specified location "HKLM:\Software\Fabrikam".
+In the **Registry** provider, use the `Copy-Item` cmdlet copies registry keys
+and values. Use the `Copy-ItemProperty` cmdlet to copy registry values only.
+The following command copies the "Contoso" registry key, and its properties to
+the specified location "HKLM:\Software\Fabrikam".
 
 `Copy-Item` creates the destination key if it does not exist. If the
 destination key exists, `Copy-Item` creates a duplicate of the source key
@@ -344,9 +358,9 @@ articles.
 ## Moving registry keys and values
 
 The `Move-Item` and `Move-ItemProperty` cmdlets behave like their "Copy"
-counterparts. If the destination exists, `Move-Item` moves the source
-key underneath the destination key. If the destination key does not exist,
-the source key is moved to the destination path.
+counterparts. If the destination exists, `Move-Item` moves the source key
+underneath the destination key. If the destination key does not exist, the
+source key is moved to the destination path.
 
 The following command moves the "Contoso" key to the path
 "HKLM:\SOFTWARE\Fabrikam".
@@ -403,7 +417,8 @@ For more examples and cmdlet usage details see the following articles.
 
 ## Removing and clearing registry keys and values
 
-You can remove contained items by using **Remove-Item**, but you will be prompted to confirm the removal if the item contains anything else. The
+You can remove contained items by using **Remove-Item**, but you will be
+prompted to confirm the removal if the item contains anything else. The
 following example attempts to delete a key "HKLM:\SOFTWARE\Contoso".
 
 ```
@@ -419,8 +434,8 @@ PS C:\> Remove-Item -Path HKLM:\SOFTWARE\Contoso
 
 Confirm
 The item at HKLM:\SOFTWARE\Contoso has children and the -Recurse
-parameter was not specified. If you continue, all children will be removed with
- the item. Are you sure you want to continue?
+parameter was not specified. If you continue, all children will be removed
+with the item. Are you sure you want to continue?
 [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help
 (default is "Y"):
 ```
@@ -431,14 +446,16 @@ To delete contained items without prompting, specify the `-Recurse` parameter.
 Remove-Item -Path HKLM:\SOFTWARE\Contoso -Recurse
 ```
 
-If you wanted to remove all items within "HKLM:\SOFTWARE\Contoso" but not "HKLM:\SOFTWARE\Contoso" itself, use a trailing backslash `\` followed by a
+If you wanted to remove all items within "HKLM:\SOFTWARE\Contoso" but not
+"HKLM:\SOFTWARE\Contoso" itself, use a trailing backslash `\` followed by a
 wildcard.
 
 ```powershell
 Remove-Item -Path HKLM:\SOFTWARE\Contoso\* -Recurse
 ```
 
-This command deletes the "ContosoTest" registry value from the "HKLM:\SOFTWARE\Contoso" registry key.
+This command deletes the "ContosoTest" registry value from the
+"HKLM:\SOFTWARE\Contoso" registry key.
 
 ```powershell
 Remove-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name ContosoTest
@@ -453,12 +470,12 @@ PS HKLM:\SOFTWARE\> Get-Item .\Contoso\
 
     Hive: HKEY_LOCAL_MACHINE\SOFTWARE
 
-Name                           Property
-----                           --------
-Contoso                        Server     : {a, b, c}
-                               HereString : {This is text which contains
-                                            newlines. It also contains "quoted" strings}
-                               (default)  : 1
+Name           Property
+----           --------
+Contoso        Server     : {a, b, c}
+               HereString : {This is text which contains
+               newlines. It also contains "quoted" strings}
+               (default)  : 1
 
 PS HKLM:\SOFTWARE\> Clear-Item .\Contoso\
 PS HKLM:\SOFTWARE\> Get-Item .\Contoso\
@@ -479,23 +496,33 @@ For more examples and cmdlet usage details see the following articles.
 
 ## Dynamic parameters
 
-Dynamic parameters are cmdlet parameters that are added by a PowerShell provider and are available only when the cmdlet is being used in the provider-enabled drive.
+Dynamic parameters are cmdlet parameters that are added by a PowerShell
+provider and are available only when the cmdlet is being used in the
+provider-enabled drive.
 
 ### Type <Microsoft.Win32.RegistryValueKind>
 
 Establishes or changes the data type of a registry value. The default is `String` (REG_SZ).
 
-This parameter works as designed on the [Set-ItemProperty](../../Microsoft.PowerShell.Management/Set-ItemProperty.md) cmdlet. It is also available on the [Set-Item](../../Microsoft.PowerShell.Management/Set-Item.md) cmdlet in the registry drives, but it has no effect.
+This parameter works as designed on the
+[Set-ItemProperty](../../Microsoft.PowerShell.Management/Set-ItemProperty.md)
+cmdlet. It is also available on the
+[Set-Item](../../Microsoft.PowerShell.Management/Set-Item.md) cmdlet in the
+registry drives, but it has no effect.
 
-|Value|Description|
-|-----------|-----------------|
-|  `String` | Specifies a null-terminated string. Equivalent to REG_SZ. |
-|  `ExpandString` | Specifies a null-terminated string that contains unexpanded references to environment variables that are expanded when the value is retrieved. Equivalent to REG_EXPAND_SZ. |
-|  `Binary` | Specifies binary data in any form. Equivalent to REG_BINARY. |
-|  `DWord` | Specifies a 32-bit binary number. Equivalent to REG_DWORD. |
-|  `MultiString` | Specifies an array of null-terminated strings terminated by two null characters. Equivalent to REG_MULTI_SZ. |
-|  `QWord` | Specifies a 64-bit binary number. Equivalent to REG_QWORD. |
-|  `Unknown` | Indicates an unsupported registry data type, such as REG_RESOURCE_LIST. |
+|Value | Description |
+| ---- | ----------- |
+| `String` | Specifies a null-terminated string. Equivalent to REG_SZ. |
+| `ExpandString` | Specifies a null-terminated string that contains unexpanded |
+|                | references to environment variables that are expanded when |
+|                | the value is retrieved. Equivalent to REG_EXPAND_SZ. |
+| `Binary` | Specifies binary data in any form. Equivalent to REG_BINARY. |
+| `DWord` | Specifies a 32-bit binary number. Equivalent to REG_DWORD. |
+| `MultiString` | Specifies an array of null-terminated strings terminated by |
+|               | two null characters. Equivalent to REG_MULTI_SZ. |
+| `QWord` | Specifies a 64-bit binary number. Equivalent to REG_QWORD. |
+| `Unknown` | Indicates an unsupported registry data type, such as |
+|           | REG_RESOURCE_LIST. |
 
 #### Cmdlets supported
 
@@ -505,9 +532,9 @@ This parameter works as designed on the [Set-ItemProperty](../../Microsoft.Power
 ## Using the pipeline
 
 Provider cmdlets accept pipeline input. You can use the pipeline to simplify
-task by sending provider data from one cmdlet to another provider cmdlet.
-To read more about how to use the pipeline with provider cmdlets, see the
-cmdlet references provided throughout this article.
+task by sending provider data from one cmdlet to another provider cmdlet. To
+read more about how to use the pipeline with provider cmdlets, see the cmdlet
+references provided throughout this article.
 
 ## Getting help
 
@@ -515,8 +542,8 @@ Beginning in Windows PowerShell 3.0, you can get customized help topics for
 provider cmdlets that explain how those cmdlets behave in a file system drive.
 
 To get the help topics that are customized for the file system drive, run a
-[Get-Help](../Get-Help.md) command in a file system drive or use the `-Path`
-parameter of [Get-Help](../Get-Help.md) to specify a file system drive.
+`Get-Help` command in a file system drive or use the `-Path` parameter to
+specify a file system drive.
 
 ```powershell
 Get-Help Get-ChildItem

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -90,7 +90,7 @@ PS C:\> cd HKLM:\Software
 > PowerShell uses aliases to allow you a familiar way to work with provider
 > paths. Commands such as `dir` and `ls` are now aliases for
 > [Get-ChildItem](../../Microsoft.PowerShell.Management/Get-ChildItem.md),
-> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md)
+> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md),
 > and `pwd` is an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
 
 This last example shows another path syntax you can use to navigate the
@@ -137,8 +137,7 @@ Spooler     DependOnService    : {RPCSS, http}
             Group              : SpoolerGroup
             ImagePath          : C:\WINDOWS\System32\spoolsv.exe
             ObjectName         : LocalSystem
-            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege,
-            SeAuditPrivilege, SeChangeNotifyPrivilege...}
+            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege, ...
             ServiceSidType     : 1
             Start              : 2
             Type               : 27
@@ -195,7 +194,7 @@ articles.
 
 Registry key values are stored as properties of each registry key. The
 `Get-ItemProperty` cmdlet views registry key properties using the name you
-specify. The result is a **PSCustom** object containing the properties you
+specify. The result is a **PSCustomObject** containing the properties you
 specify.
 
 The Following example uses the `Get-ItemProperty` cmdlet to view all
@@ -310,9 +309,9 @@ Name                           Property
 ContosoCompany
 ```
 
-You can use the `New-ItemProperty` cmdlet to create to **Item Properties** on
-a registry key that you specify. The following example creates a new DWORD
-value on the ContosoCompany registry key.
+You can use the `New-ItemProperty` cmdlet to create values in a registry key
+that you specify. The following example creates a new DWORD value on the
+ContosoCompany registry key.
 
 ```powershell
 $path = "HKLM:\SOFTWARE\ContosoCompany"
@@ -542,7 +541,7 @@ Beginning in Windows PowerShell 3.0, you can get customized help topics for
 provider cmdlets that explain how those cmdlets behave in a file system drive.
 
 To get the help topics that are customized for the file system drive, run a
-`Get-Help` command in a file system drive or use the `-Path` parameter to
+`Get-Help` command in a file system drive or use the **Path** parameter to
 specify a file system drive.
 
 ```powershell

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -166,7 +166,7 @@ creates firewall rules that allows remote access from the same local subnet.
 
 On client versions of Windows, `Enable-PSRemoting` succeeds on private and
 domain networks. By default, it fails on public networks, but if
-you use the SkipNetworkProfileCheck parameter, `Enable-PSRemoting` succeeds
+you use the **SkipNetworkProfileCheck** parameter, `Enable-PSRemoting` succeeds
 and creates a firewall rule that allows traffic from the same local subnet.
 
 To remove the local subnet restriction on public networks and allow
@@ -279,8 +279,8 @@ Get-Item wsman:\localhost\Service\RootSDDL
 
 To change the RootSDDL, use the `Set-Item` cmdlet in the WSMan: drive. To
 change the security descriptor of a session configuration, use the
-`Set-PSSessionConfiguration` cmdlet with the SecurityDescriptorSDDL or
-ShowSecurityDescriptorUI parameters.
+`Set-PSSessionConfiguration` cmdlet with the **SecurityDescriptorSDDL** or
+**ShowSecurityDescriptorUI** parameters.
 
 For more information about the WSMan: drive, see the Help topic for the
 WSMan provider ("Get-Help wsman").
@@ -308,8 +308,8 @@ Administrator.
 Invoke-Command -ComputerName Server01 -Credential Domain01\Admin01
 ```
 
-For more information about the Credential parameter, see `New-PSSession`,
-`Enter-PSSession` or `Invoke-Command`.
+For more information about the **Credential** parameter, see [New-PSSession](../New-PSSession.md),
+[Enter-PSSession](../Enter-PSSession.md) or [Invoke-Command](../Invoke-Command.md).
 
 ### HOW TO ENABLE REMOTING FOR NON-ADMINISTRATIVE USERS
 
@@ -737,8 +737,8 @@ Set-PSSessionConfiguration -Name microsoft.PowerShell `
 For more information about the `New-PSSessionOption` cmdlet, see
 `New-PSSessionOption`.
 
-For more information about the WS-Management quotas, see the Help topic for
-the WSMan provider (type `Get-Help WSMan`).
+For more information about the WS-Management quotas, see
+[about_WSMan_Provider](../../Microsoft.WsMan.Management/About/about_WSMan_Provider.md).
 
 ### HOW TO RESOLVE TIMEOUT ERRORS
 

--- a/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -18,15 +18,16 @@ This section describes some of the problems that you might encounter when
 using the remoting features of PowerShell that are based on
 WS-Management technology and it suggests solutions to these problems.
 
-Before using PowerShell remoting, see about_Remote and
-about_Remote_Requirements for guidance on configuration and basic use Also,
-the Help topics for each of the remoting cmdlets, particularly the parameter
-descriptions, have useful information that is designed to help you avoid
-problems.
+Before using PowerShell remoting, see [about_Remote](about_remote.md) and
+[about_Remote_Requirements](about_Remote_Requirements.md) for guidance on
+configuration and basic use. Also, the Help topics for each of the remoting
+cmdlets, particularly the parameter descriptions, have useful information that
+is designed to help you avoid problems.
 
-NOTE: To view or change settings for the local computer in the WSMan: drive,
-including changes to the session configurations, trusted hosts, ports, or
-listeners, start PowerShell with the "Run as administrator" option.
+> [!NOTE]
+> To view or change settings for the local computer in the WSMan: drive,
+> including changes to the session configurations, trusted hosts, ports, or
+> listeners, start PowerShell with the "Run as administrator" option.
 
 ## TROUBLESHOOTING PERMISSION AND AUTHENTICATION ISSUES
 
@@ -54,11 +55,12 @@ To start Windows PowerShell with the "Run as administrator option:
 - In the Windows taskbar, right-click the Windows PowerShell icon, and then
   click "Run as Administrator."
 
-  Note: In Windows Server 2008 R2, the Windows PowerShell icon is pinned
-  to the taskbar by default.
+  In Windows Server 2008 R2, the Windows PowerShell icon is pinned to the
+  taskbar by default.
 
 ### HOW TO ENABLE REMOTING
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -66,6 +68,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 No configuration is required to enable a computer to send remote
 commands. However, to receive remote commands, PowerShell remoting
@@ -76,25 +79,26 @@ session configurations.
 
 Windows PowerShell remoting is enabled on Windows Server 2012 and newer
 releases of Windows Server by default. On all other systems, run the
-Enable-PSRemoting cmdlet to enable remoting. You can also run the
-Enable-PSRemoting cmdlet to re-enable remoting on Windows Server 2012 and
+`Enable-PSRemoting` cmdlet to enable remoting. You can also run the
+`Enable-PSRemoting` cmdlet to re-enable remoting on Windows Server 2012 and
 newer releases of Windows Server if remoting is disabled.
 
 To configure a computer to receive remote commands, use the
-Enable-PSRemoting cmdlet. The following command enables all required
+`Enable-PSRemoting` cmdlet. The following command enables all required
 remote settings, enables the session configurations, and restarts the
 WinRM service to make the changes effective.
 
-Enable-PSRemoting
+`Enable-PSRemoting`
 
 To suppress all user prompts, type:
 
-Enable-PSRemoting -Force
+`Enable-PSRemoting -Force`
 
-For more information, see Enable-PSRemoting.
+For more information, see [Enable-PSRemoting](../Enable-PSRemoting.md).
 
 ### HOW TO ENABLE REMOTING IN AN ENTERPRISE
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -102,9 +106,10 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 To enable a single computer to receive remote PowerShell commands
-and accept connections, use the Enable-PSRemoting cmdlet.
+and accept connections, use the `Enable-PSRemoting` cmdlet.
 
 To enable remoting for multiple computers in an enterprise, you can use the
 following scaled options.
@@ -114,7 +119,7 @@ following scaled options.
   Enable Listeners by Using a Group Policy" (below).
 
 - To set the startup type of the Windows Remote Management (WinRM)
-  to Automatic on multiple computers, use the Set-Service cmdlet. For
+  to Automatic on multiple computers, use the `Set-Service` cmdlet. For
   instructions, see "How to Set the Startup Type of the WinrM Service"
   (below).
 
@@ -124,6 +129,7 @@ following scaled options.
 
 ### HOW TO ENABLE LISTENERS BY USING A GROUP POLICY
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -131,6 +137,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to listen
 for requests on the correct port and HTTP URL.
+```
 
 To configure the listeners for all computers in a domain, enable the "Allow
 automatic configuration of listeners" policy in the following Group Policy
@@ -144,20 +151,22 @@ permitted.
 
 ### HOW TO ENABLE REMOTING ON PUBLIC NETWORKS
 
+```
 ERROR:  Unable to check the status of the firewall
+```
 
-The Enable-PSRemoting cmdlet returns this error when the local network
+The `Enable-PSRemoting` cmdlet returns this error when the local network
 is public and the SkipNetworkProfileCheck parameter is not used in the
 command.
 
-On server versions of Windows, Enable-PSRemoting succeeds on all network
+On server versions of Windows, `Enable-PSRemoting` succeeds on all network
 location types. It creates firewall rules that allow remote access to
 private and domain ("Home" and "Work") networks. For public networks, it
 creates firewall rules that allows remote access from the same local subnet.
 
-On client versions of Windows, Enable-PSRemoting succeeds on private and
+On client versions of Windows, `Enable-PSRemoting` succeeds on private and
 domain networks. By default, it fails on public networks, but if
-you use the SkipNetworkProfileCheck parameter, Enable-PSRemoting succeeds
+you use the SkipNetworkProfileCheck parameter, `Enable-PSRemoting` succeeds
 and creates a firewall rule that allows traffic from the same local subnet.
 
 To remove the local subnet restriction on public networks and allow
@@ -167,16 +176,18 @@ remote access from any location, run the following command:
 Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP-PUBLIC" -RemoteAddress Any
 ```
 
-The Set-NetFirewallRule cmdlet is exported by the NetSecurity module.
+The `Set-NetFirewallRule` cmdlet is exported by the NetSecurity module.
 
-NOTE: In Windows PowerShell 2.0, on computers running server versions
-of Windows, Enable-PSRemoting creates firewall rules that allow remote
-access on private, domain and public networks. On computers running
-client versions of Windows, Enable-PSRemoting creates firewall rules
-that allow remote access only on private and domain networks.
+> [!NOTE]
+> In Windows PowerShell 2.0, on computers running server versions
+> of Windows, `Enable-PSRemoting` creates firewall rules that allow remote
+> access on private, domain and public networks. On computers running
+> client versions of Windows, `Enable-PSRemoting` creates firewall rules
+> that allow remote access only on private and domain networks.
 
 ### HOW TO ENABLE A FIREWALL EXCEPTION BY USING A GROUP POLICY
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -184,6 +195,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 To enable a firewall exception for in all computers in a domain, enable the
 "Windows Firewall: Allow local port exceptions" policy in the following
@@ -198,7 +210,9 @@ the Windows Remote Management service.
 
 ### HOW TO SET THE STARTUP TYPE OF THE WINRM SERVICE
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 PowerShell remoting depends upon the Windows Remote Management
 (WinRM) service. The service must be running to support remote commands.
@@ -210,7 +224,7 @@ However, on client versions of Windows, the WinRM service is disabled
 by default.
 
 To set the startup type of a service on a remote computer, use the
-Set-Service cmdlet.
+`Set-Service` cmdlet.
 
 To run the command on multiple computers, you can create a text file or
 CSV file of the computer names.
@@ -220,38 +234,42 @@ Servers.txt file and then sets the startup type of the WinRM service on all
 of the computers to Automatic.
 
 ```powershell
-C:\PS> $servers = Get-Content servers.txt
-C:\PS> Set-Service WinRM -ComputerName $servers -startuptype Automatic
+$servers = Get-Content servers.txt
+Set-Service WinRM -ComputerName $servers -startuptype Automatic
 ```
 
-To see the results use the Get-WMIObject cmdlet with the Win32_Service object.
-For more information, see Set-Service.
+To see the results use the `Get-WMIObject` cmdlet with the **Win32_Service**
+object. For more information, see
+[Set-Service](../../Microsoft.PowerShell.Management/Set-Service.md).
 
 ### HOW TO RECREATE THE DEFAULT SESSION CONFIGURATIONS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To connect to the local computer and run commands remotely, the local
 computer must include session configurations for remote commands.
 
-When you use Enable-PSRemoting, it creates default session configurations
+When you use `Enable-PSRemoting`, it creates default session configurations
 on the local computer. Remote users use these session configurations
 whenever a remote command does not include the ConfigurationName parameter.
 
 If the default configurations on a computer are unregistered or deleted,
-use the Enable-PSRemoting cmdlet to recreate them. You can use this cmdlet
+use the `Enable-PSRemoting` cmdlet to recreate them. You can use this cmdlet
 repeatedly. It does not generate errors if a feature is already configured.
 
 If you change the default session configurations and want to restore the
 original default session configurations, use the
-Unregister-PSSessionConfiguration cmdlet to delete the changed session
-configurations and then use the Enable-PSRemoting cmdlet to restore them.
-Enable-PSRemoting does not change existing session configurations.
+`Unregister-PSSessionConfiguration` cmdlet to delete the changed session
+configurations and then use the `Enable-PSRemoting` cmdlet to restore them.
+`Enable-PSRemoting` does not change existing session configurations.
 
-Note: When Enable-PSRemoting restores the default session configuration, it
-does not create explicit security descriptors for the configurations.
-Instead, the configurations inherit the security descriptor of the RootSDDL,
-which is secure by default.
+> [!NOTE]
+> When `Enable-PSRemoting` restores the default session configuration, it
+> does not create explicit security descriptors for the configurations.
+> Instead, the configurations inherit the security descriptor of the
+> RootSDDL, which is secure by default.
 
 To see the RootSDDL security descriptor, type:
 
@@ -259,9 +277,9 @@ To see the RootSDDL security descriptor, type:
 Get-Item wsman:\localhost\Service\RootSDDL
 ```
 
-To change the RootSDDL, use the Set-Item cmdlet in the WSMan: drive. To
+To change the RootSDDL, use the `Set-Item` cmdlet in the WSMan: drive. To
 change the security descriptor of a session configuration, use the
-Set-PSSessionConfiguration cmdlet with the SecurityDescriptorSDDL or
+`Set-PSSessionConfiguration` cmdlet with the SecurityDescriptorSDDL or
 ShowSecurityDescriptorUI parameters.
 
 For more information about the WSMan: drive, see the Help topic for the
@@ -269,7 +287,9 @@ WSMan provider ("Get-Help wsman").
 
 ### HOW TO PROVIDE ADMINISTRATOR CREDENTIALS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To create a PSSession or run commands on a remote computer, by default, the
 current user must be a member of the Administrators group on the remote
@@ -278,8 +298,8 @@ logged on to an account that is a member of the Administrators group.
 
 If the current user is a member of the Administrators group on the remote
 computer, or can provide the credentials of a member of the Administrators
-group, use the Credential parameter of the New-PSSession, Enter-PSSession
-or Invoke-Command cmdlets to connect remotely.
+group, use the Credential parameter of the `New-PSSession`, `Enter-PSSession`
+or `Invoke-Command` cmdlets to connect remotely.
 
 For example, the following command provides the credentials of an
 Administrator.
@@ -288,12 +308,14 @@ Administrator.
 Invoke-Command -ComputerName Server01 -Credential Domain01\Admin01
 ```
 
-For more information about the Credential parameter, see New-PSSession,
-Enter-PSSession or Invoke-Command.
+For more information about the Credential parameter, see `New-PSSession`,
+`Enter-PSSession` or `Invoke-Command`.
 
 ### HOW TO ENABLE REMOTING FOR NON-ADMINISTRATIVE USERS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To establish a PSSession or run a command on a remote computer, the user
 must have permission to use the session configurations on the remote
@@ -319,7 +341,9 @@ For more information, see [about_Session_Configurations](about_Session_Configura
 
 ### HOW TO ENABLE REMOTING FOR ADMINISTRATORS IN OTHER DOMAINS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 When a user in another domain is a member of the Administrators group on
 the local computer, the user cannot connect to the local computer remotely
@@ -330,30 +354,33 @@ However, you can use the LocalAccountTokenFilterPolicy registry entry to
 change the default behavior and allow remote users who are members of the
 Administrators group to run with Administrator privileges.
 
-Caution: The LocalAccountTokenFilterPolicy entry disables user account
-control (UAC) remote restrictions for all users of all affected
-computers. Consider the implications of this setting carefully
-before changing the policy.
+> [!CAUTION]
+> The LocalAccountTokenFilterPolicy entry disables user account
+> control (UAC) remote restrictions for all users of all affected
+> computers. Consider the implications of this setting carefully
+> before changing the policy.
 
 To change the policy, use the following command to set the value of the
 LocalAccountTokenFilterPolicy registry entry to 1.
 
 ```powershell
-C:\PS> New-ItemProperty -Name LocalAccountTokenFilterPolicy -Path `
-HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System `
--PropertyType DWord -Value 1
+New-ItemProperty -Name LocalAccountTokenFilterPolicy `
+  -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System `
+  -PropertyType DWord -Value 1
 ```
 
 ### HOW TO USE AN IP ADDRESS IN A REMOTE COMMAND
 
+```
 ERROR:  The WinRM client cannot process the request. If the
 authentication scheme is different from Kerberos, or if the client
 computer is not joined to a domain, then HTTPS transport must be used
 or the destination machine must be added to the TrustedHosts
 configuration setting.
+```
 
-The ComputerName parameters of the New-PSSession, Enter-PSSession and
-Invoke-Command cmdlets accept an IP address as a valid value. However,
+The ComputerName parameters of the `New-PSSession`, `Enter-PSSession` and
+`Invoke-Command` cmdlets accept an IP address as a valid value. However,
 because Kerberos authentication does not support IP addresses, NTLM
 authentication is used by default whenever you specify an IP address.
 
@@ -374,11 +401,13 @@ for remoting.
 
 ### HOW TO CONNECT REMOTELY FROM A WORKGROUP-BASED COMPUTER
 
+```
 ERROR:  The WinRM client cannot process the request. If the
 authentication scheme is different from Kerberos, or if the client
 computer is not joined to a domain, then HTTPS transport must be used
 or the destination machine must be added to the TrustedHosts
 configuration setting.
+```
 
 When the local computer is not in a domain, the following procedure is required
 for remoting.
@@ -422,7 +451,7 @@ To view the list of trusted hosts, use the following command:
 Get-Item wsman:\localhost\Client\TrustedHosts
 ```
 
-You can also use the Set-Location cmdlet (alias = cd) to navigate
+You can also use the `Set-Location` cmdlet (alias = cd) to navigate
 though the WSMan: drive to the location.
 For example:
 
@@ -453,7 +482,7 @@ the following command format:
 Set-Item wsman:\localhost\Client\TrustedHosts -Value <ComputerName>
 ```
 
-where each value <ComputerName> must have the following format:
+where each value `<ComputerName>` must have the following format:
 
 ```
 <Computer>.<Domain>.<Company>.<top-level-domain>
@@ -494,10 +523,12 @@ Set-Item wsman:\localhost\Client\TrustedHosts -Value 172.16.0.0
 ```
 
 To add a computer to the TrustedHosts list of a remote computer, use the
-Connect-WSMan cmdlet to add a node for the remote computer to the WSMan: drive
-on the local computer. Then use a Set-Item command to add the computer.
+`Connect-WSMan` cmdlet to add a node for the remote computer to the WSMan:
+drive on the local computer. Then use a `Set-Item` command to add the
+computer.
 
-For more information about the Connect-WSMan cmdlet, see Connect-WSMan.
+For more information about the `Connect-WSMan` cmdlet, see
+[Connect-WSMan](../../Microsoft.WSMan.Management/Connect-WSMan.md).
 
 ## TROUBLESHOOTING COMPUTER CONFIGURATION ISSUES
 
@@ -506,15 +537,17 @@ configurations of a computer, domain, or enterprise.
 
 ### HOW TO CONFIGURE REMOTING ON ALTERNATE PORTS
 
+```
 ERROR:  The connection to the specified remote host was refused. Verify
 that the WS-Management service is running on the remote host and
 configured to listen for requests on the correct port and HTTP URL.
+```
 
 Windows PowerShell remoting uses port 80 for HTTP transport by default. The
 default port is used whenever the user does not specify the ConnectionURI
 or Port parameters in a remote command.
 
-To change the default port that Windows PowerShell uses, use Set-Item cmdlet
+To change the default port that Windows PowerShell uses, use `Set-Item` cmdlet
 in the WSMan: drive to change the Port value in the  listener leaf node.
 
 For example, the following command changes the default port to 8080.
@@ -525,9 +558,11 @@ Set-Item wsman:\localhost\listener\listener*\port -Value 8080
 
 ### HOW TO CONFIGURE REMOTING WITH A PROXY SERVER
 
+```
 ERROR: The client cannot connect to the destination specified in the
 request. Verify that the service on the destination is running and is
 accepting requests.
+```
 
 Because PowerShell remoting uses the HTTP protocol, it is affected
 by HTTP proxy settings. In enterprises that have proxy servers, users
@@ -543,29 +578,29 @@ The following settings are available:
 To set these options for a particular command, use the following procedure:
 
 1. Use the ProxyAccessType, ProxyAuthentication, and ProxyCredential
-   parameters of the New-PSSessionOption cmdlet to create a session
+   parameters of the `New-PSSessionOption` cmdlet to create a session
    option object with the proxy settings for your enterprise. Save the
    option object is a variable.
 
 2. Use the variable that contains the option object as the value of the
-   SessionOption parameter of a New-PSSession, Enter-PSSession, or
-   Invoke-Command command.
+   SessionOption parameter of a `New-PSSession`, `Enter-PSSession`, or
+   `Invoke-Command` command.
 
 For example, the following command creates a session option object with
 proxy session options and then uses the object to create a remote session.
 
 ```powershell
-C:\PS> $SessionOption = New-PSSessionOption -ProxyAccessType IEConfig `
+$SessionOption = New-PSSessionOption -ProxyAccessType IEConfig `
 -ProxyAuthentication Negotiate -ProxyCredential Domain01\User01
 
-C:\PS> New-PSSession -ConnectionURI https://www.fabrikam.com
+New-PSSession -ConnectionURI https://www.fabrikam.com
 ```
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+[New-PSSessionOption](../New-PSSessionOption.md).
 
 To set these options for all remote commands in the current session, use
-the option object that New-PSSessionOption creates in the value of the
+the option object that `New-PSSessionOption` creates in the value of the
 $PSSessionOption preference variable. For more information about the
 $PSSessionOption preference variable, see about_Preference_Variables.
 
@@ -576,19 +611,21 @@ profiles, see about_Profiles.
 
 ### HOW TO DETECT A 32-BIT SESSION ON A 64-BIT COMPUTER
 
+```
 ERROR: The term "<tool-Name>" is not recognized as the name of a cmdlet,
 function, script file, or operable program. Check the spelling of the
 name, or if a path was included, verify that the path is correct and try
 again.
+```
 
 If the remote computer is running a 64-bit version of Windows, and the
 remote command is using a 32-bit session configuration, such as
 Microsoft.PowerShell32, Windows Remote Management (WinRM) loads a WOW64
 process and Windows automatically redirects all references to the
-%Windir%\\System32 directory to the %windir%\\SysWOW64 directory.
+`$env:Windir\System32` directory to the `$env:Windir\SysWOW64` directory.
 
 As a result, if you try to use tools in the System32 directory that do
-not have counterparts in the SysWow64 directory, such as Defrag.exe,
+not have counterparts in the SysWow64 directory, such as **Defrag.exe**,
 the tools cannot be found in the directory.
 
 To find the processor architecture that is being used in the session,
@@ -599,10 +636,14 @@ following command finds the processor architecture of the session in the
 ```powershell
 $s = New-PSSession -ComputerName Server01 -ConfigurationName CustomShell
 Invoke-Command -Session $s {$env:PROCESSOR_ARCHITECTURE}
+```
+
+```Output
 x86
 ```
 
-For more information about session configurations, see [about_Session_Configurations](about_Session_Configurations.md).
+For more information about session configurations, see
+[about_Session_Configurations](about_Session_Configurations.md).
 
 ## TROUBLESHOOTING POLICY AND PREFERENCE ISSUES
 
@@ -611,20 +652,22 @@ preferences set on the local and remote computers.
 
 ### HOW TO CHANGE THE EXECUTION POLICY FOR IMPORT-PSSESSION AND IMPORT-MODULE
 
+```
 ERROR: Import-Module: File <filename> cannot be loaded because the
 execution of scripts is disabled on this system.
+```
 
-The Import-PSSession and Export-PSSession cmdlets create modules that
+The `Import-PSSession` and `Export-PSSession` cmdlets create modules that
 contains unsigned script files and formatting files.
 
 To import the modules that are created by these cmdlets, either by using
-Import-PSSession or Import-Module, the execution policy in the current
+`Import-PSSession` or `Import-Module`, the execution policy in the current
 session cannot be Restricted or AllSigned. (For information about Windows
 PowerShell execution policies, see about_Execution_Policies.
 
 To import the modules without changing the execution policy for the local
 computer that is set in the registry, use the Scope parameter of
-Set-ExecutionPolicy to set a less restrictive execution policy for a single
+`Set-ExecutionPolicy` to set a less restrictive execution policy for a single
 process.
 
 For example, the following command starts a process with the RemoteSigned
@@ -636,22 +679,24 @@ setting.
 Set-ExecutionPolicy -Scope process -ExecutionPolicy RemoteSigned
 ```
 
-You can also use the ExecutionPolicy parameter of PowerShell.exe to start
+You can also use the ExecutionPolicy parameter of **PowerShell.exe** to start
 a single session with a less restrictive execution policy.
 
 ```powershell
 PowerShell.exe -ExecutionPolicy RemoteSigned
 ```
 
-For more information about the cmdlets, see Import-PSSession,
-Export-PSSession, and Import-Module. For more information about
+For more information about the cmdlets, see `Import-PSSession`,
+`Export-PSSession`, and `Import-Module`. For more information about
 execution policies, see about_Execution_Policies. For more information
 about the PowerShell.exe console help options, type "PowerShell.exe -?".
 
 ### HOW TO SET AND CHANGE QUOTAS
 
+```
 ERROR: The total data received from the remote client exceeded allowed
 maximum.
+```
 
 You can use quotas to protect the local computer and the remote computer
 from excessive resource use, both accidental and malicious.
@@ -659,19 +704,20 @@ from excessive resource use, both accidental and malicious.
 The following quotas are available in the basic configuration.
 
 - The WSMan provider (WSMan:) provides several quota settings, such as the
-  MaxEnvelopeSizeKB and MaxProviderRequests settings in the
-  WSMan:\<ComputerName\> node and the MaxConcurrentOperations,
-  MaxConcurrentOperationsPerUser, and MaxConnections settings in the
-  WSMan:\<ComputerName\>\\Service node.
+  **MaxEnvelopeSizeKB** and **MaxProviderRequests** settings in the
+  `WSMan:<ComputerName>` node and the **MaxConcurrentOperations**,
+  **MaxConcurrentOperationsPerUser**, and **MaxConnections** settings in the
+  `WSMan:<ComputerName>\Service` node.
 
 - You can protect the local computer by using the
-  MaximumReceivedDataSizePerCommand and MaximumReceivedObjectSize parameters of
-  the New-PSSessionOption cmdlet and the \$PSSessionOption preference variable.
+  MaximumReceivedDataSizePerCommand and MaximumReceivedObjectSize parameters
+  of the `New-PSSessionOption` cmdlet and the \$PSSessionOption preference
+  variable.
 
 - You can protect the remote computer by adding restrictions to the session
-  configurations, such as by using the MaximumReceivedDataSizePerCommandMB and
-  MaximumReceivedObjectSizeMB parameters of the Register-PSSessionConfiguration
-  cmdlet.
+  configurations, such as by using the **MaximumReceivedDataSizePerCommandMB**
+  and **MaximumReceivedObjectSizeMB** parameters of the
+  `Register-PSSessionConfiguration` cmdlet.
 
 When quotas conflict with a command, PowerShell generates an error.
 
@@ -685,19 +731,21 @@ Microsoft.PowerShell session configuration on the remote computer from 10 MB
 
 ```powershell
 Set-PSSessionConfiguration -Name microsoft.PowerShell `
--MaximumReceivedObjectSizeMB 11 -Force
+  -MaximumReceivedObjectSizeMB 11 -Force
 ```
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+`New-PSSessionOption`.
 
 For more information about the WS-Management quotas, see the Help topic for
-the WSMan provider (type "Get-Help WSMan").
+the WSMan provider (type `Get-Help WSMan`).
 
 ### HOW TO RESOLVE TIMEOUT ERRORS
 
+```
 ERROR: The WS-Management service cannot complete the operation within
 the time specified in OperationTimeout.
+```
 
 You can use timeouts to protect the local computer and the remote computer
 from excessive resource use, both accidental and malicious. When timeouts
@@ -707,14 +755,14 @@ shortest timeout settings.
 The following timeouts are available in the basic configuration.
 
 - The WSMan provider (WSMan:) provides several client-side and service-side
-  timeout settings, such as the MaxTimeoutms setting in the
-  WSMan:\<ComputerName\> node and the EnumerationTimeoutms and
-  MaxPacketRetrievalTimeSeconds settings in the WSMan:\<ComputerName\>\\Service
-  node.
+  timeout settings, such as the **MaxTimeoutms** setting in the
+  `WSMan:<ComputerName>` node and the **EnumerationTimeoutms** and
+  **MaxPacketRetrievalTimeSeconds** settings in the
+  `WSMan:<ComputerName>\Service` node.
 
-- You can protect the local computer by using the CancelTimeout, IdleTimeout,
-  OpenTimeout, and OperationTimeout parameters of the New-PSSessionOption
-  cmdlet and the $PSSessionOption preference variable.
+- You can protect the local computer by using the **CancelTimeout**,
+  **IdleTimeout**, **OpenTimeout**, and **OperationTimeout** parameters of the
+  `New-PSSessionOption` cmdlet and the $PSSessionOption preference variable.
 
 - You can also protect the remote computer by setting timeout values
   programmatically in the session configuration for the session.
@@ -726,21 +774,21 @@ To resolve the error, change the command to complete within the timeout
 interval or determine the source of the timeout limit and increase the
 timeout interval to allow the command to complete.
 
-For example, the following commans use the New-PSSessionOption cmdlet to
-create a session option object with an OperationTimeout value of 4 minutes
+For example, the following commands use the `New-PSSessionOption` cmdlet to
+create a session option object with an **OperationTimeout** value of 4 minutes
 (in MS) and then use the session option object to create a remote session.
 
 ```powershell
-C:\PS> $pso = New-PSSessionoption -OperationTimeout 240000
+$pso = New-PSSessionoption -OperationTimeout 240000
 
-C:\PS> New-PSSession -ComputerName Server01 -sessionOption $pso
+New-PSSession -ComputerName Server01 -sessionOption $pso
 ```
 
 For more information about the WS-Management timeouts, see the Help topic for
 the WSMan provider (type "Get-Help WSMan").
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+[New-PSSessionOption](../New-PSSessionOption.md).
 
 ## TROUBLESHOOTING UNRESPONSIVE BEHAVIOR
 
@@ -756,13 +804,15 @@ Win32 console API, do not work correctly in the PowerShell remote host.
 When you use these programs, you might see unexpected behavior, such as no
 output, partial output, or a remote command that does not complete.
 
-To end an unresponsive program, type CTRL + C. To view any errors that might
-have been reported, type "$error" in the local host and the remote session.
+To end an unresponsive program, type `CTRL+C`. To view any errors that might
+have been reported, type `$error` in the local host and the remote session.
 
 ## HOW TO RECOVER FROM AN OPERATION FAILURE
 
+```
 ERROR: The I/O operation has been aborted because of either a thread exit
 or an  application request.
+```
 
 This error is returned when an operation is terminated before it completes.
 Typically, it occurs when the WinRM service stops or restarts while other
@@ -774,7 +824,7 @@ the command again.
 1. Start PowerShell with the "Run as administrator" option.
 2. Run the following command:
 
-   Start-Service WinRM
+   `Start-Service WinRM`
 
 3. Re-run the command that generated the error.
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -17,6 +17,7 @@ Disconnects from a session.
 ## SYNTAX
 
 ### Session (Default)
+
 ```
 Disconnect-PSSession [-Session] <PSSession[]> [-IdleTimeoutSec <Int32>]
  [-OutputBufferingMode <OutputBufferingMode>] [-ThrottleLimit <Int32>] [-WhatIf] [-Confirm]
@@ -24,138 +25,182 @@ Disconnect-PSSession [-Session] <PSSession[]> [-IdleTimeoutSec <Int32>]
 ```
 
 ### Name
+
 ```
 Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBufferingMode>]
  [-ThrottleLimit <Int32>] -Name <String[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### Id
-```
-Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBufferingMode>]
- [-ThrottleLimit <Int32>] [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
 ### InstanceId
+
 ```
 Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBufferingMode>]
  [-ThrottleLimit <Int32>] -InstanceId <Guid[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
+### Id
+
+```
+Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBufferingMode>]
+ [-ThrottleLimit <Int32>] [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
 ## DESCRIPTION
-The **Disconnect-PSSession** cmdlet disconnects a Windows PowerShell session (**PSSession**), such as one started by using the New-PSSession cmdlet, from the current session.
-As a result, the **PSSession** is in a disconnected state.
-You can connect to the disconnected **PSSession** from the current session or from another session on the local computer or a different computer.
 
-The **Disconnect-PSSession** cmdlet disconnects only open **PSSessions** that are connected to the current session.
-**Disconnect-PSSession** cannot disconnect broken or closed **PSSession** objects, or interactive **PSSession** objects started by using the Enter-PSSession cmdlet, and it cannot disconnect **PSSession** objects that are connected to other sessions.
+The `Disconnect-PSSession` cmdlet disconnects a Windows PowerShell session ("PSSession"), such as
+one started by using the `New-PSSession` cmdlet, from the current session. As a result, the PSSession
+is in a disconnected state. You can connect to the disconnected PSSession from the current session
+or from another session on the local computer or a different computer.
 
-To reconnect to a disconnected **PSSession**, use the Connect-PSSession or Receive-PSSession cmdlets.
+The `Disconnect-PSSession` cmdlet disconnects only open PSSessions that are connected to the
+current session. `Disconnect-PSSession` cannot disconnect broken or closed PSSessions, or
+interactive PSSessions started by using the `Enter-PSSession` cmdlet, and it cannot disconnect
+PSSessions that are connected to other sessions.
 
-When a **PSSession** is disconnected, the commands in the **PSSession** continue to run until they finish, unless the PSSession times out or the commands in the **PSSession** are blocked by a full output buffer.
-To change the idle time-out, use the *IdleTimeoutSec* parameter.
-To change the output buffering mode, use the *OutputBufferingMode* parameter.
-You can also use the *InDisconnectedSession* parameter of the Invoke-Command cmdlet to run a command in a disconnected session.
+To reconnect to a disconnected PSSession, use the `Connect-PSSession` or `Receive-PSSession` cmdlets.
 
-For more information about the Disconnected Sessions feature, see about_Remote_Disconnected_Sessions.
+When a PSSession is disconnected, the commands in the PSSession continue to run until they
+complete, unless the PSSession times out or the commands in the PSSession are blocked by a full
+output buffer. To change the idle timeout, use the **IdleTimeoutSec** parameter. To change the
+output buffering mode, use the **OutputBufferingMode** parameter You can also use the
+**InDisconnectedSession** parameter of the `Invoke-Command` cmdlet to run a command in a disconnected
+session.
 
-This cmdlet was introduced in Windows PowerShell 3.0.
+For more information about the Disconnected Sessions feature, see
+[about_Remote_Disconnected_Sessions](./About/about_Remote_Disconnected_Sessions.md).
+
+This cmdlet is introduced in Windows PowerShell 3.0.
 
 ## EXAMPLES
 
-### Example 1: Disconnect a session
+### Example 1 - Disconnect a session by name
+
+This command disconnects the UpdateSession PSSession on the Server01 computer from the current
+session. The command uses the **Name** parameter to identify the PSSession.
+
 ```
-PS C:\> Disconnect-PSSession -Name UpdateSession
+PS> Disconnect-PSSession -Name UpdateSession
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
 1  UpdateSession   Server01        Disconnected  Microsoft.PowerShell          None
 ```
 
-This command disconnects the UpdateSession **PSSession** on the Server01 computer from the current session.
-The command uses the *Name* parameter to identify the **PSSession**.
+The output shows that the attempt to disconnect was successful. The session state is Disconnected
+and the Availability is None, which indicates that the session is not busy and can be reconnected.
 
-The output shows that the attempt to disconnect was successful.
-The session state is **Disconnected** and the **Availability** is None, which indicates that the session is not busy and can be reconnected.
+### Example 2 - Disconnect a session from a specific computer
 
-### Example 2: Disconnect a session created in the current session
+This command disconnects the ITTask PSSession on the Server12 computer from the current session.
+The ITTask session was created in the current session and connects to the Server12 computer. The
+command uses the `Get-PSSession` cmdlet to get the session and the `Disconnect-PSSession` cmdlet to
+disconnect it.
+
 ```
-PS C:\> Get-PSSession -ComputerName Server12 -Name ITTask | Disconnect-PSSession -OutputBufferingMode Drop -IdleTimeoutSec 86400
+PS> Get-PSSession -ComputerName Server12 -Name ITTask |
+  Disconnect-PSSession -OutputBufferingMode Drop -IdleTimeoutSec 86400
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
 1  ITTask          Server12        Disconnected  ITTasks               None
 ```
 
-This command disconnects the ITTask **PSSession** on the Server12 computer from the current session.
-The ITTask session was created in the current session and connects to the Server12 computer.
-The command uses the Get-PSSession cmdlet to get the session and **Disconnect-PSSession** to disconnect it.
+The `Disconnect-PSSession` command uses the **OutputBufferingMode** parameter to set the output
+mode to **Drop**. This setting ensures that the script that is running in the session can continue
+to run even if the session output buffer is full. Because the script writes its output to a report
+on a file share, other output can be lost without consequence.
 
-The **Disconnect-PSSession** command uses the *OutputBufferingMode* parameter to set the output mode to Drop.
-This setting makes sure that the script that is running in the session can continue to run even if the session output buffer is full.
-Because the script writes its output to a report on a file share, other output can be lost without consequence.
+The command also uses the **IdleTimeoutSec** parameter to extend the idle timeout of the session to
+24 hours. This setting allows time for this administrator or other administrators to reconnect to
+the session to verify that the script ran and troubleshoot if needed.
 
-The command also uses the *IdleTimeoutSec* parameter to extend the idle time-out of the session to 24 hours.
-This setting allows time for this administrator or other administrators to reconnect to the session to verify that the script ran and troubleshoot if needed.
+### Example 3 - Using multiple PSSessions on multiple computers
 
-### Example 3: Disconnecting sessions in an enterprise scenario
+This series of commands shows how the `Disconnect-PSSession` cmdlet might be used in an enterprise
+scenario. In this case, a new technician starts a script in a session on a remote computer and runs
+into a problem. The technician disconnects from the session so that a more experienced manager can
+connect to the session and resolve the problem.
+
 ```
-The technician starts by creating sessions on several remote computers and running a script in each session.The first command uses the New-PSSession cmdlet to create the ITTask session on three remote computers. The command saves the sessions in the $s variable. The second command uses the *FilePath* parameter of the Invoke-Command cmdlet to run a script in the sessions in the $s variable.
-PS C:\> $s = New-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
-
-PS C:\> Invoke-Command $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
-
-The script running on the Srv1 computer generates unexpected errors. The technician contacts his manager and asks for assistance. The manager directs the technician to disconnect from the session so he can investigate.The second command uses the Get-PSSession cmdlet to get the ITTask session on the Srv1 computer and **Disconnect-PSSession** to disconnect it. This command does not affect the ITTask sessions on  the other computers.
-PS C:\> Get-PSSession -Name ITTask -ComputerName Srv1 | Disconnect-PSSession
+PS> $s = New-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
+PS> Invoke-Command $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
+PS> Get-PSSession -Name ITTask -ComputerName Srv1 | Disconnect-PSSession
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
 1 ITTask           Srv1            Disconnected  Microsoft.PowerShell          None
 
-The third command uses the **Get-PSSession** cmdlet to get the ITTask sessions. The output shows that the ITTask sessions on the Srv2 and Srv30 computers were not affected by the command to disconnect.
-PS C:\> Get-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
+PS> Get-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
  1 ITTask          Srv1            Disconnected  Microsoft.PowerShell          None
  2 ITTask          Srv2            Opened        Microsoft.PowerShell     Available
  3 ITTask          Srv30           Opened        Microsoft.PowerShell     Available
 
-The manager logs on to his home computer, connects to his corporate network, starts Windows PowerShell, and uses the Get-PSSession cmdlet to get the ITTask session on the Srv1 computer. He uses the credentials of the technician to access the session.
-PS C:\> Get-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
+PS> Get-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
  1 ITTask          Srv1            Disconnected  Microsoft.PowerShell          None
 
-Next, the manager uses the Connect-PSSession cmdlet to connect to the ITTask session on the Srv1 computer. The command saves the session in the $s variable.
-PS C:\> $s = Connect-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
-
-The manager uses the Invoke-Command cmdlet to run some diagnostic commands in the session in the $s variable. He recognizes that the script failed because it did not find a required directory. The manager uses the MkDir function to create the directory, and then he restarts the Get-PatchStatus.ps1 script and disconnects from the session.The manager reports his findings to the technician, suggests that he reconnect to the session to complete the tasks, and asks him to add a command to the Get-PatchStatus.ps1 script that creates the required directory if it does not exist.
-PS C:\> Invoke-Command -Session $s {dir $home\Scripts\PatchStatusOutput.ps1}
-
-PS C:\> Invoke-Command -Session $s {mkdir $home\Scripts\PatchStatusOutput}
-
-PS C:\> Invoke-Command -Session $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
-
-PS C:\> Disconnect-PSSession -Session $s
+PS> $s = Connect-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
+PS> Invoke-Command -Session $s {dir $home\Scripts\PatchStatusOutput.ps1}
+PS> Invoke-Command -Session $s {mkdir $home\Scripts\PatchStatusOutput}
+PS> Invoke-Command -Session $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
+PS> Disconnect-PSSession -Session $s
 ```
 
-This series of commands shows how **Disconnect-PSSession** might be used in an enterprise scenario.
-In this case, a new technician starts a script in a session on a remote computer and runs into a problem.
-The technician disconnects from the session so that a more experienced manager can connect to the session and resolve the problem.
+The technician begins by creating sessions on several remote computers and running a script in each
+session. The first command uses the `New-PSSession` cmdlet to create the ITTask session on three
+remote computers. The command saves the sessions in the $s variable. The second command uses the
+**FilePath** parameter of the `Invoke-Command` cmdlet to run a script in the sessions in the $s
+variable.
 
-### Example 4: Correct the value of an idle time-out so it can be disconnected
+The script running on the Srv1 computer generates unexpected errors. The technician contacts his
+manager and asks for assistance. The manager directs the technician to disconnect from the session
+so he can investigate.The second command uses the `Get-PSSession` cmdlet to get the ITTask session on
+the Srv1 computer and the `Disconnect-PSSession` cmdlet to disconnect it. This command does not
+affect the ITTask sessions on the other computers.
+
+The third command uses the `Get-PSSession` cmdlet to get the ITTask sessions. The output shows that
+the ITTask sessions on the Srv2 and Srv30 computers were not affected by the command to disconnect.
+
+The manager logs on to his home computer, connects to his corporate network, starts Windows
+PowerShell, and uses the `Get-PSSession` cmdlet to get the ITTask session on the Srv1 computer. He
+uses the credentials of the technician to access the session.
+
+Next, the manager uses the `Connect-PSSession` cmdlet to connect to the ITTask session on the Srv1
+computer. The command saves the session in the $s variable.
+
+The manager uses the `Invoke-Command` cmdlet to run some diagnostic commands in the session in the
+`$s` variable. He recognizes that the script failed because it did not find a required directory.
+The manager uses the `MkDir` function to create the directory, and then he restarts the
+`Get-PatchStatus.ps1` script and disconnects from the session.The manager reports his findings to
+the technician, suggests that he reconnect to the session to complete the tasks, and asks him to
+add a command to the `Get-PatchStatus.ps1` script that creates the required directory if it does
+not exist.
+
+### Example 4 - Change the timeout value for a PSSession
+
+This example shows how to correct the value of the **IdleTimeout** property of a session so that it
+can be disconnected.
+
+The idle timeout property of a session is critical to disconnected sessions, because it determines
+how long a disconnected session is maintained before it is deleted. You can set the idle timeout
+option when you create a session and when you disconnect it. The default values for the idle
+timeout of a session are set in the `$PSSessionOption` preference variable on the local computer
+and in the session configuration on the remote computer. Values set for the session take precedence
+over values set in the session configuration, but session values cannot exceed quotas set in the
+session configuration, such as the **MaxIdleTimeoutMs** value.
+
 ```
-The first command uses the New-PSSessionOption cmdlet to create a session option object. It uses the *IdleTimeout* parameter to set an idle time-out of 48 hours (172800000 milliseconds). The command saves the session option object in the $Timeout variable.
-PS C:\> $Timeout = New-PSSessionOption -IdleTimeout 172800000
-
-The second command uses the New-PSSession cmdlet to create the ITTask session on the Server01 computer. The command saves the session in the $s variable. The value of the *SessionOption* parameter is the 48-hour idle time-out in the $Timeout variable.
-PS C:\> $s = New-PSSession -Computer Server01 -Name ITTask -SessionOption $Timeout
-
-The third command disconnects the ITTask session in the $s variable. The command fails because the idle time-out value of the session exceeds the **MaxIdleTimeoutMs** quota in the session configuration. Because the idle time-out is not used until the session is disconnected, this violation can go undetected while the session is being used.
-PS C:\> Disconnect-PSSession -Session $s
+PS> $Timeout = New-PSSessionOption -IdleTimeout 172800000
+PS> $s = New-PSSession -Computer Server01 -Name ITTask -SessionOption $Timeout
+PS> Disconnect-PSSession -Session $s
 Disconnect-PSSession : The session ITTask cannot be disconnected because the specified
 idle timeout value 172800(seconds) is either greater than the server maximum allowed
 43200 (seconds) or less that the minimum allowed60(seconds).  Choose an idle time out
 value that is within the allowed range and try again.
 
-The fourth command uses the Invoke-Command cmdlet to run a Get-PSSessionConfiguration command for the Microsoft.PowerShell session configuration on the Server01 computer. The command uses the Format-List cmdlet to display all properties of the session configuration in a list.The output shows that the **MaxIdleTimeoutMS** property, which establishes the maximum permitted **IdleTimeout** value for sessions that use the session configuration, is 43200000 milliseconds (12 hours).
-PS C:\> Invoke-Command -ComputerName Server01 {Get-PSSessionConfiguration Microsoft.PowerShell} | Format-List -Property *
+PS> Invoke-Command -ComputerName Server01 {Get-PSSessionConfiguration Microsoft.PowerShell} |
+ Format-List -Property *
+
 Architecture                  : 64
 Filename                      : %windir%\system32\pwrshplugin.dll
 ResourceUri                   : http://schemas.microsoft.com/powershell/microsoft.powershell
@@ -192,8 +237,7 @@ RunspaceId                    : aea84310-6dbf-4c21-90ac-13980039925a
 PSShowComputerName            : True
 
 
-The fifth command gets the session option values of the session in the $s variable. The values of many session options are properties of the **ConnectionInfo** property of the **Runspace** property of the session.The output shows that the value of the **IdleTimeout** property of the session is 172800000 milliseconds (48 hours), which violates the **MaxIdleTimeoutMs** quota of 12 hours in the session configuration.To resolve this conflict, you can use the *ConfigurationName* parameter to select a different session configuration or use the *IdleTimeout* parameter to reduce the idle time-out of the session.
-PS C:\> $s.Runspace.ConnectionInfo
+PS> $s.Runspace.ConnectionInfo
 ConnectionUri                     : http://Server01/wsman
 ComputerName                      : Server01
 Scheme                            : http
@@ -225,32 +269,58 @@ CancelTimeout                     : 60000
 OperationTimeout                  : 180000
 IdleTimeout                       : 172800000
 
-The sixth command disconnects the session. It uses the *IdleTimeoutSec* parameter to set the idle time-out to the 12-hour maximum.
-PS C:\> Disconnect-PSSession $s -IdleTimeoutSec 43200
+PS> Disconnect-PSSession $s -IdleTimeoutSec 43200
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
  4 ITTask          Server01        Disconnected  Microsoft.PowerShell          None
 
-The seventh command gets the value of the **IdleTimeout** property of the disconnected session, which is measured in milliseconds. The output confirms that the command was successful.
-PS C:\> $s.Runspace.ConnectionInfo.IdleTimeout
+PS> $s.Runspace.ConnectionInfo.IdleTimeout
 43200000
 ```
 
-This example shows how to correct the value of the **IdleTimeout** property of a session so that it can be disconnected.
+The first command uses the `New-PSSessionOption` cmdlet to create a session option object. It uses
+the **IdleTimeout** parameter to set an idle timeout of 48 hours (172800000 milliseconds). The
+command saves the session option object in the $Timeout variable.
 
-The idle time-out property of a session is critical to disconnected sessions, because it determines how long a disconnected session is maintained before it is deleted.
-You can set the idle time-out option when you create a session and when you disconnect it.
-The default values for the idle time-out of a session are set in the **$PSSessionOption** preference variable on the local computer and in the session configuration on the remote computer.
-Values set for the session take precedence over values set in the session configuration, but session values cannot exceed quotas set in the session configuration, such as the **MaxIdleTimeoutMs** value.
+The second command uses the `New-PSSession` cmdlet to create the ITTask session on the Server01
+computer. The command save the session in the $s variable. The value of the **SessionOption**
+parameter is the 48-hour idle timeout in the $Timeout variable.
+
+The third command disconnects the ITTask session in the $s variable. The command fails because the
+idle timeout value of the session exceeds the **MaxIdleTimeoutMs** quota in the session
+configuration. Because the idle timeout is not used until the session is disconnected, this
+violation can go undetected while the session is in use.
+
+The fourth command uses the `Invoke-Command` cmdlet to run a `Get-PSSessionConfiguration` command
+for the Microsoft.PowerShell session configuration on the Server01 computer. The command uses the
+`Format-List` cmdlet to display all properties of the session configuration in a list.The output
+shows that the **MaxIdleTimeoutMS** property, which establishes the maximum permitted
+**IdleTimeout** value for sessions that use the session configuration, is 43200000 milliseconds (12
+hours).
+
+The fifth command gets the session option values of the session in the $s variable. The values of
+many session options are properties of the **ConnectionInfo** property of the **Runspace** property
+of the session.The output shows that the value of the **IdleTimeout** property of the session is
+172800000 milliseconds (48 hours), which violates the **MaxIdleTimeoutMs** quota of 12 hours in the
+session configuration.To resolve this conflict, you can use the **ConfigurationName** parameter to
+select a different session configuration or use the **IdleTimeout** parameter to reduce the idle
+timeout of the session.
+
+The sixth command disconnects the session. It uses the **IdleTimeoutSec** parameter to set the idle
+timeout to the 12-hour maximum.
+
+The seventh command gets the value of the **IdleTimeout** property of the disconnected session,
+which is measured in milliseconds. The output confirms that the command was successful.
 
 ## PARAMETERS
 
 ### -Id
-Specifies an array of IDs of sessions that this cmdlet disconnects.
-Type one or more IDs, separated by commas, or use the range operator (..) to specify a range of IDs.
 
-To get the ID of a session, use the Get-PSSession cmdlet.
-The instance ID is stored in the **ID** property of the session.
+Disconnects from sessions with the specified session ID. Type one or more IDs (separated by
+commas), or use the range operator (..) to specify a range of IDs.
+
+To get the ID of a session, use the `Get-PSSession` cmdlet. The instance ID is stored in the **ID**
+property of the session.
 
 ```yaml
 Type: Int32[]
@@ -258,28 +328,31 @@ Parameter Sets: Id
 Aliases:
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
 ### -IdleTimeoutSec
-Changes the idle time-out value of the disconnected **PSSession**.
-Enter a value in seconds.
-The minimum value is 60 (1 minute).
 
-The idle time-out determines how long the disconnected **PSSession** is maintained on the remote computer.
-When the time-out expires, the **PSSession** is deleted.
+Changes the idle timeout value of the disconnected PSSession. Enter a value in seconds. The minimum
+value is 60 (1 minute).
 
-Disconnected **PSSession** objects are considered to be idle from the moment that they are disconnected, even if commands are running in the disconnected session.
+The idle timeout determines how long the disconnected PSSession is maintained on the remote
+computer. When the timeout expires, the PSSession is deleted.
 
-The default value for the idle time-out of a session is set by the value of the **IdleTimeoutMs** property of the session configuration.
-The default value is 7200000 milliseconds (2 hours).
+Disconnected PSSessions are considered to be idle from the moment that they are disconnected, even
+if commands are running in the disconnected session.
 
-The value of this parameter takes precedence over the value of the **IdleTimeout** property of the $PSSessionOption preference variable and the default idle time-out value in the session configuration.
-However, this value cannot exceed the value of the **MaxIdleTimeoutMs** property of the session configuration.
-The default value of **MaxIdleTimeoutMs** is 12 hours (43200000 milliseconds).
+The default value for the idle timeout of a session is set by the value of the **IdleTimeoutMs**
+property of the session configuration. The default value is 7200000 milliseconds (2 hours).
+
+The value of this parameter takes precedence over the value of the **IdleTimeout** property of the
+$PSSessionOption preference variable and the default idle timeout value in the session
+configuration. However, this value cannot exceed the value of the **MaxIdleTimeoutMs** property of
+the session configuration. The default value of **MaxIdleTimeoutMs** is 12 hours (43200000
+milliseconds).
 
 ```yaml
 Type: Int32
@@ -288,19 +361,20 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 60
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -InstanceId
-Specifies an array of GUIDs of sessions that this cmdlet disconnects.
 
-The instance ID is a GUID that uniquely identifies a session on a local or remote computer.
-The instance ID is unique, even across multiple sessions on multiple computers.
+Disconnects from sessions with the specified instance IDs.
 
-To get the instance ID of a session, use **Get-PSSession**.
-The instance ID is stored in the **InstanceID** property of the session.
+The instance ID is a GUID that uniquely identifies a session on a local or remote computer. The
+instance ID is unique, even across multiple sessions on multiple computers.
+
+To get the instance ID of a session, use the `Get-PSSession` cmdlet. The instance ID is stored in
+the **InstanceID** property of the session.
 
 ```yaml
 Type: Guid[]
@@ -315,11 +389,11 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of friendly names of sessions that this cmdlet disconnects.
-Wildcard characters are permitted.
 
-To get the friendly name of a session, use **Get-PSSession**.
-The friendly name is stored in the **Name** property of the session.
+Disconnects from sessions with the specified friendly names. Wildcards are permitted.
+
+To get the friendly name of a session, use the `Get-PSSession` cmdlet. The friendly name is stored
+in the **Name** property of the session.
 
 ```yaml
 Type: String[]
@@ -333,43 +407,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -OutputBufferingMode
-Specifies how command output is managed in the disconnected session when the output buffer is full.
-The default value is Block.
-
-If the command in the disconnected session is returning output and the output buffer fills, the value of this parameter effectively determines whether the command continues to run while the session is disconnected.
-A value of Block suspends the command until the session is reconnected.
-A value of Drop allows the command to complete, although data might be lost.
-When using the Drop value, redirect the command output to a file on disk.
-
-The acceptable values for this parameter are:
-
-- Block. When the output buffer is full, execution is suspended until the buffer is clear.
-- Drop. When the output buffer is full, execution continues. As new output is saved, the oldest output is discarded.
-- None. No output buffering mode is specified. The value of the *OutputBufferingMode* property of the session configuration is used for the disconnected session.
-
-```yaml
-Type: OutputBufferingMode
-Parameter Sets: (All)
-Aliases:
-Accepted values: None, Drop, Block
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Session
-Specifies an array of sessions.
-Enter **PSSession** objects, such as those that the **New-PSSession** cmdlet returns.
-You can also pipe a **PSSession** object to Disconnect-PSSession.
 
-**Get-PSSession** can get all **PSSession** objects that end at a remote computer.
-These include **PSSession** objects that are disconnected and **PSSession** objects that are connected to other sessions on other computers.
-**Disconnect-PSSession** disconnects only **PSSession** that are connected to the current session.
-If you pipe other **PSSession** objects to **Disconnect-PSSession**, the **Disconnect-PSSession** command fails.
+Disconnects from the specified PSSessions. Enter PSSession objects, such as those that the
+`New-PSSession` cmdlet returns. You can also pipe a PSSession object to `Disconnect-PSSession`.
+
+The `Get-PSSession` cmdlet can get all PSSessions that terminate at a remote computer, including
+PSSessions that are disconnected and PSSessions that are connected to other sessions on other
+computers. `Disconnect-PSSession` disconnects only PSSession that are connected to the current
+session. If you pipe other PSSessions to `Disconnect-PSSession`, the `Disconnect-PSSession` command
+fails.
 
 ```yaml
 Type: PSSession[]
@@ -377,17 +424,18 @@ Parameter Sets: Session
 Aliases:
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Sets the throttle limit for the **Disconnect-PSSession** command.
 
-The throttle limit is the maximum number of concurrent connections that can be established to run this command.
-If you omit this parameter or enter a value of 0, the default value, 32, is used.
+Sets the throttle limit for the `Disconnect-PSSession` command.
+
+The throttle limit is the maximum number of concurrent connections that can be established to run
+this command. If you omit this parameter or enter a value of 0, the default value, 32, is used.
 
 The throttle limit applies only to the current command, not to the session or to the computer.
 
@@ -398,12 +446,44 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 32
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputBufferingMode
+
+Determines how command output is managed in the disconnected session when the output buffer is
+full. The default value is **Block**.
+
+If the command in the disconnected session is returning output and the output buffer fills, the
+value of this parameter effectively determines whether the command continues to run while the
+session is disconnected. A value of **Block** suspends the command until the session is
+reconnected. A value of **Drop** allows the command to complete, although data might be lost. When
+using the **Drop** value, redirect the command output to a file on disk.
+
+Valid values are:
+
+- **Block**: When the output buffer is full, execution is suspended until the buffer is clear.
+- **Drop**: When the output buffer is full, execution continues. As new output is saved, the oldest
+  output is discarded.
+- **None**: No output buffering mode is specified. The value of the **OutputBufferingMode** property
+  of the session configuration is used for the disconnected session.
+
+```yaml
+Type: OutputBufferingMode
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Block
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -419,6 +499,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -435,36 +516,51 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### System.Management.Automation.Runspaces.PSSession
-You can pipe a session to this cmdlet.
+
+You can pipe a session to `Disconnect-PSSession`.
 
 ## OUTPUTS
 
 ### System.Management.Automation.Runspaces.PSSession
-This cmdlet returns an object that represents the session that it disconnected.
+
+`Disconnect-PSSession` returns an object that represents the session that it disconnected.
 
 ## NOTES
-* The **Disconnect-PSSession** cmdlet works only when the local and remote computers are running Windows PowerShell 3.0 or later versions of Windows PowerShell.
-* If you use **Disconnect-PSSession** on a disconnected session, the command does not affect the session and it does not generate errors.
-* Disconnected loopback sessions with interactive security tokens, which are created by using the *EnableNetworkAccess* parameter, can be reconnected only from the computer on which the session was created. This restriction protects the computer from malicious access.
-* When you disconnect a **PSSession**, the session state is **Disconnected** and the availability is **None**.
 
-  The value of the **State** property is relative to the current session.
-Therefore, a value of **Disconnected** means that the **PSSession** is not connected to the current session.
-However, it does not mean that the **PSSession** is disconnected from all sessions.
-It might be connected to a different session.
-To determine whether you can connect or reconnect to the session, use the **Availability** property.
+- The `Disconnect-PSSession` cmdlet works only when the local and remote computers are running
+  PowerShell 3.0 or later.
+- If you use the `Disconnect-PSSession` cmdlet on a disconnected session, the command has no effect
+  on the session and it does not generate errors.
+- Disconnected loopback sessions with interactive security tokens (those created with the
+  **EnableNetworkAccess** parameter) can be reconnected only from the computer on which the session
+  was created. This restriction protects the computer from malicious access.
+- When you disconnect a PSSession, the session state is **Disconnected** and the availability is
+  **None**.
 
-  An **Availability** value of **None** indicates that you can connect to the session.
-A value of **Busy** indicates that you cannot connect to the **PSSession** because it is connected to another session.
+  The value of the **State** property is relative to the current session. Therefore, a value of
+  **Disconnected** means that the PSSession is not connected to the current session. However, it
+  does not mean that the PSSession is disconnected from all sessions. It might be connected to a
+  different session. To determine whether you can connect or reconnect to the session, use the
+  **Availability** property.
 
-  For more information about the values of the **State** property of sessions, see [RunspaceState Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspacestate) in the MSDN library.
+  An **Availability** value of **None** indicates that you can connect to the session. A value of
+  **Busy** indicates that you cannot connect to the PSSession because it is connected to another
+  session.
 
-  For more information about the values of the **Availability** property of sessions, see [RunspaceAvailability Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspaceavailability) in the MSDN library.
+  For more information about the values of the **State** property of sessions, see
+  [RunspaceState Enumeration](/dotnet/api/system.management.automation.runspaces.runspacestate).
+
+  For more information about the values of the **Availability** property of sessions, see
+  [RunspaceAvailability Enumeration](/dotnet/api/system.management.automation.runspaces.runspaceavailability).
 
 ## RELATED LINKS
 
@@ -489,3 +585,9 @@ A value of **Busy** indicates that you cannot connect to the **PSSession** becau
 [Register-PSSessionConfiguration](Register-PSSessionConfiguration.md)
 
 [Remove-PSSession](Remove-PSSession.md)
+
+[about_PSSessions](About/about_PSSessions.md)
+
+[about_Remote](About/about_Remote.md)
+
+[about_Remote_Disconnected_Sessions](About/about_Remote_Disconnected_Sessions.md)

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -90,7 +90,7 @@ PS C:\> cd HKLM:\Software
 > PowerShell uses aliases to allow you a familiar way to work with provider
 > paths. Commands such as `dir` and `ls` are now aliases for
 > [Get-ChildItem](../../Microsoft.PowerShell.Management/Get-ChildItem.md),
-> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md)
+> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md),
 > and `pwd` is an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
 
 This last example shows another path syntax you can use to navigate the
@@ -137,8 +137,7 @@ Spooler     DependOnService    : {RPCSS, http}
             Group              : SpoolerGroup
             ImagePath          : C:\WINDOWS\System32\spoolsv.exe
             ObjectName         : LocalSystem
-            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege,
-            SeAuditPrivilege, SeChangeNotifyPrivilege...}
+            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege, ...
             ServiceSidType     : 1
             Start              : 2
             Type               : 27
@@ -195,7 +194,7 @@ articles.
 
 Registry key values are stored as properties of each registry key. The
 `Get-ItemProperty` cmdlet views registry key properties using the name you
-specify. The result is a **PSCustom** object containing the properties you
+specify. The result is a **PSCustomObject** containing the properties you
 specify.
 
 The Following example uses the `Get-ItemProperty` cmdlet to view all
@@ -310,9 +309,9 @@ Name                           Property
 ContosoCompany
 ```
 
-You can use the `New-ItemProperty` cmdlet to create to **Item Properties** on
-a registry key that you specify. The following example creates a new DWORD
-value on the ContosoCompany registry key.
+You can use the `New-ItemProperty` cmdlet to create values in a registry key
+that you specify. The following example creates a new DWORD value on the
+ContosoCompany registry key.
 
 ```powershell
 $path = "HKLM:\SOFTWARE\ContosoCompany"
@@ -542,7 +541,7 @@ Beginning in Windows PowerShell 3.0, you can get customized help topics for
 provider cmdlets that explain how those cmdlets behave in a file system drive.
 
 To get the help topics that are customized for the file system drive, run a
-`Get-Help` command in a file system drive or use the `-Path` parameter to
+`Get-Help` command in a file system drive or use the **Path** parameter to
 specify a file system drive.
 
 ```powershell

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Registry_Provider.md
@@ -29,8 +29,10 @@ Provides access to the registry keys, entries, and values in PowerShell.
 The PowerShell **Registry** provider lets you get, add, change,
 clear, and delete registry keys, entries, and values in PowerShell.
 
-The **Registry** drives are a hierarchical namespace containing the registry keys and subkeys on your computer. Registry entries and values are not
-components of that hierarchy. Instead, they are properties of each of the keys.
+The **Registry** drives are a hierarchical namespace containing the registry
+keys and subkeys on your computer. Registry entries and values are not
+components of that hierarchy. Instead, they are properties of each of the
+keys.
 
 The **Registry** provider supports the following cmdlets, which are covered
 in this article.
@@ -77,7 +79,8 @@ Set-Location C:
 
 You can also work with the **Registry** provider from any other PowerShell
 drive. To reference a registry key from another location, use the drive name
-(`HKLM:`, `HKCU:`) in the path. Use a backslash (\\) or a forward slash (/) to indicate a level of the **Registry** drive.
+(`HKLM:`, `HKCU:`) in the path. Use a backslash (\\) or a forward slash (/) to
+indicate a level of the **Registry** drive.
 
 ```powershell
 PS C:\> cd HKLM:\Software
@@ -87,13 +90,13 @@ PS C:\> cd HKLM:\Software
 > PowerShell uses aliases to allow you a familiar way to work with provider
 > paths. Commands such as `dir` and `ls` are now aliases for
 > [Get-ChildItem](../../Microsoft.PowerShell.Management/Get-ChildItem.md),
-> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md). and `pwd` is
-> an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
+> `cd` is an alias for [Set-Location](../../Microsoft.PowerShell.Management/Set-Location.md)
+> and `pwd` is an alias for [Get-Location](../../Microsoft.PowerShell.Management/Get-Location.md).
 
 This last example shows another path syntax you can use to navigate the
 **Registry** provider. This syntax uses the provider name, followed by two
-colons `::`.  This syntax allows you to use the full HIVE name, instead
-of the mapped drive name `HKLM`.
+colons `::`. This syntax allows you to use the full HIVE name, instead of the
+mapped drive name `HKLM`.
 
 ```powershell
 cd "Registry::HKEY_LOCAL_MACHINE\Software"
@@ -101,8 +104,8 @@ cd "Registry::HKEY_LOCAL_MACHINE\Software"
 
 ## Displaying the contents of registry keys
 
-The registry is divided into keys, subkeys, and entries.  For more information about registry
-structure, see [Structure of the Registry](/windows/desktop/sysinfo/structure-of-the-registry).
+The registry is divided into keys, subkeys, and entries. For more information
+about registry structure, see [Structure of the Registry](/windows/desktop/sysinfo/structure-of-the-registry.md).
 
 In a **Registry** drive, each key is a container. A key can contain any number
 of keys. A registry key that has a parent key is called a subkey. You can
@@ -114,7 +117,8 @@ they are called **Item Properties**. A registry key can have both children
 keys and item properties.
 
 In this example, the difference between `Get-Item` and `Get-ChildItem` is
-shown. When you use `Get-Item` on the "Spooler" registry key, you can view its properties.
+shown. When you use `Get-Item` on the "Spooler" registry key, you can view its
+properties.
 
 ```
 PS C:\ > Get-Item -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
@@ -123,21 +127,21 @@ PS C:\ > Get-Item -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services
 
 
-Name                           Property
-----                           --------
-Spooler                        DependOnService    : {RPCSS, http}
-                               Description        : @%systemroot%\system32\spoolsv.exe,-2
-                               DisplayName        : @%systemroot%\system32\spoolsv.exe,-1
-                               ErrorControl       : 1
-                               FailureActions     : {16, 14, 0, 0...}
-                               Group              : SpoolerGroup
-                               ImagePath          : C:\WINDOWS\System32\spoolsv.exe
-                               ObjectName         : LocalSystem
-                               RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege, SeAuditPrivilege,
-                               SeChangeNotifyPrivilege...}
-                               ServiceSidType     : 1
-                               Start              : 2
-                               Type               : 272
+Name        Property
+----        --------
+Spooler     DependOnService    : {RPCSS, http}
+            Description        : @%systemroot%\system32\spoolsv.exe,-2
+            DisplayName        : @%systemroot%\system32\spoolsv.exe,-1
+            ErrorControl       : 1
+            FailureActions     : {16, 14, 0, 0...}
+            Group              : SpoolerGroup
+            ImagePath          : C:\WINDOWS\System32\spoolsv.exe
+            ObjectName         : LocalSystem
+            RequiredPrivileges : {SeTcbPrivilege, SeImpersonatePrivilege,
+            SeAuditPrivilege, SeChangeNotifyPrivilege...}
+            ServiceSidType     : 1
+            Start              : 2
+            Type               : 27
 ```
 
 Each registry key can also have subkeys. When you use `Get-Item` on a registry
@@ -152,16 +156,16 @@ PS C:\> Get-ChildItem -Path HKLM:\SYSTEM\CurrentControlSet\Services\Spooler
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Spooler
 
 
-Name                           Property
-----                           --------
-Performance                    Close           : PerfClose
-                               Collect         : PerfCollect
-                               Collect Timeout : 2000
-                               Library         : C:\Windows\System32\winspool.drv
-                               Object List     : 1450
-                               Open            : PerfOpen
-                               Open Timeout    : 4000
-Security                       Security : {1, 0, 20, 128...}
+Name             Property
+----             --------
+Performance      Close           : PerfClose
+                 Collect         : PerfCollect
+                 Collect Timeout : 2000
+                 Library         : C:\Windows\System32\winspool.drv
+                 Object List     : 1450
+                 Open            : PerfOpen
+                 Open Timeout    : 4000
+Security         Security : {1, 0, 20, 128...}
 ```
 
 The `Get-Item` cmdlet can also be used on the current location. The following
@@ -174,10 +178,10 @@ PS HKLM:\SYSTEM\CurrentControlSet\Services\Spooler> Get-Item .
 
     Hive: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services
 
-Name                           Property
-----                           --------
-Spooler                        DependOnService    : {RPCSS, http}
-                               Description        : @%systemroot%\system32\spoolsv.exe,-2
+Name             Property
+----             --------
+Spooler          DependOnService    : {RPCSS, http}
+                 Description        : @%systemroot%\system32\spoolsv.exe,-2
 ...
 ```
 
@@ -189,8 +193,10 @@ articles.
 
 ## Viewing registry key values
 
-Registry key values are stored as properties of each registry key. The `Get-ItemProperty` cmdlet views registry key properties using the name you specify. The result is a **PSCustom** object containing the
-properties you specify.
+Registry key values are stored as properties of each registry key. The
+`Get-ItemProperty` cmdlet views registry key properties using the name you
+specify. The result is a **PSCustom** object containing the properties you
+specify.
 
 The Following example uses the `Get-ItemProperty` cmdlet to view all
 properties. Storing the resulting object in a variable allows you to access
@@ -251,7 +257,10 @@ articles.
 
 ## Changing registry key values
 
-The `Set-ItemProperty` cmdlet will set attributes for registry keys. The following example uses `Set-ItemProperty` to change the spooler service start type to manual. The example changes the **StartType** back to *Automatic* using the `Set-Service` cmdlet.
+The `Set-ItemProperty` cmdlet will set attributes for registry keys. The
+following example uses `Set-ItemProperty` to change the spooler service start
+type to manual. The example changes the **StartType** back to *Automatic*
+using the `Set-Service` cmdlet.
 
 ```
 PS C:\> Get-Service spooler | Select-Object Name, StartMode
@@ -275,7 +284,8 @@ Each registry key has a *default* value. You can change the *default* value
 for a registry key with either `Set-Item` or `Set-ItemProperty`.
 
 ```powershell
-Set-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name "(default)" -Value "one" Set-Item -Path HKLM:\SOFTWARE\Contoso -Value "two"
+Set-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name "(default)" -Value "one"
+Set-Item -Path HKLM:\SOFTWARE\Contoso -Value "two"
 ```
 
 For more information on the cmdlets used in this section, see the following
@@ -300,9 +310,9 @@ Name                           Property
 ContosoCompany
 ```
 
-You can use the `New-ItemProperty` cmdlet to create to **Item Properties**
-on a registry key that you specify. The following example creates a new
-DWORD value on the ContosoCompany registry key.
+You can use the `New-ItemProperty` cmdlet to create to **Item Properties** on
+a registry key that you specify. The following example creates a new DWORD
+value on the ContosoCompany registry key.
 
 ```powershell
 $path = "HKLM:\SOFTWARE\ContosoCompany"
@@ -317,7 +327,10 @@ For detailed cmdlet usage, see [New-ItemProperty](../../Microsoft.PowerShell.Man
 
 ## Copying registry keys and values
 
-In the **Registry** provider, use the `Copy-Item` cmdlet copies registry keys and values. Use the `Copy-ItemProperty` cmdlet to copy registry values only. The following command copies the "Contoso" registry key, and its properties to the specified location "HKLM:\Software\Fabrikam".
+In the **Registry** provider, use the `Copy-Item` cmdlet copies registry keys
+and values. Use the `Copy-ItemProperty` cmdlet to copy registry values only.
+The following command copies the "Contoso" registry key, and its properties to
+the specified location "HKLM:\Software\Fabrikam".
 
 `Copy-Item` creates the destination key if it does not exist. If the
 destination key exists, `Copy-Item` creates a duplicate of the source key
@@ -345,9 +358,9 @@ articles.
 ## Moving registry keys and values
 
 The `Move-Item` and `Move-ItemProperty` cmdlets behave like their "Copy"
-counterparts. If the destination exists, `Move-Item` moves the source
-key underneath the destination key. If the destination key does not exist,
-the source key is moved to the destination path.
+counterparts. If the destination exists, `Move-Item` moves the source key
+underneath the destination key. If the destination key does not exist, the
+source key is moved to the destination path.
 
 The following command moves the "Contoso" key to the path
 "HKLM:\SOFTWARE\Fabrikam".
@@ -404,7 +417,8 @@ For more examples and cmdlet usage details see the following articles.
 
 ## Removing and clearing registry keys and values
 
-You can remove contained items by using **Remove-Item**, but you will be prompted to confirm the removal if the item contains anything else. The
+You can remove contained items by using **Remove-Item**, but you will be
+prompted to confirm the removal if the item contains anything else. The
 following example attempts to delete a key "HKLM:\SOFTWARE\Contoso".
 
 ```
@@ -420,8 +434,8 @@ PS C:\> Remove-Item -Path HKLM:\SOFTWARE\Contoso
 
 Confirm
 The item at HKLM:\SOFTWARE\Contoso has children and the -Recurse
-parameter was not specified. If you continue, all children will be removed with
- the item. Are you sure you want to continue?
+parameter was not specified. If you continue, all children will be removed
+with the item. Are you sure you want to continue?
 [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help
 (default is "Y"):
 ```
@@ -432,14 +446,16 @@ To delete contained items without prompting, specify the `-Recurse` parameter.
 Remove-Item -Path HKLM:\SOFTWARE\Contoso -Recurse
 ```
 
-If you wanted to remove all items within "HKLM:\SOFTWARE\Contoso" but not "HKLM:\SOFTWARE\Contoso" itself, use a trailing backslash `\` followed by a
+If you wanted to remove all items within "HKLM:\SOFTWARE\Contoso" but not
+"HKLM:\SOFTWARE\Contoso" itself, use a trailing backslash `\` followed by a
 wildcard.
 
 ```powershell
 Remove-Item -Path HKLM:\SOFTWARE\Contoso\* -Recurse
 ```
 
-This command deletes the "ContosoTest" registry value from the "HKLM:\SOFTWARE\Contoso" registry key.
+This command deletes the "ContosoTest" registry value from the
+"HKLM:\SOFTWARE\Contoso" registry key.
 
 ```powershell
 Remove-ItemProperty -Path HKLM:\SOFTWARE\Contoso -Name ContosoTest
@@ -454,12 +470,12 @@ PS HKLM:\SOFTWARE\> Get-Item .\Contoso\
 
     Hive: HKEY_LOCAL_MACHINE\SOFTWARE
 
-Name                           Property
-----                           --------
-Contoso                        Server     : {a, b, c}
-                               HereString : {This is text which contains
-                                            newlines. It also contains "quoted" strings}
-                               (default)  : 1
+Name           Property
+----           --------
+Contoso        Server     : {a, b, c}
+               HereString : {This is text which contains
+               newlines. It also contains "quoted" strings}
+               (default)  : 1
 
 PS HKLM:\SOFTWARE\> Clear-Item .\Contoso\
 PS HKLM:\SOFTWARE\> Get-Item .\Contoso\
@@ -480,23 +496,33 @@ For more examples and cmdlet usage details see the following articles.
 
 ## Dynamic parameters
 
-Dynamic parameters are cmdlet parameters that are added by a PowerShell provider and are available only when the cmdlet is being used in the provider-enabled drive.
+Dynamic parameters are cmdlet parameters that are added by a PowerShell
+provider and are available only when the cmdlet is being used in the
+provider-enabled drive.
 
 ### Type <Microsoft.Win32.RegistryValueKind>
 
 Establishes or changes the data type of a registry value. The default is `String` (REG_SZ).
 
-This parameter works as designed on the [Set-ItemProperty](../../Microsoft.PowerShell.Management/Set-ItemProperty.md) cmdlet. It is also available on the [Set-Item](../../Microsoft.PowerShell.Management/Set-Item.md) cmdlet in the registry drives, but it has no effect.
+This parameter works as designed on the
+[Set-ItemProperty](../../Microsoft.PowerShell.Management/Set-ItemProperty.md)
+cmdlet. It is also available on the
+[Set-Item](../../Microsoft.PowerShell.Management/Set-Item.md) cmdlet in the
+registry drives, but it has no effect.
 
-|Value|Description|
-|-----------|-----------------|
-|  `String` | Specifies a null-terminated string. Equivalent to REG_SZ. |
-|  `ExpandString` | Specifies a null-terminated string that contains unexpanded references to environment variables that are expanded when the value is retrieved. Equivalent to REG_EXPAND_SZ. |
-|  `Binary` | Specifies binary data in any form. Equivalent to REG_BINARY. |
-|  `DWord` | Specifies a 32-bit binary number. Equivalent to REG_DWORD. |
-|  `MultiString` | Specifies an array of null-terminated strings terminated by two null characters. Equivalent to REG_MULTI_SZ. |
-|  `QWord` | Specifies a 64-bit binary number. Equivalent to REG_QWORD. |
-|  `Unknown` | Indicates an unsupported registry data type, such as REG_RESOURCE_LIST. |
+|Value | Description |
+| ---- | ----------- |
+| `String` | Specifies a null-terminated string. Equivalent to REG_SZ. |
+| `ExpandString` | Specifies a null-terminated string that contains unexpanded |
+|                | references to environment variables that are expanded when |
+|                | the value is retrieved. Equivalent to REG_EXPAND_SZ. |
+| `Binary` | Specifies binary data in any form. Equivalent to REG_BINARY. |
+| `DWord` | Specifies a 32-bit binary number. Equivalent to REG_DWORD. |
+| `MultiString` | Specifies an array of null-terminated strings terminated by |
+|               | two null characters. Equivalent to REG_MULTI_SZ. |
+| `QWord` | Specifies a 64-bit binary number. Equivalent to REG_QWORD. |
+| `Unknown` | Indicates an unsupported registry data type, such as |
+|           | REG_RESOURCE_LIST. |
 
 #### Cmdlets supported
 
@@ -506,9 +532,9 @@ This parameter works as designed on the [Set-ItemProperty](../../Microsoft.Power
 ## Using the pipeline
 
 Provider cmdlets accept pipeline input. You can use the pipeline to simplify
-task by sending provider data from one cmdlet to another provider cmdlet.
-To read more about how to use the pipeline with provider cmdlets, see the
-cmdlet references provided throughout this article.
+task by sending provider data from one cmdlet to another provider cmdlet. To
+read more about how to use the pipeline with provider cmdlets, see the cmdlet
+references provided throughout this article.
 
 ## Getting help
 
@@ -516,8 +542,8 @@ Beginning in Windows PowerShell 3.0, you can get customized help topics for
 provider cmdlets that explain how those cmdlets behave in a file system drive.
 
 To get the help topics that are customized for the file system drive, run a
-[Get-Help](../Get-Help.md) command in a file system drive or use the `-Path`
-parameter of [Get-Help](../Get-Help.md) to specify a file system drive.
+`Get-Help` command in a file system drive or use the `-Path` parameter to
+specify a file system drive.
 
 ```powershell
 Get-Help Get-ChildItem

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -166,7 +166,7 @@ creates firewall rules that allows remote access from the same local subnet.
 
 On client versions of Windows, `Enable-PSRemoting` succeeds on private and
 domain networks. By default, it fails on public networks, but if
-you use the SkipNetworkProfileCheck parameter, `Enable-PSRemoting` succeeds
+you use the **SkipNetworkProfileCheck** parameter, `Enable-PSRemoting` succeeds
 and creates a firewall rule that allows traffic from the same local subnet.
 
 To remove the local subnet restriction on public networks and allow
@@ -279,8 +279,8 @@ Get-Item wsman:\localhost\Service\RootSDDL
 
 To change the RootSDDL, use the `Set-Item` cmdlet in the WSMan: drive. To
 change the security descriptor of a session configuration, use the
-`Set-PSSessionConfiguration` cmdlet with the SecurityDescriptorSDDL or
-ShowSecurityDescriptorUI parameters.
+`Set-PSSessionConfiguration` cmdlet with the **SecurityDescriptorSDDL** or
+**ShowSecurityDescriptorUI** parameters.
 
 For more information about the WSMan: drive, see the Help topic for the
 WSMan provider ("Get-Help wsman").
@@ -308,8 +308,8 @@ Administrator.
 Invoke-Command -ComputerName Server01 -Credential Domain01\Admin01
 ```
 
-For more information about the Credential parameter, see `New-PSSession`,
-`Enter-PSSession` or `Invoke-Command`.
+For more information about the **Credential** parameter, see [New-PSSession](../New-PSSession.md),
+[Enter-PSSession](../Enter-PSSession.md) or [Invoke-Command](../Invoke-Command.md).
 
 ### HOW TO ENABLE REMOTING FOR NON-ADMINISTRATIVE USERS
 
@@ -737,8 +737,8 @@ Set-PSSessionConfiguration -Name microsoft.PowerShell `
 For more information about the `New-PSSessionOption` cmdlet, see
 `New-PSSessionOption`.
 
-For more information about the WS-Management quotas, see the Help topic for
-the WSMan provider (type `Get-Help WSMan`).
+For more information about the WS-Management quotas, see
+[about_WSMan_Provider](../../Microsoft.WsMan.Management/About/about_WSMan_Provider.md).
 
 ### HOW TO RESOLVE TIMEOUT ERRORS
 

--- a/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
+++ b/reference/6/Microsoft.PowerShell.Core/About/about_Remote_Troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  12/01/2017
+ms.date:  01/18/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -18,15 +18,16 @@ This section describes some of the problems that you might encounter when
 using the remoting features of PowerShell that are based on
 WS-Management technology and it suggests solutions to these problems.
 
-Before using PowerShell remoting, see about_Remote and
-about_Remote_Requirements for guidance on configuration and basic use Also,
-the Help topics for each of the remoting cmdlets, particularly the parameter
-descriptions, have useful information that is designed to help you avoid
-problems.
+Before using PowerShell remoting, see [about_Remote](about_remote.md) and
+[about_Remote_Requirements](about_Remote_Requirements.md) for guidance on
+configuration and basic use. Also, the Help topics for each of the remoting
+cmdlets, particularly the parameter descriptions, have useful information that
+is designed to help you avoid problems.
 
-NOTE: To view or change settings for the local computer in the WSMan: drive,
-including changes to the session configurations, trusted hosts, ports, or
-listeners, start PowerShell with the "Run as administrator" option.
+> [!NOTE]
+> To view or change settings for the local computer in the WSMan: drive,
+> including changes to the session configurations, trusted hosts, ports, or
+> listeners, start PowerShell with the "Run as administrator" option.
 
 ## TROUBLESHOOTING PERMISSION AND AUTHENTICATION ISSUES
 
@@ -54,11 +55,12 @@ To start Windows PowerShell with the "Run as administrator option:
 - In the Windows taskbar, right-click the Windows PowerShell icon, and then
   click "Run as Administrator."
 
-  Note: In Windows Server 2008 R2, the Windows PowerShell icon is pinned
-  to the taskbar by default.
+  In Windows Server 2008 R2, the Windows PowerShell icon is pinned to the
+  taskbar by default.
 
 ### HOW TO ENABLE REMOTING
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -66,6 +68,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 No configuration is required to enable a computer to send remote
 commands. However, to receive remote commands, PowerShell remoting
@@ -76,25 +79,26 @@ session configurations.
 
 Windows PowerShell remoting is enabled on Windows Server 2012 and newer
 releases of Windows Server by default. On all other systems, run the
-Enable-PSRemoting cmdlet to enable remoting. You can also run the
-Enable-PSRemoting cmdlet to re-enable remoting on Windows Server 2012 and
+`Enable-PSRemoting` cmdlet to enable remoting. You can also run the
+`Enable-PSRemoting` cmdlet to re-enable remoting on Windows Server 2012 and
 newer releases of Windows Server if remoting is disabled.
 
 To configure a computer to receive remote commands, use the
-Enable-PSRemoting cmdlet. The following command enables all required
+`Enable-PSRemoting` cmdlet. The following command enables all required
 remote settings, enables the session configurations, and restarts the
 WinRM service to make the changes effective.
 
-Enable-PSRemoting
+`Enable-PSRemoting`
 
 To suppress all user prompts, type:
 
-Enable-PSRemoting -Force
+`Enable-PSRemoting -Force`
 
-For more information, see Enable-PSRemoting.
+For more information, see [Enable-PSRemoting](../Enable-PSRemoting.md).
 
 ### HOW TO ENABLE REMOTING IN AN ENTERPRISE
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -102,9 +106,10 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 To enable a single computer to receive remote PowerShell commands
-and accept connections, use the Enable-PSRemoting cmdlet.
+and accept connections, use the `Enable-PSRemoting` cmdlet.
 
 To enable remoting for multiple computers in an enterprise, you can use the
 following scaled options.
@@ -114,7 +119,7 @@ following scaled options.
   Enable Listeners by Using a Group Policy" (below).
 
 - To set the startup type of the Windows Remote Management (WinRM)
-  to Automatic on multiple computers, use the Set-Service cmdlet. For
+  to Automatic on multiple computers, use the `Set-Service` cmdlet. For
   instructions, see "How to Set the Startup Type of the WinrM Service"
   (below).
 
@@ -124,6 +129,7 @@ following scaled options.
 
 ### HOW TO ENABLE LISTENERS BY USING A GROUP POLICY
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -131,6 +137,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to listen
 for requests on the correct port and HTTP URL.
+```
 
 To configure the listeners for all computers in a domain, enable the "Allow
 automatic configuration of listeners" policy in the following Group Policy
@@ -144,20 +151,22 @@ permitted.
 
 ### HOW TO ENABLE REMOTING ON PUBLIC NETWORKS
 
+```
 ERROR:  Unable to check the status of the firewall
+```
 
-The Enable-PSRemoting cmdlet returns this error when the local network
+The `Enable-PSRemoting` cmdlet returns this error when the local network
 is public and the SkipNetworkProfileCheck parameter is not used in the
 command.
 
-On server versions of Windows, Enable-PSRemoting succeeds on all network
+On server versions of Windows, `Enable-PSRemoting` succeeds on all network
 location types. It creates firewall rules that allow remote access to
 private and domain ("Home" and "Work") networks. For public networks, it
 creates firewall rules that allows remote access from the same local subnet.
 
-On client versions of Windows, Enable-PSRemoting succeeds on private and
+On client versions of Windows, `Enable-PSRemoting` succeeds on private and
 domain networks. By default, it fails on public networks, but if
-you use the SkipNetworkProfileCheck parameter, Enable-PSRemoting succeeds
+you use the SkipNetworkProfileCheck parameter, `Enable-PSRemoting` succeeds
 and creates a firewall rule that allows traffic from the same local subnet.
 
 To remove the local subnet restriction on public networks and allow
@@ -167,16 +176,18 @@ remote access from any location, run the following command:
 Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP-PUBLIC" -RemoteAddress Any
 ```
 
-The Set-NetFirewallRule cmdlet is exported by the NetSecurity module.
+The `Set-NetFirewallRule` cmdlet is exported by the NetSecurity module.
 
-NOTE: In Windows PowerShell 2.0, on computers running server versions
-of Windows, Enable-PSRemoting creates firewall rules that allow remote
-access on private, domain and public networks. On computers running
-client versions of Windows, Enable-PSRemoting creates firewall rules
-that allow remote access only on private and domain networks.
+> [!NOTE]
+> In Windows PowerShell 2.0, on computers running server versions
+> of Windows, `Enable-PSRemoting` creates firewall rules that allow remote
+> access on private, domain and public networks. On computers running
+> client versions of Windows, `Enable-PSRemoting` creates firewall rules
+> that allow remote access only on private and domain networks.
 
 ### HOW TO ENABLE A FIREWALL EXCEPTION BY USING A GROUP POLICY
 
+```
 ERROR:  ACCESS IS DENIED
 
 or
@@ -184,6 +195,7 @@ or
 ERROR: The connection to the remote host was refused. Verify that the
 WS-Management service is running on the remote host and configured to
 listen for requests on the correct port and HTTP URL.
+```
 
 To enable a firewall exception for in all computers in a domain, enable the
 "Windows Firewall: Allow local port exceptions" policy in the following
@@ -198,7 +210,9 @@ the Windows Remote Management service.
 
 ### HOW TO SET THE STARTUP TYPE OF THE WINRM SERVICE
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 PowerShell remoting depends upon the Windows Remote Management
 (WinRM) service. The service must be running to support remote commands.
@@ -210,7 +224,7 @@ However, on client versions of Windows, the WinRM service is disabled
 by default.
 
 To set the startup type of a service on a remote computer, use the
-Set-Service cmdlet.
+`Set-Service` cmdlet.
 
 To run the command on multiple computers, you can create a text file or
 CSV file of the computer names.
@@ -220,38 +234,42 @@ Servers.txt file and then sets the startup type of the WinRM service on all
 of the computers to Automatic.
 
 ```powershell
-C:\PS> $servers = Get-Content servers.txt
-C:\PS> Set-Service WinRM -ComputerName $servers -startuptype Automatic
+$servers = Get-Content servers.txt
+Set-Service WinRM -ComputerName $servers -startuptype Automatic
 ```
 
-To see the results use the Get-WMIObject cmdlet with the Win32_Service object.
-For more information, see Set-Service.
+To see the results use the `Get-WMIObject` cmdlet with the **Win32_Service**
+object. For more information, see
+[Set-Service](../../Microsoft.PowerShell.Management/Set-Service.md).
 
 ### HOW TO RECREATE THE DEFAULT SESSION CONFIGURATIONS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To connect to the local computer and run commands remotely, the local
 computer must include session configurations for remote commands.
 
-When you use Enable-PSRemoting, it creates default session configurations
+When you use `Enable-PSRemoting`, it creates default session configurations
 on the local computer. Remote users use these session configurations
 whenever a remote command does not include the ConfigurationName parameter.
 
 If the default configurations on a computer are unregistered or deleted,
-use the Enable-PSRemoting cmdlet to recreate them. You can use this cmdlet
+use the `Enable-PSRemoting` cmdlet to recreate them. You can use this cmdlet
 repeatedly. It does not generate errors if a feature is already configured.
 
 If you change the default session configurations and want to restore the
 original default session configurations, use the
-Unregister-PSSessionConfiguration cmdlet to delete the changed session
-configurations and then use the Enable-PSRemoting cmdlet to restore them.
-Enable-PSRemoting does not change existing session configurations.
+`Unregister-PSSessionConfiguration` cmdlet to delete the changed session
+configurations and then use the `Enable-PSRemoting` cmdlet to restore them.
+`Enable-PSRemoting` does not change existing session configurations.
 
-Note: When Enable-PSRemoting restores the default session configuration, it
-does not create explicit security descriptors for the configurations.
-Instead, the configurations inherit the security descriptor of the RootSDDL,
-which is secure by default.
+> [!NOTE]
+> When `Enable-PSRemoting` restores the default session configuration, it
+> does not create explicit security descriptors for the configurations.
+> Instead, the configurations inherit the security descriptor of the
+> RootSDDL, which is secure by default.
 
 To see the RootSDDL security descriptor, type:
 
@@ -259,9 +277,9 @@ To see the RootSDDL security descriptor, type:
 Get-Item wsman:\localhost\Service\RootSDDL
 ```
 
-To change the RootSDDL, use the Set-Item cmdlet in the WSMan: drive. To
+To change the RootSDDL, use the `Set-Item` cmdlet in the WSMan: drive. To
 change the security descriptor of a session configuration, use the
-Set-PSSessionConfiguration cmdlet with the SecurityDescriptorSDDL or
+`Set-PSSessionConfiguration` cmdlet with the SecurityDescriptorSDDL or
 ShowSecurityDescriptorUI parameters.
 
 For more information about the WSMan: drive, see the Help topic for the
@@ -269,7 +287,9 @@ WSMan provider ("Get-Help wsman").
 
 ### HOW TO PROVIDE ADMINISTRATOR CREDENTIALS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To create a PSSession or run commands on a remote computer, by default, the
 current user must be a member of the Administrators group on the remote
@@ -278,8 +298,8 @@ logged on to an account that is a member of the Administrators group.
 
 If the current user is a member of the Administrators group on the remote
 computer, or can provide the credentials of a member of the Administrators
-group, use the Credential parameter of the New-PSSession, Enter-PSSession
-or Invoke-Command cmdlets to connect remotely.
+group, use the Credential parameter of the `New-PSSession`, `Enter-PSSession`
+or `Invoke-Command` cmdlets to connect remotely.
 
 For example, the following command provides the credentials of an
 Administrator.
@@ -288,12 +308,14 @@ Administrator.
 Invoke-Command -ComputerName Server01 -Credential Domain01\Admin01
 ```
 
-For more information about the Credential parameter, see New-PSSession,
-Enter-PSSession or Invoke-Command.
+For more information about the Credential parameter, see `New-PSSession`,
+`Enter-PSSession` or `Invoke-Command`.
 
 ### HOW TO ENABLE REMOTING FOR NON-ADMINISTRATIVE USERS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 To establish a PSSession or run a command on a remote computer, the user
 must have permission to use the session configurations on the remote
@@ -319,7 +341,9 @@ For more information, see [about_Session_Configurations](about_Session_Configura
 
 ### HOW TO ENABLE REMOTING FOR ADMINISTRATORS IN OTHER DOMAINS
 
+```
 ERROR:  ACCESS IS DENIED
+```
 
 When a user in another domain is a member of the Administrators group on
 the local computer, the user cannot connect to the local computer remotely
@@ -330,30 +354,33 @@ However, you can use the LocalAccountTokenFilterPolicy registry entry to
 change the default behavior and allow remote users who are members of the
 Administrators group to run with Administrator privileges.
 
-Caution: The LocalAccountTokenFilterPolicy entry disables user account
-control (UAC) remote restrictions for all users of all affected
-computers. Consider the implications of this setting carefully
-before changing the policy.
+> [!CAUTION]
+> The LocalAccountTokenFilterPolicy entry disables user account
+> control (UAC) remote restrictions for all users of all affected
+> computers. Consider the implications of this setting carefully
+> before changing the policy.
 
 To change the policy, use the following command to set the value of the
 LocalAccountTokenFilterPolicy registry entry to 1.
 
 ```powershell
-C:\PS> New-ItemProperty -Name LocalAccountTokenFilterPolicy -Path `
-HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System `
--PropertyType DWord -Value 1
+New-ItemProperty -Name LocalAccountTokenFilterPolicy `
+  -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System `
+  -PropertyType DWord -Value 1
 ```
 
 ### HOW TO USE AN IP ADDRESS IN A REMOTE COMMAND
 
+```
 ERROR:  The WinRM client cannot process the request. If the
 authentication scheme is different from Kerberos, or if the client
 computer is not joined to a domain, then HTTPS transport must be used
 or the destination machine must be added to the TrustedHosts
 configuration setting.
+```
 
-The ComputerName parameters of the New-PSSession, Enter-PSSession and
-Invoke-Command cmdlets accept an IP address as a valid value. However,
+The ComputerName parameters of the `New-PSSession`, `Enter-PSSession` and
+`Invoke-Command` cmdlets accept an IP address as a valid value. However,
 because Kerberos authentication does not support IP addresses, NTLM
 authentication is used by default whenever you specify an IP address.
 
@@ -374,11 +401,13 @@ for remoting.
 
 ### HOW TO CONNECT REMOTELY FROM A WORKGROUP-BASED COMPUTER
 
+```
 ERROR:  The WinRM client cannot process the request. If the
 authentication scheme is different from Kerberos, or if the client
 computer is not joined to a domain, then HTTPS transport must be used
 or the destination machine must be added to the TrustedHosts
 configuration setting.
+```
 
 When the local computer is not in a domain, the following procedure is required
 for remoting.
@@ -422,7 +451,7 @@ To view the list of trusted hosts, use the following command:
 Get-Item wsman:\localhost\Client\TrustedHosts
 ```
 
-You can also use the Set-Location cmdlet (alias = cd) to navigate
+You can also use the `Set-Location` cmdlet (alias = cd) to navigate
 though the WSMan: drive to the location.
 For example:
 
@@ -453,7 +482,7 @@ the following command format:
 Set-Item wsman:\localhost\Client\TrustedHosts -Value <ComputerName>
 ```
 
-where each value <ComputerName> must have the following format:
+where each value `<ComputerName>` must have the following format:
 
 ```
 <Computer>.<Domain>.<Company>.<top-level-domain>
@@ -494,10 +523,12 @@ Set-Item wsman:\localhost\Client\TrustedHosts -Value 172.16.0.0
 ```
 
 To add a computer to the TrustedHosts list of a remote computer, use the
-Connect-WSMan cmdlet to add a node for the remote computer to the WSMan: drive
-on the local computer. Then use a Set-Item command to add the computer.
+`Connect-WSMan` cmdlet to add a node for the remote computer to the WSMan:
+drive on the local computer. Then use a `Set-Item` command to add the
+computer.
 
-For more information about the Connect-WSMan cmdlet, see Connect-WSMan.
+For more information about the `Connect-WSMan` cmdlet, see
+[Connect-WSMan](../../Microsoft.WSMan.Management/Connect-WSMan.md).
 
 ## TROUBLESHOOTING COMPUTER CONFIGURATION ISSUES
 
@@ -506,15 +537,17 @@ configurations of a computer, domain, or enterprise.
 
 ### HOW TO CONFIGURE REMOTING ON ALTERNATE PORTS
 
+```
 ERROR:  The connection to the specified remote host was refused. Verify
 that the WS-Management service is running on the remote host and
 configured to listen for requests on the correct port and HTTP URL.
+```
 
 Windows PowerShell remoting uses port 80 for HTTP transport by default. The
 default port is used whenever the user does not specify the ConnectionURI
 or Port parameters in a remote command.
 
-To change the default port that Windows PowerShell uses, use Set-Item cmdlet
+To change the default port that Windows PowerShell uses, use `Set-Item` cmdlet
 in the WSMan: drive to change the Port value in the  listener leaf node.
 
 For example, the following command changes the default port to 8080.
@@ -525,9 +558,11 @@ Set-Item wsman:\localhost\listener\listener*\port -Value 8080
 
 ### HOW TO CONFIGURE REMOTING WITH A PROXY SERVER
 
+```
 ERROR: The client cannot connect to the destination specified in the
 request. Verify that the service on the destination is running and is
 accepting requests.
+```
 
 Because PowerShell remoting uses the HTTP protocol, it is affected
 by HTTP proxy settings. In enterprises that have proxy servers, users
@@ -543,29 +578,29 @@ The following settings are available:
 To set these options for a particular command, use the following procedure:
 
 1. Use the ProxyAccessType, ProxyAuthentication, and ProxyCredential
-   parameters of the New-PSSessionOption cmdlet to create a session
+   parameters of the `New-PSSessionOption` cmdlet to create a session
    option object with the proxy settings for your enterprise. Save the
    option object is a variable.
 
 2. Use the variable that contains the option object as the value of the
-   SessionOption parameter of a New-PSSession, Enter-PSSession, or
-   Invoke-Command command.
+   SessionOption parameter of a `New-PSSession`, `Enter-PSSession`, or
+   `Invoke-Command` command.
 
 For example, the following command creates a session option object with
 proxy session options and then uses the object to create a remote session.
 
 ```powershell
-C:\PS> $SessionOption = New-PSSessionOption -ProxyAccessType IEConfig `
+$SessionOption = New-PSSessionOption -ProxyAccessType IEConfig `
 -ProxyAuthentication Negotiate -ProxyCredential Domain01\User01
 
-C:\PS> New-PSSession -ConnectionURI https://www.fabrikam.com
+New-PSSession -ConnectionURI https://www.fabrikam.com
 ```
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+[New-PSSessionOption](../New-PSSessionOption.md).
 
 To set these options for all remote commands in the current session, use
-the option object that New-PSSessionOption creates in the value of the
+the option object that `New-PSSessionOption` creates in the value of the
 $PSSessionOption preference variable. For more information about the
 $PSSessionOption preference variable, see about_Preference_Variables.
 
@@ -576,19 +611,21 @@ profiles, see about_Profiles.
 
 ### HOW TO DETECT A 32-BIT SESSION ON A 64-BIT COMPUTER
 
+```
 ERROR: The term "<tool-Name>" is not recognized as the name of a cmdlet,
 function, script file, or operable program. Check the spelling of the
 name, or if a path was included, verify that the path is correct and try
 again.
+```
 
 If the remote computer is running a 64-bit version of Windows, and the
 remote command is using a 32-bit session configuration, such as
 Microsoft.PowerShell32, Windows Remote Management (WinRM) loads a WOW64
 process and Windows automatically redirects all references to the
-%Windir%\\System32 directory to the %windir%\\SysWOW64 directory.
+`$env:Windir\System32` directory to the `$env:Windir\SysWOW64` directory.
 
 As a result, if you try to use tools in the System32 directory that do
-not have counterparts in the SysWow64 directory, such as Defrag.exe,
+not have counterparts in the SysWow64 directory, such as **Defrag.exe**,
 the tools cannot be found in the directory.
 
 To find the processor architecture that is being used in the session,
@@ -599,10 +636,14 @@ following command finds the processor architecture of the session in the
 ```powershell
 $s = New-PSSession -ComputerName Server01 -ConfigurationName CustomShell
 Invoke-Command -Session $s {$env:PROCESSOR_ARCHITECTURE}
+```
+
+```Output
 x86
 ```
 
-For more information about session configurations, see [about_Session_Configurations](about_Session_Configurations.md).
+For more information about session configurations, see
+[about_Session_Configurations](about_Session_Configurations.md).
 
 ## TROUBLESHOOTING POLICY AND PREFERENCE ISSUES
 
@@ -611,20 +652,22 @@ preferences set on the local and remote computers.
 
 ### HOW TO CHANGE THE EXECUTION POLICY FOR IMPORT-PSSESSION AND IMPORT-MODULE
 
+```
 ERROR: Import-Module: File <filename> cannot be loaded because the
 execution of scripts is disabled on this system.
+```
 
-The Import-PSSession and Export-PSSession cmdlets create modules that
+The `Import-PSSession` and `Export-PSSession` cmdlets create modules that
 contains unsigned script files and formatting files.
 
 To import the modules that are created by these cmdlets, either by using
-Import-PSSession or Import-Module, the execution policy in the current
+`Import-PSSession` or `Import-Module`, the execution policy in the current
 session cannot be Restricted or AllSigned. (For information about Windows
 PowerShell execution policies, see about_Execution_Policies.
 
 To import the modules without changing the execution policy for the local
 computer that is set in the registry, use the Scope parameter of
-Set-ExecutionPolicy to set a less restrictive execution policy for a single
+`Set-ExecutionPolicy` to set a less restrictive execution policy for a single
 process.
 
 For example, the following command starts a process with the RemoteSigned
@@ -636,22 +679,24 @@ setting.
 Set-ExecutionPolicy -Scope process -ExecutionPolicy RemoteSigned
 ```
 
-You can also use the ExecutionPolicy parameter of PowerShell.exe to start
+You can also use the ExecutionPolicy parameter of **PowerShell.exe** to start
 a single session with a less restrictive execution policy.
 
 ```powershell
 PowerShell.exe -ExecutionPolicy RemoteSigned
 ```
 
-For more information about the cmdlets, see Import-PSSession,
-Export-PSSession, and Import-Module. For more information about
+For more information about the cmdlets, see `Import-PSSession`,
+`Export-PSSession`, and `Import-Module`. For more information about
 execution policies, see about_Execution_Policies. For more information
 about the PowerShell.exe console help options, type "PowerShell.exe -?".
 
 ### HOW TO SET AND CHANGE QUOTAS
 
+```
 ERROR: The total data received from the remote client exceeded allowed
 maximum.
+```
 
 You can use quotas to protect the local computer and the remote computer
 from excessive resource use, both accidental and malicious.
@@ -659,19 +704,20 @@ from excessive resource use, both accidental and malicious.
 The following quotas are available in the basic configuration.
 
 - The WSMan provider (WSMan:) provides several quota settings, such as the
-  MaxEnvelopeSizeKB and MaxProviderRequests settings in the
-  WSMan:\<ComputerName\> node and the MaxConcurrentOperations,
-  MaxConcurrentOperationsPerUser, and MaxConnections settings in the
-  WSMan:\<ComputerName\>\\Service node.
+  **MaxEnvelopeSizeKB** and **MaxProviderRequests** settings in the
+  `WSMan:<ComputerName>` node and the **MaxConcurrentOperations**,
+  **MaxConcurrentOperationsPerUser**, and **MaxConnections** settings in the
+  `WSMan:<ComputerName>\Service` node.
 
 - You can protect the local computer by using the
-  MaximumReceivedDataSizePerCommand and MaximumReceivedObjectSize parameters of
-  the New-PSSessionOption cmdlet and the \$PSSessionOption preference variable.
+  MaximumReceivedDataSizePerCommand and MaximumReceivedObjectSize parameters
+  of the `New-PSSessionOption` cmdlet and the \$PSSessionOption preference
+  variable.
 
 - You can protect the remote computer by adding restrictions to the session
-  configurations, such as by using the MaximumReceivedDataSizePerCommandMB and
-  MaximumReceivedObjectSizeMB parameters of the Register-PSSessionConfiguration
-  cmdlet.
+  configurations, such as by using the **MaximumReceivedDataSizePerCommandMB**
+  and **MaximumReceivedObjectSizeMB** parameters of the
+  `Register-PSSessionConfiguration` cmdlet.
 
 When quotas conflict with a command, PowerShell generates an error.
 
@@ -685,19 +731,21 @@ Microsoft.PowerShell session configuration on the remote computer from 10 MB
 
 ```powershell
 Set-PSSessionConfiguration -Name microsoft.PowerShell `
--MaximumReceivedObjectSizeMB 11 -Force
+  -MaximumReceivedObjectSizeMB 11 -Force
 ```
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+`New-PSSessionOption`.
 
 For more information about the WS-Management quotas, see the Help topic for
-the WSMan provider (type "Get-Help WSMan").
+the WSMan provider (type `Get-Help WSMan`).
 
 ### HOW TO RESOLVE TIMEOUT ERRORS
 
+```
 ERROR: The WS-Management service cannot complete the operation within
 the time specified in OperationTimeout.
+```
 
 You can use timeouts to protect the local computer and the remote computer
 from excessive resource use, both accidental and malicious. When timeouts
@@ -707,14 +755,14 @@ shortest timeout settings.
 The following timeouts are available in the basic configuration.
 
 - The WSMan provider (WSMan:) provides several client-side and service-side
-  timeout settings, such as the MaxTimeoutms setting in the
-  WSMan:\<ComputerName\> node and the EnumerationTimeoutms and
-  MaxPacketRetrievalTimeSeconds settings in the WSMan:\<ComputerName\>\\Service
-  node.
+  timeout settings, such as the **MaxTimeoutms** setting in the
+  `WSMan:<ComputerName>` node and the **EnumerationTimeoutms** and
+  **MaxPacketRetrievalTimeSeconds** settings in the
+  `WSMan:<ComputerName>\Service` node.
 
-- You can protect the local computer by using the CancelTimeout, IdleTimeout,
-  OpenTimeout, and OperationTimeout parameters of the New-PSSessionOption
-  cmdlet and the $PSSessionOption preference variable.
+- You can protect the local computer by using the **CancelTimeout**,
+  **IdleTimeout**, **OpenTimeout**, and **OperationTimeout** parameters of the
+  `New-PSSessionOption` cmdlet and the $PSSessionOption preference variable.
 
 - You can also protect the remote computer by setting timeout values
   programmatically in the session configuration for the session.
@@ -726,21 +774,21 @@ To resolve the error, change the command to complete within the timeout
 interval or determine the source of the timeout limit and increase the
 timeout interval to allow the command to complete.
 
-For example, the following commans use the New-PSSessionOption cmdlet to
-create a session option object with an OperationTimeout value of 4 minutes
+For example, the following commands use the `New-PSSessionOption` cmdlet to
+create a session option object with an **OperationTimeout** value of 4 minutes
 (in MS) and then use the session option object to create a remote session.
 
 ```powershell
-C:\PS> $pso = New-PSSessionoption -OperationTimeout 240000
+$pso = New-PSSessionoption -OperationTimeout 240000
 
-C:\PS> New-PSSession -ComputerName Server01 -sessionOption $pso
+New-PSSession -ComputerName Server01 -sessionOption $pso
 ```
 
 For more information about the WS-Management timeouts, see the Help topic for
 the WSMan provider (type "Get-Help WSMan").
 
-For more information about the New-PSSessionOption cmdlet, see
-New-PSSessionOption.
+For more information about the `New-PSSessionOption` cmdlet, see
+[New-PSSessionOption](../New-PSSessionOption.md).
 
 ## TROUBLESHOOTING UNRESPONSIVE BEHAVIOR
 
@@ -756,13 +804,15 @@ Win32 console API, do not work correctly in the PowerShell remote host.
 When you use these programs, you might see unexpected behavior, such as no
 output, partial output, or a remote command that does not complete.
 
-To end an unresponsive program, type CTRL + C. To view any errors that might
-have been reported, type "$error" in the local host and the remote session.
+To end an unresponsive program, type `CTRL+C`. To view any errors that might
+have been reported, type `$error` in the local host and the remote session.
 
 ## HOW TO RECOVER FROM AN OPERATION FAILURE
 
+```
 ERROR: The I/O operation has been aborted because of either a thread exit
 or an  application request.
+```
 
 This error is returned when an operation is terminated before it completes.
 Typically, it occurs when the WinRM service stops or restarts while other
@@ -774,7 +824,7 @@ the command again.
 1. Start PowerShell with the "Run as administrator" option.
 2. Run the following command:
 
-   Start-Service WinRM
+   `Start-Service WinRM`
 
 3. Re-run the command that generated the error.
 

--- a/reference/6/Microsoft.PowerShell.Core/Disconnect-PSSession.md
+++ b/reference/6/Microsoft.PowerShell.Core/Disconnect-PSSession.md
@@ -17,147 +17,190 @@ Disconnects from a session.
 ## SYNTAX
 
 ### Session (Default)
+
 ```
 Disconnect-PSSession [-Session] <PSSession[]> [-IdleTimeoutSec <Int32>]
  [-OutputBufferingMode <OutputBufferingMode>] [-ThrottleLimit <Int32>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
-### InstanceId
-```
-Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBufferingMode>]
- [-ThrottleLimit <Int32>] -InstanceId <Guid[]> [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
 ### Name
+
 ```
 Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBufferingMode>]
  [-ThrottleLimit <Int32>] -Name <String[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
+### InstanceId
+
+```
+Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBufferingMode>]
+ [-ThrottleLimit <Int32>] -InstanceId <Guid[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
 ### Id
+
 ```
 Disconnect-PSSession [-IdleTimeoutSec <Int32>] [-OutputBufferingMode <OutputBufferingMode>]
  [-ThrottleLimit <Int32>] [-Id] <Int32[]> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Disconnect-PSSession** cmdlet disconnects a PowerShell session (**PSSession**), such as one started by using the New-PSSession cmdlet, from the current session.
-As a result, the **PSSession** is in a disconnected state.
-You can connect to the disconnected **PSSession** from the current session or from another session on the local computer or a different computer.
 
-Note that this capability only works with PSSessions using the WSMan transport.
+The `Disconnect-PSSession` cmdlet disconnects a Windows PowerShell session ("PSSession"), such as
+one started by using the `New-PSSession` cmdlet, from the current session. As a result, the PSSession
+is in a disconnected state. You can connect to the disconnected PSSession from the current session
+or from another session on the local computer or a different computer.
 
-The **Disconnect-PSSession** cmdlet disconnects only open **PSSessions** that are connected to the current session.
-**Disconnect-PSSession** cannot disconnect broken or closed **PSSession** objects, or interactive **PSSession** objects started by using the Enter-PSSession cmdlet, and it cannot disconnect **PSSession** objects that are connected to other sessions.
+The `Disconnect-PSSession` cmdlet disconnects only open PSSessions that are connected to the
+current session. `Disconnect-PSSession` cannot disconnect broken or closed PSSessions, or
+interactive PSSessions started by using the `Enter-PSSession` cmdlet, and it cannot disconnect
+PSSessions that are connected to other sessions.
 
-To reconnect to a disconnected **PSSession**, use the Connect-PSSession or Receive-PSSession cmdlets.
+To reconnect to a disconnected PSSession, use the `Connect-PSSession` or `Receive-PSSession` cmdlets.
 
-When a **PSSession** is disconnected, the commands in the **PSSession** continue to run until they finish, unless the PSSession times out or the commands in the **PSSession** are blocked by a full output buffer.
-To change the idle time-out, use the *IdleTimeoutSec* parameter.
-To change the output buffering mode, use the *OutputBufferingMode* parameter.
-You can also use the *InDisconnectedSession* parameter of the Invoke-Command cmdlet to run a command in a disconnected session.
+When a PSSession is disconnected, the commands in the PSSession continue to run until they
+complete, unless the PSSession times out or the commands in the PSSession are blocked by a full
+output buffer. To change the idle timeout, use the **IdleTimeoutSec** parameter. To change the
+output buffering mode, use the **OutputBufferingMode** parameter You can also use the
+**InDisconnectedSession** parameter of the `Invoke-Command` cmdlet to run a command in a disconnected
+session.
 
-For more information about the Disconnected Sessions feature, see about_Remote_Disconnected_Sessions.
+For more information about the Disconnected Sessions feature, see
+[about_Remote_Disconnected_Sessions](./About/about_Remote_Disconnected_Sessions.md).
 
-This cmdlet was introduced in Windows PowerShell 3.0.
+This cmdlet is introduced in Windows PowerShell 3.0.
 
 ## EXAMPLES
 
-### Example 1: Disconnect a session
+### Example 1 - Disconnect a session by name
+
+This command disconnects the UpdateSession PSSession on the Server01 computer from the current
+session. The command uses the **Name** parameter to identify the PSSession.
+
 ```
-PS C:\> Disconnect-PSSession -Name UpdateSession
+PS> Disconnect-PSSession -Name UpdateSession
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
 1  UpdateSession   Server01        Disconnected  Microsoft.PowerShell          None
 ```
 
-This command disconnects the UpdateSession **PSSession** on the Server01 computer from the current session.
-The command uses the *Name* parameter to identify the **PSSession**.
+The output shows that the attempt to disconnect was successful. The session state is Disconnected
+and the Availability is None, which indicates that the session is not busy and can be reconnected.
 
-The output shows that the attempt to disconnect was successful.
-The session state is **Disconnected** and the **Availability** is None, which indicates that the session is not busy and can be reconnected.
+### Example 2 - Disconnect a session from a specific computer
 
-### Example 2: Disconnect a session created in the current session
+This command disconnects the ITTask PSSession on the Server12 computer from the current session.
+The ITTask session was created in the current session and connects to the Server12 computer. The
+command uses the `Get-PSSession` cmdlet to get the session and the `Disconnect-PSSession` cmdlet to
+disconnect it.
+
 ```
-PS C:\> Get-PSSession -ComputerName Server12 -Name ITTask | Disconnect-PSSession -OutputBufferingMode Drop -IdleTimeoutSec 86400
+PS> Get-PSSession -ComputerName Server12 -Name ITTask |
+  Disconnect-PSSession -OutputBufferingMode Drop -IdleTimeoutSec 86400
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
 1  ITTask          Server12        Disconnected  ITTasks               None
 ```
 
-This command disconnects the ITTask **PSSession** on the Server12 computer from the current session.
-The ITTask session was created in the current session and connects to the Server12 computer.
-The command uses the Get-PSSession cmdlet to get the session and **Disconnect-PSSession** to disconnect it.
+The `Disconnect-PSSession` command uses the **OutputBufferingMode** parameter to set the output
+mode to **Drop**. This setting ensures that the script that is running in the session can continue
+to run even if the session output buffer is full. Because the script writes its output to a report
+on a file share, other output can be lost without consequence.
 
-The **Disconnect-PSSession** command uses the *OutputBufferingMode* parameter to set the output mode to Drop.
-This setting makes sure that the script that is running in the session can continue to run even if the session output buffer is full.
-Because the script writes its output to a report on a file share, other output can be lost without consequence.
+The command also uses the **IdleTimeoutSec** parameter to extend the idle timeout of the session to
+24 hours. This setting allows time for this administrator or other administrators to reconnect to
+the session to verify that the script ran and troubleshoot if needed.
 
-The command also uses the *IdleTimeoutSec* parameter to extend the idle time-out of the session to 24 hours.
-This setting allows time for this administrator or other administrators to reconnect to the session to verify that the script ran and troubleshoot if needed.
+### Example 3 - Using multiple PSSessions on multiple computers
 
-### Example 3: Disconnecting sessions in an enterprise scenario
+This series of commands shows how the `Disconnect-PSSession` cmdlet might be used in an enterprise
+scenario. In this case, a new technician starts a script in a session on a remote computer and runs
+into a problem. The technician disconnects from the session so that a more experienced manager can
+connect to the session and resolve the problem.
+
 ```
-The technician starts by creating sessions on several remote computers and running a script in each session.The first command uses the New-PSSession cmdlet to create the ITTask session on three remote computers. The command saves the sessions in the $s variable. The second command uses the *FilePath* parameter of the Invoke-Command cmdlet to run a script in the sessions in the $s variable.
-PS C:\> $s = New-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
-
-PS C:\> Invoke-Command $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
-
-The script running on the Srv1 computer generates unexpected errors. The technician contacts his manager and asks for assistance. The manager directs the technician to disconnect from the session so he can investigate.The second command uses the Get-PSSession cmdlet to get the ITTask session on the Srv1 computer and **Disconnect-PSSession** to disconnect it. This command does not affect the ITTask sessions on  the other computers.
-PS C:\> Get-PSSession -Name ITTask -ComputerName Srv1 | Disconnect-PSSession
+PS> $s = New-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
+PS> Invoke-Command $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
+PS> Get-PSSession -Name ITTask -ComputerName Srv1 | Disconnect-PSSession
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
 1 ITTask           Srv1            Disconnected  Microsoft.PowerShell          None
 
-The third command uses the **Get-PSSession** cmdlet to get the ITTask sessions. The output shows that the ITTask sessions on the Srv2 and Srv30 computers were not affected by the command to disconnect.
-PS C:\> Get-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
+PS> Get-PSSession -ComputerName Srv1, Srv2, Srv30 -Name ITTask
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
  1 ITTask          Srv1            Disconnected  Microsoft.PowerShell          None
  2 ITTask          Srv2            Opened        Microsoft.PowerShell     Available
  3 ITTask          Srv30           Opened        Microsoft.PowerShell     Available
 
-The manager logs on to his home computer, connects to his corporate network, starts PowerShell, and uses the Get-PSSession cmdlet to get the ITTask session on the Srv1 computer. He uses the credentials of the technician to access the session.
-PS C:\> Get-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
+PS> Get-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
  1 ITTask          Srv1            Disconnected  Microsoft.PowerShell          None
 
-Next, the manager uses the Connect-PSSession cmdlet to connect to the ITTask session on the Srv1 computer. The command saves the session in the $s variable.
-PS C:\> $s = Connect-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
-
-The manager uses the Invoke-Command cmdlet to run some diagnostic commands in the session in the $s variable. He recognizes that the script failed because it did not find a required directory. The manager uses the MkDir function to create the directory, and then he restarts the Get-PatchStatus.ps1 script and disconnects from the session.The manager reports his findings to the technician, suggests that he reconnect to the session to complete the tasks, and asks him to add a command to the Get-PatchStatus.ps1 script that creates the required directory if it does not exist.
-PS C:\> Invoke-Command -Session $s {dir $home\Scripts\PatchStatusOutput.ps1}
-
-PS C:\> Invoke-Command -Session $s {mkdir $home\Scripts\PatchStatusOutput}
-
-PS C:\> Invoke-Command -Session $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
-
-PS C:\> Disconnect-PSSession -Session $s
+PS> $s = Connect-PSSession -ComputerName Srv1 -Name ITTask -Credential Domain01\User01
+PS> Invoke-Command -Session $s {dir $home\Scripts\PatchStatusOutput.ps1}
+PS> Invoke-Command -Session $s {mkdir $home\Scripts\PatchStatusOutput}
+PS> Invoke-Command -Session $s -FilePath \\Server01\Scripts\Get-PatchStatus.ps1
+PS> Disconnect-PSSession -Session $s
 ```
 
-This series of commands shows how **Disconnect-PSSession** might be used in an enterprise scenario.
-In this case, a new technician starts a script in a session on a remote computer and runs into a problem.
-The technician disconnects from the session so that a more experienced manager can connect to the session and resolve the problem.
+The technician begins by creating sessions on several remote computers and running a script in each
+session. The first command uses the `New-PSSession` cmdlet to create the ITTask session on three
+remote computers. The command saves the sessions in the $s variable. The second command uses the
+**FilePath** parameter of the `Invoke-Command` cmdlet to run a script in the sessions in the $s
+variable.
 
-### Example 4: Correct the value of an idle time-out so it can be disconnected
+The script running on the Srv1 computer generates unexpected errors. The technician contacts his
+manager and asks for assistance. The manager directs the technician to disconnect from the session
+so he can investigate.The second command uses the `Get-PSSession` cmdlet to get the ITTask session on
+the Srv1 computer and the `Disconnect-PSSession` cmdlet to disconnect it. This command does not
+affect the ITTask sessions on the other computers.
+
+The third command uses the `Get-PSSession` cmdlet to get the ITTask sessions. The output shows that
+the ITTask sessions on the Srv2 and Srv30 computers were not affected by the command to disconnect.
+
+The manager logs on to his home computer, connects to his corporate network, starts Windows
+PowerShell, and uses the `Get-PSSession` cmdlet to get the ITTask session on the Srv1 computer. He
+uses the credentials of the technician to access the session.
+
+Next, the manager uses the `Connect-PSSession` cmdlet to connect to the ITTask session on the Srv1
+computer. The command saves the session in the $s variable.
+
+The manager uses the `Invoke-Command` cmdlet to run some diagnostic commands in the session in the
+`$s` variable. He recognizes that the script failed because it did not find a required directory.
+The manager uses the `MkDir` function to create the directory, and then he restarts the
+`Get-PatchStatus.ps1` script and disconnects from the session.The manager reports his findings to
+the technician, suggests that he reconnect to the session to complete the tasks, and asks him to
+add a command to the `Get-PatchStatus.ps1` script that creates the required directory if it does
+not exist.
+
+### Example 4 - Change the timeout value for a PSSession
+
+This example shows how to correct the value of the **IdleTimeout** property of a session so that it
+can be disconnected.
+
+The idle timeout property of a session is critical to disconnected sessions, because it determines
+how long a disconnected session is maintained before it is deleted. You can set the idle timeout
+option when you create a session and when you disconnect it. The default values for the idle
+timeout of a session are set in the `$PSSessionOption` preference variable on the local computer
+and in the session configuration on the remote computer. Values set for the session take precedence
+over values set in the session configuration, but session values cannot exceed quotas set in the
+session configuration, such as the **MaxIdleTimeoutMs** value.
+
 ```
-The first command uses the New-PSSessionOption cmdlet to create a session option object. It uses the *IdleTimeout* parameter to set an idle time-out of 48 hours (172800000 milliseconds). The command saves the session option object in the $Timeout variable.
-PS C:\> $Timeout = New-PSSessionOption -IdleTimeout 172800000
-
-The second command uses the New-PSSession cmdlet to create the ITTask session on the Server01 computer. The command saves the session in the $s variable. The value of the *SessionOption* parameter is the 48-hour idle time-out in the $Timeout variable.
-PS C:\> $s = New-PSSession -Computer Server01 -Name ITTask -SessionOption $Timeout
-
-The third command disconnects the ITTask session in the $s variable. The command fails because the idle time-out value of the session exceeds the **MaxIdleTimeoutMs** quota in the session configuration. Because the idle time-out is not used until the session is disconnected, this violation can go undetected while the session is being used.
-PS C:\> Disconnect-PSSession -Session $s
+PS> $Timeout = New-PSSessionOption -IdleTimeout 172800000
+PS> $s = New-PSSession -Computer Server01 -Name ITTask -SessionOption $Timeout
+PS> Disconnect-PSSession -Session $s
 Disconnect-PSSession : The session ITTask cannot be disconnected because the specified
 idle timeout value 172800(seconds) is either greater than the server maximum allowed
 43200 (seconds) or less that the minimum allowed60(seconds).  Choose an idle time out
 value that is within the allowed range and try again.
 
-The fourth command uses the Invoke-Command cmdlet to run a Get-PSSessionConfiguration command for the Microsoft.PowerShell session configuration on the Server01 computer. The command uses the Format-List cmdlet to display all properties of the session configuration in a list.The output shows that the **MaxIdleTimeoutMS** property, which establishes the maximum permitted **IdleTimeout** value for sessions that use the session configuration, is 43200000 milliseconds (12 hours).
-PS C:\> Invoke-Command -ComputerName Server01 {Get-PSSessionConfiguration Microsoft.PowerShell} | Format-List -Property *
+PS> Invoke-Command -ComputerName Server01 {Get-PSSessionConfiguration Microsoft.PowerShell} |
+ Format-List -Property *
+
 Architecture                  : 64
 Filename                      : %windir%\system32\pwrshplugin.dll
 ResourceUri                   : http://schemas.microsoft.com/powershell/microsoft.powershell
@@ -194,8 +237,7 @@ RunspaceId                    : aea84310-6dbf-4c21-90ac-13980039925a
 PSShowComputerName            : True
 
 
-The fifth command gets the session option values of the session in the $s variable. The values of many session options are properties of the **ConnectionInfo** property of the **Runspace** property of the session.The output shows that the value of the **IdleTimeout** property of the session is 172800000 milliseconds (48 hours), which violates the **MaxIdleTimeoutMs** quota of 12 hours in the session configuration.To resolve this conflict, you can use the *ConfigurationName* parameter to select a different session configuration or use the *IdleTimeout* parameter to reduce the idle time-out of the session.
-PS C:\> $s.Runspace.ConnectionInfo
+PS> $s.Runspace.ConnectionInfo
 ConnectionUri                     : http://Server01/wsman
 ComputerName                      : Server01
 Scheme                            : http
@@ -227,32 +269,58 @@ CancelTimeout                     : 60000
 OperationTimeout                  : 180000
 IdleTimeout                       : 172800000
 
-The sixth command disconnects the session. It uses the *IdleTimeoutSec* parameter to set the idle time-out to the 12-hour maximum.
-PS C:\> Disconnect-PSSession $s -IdleTimeoutSec 43200
+PS> Disconnect-PSSession $s -IdleTimeoutSec 43200
 Id Name            ComputerName    State         ConfigurationName     Availability
 -- ----            ------------    -----         -----------------     ------------
  4 ITTask          Server01        Disconnected  Microsoft.PowerShell          None
 
-The seventh command gets the value of the **IdleTimeout** property of the disconnected session, which is measured in milliseconds. The output confirms that the command was successful.
-PS C:\> $s.Runspace.ConnectionInfo.IdleTimeout
+PS> $s.Runspace.ConnectionInfo.IdleTimeout
 43200000
 ```
 
-This example shows how to correct the value of the **IdleTimeout** property of a session so that it can be disconnected.
+The first command uses the `New-PSSessionOption` cmdlet to create a session option object. It uses
+the **IdleTimeout** parameter to set an idle timeout of 48 hours (172800000 milliseconds). The
+command saves the session option object in the $Timeout variable.
 
-The idle time-out property of a session is critical to disconnected sessions, because it determines how long a disconnected session is maintained before it is deleted.
-You can set the idle time-out option when you create a session and when you disconnect it.
-The default values for the idle time-out of a session are set in the **$PSSessionOption** preference variable on the local computer and in the session configuration on the remote computer.
-Values set for the session take precedence over values set in the session configuration, but session values cannot exceed quotas set in the session configuration, such as the **MaxIdleTimeoutMs** value.
+The second command uses the `New-PSSession` cmdlet to create the ITTask session on the Server01
+computer. The command save the session in the $s variable. The value of the **SessionOption**
+parameter is the 48-hour idle timeout in the $Timeout variable.
+
+The third command disconnects the ITTask session in the $s variable. The command fails because the
+idle timeout value of the session exceeds the **MaxIdleTimeoutMs** quota in the session
+configuration. Because the idle timeout is not used until the session is disconnected, this
+violation can go undetected while the session is in use.
+
+The fourth command uses the `Invoke-Command` cmdlet to run a `Get-PSSessionConfiguration` command
+for the Microsoft.PowerShell session configuration on the Server01 computer. The command uses the
+`Format-List` cmdlet to display all properties of the session configuration in a list.The output
+shows that the **MaxIdleTimeoutMS** property, which establishes the maximum permitted
+**IdleTimeout** value for sessions that use the session configuration, is 43200000 milliseconds (12
+hours).
+
+The fifth command gets the session option values of the session in the $s variable. The values of
+many session options are properties of the **ConnectionInfo** property of the **Runspace** property
+of the session.The output shows that the value of the **IdleTimeout** property of the session is
+172800000 milliseconds (48 hours), which violates the **MaxIdleTimeoutMs** quota of 12 hours in the
+session configuration.To resolve this conflict, you can use the **ConfigurationName** parameter to
+select a different session configuration or use the **IdleTimeout** parameter to reduce the idle
+timeout of the session.
+
+The sixth command disconnects the session. It uses the **IdleTimeoutSec** parameter to set the idle
+timeout to the 12-hour maximum.
+
+The seventh command gets the value of the **IdleTimeout** property of the disconnected session,
+which is measured in milliseconds. The output confirms that the command was successful.
 
 ## PARAMETERS
 
 ### -Id
-Specifies an array of IDs of sessions that this cmdlet disconnects.
-Type one or more IDs, separated by commas, or use the range operator (..) to specify a range of IDs.
 
-To get the ID of a session, use the Get-PSSession cmdlet.
-The instance ID is stored in the **ID** property of the session.
+Disconnects from sessions with the specified session ID. Type one or more IDs (separated by
+commas), or use the range operator (..) to specify a range of IDs.
+
+To get the ID of a session, use the `Get-PSSession` cmdlet. The instance ID is stored in the **ID**
+property of the session.
 
 ```yaml
 Type: Int32[]
@@ -260,28 +328,31 @@ Parameter Sets: Id
 Aliases:
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
 ### -IdleTimeoutSec
-Changes the idle time-out value of the disconnected **PSSession**.
-Enter a value in seconds.
-The minimum value is 60 (1 minute).
 
-The idle time-out determines how long the disconnected **PSSession** is maintained on the remote computer.
-When the time-out expires, the **PSSession** is deleted.
+Changes the idle timeout value of the disconnected PSSession. Enter a value in seconds. The minimum
+value is 60 (1 minute).
 
-Disconnected **PSSession** objects are considered to be idle from the moment that they are disconnected, even if commands are running in the disconnected session.
+The idle timeout determines how long the disconnected PSSession is maintained on the remote
+computer. When the timeout expires, the PSSession is deleted.
 
-The default value for the idle time-out of a session is set by the value of the **IdleTimeoutMs** property of the session configuration.
-The default value is 7200000 milliseconds (2 hours).
+Disconnected PSSessions are considered to be idle from the moment that they are disconnected, even
+if commands are running in the disconnected session.
 
-The value of this parameter takes precedence over the value of the **IdleTimeout** property of the $PSSessionOption preference variable and the default idle time-out value in the session configuration.
-However, this value cannot exceed the value of the **MaxIdleTimeoutMs** property of the session configuration.
-The default value of **MaxIdleTimeoutMs** is 12 hours (43200000 milliseconds).
+The default value for the idle timeout of a session is set by the value of the **IdleTimeoutMs**
+property of the session configuration. The default value is 7200000 milliseconds (2 hours).
+
+The value of this parameter takes precedence over the value of the **IdleTimeout** property of the
+$PSSessionOption preference variable and the default idle timeout value in the session
+configuration. However, this value cannot exceed the value of the **MaxIdleTimeoutMs** property of
+the session configuration. The default value of **MaxIdleTimeoutMs** is 12 hours (43200000
+milliseconds).
 
 ```yaml
 Type: Int32
@@ -290,19 +361,20 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 60
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -InstanceId
-Specifies an array of GUIDs of sessions that this cmdlet disconnects.
 
-The instance ID is a GUID that uniquely identifies a session on a local or remote computer.
-The instance ID is unique, even across multiple sessions on multiple computers.
+Disconnects from sessions with the specified instance IDs.
 
-To get the instance ID of a session, use **Get-PSSession**.
-The instance ID is stored in the **InstanceID** property of the session.
+The instance ID is a GUID that uniquely identifies a session on a local or remote computer. The
+instance ID is unique, even across multiple sessions on multiple computers.
+
+To get the instance ID of a session, use the `Get-PSSession` cmdlet. The instance ID is stored in
+the **InstanceID** property of the session.
 
 ```yaml
 Type: Guid[]
@@ -317,11 +389,11 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of friendly names of sessions that this cmdlet disconnects.
-Wildcard characters are permitted.
 
-To get the friendly name of a session, use **Get-PSSession**.
-The friendly name is stored in the **Name** property of the session.
+Disconnects from sessions with the specified friendly names. Wildcards are permitted.
+
+To get the friendly name of a session, use the `Get-PSSession` cmdlet. The friendly name is stored
+in the **Name** property of the session.
 
 ```yaml
 Type: String[]
@@ -335,43 +407,16 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -OutputBufferingMode
-Specifies how command output is managed in the disconnected session when the output buffer is full.
-The default value is Block.
-
-If the command in the disconnected session is returning output and the output buffer fills, the value of this parameter effectively determines whether the command continues to run while the session is disconnected.
-A value of Block suspends the command until the session is reconnected.
-A value of Drop allows the command to complete, although data might be lost.
-When using the Drop value, redirect the command output to a file on disk.
-
-The acceptable values for this parameter are:
-
-- Block. When the output buffer is full, execution is suspended until the buffer is clear.
-- Drop. When the output buffer is full, execution continues. As new output is saved, the oldest output is discarded.
-- None. No output buffering mode is specified. The value of the *OutputBufferingMode* property of the session configuration is used for the disconnected session.
-
-```yaml
-Type: OutputBufferingMode
-Parameter Sets: (All)
-Aliases:
-Accepted values: None, Drop, Block
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Session
-Specifies an array of sessions.
-Enter **PSSession** objects, such as those that the **New-PSSession** cmdlet returns.
-You can also pipe a **PSSession** object to Disconnect-PSSession.
 
-**Get-PSSession** can get all **PSSession** objects that end at a remote computer.
-These include **PSSession** objects that are disconnected and **PSSession** objects that are connected to other sessions on other computers.
-**Disconnect-PSSession** disconnects only **PSSession** that are connected to the current session.
-If you pipe other **PSSession** objects to **Disconnect-PSSession**, the **Disconnect-PSSession** command fails.
+Disconnects from the specified PSSessions. Enter PSSession objects, such as those that the
+`New-PSSession` cmdlet returns. You can also pipe a PSSession object to `Disconnect-PSSession`.
+
+The `Get-PSSession` cmdlet can get all PSSessions that terminate at a remote computer, including
+PSSessions that are disconnected and PSSessions that are connected to other sessions on other
+computers. `Disconnect-PSSession` disconnects only PSSession that are connected to the current
+session. If you pipe other PSSessions to `Disconnect-PSSession`, the `Disconnect-PSSession` command
+fails.
 
 ```yaml
 Type: PSSession[]
@@ -379,17 +424,18 @@ Parameter Sets: Session
 Aliases:
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
 ### -ThrottleLimit
-Sets the throttle limit for the **Disconnect-PSSession** command.
 
-The throttle limit is the maximum number of concurrent connections that can be established to run this command.
-If you omit this parameter or enter a value of 0, the default value, 32, is used.
+Sets the throttle limit for the `Disconnect-PSSession` command.
+
+The throttle limit is the maximum number of concurrent connections that can be established to run
+this command. If you omit this parameter or enter a value of 0, the default value, 32, is used.
 
 The throttle limit applies only to the current command, not to the session or to the computer.
 
@@ -400,12 +446,44 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 32
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputBufferingMode
+
+Determines how command output is managed in the disconnected session when the output buffer is
+full. The default value is **Block**.
+
+If the command in the disconnected session is returning output and the output buffer fills, the
+value of this parameter effectively determines whether the command continues to run while the
+session is disconnected. A value of **Block** suspends the command until the session is
+reconnected. A value of **Drop** allows the command to complete, although data might be lost. When
+using the **Drop** value, redirect the command output to a file on disk.
+
+Valid values are:
+
+- **Block**: When the output buffer is full, execution is suspended until the buffer is clear.
+- **Drop**: When the output buffer is full, execution continues. As new output is saved, the oldest
+  output is discarded.
+- **None**: No output buffering mode is specified. The value of the **OutputBufferingMode** property
+  of the session configuration is used for the disconnected session.
+
+```yaml
+Type: OutputBufferingMode
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Block
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -421,6 +499,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -437,36 +516,51 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### System.Management.Automation.Runspaces.PSSession
-You can pipe a session to this cmdlet.
+
+You can pipe a session to `Disconnect-PSSession`.
 
 ## OUTPUTS
 
 ### System.Management.Automation.Runspaces.PSSession
-This cmdlet returns an object that represents the session that it disconnected.
+
+`Disconnect-PSSession` returns an object that represents the session that it disconnected.
 
 ## NOTES
-* The **Disconnect-PSSession** cmdlet works only when the local and remote computers are running Windows PowerShell 3.0 or later versions of Windows PowerShell or PowerShell Core.
-* If you use **Disconnect-PSSession** on a disconnected session, the command does not affect the session and it does not generate errors.
-* Disconnected loopback sessions with interactive security tokens, which are created by using the *EnableNetworkAccess* parameter, can be reconnected only from the computer on which the session was created. This restriction protects the computer from malicious access.
-* When you disconnect a **PSSession**, the session state is **Disconnected** and the availability is **None**.
 
-  The value of the **State** property is relative to the current session.
-Therefore, a value of **Disconnected** means that the **PSSession** is not connected to the current session.
-However, it does not mean that the **PSSession** is disconnected from all sessions.
-It might be connected to a different session.
-To determine whether you can connect or reconnect to the session, use the **Availability** property.
+- The `Disconnect-PSSession` cmdlet works only when the local and remote computers are running
+  PowerShell 3.0 or later.
+- If you use the `Disconnect-PSSession` cmdlet on a disconnected session, the command has no effect
+  on the session and it does not generate errors.
+- Disconnected loopback sessions with interactive security tokens (those created with the
+  **EnableNetworkAccess** parameter) can be reconnected only from the computer on which the session
+  was created. This restriction protects the computer from malicious access.
+- When you disconnect a PSSession, the session state is **Disconnected** and the availability is
+  **None**.
 
-  An **Availability** value of **None** indicates that you can connect to the session.
-A value of **Busy** indicates that you cannot connect to the **PSSession** because it is connected to another session.
+  The value of the **State** property is relative to the current session. Therefore, a value of
+  **Disconnected** means that the PSSession is not connected to the current session. However, it
+  does not mean that the PSSession is disconnected from all sessions. It might be connected to a
+  different session. To determine whether you can connect or reconnect to the session, use the
+  **Availability** property.
 
-  For more information about the values of the **State** property of sessions, see [RunspaceState Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspacestate) in the MSDN library.
+  An **Availability** value of **None** indicates that you can connect to the session. A value of
+  **Busy** indicates that you cannot connect to the PSSession because it is connected to another
+  session.
 
-  For more information about the values of the **Availability** property of sessions, see [RunspaceAvailability Enumeration](https://msdn.microsoft.com/library/system.management.automation.runspaces.runspaceavailability) in the MSDN library.
+  For more information about the values of the **State** property of sessions, see
+  [RunspaceState Enumeration](/dotnet/api/system.management.automation.runspaces.runspacestate).
+
+  For more information about the values of the **Availability** property of sessions, see
+  [RunspaceAvailability Enumeration](/dotnet/api/system.management.automation.runspaces.runspaceavailability).
 
 ## RELATED LINKS
 
@@ -491,3 +585,9 @@ A value of **Busy** indicates that you cannot connect to the **PSSession** becau
 [Register-PSSessionConfiguration](Register-PSSessionConfiguration.md)
 
 [Remove-PSSession](Remove-PSSession.md)
+
+[about_PSSessions](About/about_PSSessions.md)
+
+[about_Remote](About/about_Remote.md)
+
+[about_Remote_Disconnected_Sessions](About/about_Remote_Disconnected_Sessions.md)


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
This is the first of several PRs to change references to environment variables from `%variablename%` to `$env:variablename`.

Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [x] This PR partially fixes the issue, and issue #3559 tracks the remaining work