### PR TITLE
removing %-style environment variables and other cleanup

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/Get-PSSessionConfiguration.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/Get-PSSessionConfiguration.md
@@ -10,7 +10,6 @@ title:  Get-PSSessionConfiguration
 # Get-PSSessionConfiguration
 
 ## SYNOPSIS
-
 Gets the registered session configurations on the computer.
 
 ## SYNTAX
@@ -21,30 +20,35 @@ Get-PSSessionConfiguration [[-Name] <String[]>] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The **Get-PSSessionConfiguration** cmdlet gets the session configurations that have been registered on the local computer.
-This is an advanced cmdlet that is designed to be used by system administrators to manage customized session configurations for their users.
+The `Get-PSSessionConfiguration` cmdlet gets the session configurations that have been registered
+on the local computer. This is an advanced cmdlet that is designed to be used by system
+administrators to manage customized session configurations for their users.
 
-Beginning in Windows PowerShell 3.0, you can define the properties of a session configuration by using a session configuration (.pssc) file.
-This feature lets you create customized and restricted sessions without writing a computer program.
-For more information about session configuration files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
+Beginning in Windows PowerShell 3.0, you can define the properties of a session configuration by
+using a session configuration (.pssc) file. This feature lets you create customized and restricted
+sessions without writing a computer program. For more information about session configuration
+files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
 
-Also, beginning in Windows PowerShell 3.0, new note properties have been added to the session configuration object that **Get-PSSessionConfiguration** returns.
-These properties make it easier for users and session configuration authors to examine and compare session configurations.
+Also, beginning in Windows PowerShell 3.0, new note properties have been added to the session
+configuration object that `Get-PSSessionConfiguration` returns. These properties make it easier
+for users and session configuration authors to examine and compare session configurations.
 
-To create and register a session configuration, use the Register-PSSessionConfiguration cmdlet.
-For more information about session configurations, see [about_Session_Configurations](About/about_Session_Configurations.md).
+To create and register a session configuration, use the `Register-PSSessionConfiguration` cmdlet. For
+more information about session configurations, see
+[about_Session_Configurations](About/about_Session_Configurations.md).
 
 ## EXAMPLES
 
-### Example 1
+### Example 1 - Get session configurations on the local computer
 
 ```
 PS> Get-PSSessionConfiguration
 ```
 
-This command gets the session configurations on the local computer.
+### Example 2 - Get the two default session configurations
 
-### Example 2
+The command uses the **Name** parameter of `Get-PSSessionConfiguration` to get only the session
+configurations with names that begin with "Microsoft".
 
 ```
 PS> Get-PSSessionConfiguration -Name Microsoft*
@@ -55,10 +59,10 @@ microsoft.powershell      2.0                             BUILTIN\Administrators
 microsoft.powershell32    2.0                             BUILTIN\Administrators AccessAll...
 ```
 
-This command gets the two default session configurations that come with Windows PowerShell.
-The command uses the **Name** parameter of **Get-PSSessionConfiguration** to get only the session configurations with names that begin with "Microsoft".
+### Example 3 - Get the properties and values of a session configuration
 
-### Example 3
+This example shows the properties and property values of a session configuration that was created
+by using a session configuration file.
 
 ```
 PS> Get-PSSessionConfiguration -Name Full  | Format-List -Property *
@@ -104,135 +108,91 @@ MaxShellsPerUser              : 30
 Permission                    :
 ```
 
-This example shows the properties and property values of a session configuration that was created by using a session configuration file.
+The example uses the `Get-PSSessionConfiguration` cmdlet to get the full session configuration.
+A pipeline operator sends the Full session configuration to the `Format-List` cmdlet. The
+**Property** parameter with a value of `*` (all) directs `Format-List` to display all of the
+properties and property values of the object in a list.
 
-The command uses the **Get-PSSessionConfiguration** command to get the Full session configuration.
-A pipeline operator sends the Full session configuration to the Format-List cmdlet.
-The **Property** parameter with a value of * (all) directs **Format-List** to display all of the properties and property values of the object in a list.
+The output of this command has useful information, including the author of the session
+configuration, the session type, language mode, and execution policy of sessions that are created
+with this session configuration, session quotas, and the full path to the session configuration
+file.
 
-The output of this command has very useful information, including the author of the session configuration, the session type, language mode, and execution policy of sessions that are created with this session configuration, session quotas, and the full path to the session configuration file.
+This view of a session configuration is used for sessions that include a session configuration
+file. For more information about session configuration files, see
+[about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
 
-This view of a session configuration is used for sessions that include a session configuration file.
-For more information about session configuration files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
+### Example 4 - Get the configuration of a workflow session
 
-### Example 4
+This command gets the properties of the Microsoft.PowerShell.Worfklow session configuration and
+sorts them into alphabetical order for easy reading. You can use this command format in a function
+to get this display for any session configuration.
 
 ```
-PS> (Get-PSSessionConfiguration Microsoft.PowerShell.Workflow).PSObject.Properties | Select-Object Name,Value | Sort-Object Name
-
-Name                                                                                                              Value
-
-----                                                                                                              -----
-
-ActivityProcessIdleTimeoutSec                                                                                        60
-
-AllowedActivity                                                                                   {PSDefaultActivities}
-
-Architecture                                                                                                         64
-
-AssemblyName                                                ...licKeyToken=31bf3856ad364e35, processorArchitecture=MSIL
-
-AutoRestart                                                                                                       false
-
-Capability                                                                                                      {Shell}
-
-Enabled                                                                                                            true
-
-EnableValidation                                                                                                   true
-
-ExactMatch                                                                                                        False
-
-Filename                                                                              %windir%\system32\pwrshplugin.dll
-
-IdleTimeoutms                                                                                                   7200000
-
-lang                                                                                                              en-US
-
-MaxActivityProcesses                                                                                                  5
-
-MaxConcurrentCommandsPerShell                                                                                      1000
-
-MaxConcurrentUsers                                                                                                    5
-
-MaxConnectedSessions                                                                                                100
-
-MaxDisconnectedSessions                                                                                            1000
-
-MaxIdleTimeoutms                                                                                             2147483647
-
-MaxMemoryPerShellMB                                                                                                1024
-
-MaxPersistenceStoreSizeGB                                                                                            10
-
-MaxProcessesPerShell                                                                                                 15
-
-MaxRunningWorkflows                                                                                                  30
-
-MaxSessionsPerRemoteNode                                                                                              5
-
-MaxSessionsPerWorkflow                                                                                                5
-
-MaxShells                                                                                                            25
-
-MaxShellsPerUser                                                                                                     25
-
-ModulesToImport                                             %windir%\system32\windowspowershell\v1.0\Modules\PSWorkflow
-
-Name                                                                                      microsoft.powershell.workflow
-
-OutOfProcessActivity                                                                                     {InlineScript}
-
-OutputBufferingMode                                                                                               Block
-
-ParentResourceUri                                           ...s.microsoft.com/powershell/microsoft.powershell.workflow
-
-Permission                                                  ...ssAllowed, BUILTIN\Remote Management Users AccessAllowed
-
-PersistencePath                                             ...s\juneb\AppData\Local\Microsoft\Windows\PowerShell\WF\PS
-
-PersistWithEncryption                                                                                             False
-
-ProcessIdleTimeoutSec                                                                                             28800
-
-PSSessionConfigurationTypeName                              ...osoft.PowerShell.Workflow.PSWorkflowSessionConfiguration
-
-PSVersion                                                                                                           3.0
-
-RemoteNodeSessionIdleTimeoutSec                                                                                      60
-
-ResourceUri                                                 ...s.microsoft.com/powershell/microsoft.powershell.workflow
-
+PS> (Get-PSSessionConfiguration Microsoft.PowerShell.Workflow).PSObject.Properties |
+  Select-Object Name,Value | Sort-Object Name
+Name                                                                                                  Value
+----                                                                                                  -----
+ActivityProcessIdleTimeoutSec                                                                            60
+AllowedActivity                                                                       {PSDefaultActivities}
+Architecture                                                                                             64
+AssemblyName                                    ...licKeyToken=31bf3856ad364e35, processorArchitecture=MSIL
+AutoRestart                                                                                           false
+Capability                                                                                          {Shell}
+Enabled                                                                                                true
+EnableValidation                                                                                       true
+ExactMatch                                                                                            False
+Filename                                                                  %windir%\system32\pwrshplugin.dll
+IdleTimeoutms                                                                                       7200000
+lang                                                                                                  en-US
+MaxActivityProcesses                                                                                      5
+MaxConcurrentCommandsPerShell                                                                          1000
+MaxConcurrentUsers                                                                                        5
+MaxConnectedSessions                                                                                    100
+MaxDisconnectedSessions                                                                                1000
+MaxIdleTimeoutms                                                                                 2147483647
+MaxMemoryPerShellMB                                                                                    1024
+MaxPersistenceStoreSizeGB                                                                                10
+MaxProcessesPerShell                                                                                     15
+MaxRunningWorkflows                                                                                      30
+MaxSessionsPerRemoteNode                                                                                  5
+MaxSessionsPerWorkflow                                                                                    5
+MaxShells                                                                                                25
+MaxShellsPerUser                                                                                         25
+ModulesToImport                                 %windir%\system32\windowspowershell\v1.0\Modules\PSWorkflow
+Name                                                                          microsoft.powershell.workflow
+OutOfProcessActivity                                                                         {InlineScript}
+OutputBufferingMode                                                                                   Block
+ParentResourceUri                               ...s.microsoft.com/powershell/microsoft.powershell.workflow
+Permission                                      ...ssAllowed, BUILTIN\Remote Management Users AccessAllowed
+PersistencePath                                 ...s\juneb\AppData\Local\Microsoft\Windows\PowerShell\WF\PS
+PersistWithEncryption                                                                                 False
+ProcessIdleTimeoutSec                                                                                 28800
+PSSessionConfigurationTypeName                  ...osoft.PowerShell.Workflow.PSWorkflowSessionConfiguration
+PSVersion                                                                                               3.0
+RemoteNodeSessionIdleTimeoutSec                                                                          60
+ResourceUri                                     ...s.microsoft.com/powershell/microsoft.powershell.workflow
 RunAsPassword
-
 RunAsUser
-
-SDKVersion                                                                                                            2
-
-SecurityDescriptorSddl                                      ...;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)
-
-SessionConfigurationData                                    ...    </SessionConfigurationData>
-
-SessionThrottleLimit                                                                                                100
-
-SupportsOptions                                                                                                    true
-
-Uri                                                         ...s.microsoft.com/powershell/microsoft.powershell.workflow
-
-UseSharedProcess                                                                                                   true
-
-WorkflowShutdownTimeoutMSec                                                                                         500
-
-xmlns                                                       ...as.microsoft.com/wbem/wsman/1/config/PluginConfiguration
-
-XmlRenderingType                                                                                                   text
+SDKVersion                                                                                                2
+SecurityDescriptorSddl                          ...;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)
+SessionConfigurationData                                                 ...    </SessionConfigurationData>
+SessionThrottleLimit                                                                                    100
+SupportsOptions                                                                                        true
+Uri                                             ...s.microsoft.com/powershell/microsoft.powershell.workflow
+UseSharedProcess                                                                                       true
+WorkflowShutdownTimeoutMSec                                                                             500
+xmlns                                           ...as.microsoft.com/wbem/wsman/1/config/PluginConfiguration
+XmlRenderingType                                                                                       text
 ```
-
-This command gets the properties of the Microsoft.PowerShell.Worfklow session configuration and sorts them into alphabetical order for easy reading.
-You can use this command format in a function to get this display for any session configuration.
 
 This example was contributed by Shay Levy, a Windows PowerShell MVP from Sderot, Israel.
 
-### Example 5
+### Example 5 - Another way to look at the session configurations
+
+This command uses the `Get-ChildItem` cmdlet (alias = dir) in the WSMan: provider drive to look at
+the content of the Plugin node. This is another way to look at the session configurations on the
+computer.
 
 ```
 PS> dir wsman:\localhost\plugin
@@ -247,18 +207,19 @@ Container       {Name=microsoft.ServerManager}      microsoft.ServerManager
 Container       {Name=WMI Provider}                 WMI Provider
 ```
 
-This command uses the Get-ChildItem cmdlet (alias = dir) in the WSMan: provider drive to look at the content of the Plugin node.
-This is another way to look at the session configurations on the computer.
+The **PlugIn** node contains **ContainerElement** objects
+(Microsoft.WSMan.Management.WSManConfigContainerElement) that represent the registered PowerShell
+session configurations, along with other plug-ins for WS-Management.
 
-The **PlugIn** node contains **ContainerElement** objects (Microsoft.WSMan.Management.WSManConfigContainerElement) that represent the registered Windows PowerShell session configurations, along with other plug-ins for WS-Management.
+### Example 6 - View session configurations on a remote computer
 
-### Example 6
+This example shows how to use the WSMan provider to view the session configurations on a remote
+computer. This method does not provide as much information as a `Get-PSSessionConfiguration`
+command, but the user does not need to be a member of the Administrators group to run this command.
 
 ```
-The first command uses the Connect-WSMan cmdlet to connect to the WinRM service on the Server01 remote computer.
 PS> Connect-WSMan -ComputerName Server01
 
-The second command uses the Get-ChildItem cmdlet ("dir") in the WSMan: drive to get the items in the Server01\Plugin path.The output shows the items in the Plugin directory on the Server01 computer. The items include the session configurations, which are a type of WSMan plug-in, along with other types of plug-ins on the computer.
 PS> dir WSMan:\Server01\Plugin
    WSManConfig: Microsoft.WSMan.Management\WSMan::localhost\Plugin
 
@@ -278,8 +239,9 @@ Container       {Name=SEL Plugin}                   SEL Plugin
 Container       {Name=WithProfile}                  WithProfile
 Container       {Name=WMI Provider}                 WMI Provider
 
-The third command returns the names of the plugins that are session configurations. The command searches for a value of **Shell** in the **Capability** property, which is in the Plugin\Resources\<ResourceNumber> path in the WSMan: drive.
-PS> dir WSMan:\Server01\Plugin\*\Resources\Resource*\Capability | where {$_.Value -eq "Shell"} | foreach {($_.PSPath.split("\"))[3] }
+PS> dir WSMan:\Server01\Plugin\*\Resources\Resource*\Capability |
+  where {$_.Value -eq "Shell"} |
+    foreach {($_.PSPath.split("\"))[3] }
 Empty
 Full
 microsoft.powershell
@@ -292,22 +254,32 @@ RRS
 WithProfile
 ```
 
-This example shows how to use the WSMan provider to view the session configurations on a remote computer.
-This method does not provide as much information as a **Get-PSSessionConfiguration** command, but the user does not need to be a member of the Administrators group to run this command.
+The first command uses the `Connect-WSMan` cmdlet to connect to the WinRM service on the Server01
+remote computer.
 
-### Example 7
+The second command uses the `Get-ChildItem` cmdlet ("dir") in the WSMan: drive to get the items in
+the Server01\Plugin path.The output shows the items in the Plugin directory on the Server01
+computer. The items include the session configurations, which are a type of WSMan plug-in, along
+with other types of plug-ins on the computer.
+
+The third command returns the names of the plugins that are session configurations. The command
+searches for a value of **Shell** in the **Capability** property, which is in the
+`Plugin\Resources\<ResourceNumber>` path in the WSMan: drive.
+
+### Example 7 - Get detailed session configurations from a remote computer
+
+This example shows how to run a `Get-PSSessionConfiguration` command on a remote computer. The
+command requires that CredSSP delegation be enabled in the client settings on the local computer
+and in the service settings on the remote computer.
+
+To run the commands in this example, you must be a member of the Administrators group on the local
+computer and the remote computer and you must start Windows PowerShell with the "Run as
+administrator" option.
 
 ```
-The first command uses the Enable-WSManCredSSP cmdlet to enable **CredSSP** delegation from the Server01 local computer to the Server02 remote computer. This configures the **CredSSP** client setting on the local computer.
 PS> Enable-WSManCredSSP -Delegate Server02
-
-The second command uses the Connect-WSMan cmdlet to connect to the Server02 computer. This action adds a node for the Server02 computer to the WSMan: drive on the local computer, allowing you to view and change the WS-Management settings on the Server02 computer.
 PS> Connect-WSMan Server02
-
-The third command uses the Set-Item cmdlet to change the value of the **CredSSP** item in the Service node of the Server02 computer to True. This configures the service settings on the remote computer.
 PS> Set-Item WSMan:\Server02*\Service\Auth\CredSSP -Value $true
-
-The fourth command uses the Invoke-Command cmdlet to run a **Get-PSSessionConfiguration** command on the Server02 computer. The command uses the **Credential** parameter, and it uses the **Authentication** parameter with a value of **CredSSP**.The output shows the session configurations on the Server02 remote computer.
 PS> Invoke-Command -ScriptBlock {Get-PSSessionConfiguration} -ComputerName Server02 -Authentication CredSSP -Credential Domain01\Admin01
 
 Name                      PSVersion  StartupScript        Permission                          PSComputerName
@@ -317,33 +289,44 @@ microsoft.powershell32    2.0                             BUILTIN\Administrators
 MyX86Shell                2.0        c:\test\x86Shell.ps1 BUILTIN\Administrators AccessAll... server02.corp.fabrikam.com
 ```
 
-This example shows how to run a **Get-PSSessionConfiguration** command on a remote computer.
-The command requires that CredSSP delegation be enabled in the client settings on the local computer and in the service settings on the remote computer.
+The first command uses the `Enable-WSManCredSSP` cmdlet to enable **CredSSP** delegation from the
+Server01 local computer to the Server02 remote computer. This configures the **CredSSP** client
+setting on the local computer.
 
-To run the commands in this example, you must be a member of the Administrators group on the local computer and the remote computer and you must start Windows PowerShell with the "Run as administrator" option.
+The second command uses the `Connect-WSMan` cmdlet to connect to the Server02 computer. This action
+adds a node for the Server02 computer to the WSMan: drive on the local computer, allowing you to
+view and change the WS-Management settings on the Server02 computer.
 
-### Example 8
+The third command uses the `Set-Item` cmdlet to change the value of the **CredSSP** item in the
+Service node of the Server02 computer to True. This configures the service settings on the remote
+computer.
+
+The fourth command uses the `Invoke-Command` cmdlet to run a `Get-PSSessionConfiguration` command
+on the Server02 computer. The command uses the **Credential** parameter, and it uses the
+**Authentication** parameter with a value of **CredSSP**.The output shows the session
+configurations on the Server02 remote computer.
+
+### Example 8 - Get the resource URI of a session configuration
+
+This command is useful when setting the value of the $PSSessionConfigurationName preference
+variable, which takes a resource URI.
 
 ```
 PS> (Get-PSSessionConfiguration -Name CustomShell).resourceURI
 http://schemas.microsoft.com/powershell/microsoft.CustomShell
 ```
 
-This command uses the **Get-PSSessionConfiguration** cmdlet to get the resource URI of a session configuration.
-
-This command is useful when setting the value of the $PSSessionConfigurationName preference variable, which takes a resource URI.
-
-The $PSSessionConfiguationName variable specifies the default configuration that is used when you create a session.
-This variable is set on the local computer, but it specifies a configuration on the remote computer.
-For more information about the $PSSessionConfiguration variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
+The `$PSSessionConfiguationName` variable specifies the default configuration that is used when you
+create a session. This variable is set on the local computer, but it specifies a configuration on
+the remote computer. For more information about the `$PSSessionConfiguration` variable, see
+[about_Preference_Variables](About/about_Preference_Variables.md).
 
 ## PARAMETERS
 
 ### -Name
 
-Gets only the session configurations with the specified name or name pattern.
-Enter one or more session configuration names.
-Wildcards are permitted.
+Gets only the session configurations with the specified name or name pattern. Enter one or more
+session configuration names. Wildcards are permitted.
 
 ```yaml
 Type: String[]
@@ -351,7 +334,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 1
+Position: 0
 Default value: All session configurations on the local computer
 Accept pipeline input: False
 Accept wildcard characters: True
@@ -359,7 +342,10 @@ Accept wildcard characters: True
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](./About/about_CommonParameters.md).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
@@ -374,11 +360,30 @@ You cannot pipe input to this cmdlet.
 ## NOTES
 
 - To run this cmdlet, start Windows PowerShell with the "Run as administrator" option.
-- To view the session configurations on the computer, you must be a member of the Administrators group on the computer.
-- To run a **Get-PSSessionConfiguration** command on a remote computer, Credential Security Service Provider (CredSSP) authentication must be enabled in the client settings on the local computer (by using the Enable-WSManCredSSP cmdlet) and in the service settings on the remote computer, and you must use the **CredSSP** value of the **Authentication** parameter when establishing the remote session. Otherwise, access is denied.
-- The note properties of the object that **Get-PSSessionConfiguration** returns appear on the object only when they have a value. Only session configurations that were created by using a session configuration file have all of the defined properties.
-- The properties of a session configuration object vary with the options set for the session configuration and the values of those options. Also, session configurations that use a session configuration file have additional properties.
-- You can use commands in the WSMan: drive to change the properties of session configurations. However, you cannot use the WSMan: drive in Windows PowerShell 2.0 to change session configuration properties that are introduced in Windows PowerShell 3.0, such as **OutputBufferingMode**. Windows PowerShell 2.0 commands do not generate an error, but they are ineffective. To change  properties introduced in Windows PowerShell 3.0, use the WSMan: drive in Windows PowerShell 3.0.
+
+- To view the session configurations on the computer, you must be a member of the Administrators
+  group on the computer.
+
+- To run a `Get-PSSessionConfiguration` command on a remote computer, Credential Security Service
+  Provider (CredSSP) authentication must be enabled in the client settings on the local computer
+  (by using the `Enable-WSManCredSSP` cmdlet) and in the service settings on the remote computer,
+  and you must use the **CredSSP** value of the **Authentication** parameter when establishing the
+  remote session. Otherwise, access is denied.
+
+- The note properties of the object that `Get-PSSessionConfiguration` returns appear on the
+  object only when they have a value. Only session configurations that were created by using a
+  session configuration file have all of the defined properties.
+
+- The properties of a session configuration object vary with the options set for the session
+  configuration and the values of those options. Also, session configurations that use a session
+  configuration file have additional properties.
+
+- You can use commands in the WSMan: drive to change the properties of session configurations.
+  However, you cannot use the WSMan: drive in Windows PowerShell 2.0 to change session
+  configuration properties that are introduced in Windows PowerShell 3.0, such as
+  **OutputBufferingMode**. Windows PowerShell 2.0 commands do not generate an error, but they are
+  ineffective. To change properties introduced in Windows PowerShell 3.0, use the WSMan: drive in
+  Windows PowerShell 3.0.
 
 ## RELATED LINKS
 
@@ -400,7 +405,7 @@ You cannot pipe input to this cmdlet.
 
 [Unregister-PSSessionConfiguration](Unregister-PSSessionConfiguration.md)
 
-[WSMan Provider](../Microsoft.WsMan.Management/About/about_WSMan_Provider.md)
+[WSMan Provider](../microsoft.wsman.management/about/about_WSMan_Provider.md)
 
 [about_Session_Configurations](About/about_Session_Configurations.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Core/Get-PSSessionConfiguration.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/Get-PSSessionConfiguration.md
@@ -7,44 +7,52 @@ online version:  http://go.microsoft.com/fwlink/p/?linkid=289589
 external help file:  System.Management.Automation.dll-Help.xml
 title:  Get-PSSessionConfiguration
 ---
-
 # Get-PSSessionConfiguration
 
 ## SYNOPSIS
+
 Gets the registered session configurations on the computer.
 
 ## SYNTAX
 
 ```
-Get-PSSessionConfiguration [[-Name] <String[]>] [-Force] [<CommonParameters>]
+Get-PSSessionConfiguration [[-Name] <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-PSSessionConfiguration** cmdlet gets the session configurations that have been registered on the local computer.
-This is an advanced cmdlet that is designed to be used by system administrators to manage customized session configurations for their users.
 
-Beginning in Windows PowerShell 3.0, you can define the properties of a session configuration by using a session configuration (.pssc) file.
-This feature lets you create customized and restricted sessions without writing a computer program.
-For more information about session configuration files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
+The `Get-PSSessionConfiguration` cmdlet gets the session configurations that have been registered
+on the local computer. This is an advanced cmdlet that is designed to be used by system
+administrators to manage customized session configurations for their users.
 
-Also, beginning in Windows PowerShell 3.0, new note properties have been added to the session configuration object that **Get-PSSessionConfiguration** returns.
-These properties make it easier for users and session configuration authors to examine and compare session configurations.
+Beginning in Windows PowerShell 3.0, you can define the properties of a session configuration by
+using a session configuration (.pssc) file. This feature lets you create customized and restricted
+sessions without writing a computer program. For more information about session configuration
+files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
 
-To create and register a session configuration, use the Register-PSSessionConfiguration cmdlet.
-For more information about session configurations, see [about_Session_Configurations](About/about_Session_Configurations.md).
+Also, beginning in Windows PowerShell 3.0, new note properties have been added to the session
+configuration object that `Get-PSSessionConfiguration` returns. These properties make it easier
+for users and session configuration authors to examine and compare session configurations.
+
+To create and register a session configuration, use the `Register-PSSessionConfiguration` cmdlet. For
+more information about session configurations, see
+[about_Session_Configurations](About/about_Session_Configurations.md).
 
 ## EXAMPLES
 
-### Example 1
+### Example 1 - Get session configurations on the local computer
+
 ```
-PS C:\> Get-PSSessionConfiguration
+PS> Get-PSSessionConfiguration
 ```
 
-This command gets the session configurations on the local computer.
+### Example 2 - Get the two default session configurations
 
-### Example 2
+The command uses the **Name** parameter of `Get-PSSessionConfiguration` to get only the session
+configurations with names that begin with "Microsoft".
+
 ```
-PS C:\> Get-PSSessionConfiguration -Name Microsoft*
+PS> Get-PSSessionConfiguration -Name Microsoft*
 
 Name                      PSVersion  StartupScript        Permission
 ----                      ---------  -------------        ----------
@@ -52,12 +60,13 @@ microsoft.powershell      2.0                             BUILTIN\Administrators
 microsoft.powershell32    2.0                             BUILTIN\Administrators AccessAll...
 ```
 
-This command gets the two default session configurations that come with Windows PowerShell.
-The command uses the **Name** parameter of **Get-PSSessionConfiguration** to get only the session configurations with names that begin with "Microsoft".
+### Example 3 - Get the properties and values of a session configuration
 
-### Example 3
+This example shows the properties and property values of a session configuration that was created
+by using a session configuration file.
+
 ```
-PS C:\> Get-PSSessionConfiguration -Name Full  | Format-List -Property *
+PS> Get-PSSessionConfiguration -Name Full  | Format-List -Property *
 
 
 Copyright                     : (c) 2011 User01. All rights reserved.
@@ -100,136 +109,94 @@ MaxShellsPerUser              : 30
 Permission                    :
 ```
 
-This example shows the properties and property values of a session configuration that was created by using a session configuration file.
+The example uses the `Get-PSSessionConfiguration` cmdlet to get the full session configuration.
+A pipeline operator sends the Full session configuration to the `Format-List` cmdlet. The
+**Property** parameter with a value of `*` (all) directs `Format-List` to display all of the
+properties and property values of the object in a list.
 
-The command uses the **Get-PSSessionConfiguration** command to get the Full session configuration.
-A pipeline operator sends the Full session configuration to the Format-List cmdlet.
-The **Property** parameter with a value of * (all) directs **Format-List** to display all of the properties and property values of the object in a list.
+The output of this command has useful information, including the author of the session
+configuration, the session type, language mode, and execution policy of sessions that are created
+with this session configuration, session quotas, and the full path to the session configuration
+file.
 
-The output of this command has very useful information, including the author of the session configuration, the session type, language mode, and execution policy of sessions that are created with this session configuration, session quotas, and the full path to the session configuration file.
+This view of a session configuration is used for sessions that include a session configuration
+file. For more information about session configuration files, see
+[about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
 
-This view of a session configuration is used for sessions that include a session configuration file.
-For more information about session configuration files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
+### Example 4 - Get the configuration of a workflow session
 
-### Example 4
+This command gets the properties of the Microsoft.PowerShell.Worfklow session configuration and
+sorts them into alphabetical order for easy reading. You can use this command format in a function
+to get this display for any session configuration.
+
 ```
-PS C:\> (Get-PSSessionConfiguration Microsoft.PowerShell.Workflow).PSObject.Properties | Select-Object Name,Value | Sort-Object Name
-
-Name                                                                                                              Value
-
-----                                                                                                              -----
-
-ActivityProcessIdleTimeoutSec                                                                                        60
-
-AllowedActivity                                                                                   {PSDefaultActivities}
-
-Architecture                                                                                                         64
-
-AssemblyName                                                ...licKeyToken=31bf3856ad364e35, processorArchitecture=MSIL
-
-AutoRestart                                                                                                       false
-
-Capability                                                                                                      {Shell}
-
-Enabled                                                                                                            true
-
-EnableValidation                                                                                                   true
-
-ExactMatch                                                                                                        False
-
-Filename                                                                              %windir%\system32\pwrshplugin.dll
-
-IdleTimeoutms                                                                                                   7200000
-
-lang                                                                                                              en-US
-
-MaxActivityProcesses                                                                                                  5
-
-MaxConcurrentCommandsPerShell                                                                                      1000
-
-MaxConcurrentUsers                                                                                                    5
-
-MaxConnectedSessions                                                                                                100
-
-MaxDisconnectedSessions                                                                                            1000
-
-MaxIdleTimeoutms                                                                                             2147483647
-
-MaxMemoryPerShellMB                                                                                                1024
-
-MaxPersistenceStoreSizeGB                                                                                            10
-
-MaxProcessesPerShell                                                                                                 15
-
-MaxRunningWorkflows                                                                                                  30
-
-MaxSessionsPerRemoteNode                                                                                              5
-
-MaxSessionsPerWorkflow                                                                                                5
-
-MaxShells                                                                                                            25
-
-MaxShellsPerUser                                                                                                     25
-
-ModulesToImport                                             %windir%\system32\windowspowershell\v1.0\Modules\PSWorkflow
-
-Name                                                                                      microsoft.powershell.workflow
-
-OutOfProcessActivity                                                                                     {InlineScript}
-
-OutputBufferingMode                                                                                               Block
-
-ParentResourceUri                                           ...s.microsoft.com/powershell/microsoft.powershell.workflow
-
-Permission                                                  ...ssAllowed, BUILTIN\Remote Management Users AccessAllowed
-
-PersistencePath                                             ...s\juneb\AppData\Local\Microsoft\Windows\PowerShell\WF\PS
-
-PersistWithEncryption                                                                                             False
-
-ProcessIdleTimeoutSec                                                                                             28800
-
-PSSessionConfigurationTypeName                              ...osoft.PowerShell.Workflow.PSWorkflowSessionConfiguration
-
-PSVersion                                                                                                           3.0
-
-RemoteNodeSessionIdleTimeoutSec                                                                                      60
-
-ResourceUri                                                 ...s.microsoft.com/powershell/microsoft.powershell.workflow
-
+PS> (Get-PSSessionConfiguration Microsoft.PowerShell.Workflow).PSObject.Properties |
+  Select-Object Name,Value | Sort-Object Name
+Name                                                                                                  Value
+----                                                                                                  -----
+ActivityProcessIdleTimeoutSec                                                                            60
+AllowedActivity                                                                       {PSDefaultActivities}
+Architecture                                                                                             64
+AssemblyName                                    ...licKeyToken=31bf3856ad364e35, processorArchitecture=MSIL
+AutoRestart                                                                                           false
+Capability                                                                                          {Shell}
+Enabled                                                                                                true
+EnableValidation                                                                                       true
+ExactMatch                                                                                            False
+Filename                                                                  %windir%\system32\pwrshplugin.dll
+IdleTimeoutms                                                                                       7200000
+lang                                                                                                  en-US
+MaxActivityProcesses                                                                                      5
+MaxConcurrentCommandsPerShell                                                                          1000
+MaxConcurrentUsers                                                                                        5
+MaxConnectedSessions                                                                                    100
+MaxDisconnectedSessions                                                                                1000
+MaxIdleTimeoutms                                                                                 2147483647
+MaxMemoryPerShellMB                                                                                    1024
+MaxPersistenceStoreSizeGB                                                                                10
+MaxProcessesPerShell                                                                                     15
+MaxRunningWorkflows                                                                                      30
+MaxSessionsPerRemoteNode                                                                                  5
+MaxSessionsPerWorkflow                                                                                    5
+MaxShells                                                                                                25
+MaxShellsPerUser                                                                                         25
+ModulesToImport                                 %windir%\system32\windowspowershell\v1.0\Modules\PSWorkflow
+Name                                                                          microsoft.powershell.workflow
+OutOfProcessActivity                                                                         {InlineScript}
+OutputBufferingMode                                                                                   Block
+ParentResourceUri                               ...s.microsoft.com/powershell/microsoft.powershell.workflow
+Permission                                      ...ssAllowed, BUILTIN\Remote Management Users AccessAllowed
+PersistencePath                                 ...s\juneb\AppData\Local\Microsoft\Windows\PowerShell\WF\PS
+PersistWithEncryption                                                                                 False
+ProcessIdleTimeoutSec                                                                                 28800
+PSSessionConfigurationTypeName                  ...osoft.PowerShell.Workflow.PSWorkflowSessionConfiguration
+PSVersion                                                                                               3.0
+RemoteNodeSessionIdleTimeoutSec                                                                          60
+ResourceUri                                     ...s.microsoft.com/powershell/microsoft.powershell.workflow
 RunAsPassword
-
 RunAsUser
-
-SDKVersion                                                                                                            2
-
-SecurityDescriptorSddl                                      ...;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)
-
-SessionConfigurationData                                    ...    </SessionConfigurationData>
-
-SessionThrottleLimit                                                                                                100
-
-SupportsOptions                                                                                                    true
-
-Uri                                                         ...s.microsoft.com/powershell/microsoft.powershell.workflow
-
-UseSharedProcess                                                                                                   true
-
-WorkflowShutdownTimeoutMSec                                                                                         500
-
-xmlns                                                       ...as.microsoft.com/wbem/wsman/1/config/PluginConfiguration
-
-XmlRenderingType                                                                                                   text
+SDKVersion                                                                                                2
+SecurityDescriptorSddl                          ...;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)
+SessionConfigurationData                                                 ...    </SessionConfigurationData>
+SessionThrottleLimit                                                                                    100
+SupportsOptions                                                                                        true
+Uri                                             ...s.microsoft.com/powershell/microsoft.powershell.workflow
+UseSharedProcess                                                                                       true
+WorkflowShutdownTimeoutMSec                                                                             500
+xmlns                                           ...as.microsoft.com/wbem/wsman/1/config/PluginConfiguration
+XmlRenderingType                                                                                       text
 ```
-
-This command gets the properties of the Microsoft.PowerShell.Worfklow session configuration and sorts them into alphabetical order for easy reading.
-You can use this command format in a function to get this display for any session configuration.
 
 This example was contributed by Shay Levy, a Windows PowerShell MVP from Sderot, Israel.
 
-### Example 5
+### Example 5 - Another way to look at the session configurations
+
+This command uses the `Get-ChildItem` cmdlet (alias = dir) in the WSMan: provider drive to look at
+the content of the Plugin node. This is another way to look at the session configurations on the
+computer.
+
 ```
-PS C:\> dir wsman:\localhost\plugin
+PS> dir wsman:\localhost\plugin
 Type            Keys                                Name
 ----            ----                                ----
 Container       {Name=Event Forwarding Plugin}      Event Forwarding Plugin
@@ -241,18 +208,20 @@ Container       {Name=microsoft.ServerManager}      microsoft.ServerManager
 Container       {Name=WMI Provider}                 WMI Provider
 ```
 
-This command uses the Get-ChildItem cmdlet (alias = dir) in the WSMan: provider drive to look at the content of the Plugin node.
-This is another way to look at the session configurations on the computer.
+The **PlugIn** node contains **ContainerElement** objects
+(Microsoft.WSMan.Management.WSManConfigContainerElement) that represent the registered PowerShell
+session configurations, along with other plug-ins for WS-Management.
 
-The **PlugIn** node contains **ContainerElement** objects (Microsoft.WSMan.Management.WSManConfigContainerElement) that represent the registered Windows PowerShell session configurations, along with other plug-ins for WS-Management.
+### Example 6 - View session configurations on a remote computer
 
-### Example 6
+This example shows how to use the WSMan provider to view the session configurations on a remote
+computer. This method does not provide as much information as a `Get-PSSessionConfiguration`
+command, but the user does not need to be a member of the Administrators group to run this command.
+
 ```
-The first command uses the Connect-WSMan cmdlet to connect to the WinRM service on the Server01 remote computer.
-PS C:\> Connect-WSMan -ComputerName Server01
+PS> Connect-WSMan -ComputerName Server01
 
-The second command uses the Get-ChildItem cmdlet ("dir") in the WSMan: drive to get the items in the Server01\Plugin path.The output shows the items in the Plugin directory on the Server01 computer. The items include the session configurations, which are a type of WSMan plug-in, along with other types of plug-ins on the computer.
-PS C:\> dir WSMan:\Server01\Plugin
+PS> dir WSMan:\Server01\Plugin
    WSManConfig: Microsoft.WSMan.Management\WSMan::localhost\Plugin
 
 Type            Keys                                Name
@@ -271,8 +240,9 @@ Container       {Name=SEL Plugin}                   SEL Plugin
 Container       {Name=WithProfile}                  WithProfile
 Container       {Name=WMI Provider}                 WMI Provider
 
-The third command returns the names of the plugins that are session configurations. The command searches for a value of **Shell** in the **Capability** property, which is in the Plugin\Resources\<ResourceNumber> path in the WSMan: drive.
-PS C:\> dir WSMan:\Server01\Plugin\*\Resources\Resource*\Capability | where {$_.Value -eq "Shell"} | foreach {($_.PSPath.split("\"))[3] }
+PS> dir WSMan:\Server01\Plugin\*\Resources\Resource*\Capability |
+  where {$_.Value -eq "Shell"} |
+    foreach {($_.PSPath.split("\"))[3] }
 Empty
 Full
 microsoft.powershell
@@ -285,22 +255,33 @@ RRS
 WithProfile
 ```
 
-This example shows how to use the WSMan provider to view the session configurations on a remote computer.
-This method does not provide as much information as a **Get-PSSessionConfiguration** command, but the user does not need to be a member of the Administrators group to run this command.
+The first command uses the `Connect-WSMan` cmdlet to connect to the WinRM service on the Server01
+remote computer.
 
-### Example 7
+The second command uses the `Get-ChildItem` cmdlet ("dir") in the WSMan: drive to get the items in
+the Server01\Plugin path.The output shows the items in the Plugin directory on the Server01
+computer. The items include the session configurations, which are a type of WSMan plug-in, along
+with other types of plug-ins on the computer.
+
+The third command returns the names of the plugins that are session configurations. The command
+searches for a value of **Shell** in the **Capability** property, which is in the
+`Plugin\Resources\<ResourceNumber>` path in the WSMan: drive.
+
+### Example 7 - Get detailed session configurations from a remote computer
+
+This example shows how to run a `Get-PSSessionConfiguration` command on a remote computer. The
+command requires that CredSSP delegation be enabled in the client settings on the local computer
+and in the service settings on the remote computer.
+
+To run the commands in this example, you must be a member of the Administrators group on the local
+computer and the remote computer and you must start Windows PowerShell with the "Run as
+administrator" option.
+
 ```
-The first command uses the Enable-WSManCredSSP cmdlet to enable **CredSSP** delegation from the Server01 local computer to the Server02 remote computer. This configures the **CredSSP** client setting on the local computer.
-PS C:\> Enable-WSManCredSSP -Delegate Server02
-
-The second command uses the Connect-WSMan cmdlet to connect to the Server02 computer. This action adds a node for the Server02 computer to the WSMan: drive on the local computer, allowing you to view and change the WS-Management settings on the Server02 computer.
-PS C:\> Connect-WSMan Server02
-
-The third command uses the Set-Item cmdlet to change the value of the **CredSSP** item in the Service node of the Server02 computer to True. This configures the service settings on the remote computer.
-PS C:\> Set-Item WSMan:\Server02*\Service\Auth\CredSSP -Value $true
-
-The fourth command uses the Invoke-Command cmdlet to run a **Get-PSSessionConfiguration** command on the Server02 computer. The command uses the **Credential** parameter, and it uses the **Authentication** parameter with a value of **CredSSP**.The output shows the session configurations on the Server02 remote computer.
-PS C:\> Invoke-Command -ScriptBlock {Get-PSSessionConfiguration} -ComputerName Server02 -Authentication CredSSP -Credential Domain01\Admin01
+PS> Enable-WSManCredSSP -Delegate Server02
+PS> Connect-WSMan Server02
+PS> Set-Item WSMan:\Server02*\Service\Auth\CredSSP -Value $true
+PS> Invoke-Command -ScriptBlock {Get-PSSessionConfiguration} -ComputerName Server02 -Authentication CredSSP -Credential Domain01\Admin01
 
 Name                      PSVersion  StartupScript        Permission                          PSComputerName
 ----                      ---------  -------------        ----------                          --------------
@@ -309,46 +290,44 @@ microsoft.powershell32    2.0                             BUILTIN\Administrators
 MyX86Shell                2.0        c:\test\x86Shell.ps1 BUILTIN\Administrators AccessAll... server02.corp.fabrikam.com
 ```
 
-This example shows how to run a **Get-PSSessionConfiguration** command on a remote computer.
-The command requires that CredSSP delegation be enabled in the client settings on the local computer and in the service settings on the remote computer.
+The first command uses the `Enable-WSManCredSSP` cmdlet to enable **CredSSP** delegation from the
+Server01 local computer to the Server02 remote computer. This configures the **CredSSP** client
+setting on the local computer.
 
-To run the commands in this example, you must be a member of the Administrators group on the local computer and the remote computer and you must start Windows PowerShell with the "Run as administrator" option.
+The second command uses the `Connect-WSMan` cmdlet to connect to the Server02 computer. This action
+adds a node for the Server02 computer to the WSMan: drive on the local computer, allowing you to
+view and change the WS-Management settings on the Server02 computer.
 
-### Example 8
+The third command uses the `Set-Item` cmdlet to change the value of the **CredSSP** item in the
+Service node of the Server02 computer to True. This configures the service settings on the remote
+computer.
+
+The fourth command uses the `Invoke-Command` cmdlet to run a `Get-PSSessionConfiguration` command
+on the Server02 computer. The command uses the **Credential** parameter, and it uses the
+**Authentication** parameter with a value of **CredSSP**.The output shows the session
+configurations on the Server02 remote computer.
+
+### Example 8 - Get the resource URI of a session configuration
+
+This command is useful when setting the value of the $PSSessionConfigurationName preference
+variable, which takes a resource URI.
+
 ```
-PS C:\> (Get-PSSessionConfiguration -Name CustomShell).resourceURI
+PS> (Get-PSSessionConfiguration -Name CustomShell).resourceURI
 http://schemas.microsoft.com/powershell/microsoft.CustomShell
 ```
 
-This command uses the **Get-PSSessionConfiguration** cmdlet to get the resource URI of a session configuration.
-
-This command is useful when setting the value of the $PSSessionConfigurationName preference variable, which takes a resource URI.
-
-The $PSSessionConfiguationName variable specifies the default configuration that is used when you create a session.
-This variable is set on the local computer, but it specifies a configuration on the remote computer.
-For more information about the $PSSessionConfiguration variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
+The `$PSSessionConfiguationName` variable specifies the default configuration that is used when you
+create a session. This variable is set on the local computer, but it specifies a configuration on
+the remote computer. For more information about the `$PSSessionConfiguration` variable, see
+[about_Preference_Variables](About/about_Preference_Variables.md).
 
 ## PARAMETERS
 
-### -Force
-Suppresses the prompt to restart the WinRM service, if the service is not already running.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Name
-Gets only the session configurations with the specified name or name pattern.
-Enter one or more session configuration names.
-Wildcards are permitted.
+
+Gets only the session configurations with the specified name or name pattern. Enter one or more
+session configuration names. Wildcards are permitted.
 
 ```yaml
 Type: String[]
@@ -359,15 +338,20 @@ Required: False
 Position: 0
 Default value: All session configurations on the local computer
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### None
+
 You cannot pipe input to this cmdlet.
 
 ## OUTPUTS
@@ -375,12 +359,32 @@ You cannot pipe input to this cmdlet.
 ### Microsoft.PowerShell.Commands.PSSessionConfigurationCommands#PSSessionConfiguration
 
 ## NOTES
-* To run this cmdlet, start Windows PowerShell with the "Run as administrator" option.
-* To view the session configurations on the computer, you must be a member of the Administrators group on the computer.
-* To run a **Get-PSSessionConfiguration** command on a remote computer, Credential Security Service Provider (CredSSP) authentication must be enabled in the client settings on the local computer (by using the Enable-WSManCredSSP cmdlet) and in the service settings on the remote computer, and you must use the **CredSSP** value of the **Authentication** parameter when establishing the remote session. Otherwise, access is denied.
-* The note properties of the object that **Get-PSSessionConfiguration** returns appear on the object only when they have a value. Only session configurations that were created by using a session configuration file have all of the defined properties.
-* The properties of a session configuration object vary with the options set for the session configuration and the values of those options. Also, session configurations that use a session configuration file have additional properties.
-* You can use commands in the WSMan: drive to change the properties of session configurations. However, you cannot use the WSMan: drive in Windows PowerShell 2.0 to change session configuration properties that are introduced in Windows PowerShell 3.0, such as **OutputBufferingMode**. Windows PowerShell 2.0 commands do not generate an error, but they are ineffective. To change  properties introduced in Windows PowerShell 3.0, use the WSMan: drive in Windows PowerShell 3.0.
+
+- To run this cmdlet, start Windows PowerShell with the "Run as administrator" option.
+
+- To view the session configurations on the computer, you must be a member of the Administrators
+  group on the computer.
+
+- To run a `Get-PSSessionConfiguration` command on a remote computer, Credential Security Service
+  Provider (CredSSP) authentication must be enabled in the client settings on the local computer
+  (by using the `Enable-WSManCredSSP` cmdlet) and in the service settings on the remote computer,
+  and you must use the **CredSSP** value of the **Authentication** parameter when establishing the
+  remote session. Otherwise, access is denied.
+
+- The note properties of the object that `Get-PSSessionConfiguration` returns appear on the
+  object only when they have a value. Only session configurations that were created by using a
+  session configuration file have all of the defined properties.
+
+- The properties of a session configuration object vary with the options set for the session
+  configuration and the values of those options. Also, session configurations that use a session
+  configuration file have additional properties.
+
+- You can use commands in the WSMan: drive to change the properties of session configurations.
+  However, you cannot use the WSMan: drive in Windows PowerShell 2.0 to change session
+  configuration properties that are introduced in Windows PowerShell 3.0, such as
+  **OutputBufferingMode**. Windows PowerShell 2.0 commands do not generate an error, but they are
+  ineffective. To change properties introduced in Windows PowerShell 3.0, use the WSMan: drive in
+  Windows PowerShell 3.0.
 
 ## RELATED LINKS
 
@@ -402,7 +406,7 @@ You cannot pipe input to this cmdlet.
 
 [Unregister-PSSessionConfiguration](Unregister-PSSessionConfiguration.md)
 
-[WSMan Provider](../microsoft.wsman.management/provider/wsman-provider.md)
+[WSMan Provider](../microsoft.wsman.management/about/about_WSMan_Provider.md)
 
 [about_Session_Configurations](About/about_Session_Configurations.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Core/Get-PSSessionConfiguration.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/Get-PSSessionConfiguration.md
@@ -7,10 +7,10 @@ online version:  http://go.microsoft.com/fwlink/?LinkId=821490
 external help file:  System.Management.Automation.dll-Help.xml
 title:  Get-PSSessionConfiguration
 ---
-
 # Get-PSSessionConfiguration
 
 ## SYNOPSIS
+
 Gets the registered session configurations on the computer.
 
 ## SYNTAX
@@ -20,43 +20,55 @@ Get-PSSessionConfiguration [[-Name] <String[]>] [-Force] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-PSSessionConfiguration** cmdlet gets the session configurations that have been registered on the local computer.
-This is an advanced cmdlet is designed for system administrators to manage customized session configurations your users.
 
-Starting in Windows PowerShell 3.0, you can define the properties of a session configuration by using a session configuration (.pssc) file.
-This feature lets you create customized and restricted sessions without writing a computer program.
-For more information about session configuration files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
+The `Get-PSSessionConfiguration` cmdlet gets the session configurations that have been registered
+on the local computer. This is an advanced cmdlet that is designed to be used by system
+administrators to manage customized session configurations for their users.
 
-Starting in Windows PowerShell 3.0, new note properties have been added to the session configuration object that **Get-PSSessionConfiguration** returns.
-These properties make it easier for users and session configuration authors to examine and compare session configurations.
+Beginning in Windows PowerShell 3.0, you can define the properties of a session configuration by
+using a session configuration (.pssc) file. This feature lets you create customized and restricted
+sessions without writing a computer program. For more information about session configuration
+files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
 
-To create and register a session configuration, use the Register-PSSessionConfiguration cmdlet.
-For more information about session configurations, see [about_Session_Configurations](About/about_Session_Configurations.md).
+Also, beginning in Windows PowerShell 3.0, new note properties have been added to the session
+configuration object that `Get-PSSessionConfiguration` returns. These properties make it easier
+for users and session configuration authors to examine and compare session configurations.
+
+To create and register a session configuration, use the `Register-PSSessionConfiguration` cmdlet. For
+more information about session configurations, see
+[about_Session_Configurations](About/about_Session_Configurations.md).
 
 ## EXAMPLES
 
-### Example 1: Get session configurations for the local computer
+### Example 1 - Get session configurations on the local computer
+
 ```
-PS C:\> Get-PSSessionConfiguration
+PS> Get-PSSessionConfiguration
 ```
 
-This command gets the session configurations on the local computer.
+### Example 2 - Get the two default session configurations
 
-### Example 2: Get default session configurations
+The command uses the **Name** parameter of `Get-PSSessionConfiguration` to get only the session
+configurations with names that begin with "Microsoft".
+
 ```
-PS C:\> Get-PSSessionConfiguration -Name Microsoft*
+PS> Get-PSSessionConfiguration -Name Microsoft*
+
 Name                      PSVersion  StartupScript        Permission
 ----                      ---------  -------------        ----------
 microsoft.powershell      2.0                             BUILTIN\Administrators AccessAll...
 microsoft.powershell32    2.0                             BUILTIN\Administrators AccessAll...
 ```
 
-This command gets the two default session configurations that come with Windows PowerShell.
-The command uses the *Name* parameter of **Get-PSSessionConfiguration** to get only the session configurations with names that begin with "Microsoft".
+### Example 3 - Get the properties and values of a session configuration
 
-### Example 3: Display properties of a session configuration created from a file
+This example shows the properties and property values of a session configuration that was created
+by using a session configuration file.
+
 ```
-PS C:\> Get-PSSessionConfiguration -Name Full | Format-List -Property *
+PS> Get-PSSessionConfiguration -Name Full  | Format-List -Property *
+
+
 Copyright                     : (c) 2011 User01. All rights reserved.
 AliasDefinitions              : {System.Collections.Hashtable}
 SessionType                   : Default
@@ -97,86 +109,94 @@ MaxShellsPerUser              : 30
 Permission                    :
 ```
 
-This example shows the properties and property values of a session configuration that was created by using a session configuration file.
+The example uses the `Get-PSSessionConfiguration` cmdlet to get the full session configuration.
+A pipeline operator sends the Full session configuration to the `Format-List` cmdlet. The
+**Property** parameter with a value of `*` (all) directs `Format-List` to display all of the
+properties and property values of the object in a list.
 
-The command uses the **Get-PSSessionConfiguration** command to get the Full session configuration.
-A pipeline operator sends the Full session configuration to the Format-List cmdlet.
-The *Property* parameter with a value of * (all) directs **Format-List** to display all of the properties and property values of the object in a list.
+The output of this command has useful information, including the author of the session
+configuration, the session type, language mode, and execution policy of sessions that are created
+with this session configuration, session quotas, and the full path to the session configuration
+file.
 
-The output of this command has very useful information.
-This includes the author of the session configuration, the session type, language mode, and execution policy of sessions that are created by using this session configuration, session quotas, and the full path of the session configuration file.
+This view of a session configuration is used for sessions that include a session configuration
+file. For more information about session configuration files, see
+[about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
 
-This view of a session configuration is used for sessions that include a session configuration file.
-For more information about session configuration files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
+### Example 4 - Get the configuration of a workflow session
 
-### Example 4: Get and sort properties of a session configuration
+This command gets the properties of the Microsoft.PowerShell.Worfklow session configuration and
+sorts them into alphabetical order for easy reading. You can use this command format in a function
+to get this display for any session configuration.
+
 ```
-PS C:\> (Get-PSSessionConfiguration Microsoft.PowerShell.Workflow).PSObject.Properties | Select-Object Name,Value | Sort-Object Name
-
-Name                                                                                                              Value
-----                                                                                                              -----
-ActivityProcessIdleTimeoutSec                                                                                        60
-AllowedActivity                                                                                   {PSDefaultActivities}
-Architecture                                                                                                         64
-AssemblyName                                                ...licKeyToken=31bf3856ad364e35, processorArchitecture=MSIL
-AutoRestart                                                                                                       false
-Capability                                                                                                      {Shell}
-Enabled                                                                                                            true
-EnableValidation                                                                                                   true
-ExactMatch                                                                                                        False
-Filename                                                                              %windir%\system32\pwrshplugin.dll
-IdleTimeoutms                                                                                                   7200000
-lang                                                                                                              en-US
-MaxActivityProcesses                                                                                                  5
-MaxConcurrentCommandsPerShell                                                                                      1000
-MaxConcurrentUsers                                                                                                    5
-MaxConnectedSessions                                                                                                100
-MaxDisconnectedSessions                                                                                            1000
-MaxIdleTimeoutms                                                                                             2147483647
-MaxMemoryPerShellMB                                                                                                1024
-MaxPersistenceStoreSizeGB                                                                                            10
-MaxProcessesPerShell                                                                                                 15
-MaxRunningWorkflows                                                                                                  30
-MaxSessionsPerRemoteNode                                                                                              5
-MaxSessionsPerWorkflow                                                                                                5
-
-MaxShells                                                                                                            25
-MaxShellsPerUser                                                                                                     25
-ModulesToImport                                             %windir%\system32\windowspowershell\v1.0\Modules\PSWorkflow
-Name                                                                                      microsoft.powershell.workflow
-OutOfProcessActivity                                                                                     {InlineScript}
-OutputBufferingMode                                                                                               Block
-ParentResourceUri                                           ...s.microsoft.com/powershell/microsoft.powershell.workflow
-Permission                                                  ...ssAllowed, BUILTIN\Remote Management Users AccessAllowed
-PersistencePath                                             ...s\juneb\AppData\Local\Microsoft\Windows\PowerShell\WF\PS
-PersistWithEncryption                                                                                             False
-ProcessIdleTimeoutSec                                                                                             28800
-PSSessionConfigurationTypeName                              ...osoft.PowerShell.Workflow.PSWorkflowSessionConfiguration
-PSVersion                                                                                                           3.0
-RemoteNodeSessionIdleTimeoutSec                                                                                      60
-ResourceUri                                                 ...s.microsoft.com/powershell/microsoft.powershell.workflow
+PS> (Get-PSSessionConfiguration Microsoft.PowerShell.Workflow).PSObject.Properties |
+  Select-Object Name,Value | Sort-Object Name
+Name                                                                                                  Value
+----                                                                                                  -----
+ActivityProcessIdleTimeoutSec                                                                            60
+AllowedActivity                                                                       {PSDefaultActivities}
+Architecture                                                                                             64
+AssemblyName                                    ...licKeyToken=31bf3856ad364e35, processorArchitecture=MSIL
+AutoRestart                                                                                           false
+Capability                                                                                          {Shell}
+Enabled                                                                                                true
+EnableValidation                                                                                       true
+ExactMatch                                                                                            False
+Filename                                                                  %windir%\system32\pwrshplugin.dll
+IdleTimeoutms                                                                                       7200000
+lang                                                                                                  en-US
+MaxActivityProcesses                                                                                      5
+MaxConcurrentCommandsPerShell                                                                          1000
+MaxConcurrentUsers                                                                                        5
+MaxConnectedSessions                                                                                    100
+MaxDisconnectedSessions                                                                                1000
+MaxIdleTimeoutms                                                                                 2147483647
+MaxMemoryPerShellMB                                                                                    1024
+MaxPersistenceStoreSizeGB                                                                                10
+MaxProcessesPerShell                                                                                     15
+MaxRunningWorkflows                                                                                      30
+MaxSessionsPerRemoteNode                                                                                  5
+MaxSessionsPerWorkflow                                                                                    5
+MaxShells                                                                                                25
+MaxShellsPerUser                                                                                         25
+ModulesToImport                                 %windir%\system32\windowspowershell\v1.0\Modules\PSWorkflow
+Name                                                                          microsoft.powershell.workflow
+OutOfProcessActivity                                                                         {InlineScript}
+OutputBufferingMode                                                                                   Block
+ParentResourceUri                               ...s.microsoft.com/powershell/microsoft.powershell.workflow
+Permission                                      ...ssAllowed, BUILTIN\Remote Management Users AccessAllowed
+PersistencePath                                 ...s\juneb\AppData\Local\Microsoft\Windows\PowerShell\WF\PS
+PersistWithEncryption                                                                                 False
+ProcessIdleTimeoutSec                                                                                 28800
+PSSessionConfigurationTypeName                  ...osoft.PowerShell.Workflow.PSWorkflowSessionConfiguration
+PSVersion                                                                                               3.0
+RemoteNodeSessionIdleTimeoutSec                                                                          60
+ResourceUri                                     ...s.microsoft.com/powershell/microsoft.powershell.workflow
 RunAsPassword
 RunAsUser
-SDKVersion                                                                                                            2
-SecurityDescriptorSddl                                      ...;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)
-SessionConfigurationData                                    ...    </SessionConfigurationData>
-SessionThrottleLimit                                                                                                100
-SupportsOptions                                                                                                    true
-Uri                                                         ...s.microsoft.com/powershell/microsoft.powershell.workflow
-UseSharedProcess                                                                                                   true
-WorkflowShutdownTimeoutMSec                                                                                         500
-xmlns                                                       ...as.microsoft.com/wbem/wsman/1/config/PluginConfiguration
-XmlRenderingType                                                                                                   text
+SDKVersion                                                                                                2
+SecurityDescriptorSddl                          ...;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)
+SessionConfigurationData                                                 ...    </SessionConfigurationData>
+SessionThrottleLimit                                                                                    100
+SupportsOptions                                                                                        true
+Uri                                             ...s.microsoft.com/powershell/microsoft.powershell.workflow
+UseSharedProcess                                                                                       true
+WorkflowShutdownTimeoutMSec                                                                             500
+xmlns                                           ...as.microsoft.com/wbem/wsman/1/config/PluginConfiguration
+XmlRenderingType                                                                                       text
 ```
-
-This command gets the properties of the Microsoft.PowerShell.Worfklow session configuration and sorts them into alphabetical order for easy reading.
-You can use this command format in a function to get this display for any session configuration.
 
 This example was contributed by Shay Levy, a Windows PowerShell MVP from Sderot, Israel.
 
-### Example 5: Examine the contents of the Plugin node
+### Example 5 - Another way to look at the session configurations
+
+This command uses the `Get-ChildItem` cmdlet (alias = dir) in the WSMan: provider drive to look at
+the content of the Plugin node. This is another way to look at the session configurations on the
+computer.
+
 ```
-PS C:\> dir wsman:\localhost\plugin
+PS> dir wsman:\localhost\plugin
 Type            Keys                                Name
 ----            ----                                ----
 Container       {Name=Event Forwarding Plugin}      Event Forwarding Plugin
@@ -188,18 +208,20 @@ Container       {Name=microsoft.ServerManager}      microsoft.ServerManager
 Container       {Name=WMI Provider}                 WMI Provider
 ```
 
-This command uses the dir alias of the Get-ChildItem cmdlet in the WSMan: provider drive to examine the content of the **Plugin** node.
-This is another way to view the session configurations on the computer.
+The **PlugIn** node contains **ContainerElement** objects
+(Microsoft.WSMan.Management.WSManConfigContainerElement) that represent the registered PowerShell
+session configurations, along with other plug-ins for WS-Management.
 
-The **PlugIn** node contains **ContainerElement** objects (Microsoft.WSMan.Management.WSManConfigContainerElement) that represent the registered Windows PowerShell session configurations, together with other plug-ins for WS-Management.
+### Example 6 - View session configurations on a remote computer
 
-### Example 6: View session configuration on a remote computer
+This example shows how to use the WSMan provider to view the session configurations on a remote
+computer. This method does not provide as much information as a `Get-PSSessionConfiguration`
+command, but the user does not need to be a member of the Administrators group to run this command.
+
 ```
-The first command uses the Connect-WSMan cmdlet to connect to the WinRM service on the Server01 remote computer.
-PS C:\> Connect-WSMan -ComputerName Server01
+PS> Connect-WSMan -ComputerName Server01
 
-The second command uses dir in the WSMan: drive to get the items in the Server01\Plugin path.The output shows the items in the **Plugin** directory on the Server01 computer. The items include the session configurations, which are a type of WSMan plug-in, together with other types of plug-ins on the computer.
-PS C:\> dir WSMan:\Server01\Plugin
+PS> dir WSMan:\Server01\Plugin
    WSManConfig: Microsoft.WSMan.Management\WSMan::localhost\Plugin
 
 Type            Keys                                Name
@@ -218,8 +240,9 @@ Container       {Name=SEL Plugin}                   SEL Plugin
 Container       {Name=WithProfile}                  WithProfile
 Container       {Name=WMI Provider}                 WMI Provider
 
-The third command returns the names of the plugins that are session configurations. The command searches for a value of Shell in the **Capability** property, which is in the Plugin\Resources\<ResourceNumber> path in the WSMan: drive.
-PS C:\> dir WSMan:\Server01\Plugin\*\Resources\Resource*\Capability | where {$_.Value -eq "Shell"} | foreach {($_.PSPath.split("\"))[3] }
+PS> dir WSMan:\Server01\Plugin\*\Resources\Resource*\Capability |
+  where {$_.Value -eq "Shell"} |
+    foreach {($_.PSPath.split("\"))[3] }
 Empty
 Full
 microsoft.powershell
@@ -232,22 +255,34 @@ RRS
 WithProfile
 ```
 
-This example shows how to use the WSMan provider to view the session configurations on a remote computer.
-This method does not provide as much information as a **Get-PSSessionConfiguration** command, but the user does not have to be a member of the Administrators group to run this command.
+The first command uses the `Connect-WSMan` cmdlet to connect to the WinRM service on the Server01
+remote computer.
 
-### Example 7: Run this cmdlet on a remote computer
+The second command uses the `Get-ChildItem` cmdlet ("dir") in the WSMan: drive to get the items in
+the Server01\Plugin path.The output shows the items in the Plugin directory on the Server01
+computer. The items include the session configurations, which are a type of WSMan plug-in, along
+with other types of plug-ins on the computer.
+
+The third command returns the names of the plugins that are session configurations. The command
+searches for a value of **Shell** in the **Capability** property, which is in the
+`Plugin\Resources\<ResourceNumber>` path in the WSMan: drive.
+
+### Example 7 - Get detailed session configurations from a remote computer
+
+This example shows how to run a `Get-PSSessionConfiguration` command on a remote computer. The
+command requires that CredSSP delegation be enabled in the client settings on the local computer
+and in the service settings on the remote computer.
+
+To run the commands in this example, you must be a member of the Administrators group on the local
+computer and the remote computer and you must start Windows PowerShell with the "Run as
+administrator" option.
+
 ```
-The first command uses the Enable-WSManCredSSP cmdlet to enable **CredSSP** delegation from the Server01 local computer to the Server02 remote computer. This configures the **CredSSP** client setting on the local computer.
-PS C:\> Enable-WSManCredSSP -Delegate Server02
+PS> Enable-WSManCredSSP -Delegate Server02
+PS> Connect-WSMan Server02
+PS> Set-Item WSMan:\Server02*\Service\Auth\CredSSP -Value $true
+PS> Invoke-Command -ScriptBlock {Get-PSSessionConfiguration} -ComputerName Server02 -Authentication CredSSP -Credential Domain01\Admin01
 
-The second command uses the **Connect-WSMan** cmdlet to connect to the Server02 computer. This action adds a node for the Server02 computer to the WSMan: drive on the local computer. This lets you view and change the WS-Management settings on the Server02 computer.
-PS C:\> Connect-WSMan Server02
-
-The third command uses the Set-Item cmdlet to change the value of the **CredSSP** item in the Service node of the Server02 computer to True. This configures the service settings on the remote computer.
-PS C:\> Set-Item WSMan:\Server02*\Service\Auth\CredSSP -Value $true
-
-The fourth command uses the Invoke-Command cmdlet to run a **Get-PSSessionConfiguration** command on the Server02 computer. The command uses the *Credential* parameter, and it uses the *Authentication* parameter with a value of CredSSP.The output shows the session configurations on the Server02 remote computer.
-PS C:\> Invoke-Command -ScriptBlock {Get-PSSessionConfiguration} -ComputerName Server02 -Authentication CredSSP -Credential Domain01\Admin01
 Name                      PSVersion  StartupScript        Permission                          PSComputerName
 ----                      ---------  -------------        ----------                          --------------
 microsoft.powershell      2.0                             BUILTIN\Administrators AccessAll... server02.corp.fabrikam.com
@@ -255,24 +290,37 @@ microsoft.powershell32    2.0                             BUILTIN\Administrators
 MyX86Shell                2.0        c:\test\x86Shell.ps1 BUILTIN\Administrators AccessAll... server02.corp.fabrikam.com
 ```
 
-This example shows how to run a **Get-PSSessionConfiguration** command on a remote computer.
-The command requires that CredSSP delegation be enabled in the client settings on the local computer and in the service settings on the remote computer.
+The first command uses the `Enable-WSManCredSSP` cmdlet to enable **CredSSP** delegation from the
+Server01 local computer to the Server02 remote computer. This configures the **CredSSP** client
+setting on the local computer.
 
-To run the commands in this example, you must be a member of the Administrators group on the local computer and the remote computer and you must start Windows PowerShell by using the Run as administrator option.
+The second command uses the `Connect-WSMan` cmdlet to connect to the Server02 computer. This action
+adds a node for the Server02 computer to the WSMan: drive on the local computer, allowing you to
+view and change the WS-Management settings on the Server02 computer.
 
-### Example 8: Get the resource URI of a session configuration
+The third command uses the `Set-Item` cmdlet to change the value of the **CredSSP** item in the
+Service node of the Server02 computer to True. This configures the service settings on the remote
+computer.
+
+The fourth command uses the `Invoke-Command` cmdlet to run a `Get-PSSessionConfiguration` command
+on the Server02 computer. The command uses the **Credential** parameter, and it uses the
+**Authentication** parameter with a value of **CredSSP**.The output shows the session
+configurations on the Server02 remote computer.
+
+### Example 8 - Get the resource URI of a session configuration
+
+This command is useful when setting the value of the $PSSessionConfigurationName preference
+variable, which takes a resource URI.
+
 ```
-PS C:\> (Get-PSSessionConfiguration -Name CustomShell).resourceURI
+PS> (Get-PSSessionConfiguration -Name CustomShell).resourceURI
 http://schemas.microsoft.com/powershell/microsoft.CustomShell
 ```
 
-This command uses the **Get-PSSessionConfiguration** cmdlet to get the resource Uniform Resource Identifier (URI) of a session configuration.
-
-This command is useful when you set the value of the $PSSessionConfigurationName preference variable, which takes a resource URI.
-
-The $PSSessionConfiguationName variable specifies the default configuration that is used when you create a session.
-This variable is set on the local computer, but it specifies a configuration on the remote computer.
-For more information about the $PSSessionConfiguration variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
+The `$PSSessionConfiguationName` variable specifies the default configuration that is used when you
+create a session. This variable is set on the local computer, but it specifies a configuration on
+the remote computer. For more information about the `$PSSessionConfiguration` variable, see
+[about_Preference_Variables](About/about_Preference_Variables.md).
 
 ## PARAMETERS
 
@@ -292,10 +340,9 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of names.
-This cmdlet gets the session configurations with the specified name or name pattern.
-Enter one or more session configuration names.
-Wildcard characters are permitted.
+
+Gets only the session configurations with the specified name or name pattern. Enter one or more
+session configuration names. Wildcards are permitted.
 
 ```yaml
 Type: String[]
@@ -304,17 +351,22 @@ Aliases:
 
 Required: False
 Position: 0
-Default value: None
+Default value: All session configurations on the local computer
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### None
+
 You cannot pipe input to this cmdlet.
 
 ## OUTPUTS
@@ -322,12 +374,32 @@ You cannot pipe input to this cmdlet.
 ### Microsoft.PowerShell.Commands.PSSessionConfigurationCommands#PSSessionConfiguration
 
 ## NOTES
-* To run this cmdlet, start Windows PowerShell by using the Run as administrator option.
-* To view the session configurations on the computer, you must be a member of the Administrators group on the computer.
-* To run a **Get-PSSessionConfiguration** command on a remote computer, Credential Security Service Provider (CredSSP) authentication must be enabled in the client settings on the local computer by using the Enable-WSManCredSSP cmdlet, and in the service settings on the remote computer. You must also use the **CredSSP** value of the *Authentication* parameter when establishing the remote session. Otherwise, access is denied.
-* The note properties of the object that **Get-PSSessionConfiguration** returns appear on the object only when they have a value. Only session configurations that were created by using a session configuration file have all of the defined properties.
-* The properties of a session configuration object vary with the options set for the session configuration and the values of those options. Also, session configurations that use a session configuration file have additional properties.
-* You can use commands in the WSMan: drive to change the properties of session configurations. However, you cannot use the WSMan: drive in Windows PowerShell 2.0 to change session configuration properties that are introduced in Windows PowerShell 3.0, such as **OutputBufferingMode**. Windows PowerShell 2.0 commands do not generate an error, but they are ineffective. To change  properties introduced in Windows PowerShell 3.0, use the WSMan: drive in Windows PowerShell 3.0.
+
+- To run this cmdlet, start Windows PowerShell with the "Run as administrator" option.
+
+- To view the session configurations on the computer, you must be a member of the Administrators
+  group on the computer.
+
+- To run a `Get-PSSessionConfiguration` command on a remote computer, Credential Security Service
+  Provider (CredSSP) authentication must be enabled in the client settings on the local computer
+  (by using the `Enable-WSManCredSSP` cmdlet) and in the service settings on the remote computer,
+  and you must use the **CredSSP** value of the **Authentication** parameter when establishing the
+  remote session. Otherwise, access is denied.
+
+- The note properties of the object that `Get-PSSessionConfiguration` returns appear on the
+  object only when they have a value. Only session configurations that were created by using a
+  session configuration file have all of the defined properties.
+
+- The properties of a session configuration object vary with the options set for the session
+  configuration and the values of those options. Also, session configurations that use a session
+  configuration file have additional properties.
+
+- You can use commands in the WSMan: drive to change the properties of session configurations.
+  However, you cannot use the WSMan: drive in Windows PowerShell 2.0 to change session
+  configuration properties that are introduced in Windows PowerShell 3.0, such as
+  **OutputBufferingMode**. Windows PowerShell 2.0 commands do not generate an error, but they are
+  ineffective. To change properties introduced in Windows PowerShell 3.0, use the WSMan: drive in
+  Windows PowerShell 3.0.
 
 ## RELATED LINKS
 
@@ -335,7 +407,11 @@ You cannot pipe input to this cmdlet.
 
 [Enable-PSSessionConfiguration](Enable-PSSessionConfiguration.md)
 
+[Get-PSSessionConfiguration](Get-PSSessionConfiguration.md)
+
 [New-PSSessionConfigurationFile](New-PSSessionConfigurationFile.md)
+
+[New-PSSessionOption](New-PSSessionOption.md)
 
 [Register-PSSessionConfiguration](Register-PSSessionConfiguration.md)
 
@@ -345,7 +421,7 @@ You cannot pipe input to this cmdlet.
 
 [Unregister-PSSessionConfiguration](Unregister-PSSessionConfiguration.md)
 
-[WSMan Provider](../Microsoft.WsMan.Management/Providers/WSMan-Provider.md)
+[WSMan Provider](../microsoft.wsman.management/about/about_WSMan_Provider.md)
 
 [about_Session_Configurations](About/about_Session_Configurations.md)
 

--- a/reference/5.0/PowershellGet/Install-Module.md
+++ b/reference/5.0/PowershellGet/Install-Module.md
@@ -16,6 +16,7 @@ Downloads one or more modules from an online gallery, and installs them on the l
 ## SYNTAX
 
 ### NameParameterSet (Default)
+
 ```
 Install-Module [-Name] <String[]> [-MinimumVersion <Version>] [-MaximumVersion <Version>]
  [-RequiredVersion <Version>] [-Repository <String[]>] [-Scope <String>] [-Force] [-WhatIf] [-Confirm]
@@ -23,62 +24,78 @@ Install-Module [-Name] <String[]> [-MinimumVersion <Version>] [-MaximumVersion <
 ```
 
 ### InputObject
+
 ```
 Install-Module [-InputObject] <PSObject[]> [-Scope <String>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Install-Module** cmdlet gets one or more modules that meet specified criteria from an online gallery, verifies that search results are valid modules, and copies module folders to the installation location.
 
-When no scope is defined, or when the value of the *Scope* parameter is AllUsers, the module is installed to %systemdrive%:\Program Files\WindowsPowerShell\Modules.
-When the value of *Scope* is CurrentUser, the module is installed to $home\Documents\WindowsPowerShell\Modules.
+The `Install-Module` cmdlet gets one or more modules that meet specified criteria from an online
+gallery, verifies that search results are valid modules, and copies module folders to the
+installation location.
+
+When no scope is defined, or when the value of the **Scope** parameter is AllUsers, the module is
+installed to `$env:ProgramFiles\WindowsPowerShell\Modules`. When the value of **Scope** is
+**CurrentUser**, the module is installed to `$home\Documents\WindowsPowerShell\Modules`.
 
 You can filter your results based on minimum and exact versions of specified modules.
 
 ## EXAMPLES
 
 ### Example 1: Find a module and install it
-```
-PS C:\> Find-Module -Name "MyDSC*" | Install-Module
-```
 
-In this example, modules with a name that starts with MyDSC that are found by Find-Module in the online gallery are installed to the default folder, C:\ProgramFiles\WindowsPowerShell\Modules.
+In this example, modules with a name that starts with MyDSC that are found by `Find-Module` in the
+online gallery are installed to the default folder, `C:\ProgramFiles\WindowsPowerShell\Modules`.
+
+```powershell
+Find-Module -Name "MyDSC*" | Install-Module
+```
 
 ### Example 2: Install a module by name
-```
-PS C:\> Install-Module -Name "MyDscModule"
-```
 
-In this example, the newest version of the module MyDscModule from the online gallery is installed to the default folder, Program Files.
+In this example, the newest version of the module MyDscModule from the online gallery is installed
+to the default folder.
+
+```powershell
+Install-Module -Name "MyDscModule"
+```
 
 If no module named MyDscModule exists, an error occurs.
 
 ### Example 3: Install a module using its minimum version
-```
-PS C:\> Install-Module -Name "ContosoServer" -MinimumVersion 1.0
+
+In this example, the most current version of the module ContosoServer is installed that matches the
+specified minimum version.
+
+```powershell
+Install-Module -Name "ContosoServer" -MinimumVersion 1.0
 ```
 
-In this example, the most current version of the module ContosoServer is installed that matches the specified minimum version.
 If the most current version of the module is a lower number than 1.0, the command returns errors.
 
 ### Example 4: Install a specific version of a module
-```
-PS C:\> Install-Module -Name "ContosoServer" -RequiredVersion 1.1.3
-```
 
 This example installs version 1.1.3 of the module ContosoServer to the Program Files folder.
+
+```powershell
+Install-Module -Name "ContosoServer" -RequiredVersion 1.1.3
+```
+
 If version 1.1.3 is not available, an error occurs.
 
 ### Example 5: Install the current version of a module
-```
-PS C:\> Install-Module -Name "ContosoServer" -Scope "CurrentUser"
-```
 
-This example installs the newest version of the module ContosoServer to $home\Documents\WindowsPowerShell\Modules.
+This example installs the newest version of the module ContosoServer to `$home\Documents\WindowsPowerShell\Modules`.
+
+```powershell
+Install-Module -Name "ContosoServer" -Scope "CurrentUser"
+```
 
 ## PARAMETERS
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -94,8 +111,10 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Forces the installation of modules.
-If a module of the same name and version already exists on the computer, this parameter overwrites the existing module with one of the same name that was found by the command.
+
+Forces the installation of modules. If a module of the same name and version already exists on the
+computer, this parameter overwrites the existing module with one of the same name that was found by
+the command.
 
 ```yaml
 Type: SwitchParameter
@@ -125,12 +144,13 @@ Accept wildcard characters: False
 ```
 
 ### -MaximumVersion
-Specifies the maximum version of a single module to install.
-You cannot add this parameter if you are attempting to install multiple modules.
-The *MaximumVersion* and the *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the maximum version of a single module to install. You cannot add this parameter if you
+are attempting to install multiple modules. The **MaximumVersion** and the **RequiredVersion**
+parameters are mutually exclusive; you cannot use both parameters in the same command.
 
 ```yaml
-Type: Version
+Type: String
 Parameter Sets: NameParameterSet
 Aliases:
 
@@ -142,15 +162,20 @@ Accept wildcard characters: False
 ```
 
 ### -MinimumVersion
-Specifies the minimum version of a single module to install.
-You cannot add this parameter if you are attempting to install multiple modules.
-The *MinimumVersion* and the *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
 
-If you are installing multiple modules in a single command, and a specified minimum version for a module is not available for installation, the **Install-Module** command silently continues without installing the unavailable module.
-For example, if you try to install the ContosoServer module with a minimum version of 2.0, but the latest version of the ContosoServer module is 1.5, the **Install-Module** command does not install the ContosoServer module; it goes to install the next specified module, and Windows PowerShell display errors when the command is finished.
+Specifies the minimum version of a single module to install. You cannot add this parameter if you
+are attempting to install multiple modules. The **MinimumVersion** and the **RequiredVersion**
+parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+If you are installing multiple modules in a single command, and a specified minimum version for a
+module is not available for installation, the `Install-Module` command silently continues without
+installing the unavailable module. For example, if you try to install the ContosoServer module with
+a minimum version of 2.0, but the latest version of the ContosoServer module is 1.5, the
+`Install-Module` command does not install the ContosoServer module; it goes to install the next
+specified module, and PowerShell display errors when the command is finished.
 
 ```yaml
-Type: Version
+Type: String
 Parameter Sets: NameParameterSet
 Aliases: Version
 
@@ -162,11 +187,12 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies the exact names of modules to install from the online gallery.
-This parameter supports wildcard characters.
-If wildcard characters are not specified, only modules that exactly match the specified names are returned.
-If no matches are found, and you have not used any wildcard characters, the command returns an error.
-If you use wildcard characters, but do not find matching results, no error is returned.
+
+Specifies the exact names of modules to install from the online gallery. This parameter supports
+wildcard characters. If wildcard characters are not specified, only modules that exactly match the
+specified names are returned. If no matches are found, and you have not used any wildcard
+characters, the command returns an error. If you use wildcard characters, but do not find matching
+results, no error is returned.
 
 ```yaml
 Type: String[]
@@ -181,7 +207,9 @@ Accept wildcard characters: False
 ```
 
 ### -Repository
-Specifies the friendly name of a repository that has been registered by running Register-PSRepository.
+
+Specifies the friendly name of a repository that has been registered by running
+`Register-PSRepository`.
 
 ```yaml
 Type: String[]
@@ -196,12 +224,13 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredVersion
-Specifies the exact version of a single module to install.
-You cannot add this parameter if you are attempting to install multiple modules.
-The *MinimumVersion* and the *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the exact version of a single module to install. You cannot add this parameter if you are
+attempting to install multiple modules. The **MinimumVersion** and the **RequiredVersion**
+parameters are mutually exclusive; you cannot use both parameters in the same command.
 
 ```yaml
-Type: Version
+Type: String
 Parameter Sets: NameParameterSet
 Aliases:
 
@@ -213,12 +242,19 @@ Accept wildcard characters: False
 ```
 
 ### -Scope
-Specifies the installation scope of the module.
-The acceptable values for this parameter are: AllUsers and CurrentUser.
 
-The AllUsers scope lets modules be installed in a location that is accessible to all users of the computer, that is, %systemdrive%:\ProgramFiles\WindowsPowerShell\Modules.
+Specifies the installation scope of the module. The acceptable values for this parameter are:
+AllUsers and CurrentUser.
 
-The CurrentUser scope lets modules be installed only to $home\Documents\WindowsPowerShell\Modules, so that the module is available only to the current user.
+When no **Scope** is defined, the default will be set based on the current session:
+- For an elevated PowerShell session, **Scope** defaults to AllUsers;
+- For non-elevated PowerShell sessions in [PowerShellGet versions 2.0.0](https://www.powershellgallery.com/packages/PowerShellGet)
+  and above, **Scope** is CurrentUser;
+- For non-elevated PowerShell sessions in PowerShellGet versions 1.6.7 and earlier, **Scope** is
+  undefined, and `Install-Module` will fail.
+
+The CurrentUser scope lets modules be installed only to `$home\Documents\WindowsPowerShell\Modules`,
+so that the module is available only to the current user.
 
 ```yaml
 Type: String
@@ -234,8 +270,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -250,7 +286,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -259,24 +299,43 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
-* This cmdlet runs on Windows PowerShell 3.0 or later releases of Windows PowerShell, on Windows 7 or Windows 2008 R2 and later releases of Windows.
 
-  If an installed module cannot be imported (that is, if it does not have a .psm1, .psd1, or .dll of the same name within the folder), installation fails unless you add the *Force* parameter to your command.
+This cmdlet runs on PowerShell 5.0 or later releases, on Windows 7 or Windows 2008 R2 and later
+releases of Windows.
 
-  If a version of the module on the computer matches the value specified for the *Name* parameter, and you have not added the *MinimumVersion* or *RequiredVersion* parameter, **Install-Module** silently continues without installing that module.
-If the *MinimumVersion* or *RequiredVersion* parameters are specified, and the existing module does not match the values in that parameter, then an error occurs.
-To be more specific: if the version of the currently-installed module is either lower than the value of the *MinimumVersion* parameter, or not equal to the value of the *RequiredVersion* parameter, an error occurs.
-If the version of the installed module is greater than the value of the *MinimumVersion* parameter, or equal to the value of the *RequiredVersion* parameter, **Install-Module** silently continues without installing that module.
+If an installed module cannot be imported (that is, if it does not have a .psm1, .psd1, or .dll of
+the same name within the folder), installation fails unless you add the *Force* parameter to your
+command.
 
-  **Install-Module** returns an error if no module exists in the online gallery that matches the specified name.
+If a version of the module on the computer matches the value specified for the **Name** parameter,
+and you have not added the **MinimumVersion** or **RequiredVersion** parameter, `Install-Module`
+silently continues without installing that module.
 
-  To install multiple modules, specify an array of the module names, separated by commas.
-You cannot add *MinimumVersion* or *RequiredVersion* if you specify multiple module names.
+If the **MinimumVersion** or **RequiredVersion** parameters are specified, and the existing module
+does not match the values in that parameter, then an error occurs. To be more specific: if the
+version of the currently-installed module is either lower than the value of the **MinimumVersion**
+parameter, or not equal to the value of the **RequiredVersion** parameter, an error occurs.
 
-  By default, modules are installed to the Program Files folder, to prevent confusion when you are installing Windows PowerShell Desired State Configuration (DSC) resources.You can pipe multiple **PSGetItemInfo** objects to **Install-Module**; this is another way of specifying multiple modules to install in a single command.
+If the version of the installed module is greater than the value of the **MinimumVersion**
+parameter, or equal to the value of the **RequiredVersion** parameter, `Install-Module` silently
+continues without installing that module.
 
-  To help prevent running modules that contain malicious code, installed modules are not automatically imported by installation.
-As a security best practice, evaluate module code before running any cmdlets or functions in a module for the first time.
+`Install-Module` returns an error if no module exists in the online gallery that matches the
+specified name.
+
+To install multiple modules, specify an array of the module names, separated by commas. You cannot
+add **MinimumVersion** or **RequiredVersion** if you specify multiple module names.
+
+By default, modules are installed to the Program Files folder, to prevent confusion when you are
+installing Windows PowerShell Desired State Configuration (DSC) resources.You can pipe multiple
+**PSGetItemInfo** objects to `Install-Module`; this is another way of specifying multiple modules
+to install in a single command.
+
+To help prevent running modules that contain malicious code, installed modules are not
+automatically imported by installation.
+
+As a security best practice, evaluate module code before running any cmdlets or functions in a
+module for the first time.
 
 ## RELATED LINKS
 

--- a/reference/5.1/Microsoft.PowerShell.Core/Get-PSSessionConfiguration.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/Get-PSSessionConfiguration.md
@@ -8,10 +8,10 @@ online version: http://go.microsoft.com/fwlink/?LinkId=821490
 schema: 2.0.0
 title: Get-PSSessionConfiguration
 ---
-
 # Get-PSSessionConfiguration
 
 ## SYNOPSIS
+
 Gets the registered session configurations on the computer.
 
 ## SYNTAX
@@ -21,43 +21,55 @@ Get-PSSessionConfiguration [[-Name] <String[]>] [-Force] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-PSSessionConfiguration** cmdlet gets the session configurations that have been registered on the local computer.
-This is an advanced cmdlet is designed for system administrators to manage customized session configurations your users.
 
-Starting in Windows PowerShell 3.0, you can define the properties of a session configuration by using a session configuration (.pssc) file.
-This feature lets you create customized and restricted sessions without writing a computer program.
-For more information about session configuration files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
+The `Get-PSSessionConfiguration` cmdlet gets the session configurations that have been registered
+on the local computer. This is an advanced cmdlet that is designed to be used by system
+administrators to manage customized session configurations for their users.
 
-Starting in Windows PowerShell 3.0, new note properties have been added to the session configuration object that **Get-PSSessionConfiguration** returns.
-These properties make it easier for users and session configuration authors to examine and compare session configurations.
+Beginning in Windows PowerShell 3.0, you can define the properties of a session configuration by
+using a session configuration (.pssc) file. This feature lets you create customized and restricted
+sessions without writing a computer program. For more information about session configuration
+files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
 
-To create and register a session configuration, use the Register-PSSessionConfiguration cmdlet.
-For more information about session configurations, see [about_Session_Configurations](About/about_Session_Configurations.md).
+Also, beginning in Windows PowerShell 3.0, new note properties have been added to the session
+configuration object that `Get-PSSessionConfiguration` returns. These properties make it easier
+for users and session configuration authors to examine and compare session configurations.
+
+To create and register a session configuration, use the `Register-PSSessionConfiguration` cmdlet. For
+more information about session configurations, see
+[about_Session_Configurations](About/about_Session_Configurations.md).
 
 ## EXAMPLES
 
-### Example 1: Get session configurations for the local computer
+### Example 1 - Get session configurations on the local computer
+
 ```
-PS C:\> Get-PSSessionConfiguration
+PS> Get-PSSessionConfiguration
 ```
 
-This command gets the session configurations on the local computer.
+### Example 2 - Get the two default session configurations
 
-### Example 2: Get default session configurations
+The command uses the **Name** parameter of `Get-PSSessionConfiguration` to get only the session
+configurations with names that begin with "Microsoft".
+
 ```
-PS C:\> Get-PSSessionConfiguration -Name Microsoft*
+PS> Get-PSSessionConfiguration -Name Microsoft*
+
 Name                      PSVersion  StartupScript        Permission
 ----                      ---------  -------------        ----------
 microsoft.powershell      2.0                             BUILTIN\Administrators AccessAll...
 microsoft.powershell32    2.0                             BUILTIN\Administrators AccessAll...
 ```
 
-This command gets the two default session configurations that come with Windows PowerShell.
-The command uses the *Name* parameter of **Get-PSSessionConfiguration** to get only the session configurations with names that begin with "Microsoft".
+### Example 3 - Get the properties and values of a session configuration
 
-### Example 3: Display properties of a session configuration created from a file
+This example shows the properties and property values of a session configuration that was created
+by using a session configuration file.
+
 ```
-PS C:\> Get-PSSessionConfiguration -Name Full | Format-List -Property *
+PS> Get-PSSessionConfiguration -Name Full  | Format-List -Property *
+
+
 Copyright                     : (c) 2011 User01. All rights reserved.
 AliasDefinitions              : {System.Collections.Hashtable}
 SessionType                   : Default
@@ -98,86 +110,94 @@ MaxShellsPerUser              : 30
 Permission                    :
 ```
 
-This example shows the properties and property values of a session configuration that was created by using a session configuration file.
+The example uses the `Get-PSSessionConfiguration` cmdlet to get the full session configuration.
+A pipeline operator sends the Full session configuration to the `Format-List` cmdlet. The
+**Property** parameter with a value of `*` (all) directs `Format-List` to display all of the
+properties and property values of the object in a list.
 
-The command uses the **Get-PSSessionConfiguration** command to get the Full session configuration.
-A pipeline operator sends the Full session configuration to the Format-List cmdlet.
-The *Property* parameter with a value of * (all) directs **Format-List** to display all of the properties and property values of the object in a list.
+The output of this command has useful information, including the author of the session
+configuration, the session type, language mode, and execution policy of sessions that are created
+with this session configuration, session quotas, and the full path to the session configuration
+file.
 
-The output of this command has very useful information.
-This includes the author of the session configuration, the session type, language mode, and execution policy of sessions that are created by using this session configuration, session quotas, and the full path of the session configuration file.
+This view of a session configuration is used for sessions that include a session configuration
+file. For more information about session configuration files, see
+[about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
 
-This view of a session configuration is used for sessions that include a session configuration file.
-For more information about session configuration files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
+### Example 4 - Get the configuration of a workflow session
 
-### Example 4: Get and sort properties of a session configuration
+This command gets the properties of the Microsoft.PowerShell.Worfklow session configuration and
+sorts them into alphabetical order for easy reading. You can use this command format in a function
+to get this display for any session configuration.
+
 ```
-PS C:\> (Get-PSSessionConfiguration Microsoft.PowerShell.Workflow).PSObject.Properties | Select-Object Name,Value | Sort-Object Name
-
-Name                                                                                                              Value
-----                                                                                                              -----
-ActivityProcessIdleTimeoutSec                                                                                        60
-AllowedActivity                                                                                   {PSDefaultActivities}
-Architecture                                                                                                         64
-AssemblyName                                                ...licKeyToken=31bf3856ad364e35, processorArchitecture=MSIL
-AutoRestart                                                                                                       false
-Capability                                                                                                      {Shell}
-Enabled                                                                                                            true
-EnableValidation                                                                                                   true
-ExactMatch                                                                                                        False
-Filename                                                                              %windir%\system32\pwrshplugin.dll
-IdleTimeoutms                                                                                                   7200000
-lang                                                                                                              en-US
-MaxActivityProcesses                                                                                                  5
-MaxConcurrentCommandsPerShell                                                                                      1000
-MaxConcurrentUsers                                                                                                    5
-MaxConnectedSessions                                                                                                100
-MaxDisconnectedSessions                                                                                            1000
-MaxIdleTimeoutms                                                                                             2147483647
-MaxMemoryPerShellMB                                                                                                1024
-MaxPersistenceStoreSizeGB                                                                                            10
-MaxProcessesPerShell                                                                                                 15
-MaxRunningWorkflows                                                                                                  30
-MaxSessionsPerRemoteNode                                                                                              5
-MaxSessionsPerWorkflow                                                                                                5
-
-MaxShells                                                                                                            25
-MaxShellsPerUser                                                                                                     25
-ModulesToImport                                             %windir%\system32\windowspowershell\v1.0\Modules\PSWorkflow
-Name                                                                                      microsoft.powershell.workflow
-OutOfProcessActivity                                                                                     {InlineScript}
-OutputBufferingMode                                                                                               Block
-ParentResourceUri                                           ...s.microsoft.com/powershell/microsoft.powershell.workflow
-Permission                                                  ...ssAllowed, BUILTIN\Remote Management Users AccessAllowed
-PersistencePath                                             ...s\juneb\AppData\Local\Microsoft\Windows\PowerShell\WF\PS
-PersistWithEncryption                                                                                             False
-ProcessIdleTimeoutSec                                                                                             28800
-PSSessionConfigurationTypeName                              ...osoft.PowerShell.Workflow.PSWorkflowSessionConfiguration
-PSVersion                                                                                                           3.0
-RemoteNodeSessionIdleTimeoutSec                                                                                      60
-ResourceUri                                                 ...s.microsoft.com/powershell/microsoft.powershell.workflow
+PS> (Get-PSSessionConfiguration Microsoft.PowerShell.Workflow).PSObject.Properties |
+  Select-Object Name,Value | Sort-Object Name
+Name                                                                                                  Value
+----                                                                                                  -----
+ActivityProcessIdleTimeoutSec                                                                            60
+AllowedActivity                                                                       {PSDefaultActivities}
+Architecture                                                                                             64
+AssemblyName                                    ...licKeyToken=31bf3856ad364e35, processorArchitecture=MSIL
+AutoRestart                                                                                           false
+Capability                                                                                          {Shell}
+Enabled                                                                                                true
+EnableValidation                                                                                       true
+ExactMatch                                                                                            False
+Filename                                                                  %windir%\system32\pwrshplugin.dll
+IdleTimeoutms                                                                                       7200000
+lang                                                                                                  en-US
+MaxActivityProcesses                                                                                      5
+MaxConcurrentCommandsPerShell                                                                          1000
+MaxConcurrentUsers                                                                                        5
+MaxConnectedSessions                                                                                    100
+MaxDisconnectedSessions                                                                                1000
+MaxIdleTimeoutms                                                                                 2147483647
+MaxMemoryPerShellMB                                                                                    1024
+MaxPersistenceStoreSizeGB                                                                                10
+MaxProcessesPerShell                                                                                     15
+MaxRunningWorkflows                                                                                      30
+MaxSessionsPerRemoteNode                                                                                  5
+MaxSessionsPerWorkflow                                                                                    5
+MaxShells                                                                                                25
+MaxShellsPerUser                                                                                         25
+ModulesToImport                                 %windir%\system32\windowspowershell\v1.0\Modules\PSWorkflow
+Name                                                                          microsoft.powershell.workflow
+OutOfProcessActivity                                                                         {InlineScript}
+OutputBufferingMode                                                                                   Block
+ParentResourceUri                               ...s.microsoft.com/powershell/microsoft.powershell.workflow
+Permission                                      ...ssAllowed, BUILTIN\Remote Management Users AccessAllowed
+PersistencePath                                 ...s\juneb\AppData\Local\Microsoft\Windows\PowerShell\WF\PS
+PersistWithEncryption                                                                                 False
+ProcessIdleTimeoutSec                                                                                 28800
+PSSessionConfigurationTypeName                  ...osoft.PowerShell.Workflow.PSWorkflowSessionConfiguration
+PSVersion                                                                                               3.0
+RemoteNodeSessionIdleTimeoutSec                                                                          60
+ResourceUri                                     ...s.microsoft.com/powershell/microsoft.powershell.workflow
 RunAsPassword
 RunAsUser
-SDKVersion                                                                                                            2
-SecurityDescriptorSddl                                      ...;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)
-SessionConfigurationData                                    ...    </SessionConfigurationData>
-SessionThrottleLimit                                                                                                100
-SupportsOptions                                                                                                    true
-Uri                                                         ...s.microsoft.com/powershell/microsoft.powershell.workflow
-UseSharedProcess                                                                                                   true
-WorkflowShutdownTimeoutMSec                                                                                         500
-xmlns                                                       ...as.microsoft.com/wbem/wsman/1/config/PluginConfiguration
-XmlRenderingType                                                                                                   text
+SDKVersion                                                                                                2
+SecurityDescriptorSddl                          ...;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)
+SessionConfigurationData                                                 ...    </SessionConfigurationData>
+SessionThrottleLimit                                                                                    100
+SupportsOptions                                                                                        true
+Uri                                             ...s.microsoft.com/powershell/microsoft.powershell.workflow
+UseSharedProcess                                                                                       true
+WorkflowShutdownTimeoutMSec                                                                             500
+xmlns                                           ...as.microsoft.com/wbem/wsman/1/config/PluginConfiguration
+XmlRenderingType                                                                                       text
 ```
-
-This command gets the properties of the Microsoft.PowerShell.Worfklow session configuration and sorts them into alphabetical order for easy reading.
-You can use this command format in a function to get this display for any session configuration.
 
 This example was contributed by Shay Levy, a Windows PowerShell MVP from Sderot, Israel.
 
-### Example 5: Examine the contents of the Plugin node
+### Example 5 - Another way to look at the session configurations
+
+This command uses the `Get-ChildItem` cmdlet (alias = dir) in the WSMan: provider drive to look at
+the content of the Plugin node. This is another way to look at the session configurations on the
+computer.
+
 ```
-PS C:\> dir wsman:\localhost\plugin
+PS> dir wsman:\localhost\plugin
 Type            Keys                                Name
 ----            ----                                ----
 Container       {Name=Event Forwarding Plugin}      Event Forwarding Plugin
@@ -189,18 +209,20 @@ Container       {Name=microsoft.ServerManager}      microsoft.ServerManager
 Container       {Name=WMI Provider}                 WMI Provider
 ```
 
-This command uses the dir alias of the Get-ChildItem cmdlet in the WSMan: provider drive to examine the content of the **Plugin** node.
-This is another way to view the session configurations on the computer.
+The **PlugIn** node contains **ContainerElement** objects
+(Microsoft.WSMan.Management.WSManConfigContainerElement) that represent the registered PowerShell
+session configurations, along with other plug-ins for WS-Management.
 
-The **PlugIn** node contains **ContainerElement** objects (Microsoft.WSMan.Management.WSManConfigContainerElement) that represent the registered Windows PowerShell session configurations, together with other plug-ins for WS-Management.
+### Example 6 - View session configurations on a remote computer
 
-### Example 6: View session configuration on a remote computer
+This example shows how to use the WSMan provider to view the session configurations on a remote
+computer. This method does not provide as much information as a `Get-PSSessionConfiguration`
+command, but the user does not need to be a member of the Administrators group to run this command.
+
 ```
-The first command uses the Connect-WSMan cmdlet to connect to the WinRM service on the Server01 remote computer.
-PS C:\> Connect-WSMan -ComputerName Server01
+PS> Connect-WSMan -ComputerName Server01
 
-The second command uses dir in the WSMan: drive to get the items in the Server01\Plugin path.The output shows the items in the **Plugin** directory on the Server01 computer. The items include the session configurations, which are a type of WSMan plug-in, together with other types of plug-ins on the computer.
-PS C:\> dir WSMan:\Server01\Plugin
+PS> dir WSMan:\Server01\Plugin
    WSManConfig: Microsoft.WSMan.Management\WSMan::localhost\Plugin
 
 Type            Keys                                Name
@@ -219,8 +241,9 @@ Container       {Name=SEL Plugin}                   SEL Plugin
 Container       {Name=WithProfile}                  WithProfile
 Container       {Name=WMI Provider}                 WMI Provider
 
-The third command returns the names of the plugins that are session configurations. The command searches for a value of Shell in the **Capability** property, which is in the Plugin\Resources\<ResourceNumber> path in the WSMan: drive.
-PS C:\> dir WSMan:\Server01\Plugin\*\Resources\Resource*\Capability | where {$_.Value -eq "Shell"} | foreach {($_.PSPath.split("\"))[3] }
+PS> dir WSMan:\Server01\Plugin\*\Resources\Resource*\Capability |
+  where {$_.Value -eq "Shell"} |
+    foreach {($_.PSPath.split("\"))[3] }
 Empty
 Full
 microsoft.powershell
@@ -233,22 +256,34 @@ RRS
 WithProfile
 ```
 
-This example shows how to use the WSMan provider to view the session configurations on a remote computer.
-This method does not provide as much information as a **Get-PSSessionConfiguration** command, but the user does not have to be a member of the Administrators group to run this command.
+The first command uses the `Connect-WSMan` cmdlet to connect to the WinRM service on the Server01
+remote computer.
 
-### Example 7: Run this cmdlet on a remote computer
+The second command uses the `Get-ChildItem` cmdlet ("dir") in the WSMan: drive to get the items in
+the Server01\Plugin path.The output shows the items in the Plugin directory on the Server01
+computer. The items include the session configurations, which are a type of WSMan plug-in, along
+with other types of plug-ins on the computer.
+
+The third command returns the names of the plugins that are session configurations. The command
+searches for a value of **Shell** in the **Capability** property, which is in the
+`Plugin\Resources\<ResourceNumber>` path in the WSMan: drive.
+
+### Example 7 - Get detailed session configurations from a remote computer
+
+This example shows how to run a `Get-PSSessionConfiguration` command on a remote computer. The
+command requires that CredSSP delegation be enabled in the client settings on the local computer
+and in the service settings on the remote computer.
+
+To run the commands in this example, you must be a member of the Administrators group on the local
+computer and the remote computer and you must start Windows PowerShell with the "Run as
+administrator" option.
+
 ```
-The first command uses the Enable-WSManCredSSP cmdlet to enable **CredSSP** delegation from the Server01 local computer to the Server02 remote computer. This configures the **CredSSP** client setting on the local computer.
-PS C:\> Enable-WSManCredSSP -Delegate Server02
+PS> Enable-WSManCredSSP -Delegate Server02
+PS> Connect-WSMan Server02
+PS> Set-Item WSMan:\Server02*\Service\Auth\CredSSP -Value $true
+PS> Invoke-Command -ScriptBlock {Get-PSSessionConfiguration} -ComputerName Server02 -Authentication CredSSP -Credential Domain01\Admin01
 
-The second command uses the **Connect-WSMan** cmdlet to connect to the Server02 computer. This action adds a node for the Server02 computer to the WSMan: drive on the local computer. This lets you view and change the WS-Management settings on the Server02 computer.
-PS C:\> Connect-WSMan Server02
-
-The third command uses the Set-Item cmdlet to change the value of the **CredSSP** item in the Service node of the Server02 computer to True. This configures the service settings on the remote computer.
-PS C:\> Set-Item WSMan:\Server02*\Service\Auth\CredSSP -Value $true
-
-The fourth command uses the Invoke-Command cmdlet to run a **Get-PSSessionConfiguration** command on the Server02 computer. The command uses the *Credential* parameter, and it uses the *Authentication* parameter with a value of CredSSP.The output shows the session configurations on the Server02 remote computer.
-PS C:\> Invoke-Command -ScriptBlock {Get-PSSessionConfiguration} -ComputerName Server02 -Authentication CredSSP -Credential Domain01\Admin01
 Name                      PSVersion  StartupScript        Permission                          PSComputerName
 ----                      ---------  -------------        ----------                          --------------
 microsoft.powershell      2.0                             BUILTIN\Administrators AccessAll... server02.corp.fabrikam.com
@@ -256,24 +291,37 @@ microsoft.powershell32    2.0                             BUILTIN\Administrators
 MyX86Shell                2.0        c:\test\x86Shell.ps1 BUILTIN\Administrators AccessAll... server02.corp.fabrikam.com
 ```
 
-This example shows how to run a **Get-PSSessionConfiguration** command on a remote computer.
-The command requires that CredSSP delegation be enabled in the client settings on the local computer and in the service settings on the remote computer.
+The first command uses the `Enable-WSManCredSSP` cmdlet to enable **CredSSP** delegation from the
+Server01 local computer to the Server02 remote computer. This configures the **CredSSP** client
+setting on the local computer.
 
-To run the commands in this example, you must be a member of the Administrators group on the local computer and the remote computer and you must start Windows PowerShell by using the Run as administrator option.
+The second command uses the `Connect-WSMan` cmdlet to connect to the Server02 computer. This action
+adds a node for the Server02 computer to the WSMan: drive on the local computer, allowing you to
+view and change the WS-Management settings on the Server02 computer.
 
-### Example 8: Get the resource URI of a session configuration
+The third command uses the `Set-Item` cmdlet to change the value of the **CredSSP** item in the
+Service node of the Server02 computer to True. This configures the service settings on the remote
+computer.
+
+The fourth command uses the `Invoke-Command` cmdlet to run a `Get-PSSessionConfiguration` command
+on the Server02 computer. The command uses the **Credential** parameter, and it uses the
+**Authentication** parameter with a value of **CredSSP**.The output shows the session
+configurations on the Server02 remote computer.
+
+### Example 8 - Get the resource URI of a session configuration
+
+This command is useful when setting the value of the $PSSessionConfigurationName preference
+variable, which takes a resource URI.
+
 ```
-PS C:\> (Get-PSSessionConfiguration -Name CustomShell).resourceURI
+PS> (Get-PSSessionConfiguration -Name CustomShell).resourceURI
 http://schemas.microsoft.com/powershell/microsoft.CustomShell
 ```
 
-This command uses the **Get-PSSessionConfiguration** cmdlet to get the resource Uniform Resource Identifier (URI) of a session configuration.
-
-This command is useful when you set the value of the $PSSessionConfigurationName preference variable, which takes a resource URI.
-
-The $PSSessionConfiguationName variable specifies the default configuration that is used when you create a session.
-This variable is set on the local computer, but it specifies a configuration on the remote computer.
-For more information about the $PSSessionConfiguration variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
+The `$PSSessionConfiguationName` variable specifies the default configuration that is used when you
+create a session. This variable is set on the local computer, but it specifies a configuration on
+the remote computer. For more information about the `$PSSessionConfiguration` variable, see
+[about_Preference_Variables](About/about_Preference_Variables.md).
 
 ## PARAMETERS
 
@@ -293,10 +341,9 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of names.
-This cmdlet gets the session configurations with the specified name or name pattern.
-Enter one or more session configuration names.
-Wildcard characters are permitted.
+
+Gets only the session configurations with the specified name or name pattern. Enter one or more
+session configuration names. Wildcards are permitted.
 
 ```yaml
 Type: String[]
@@ -305,17 +352,22 @@ Aliases:
 
 Required: False
 Position: 0
-Default value: None
+Default value: All session configurations on the local computer
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### None
+
 You cannot pipe input to this cmdlet.
 
 ## OUTPUTS
@@ -323,12 +375,32 @@ You cannot pipe input to this cmdlet.
 ### Microsoft.PowerShell.Commands.PSSessionConfigurationCommands#PSSessionConfiguration
 
 ## NOTES
-* To run this cmdlet, start Windows PowerShell by using the Run as administrator option.
-* To view the session configurations on the computer, you must be a member of the Administrators group on the computer.
-* To run a **Get-PSSessionConfiguration** command on a remote computer, Credential Security Service Provider (CredSSP) authentication must be enabled in the client settings on the local computer by using the Enable-WSManCredSSP cmdlet, and in the service settings on the remote computer. You must also use the **CredSSP** value of the *Authentication* parameter when establishing the remote session. Otherwise, access is denied.
-* The note properties of the object that **Get-PSSessionConfiguration** returns appear on the object only when they have a value. Only session configurations that were created by using a session configuration file have all of the defined properties.
-* The properties of a session configuration object vary with the options set for the session configuration and the values of those options. Also, session configurations that use a session configuration file have additional properties.
-* You can use commands in the WSMan: drive to change the properties of session configurations. However, you cannot use the WSMan: drive in Windows PowerShell 2.0 to change session configuration properties that are introduced in Windows PowerShell 3.0, such as **OutputBufferingMode**. Windows PowerShell 2.0 commands do not generate an error, but they are ineffective. To change  properties introduced in Windows PowerShell 3.0, use the WSMan: drive in Windows PowerShell 3.0.
+
+- To run this cmdlet, start Windows PowerShell with the "Run as administrator" option.
+
+- To view the session configurations on the computer, you must be a member of the Administrators
+  group on the computer.
+
+- To run a `Get-PSSessionConfiguration` command on a remote computer, Credential Security Service
+  Provider (CredSSP) authentication must be enabled in the client settings on the local computer
+  (by using the `Enable-WSManCredSSP` cmdlet) and in the service settings on the remote computer,
+  and you must use the **CredSSP** value of the **Authentication** parameter when establishing the
+  remote session. Otherwise, access is denied.
+
+- The note properties of the object that `Get-PSSessionConfiguration` returns appear on the
+  object only when they have a value. Only session configurations that were created by using a
+  session configuration file have all of the defined properties.
+
+- The properties of a session configuration object vary with the options set for the session
+  configuration and the values of those options. Also, session configurations that use a session
+  configuration file have additional properties.
+
+- You can use commands in the WSMan: drive to change the properties of session configurations.
+  However, you cannot use the WSMan: drive in Windows PowerShell 2.0 to change session
+  configuration properties that are introduced in Windows PowerShell 3.0, such as
+  **OutputBufferingMode**. Windows PowerShell 2.0 commands do not generate an error, but they are
+  ineffective. To change properties introduced in Windows PowerShell 3.0, use the WSMan: drive in
+  Windows PowerShell 3.0.
 
 ## RELATED LINKS
 
@@ -336,7 +408,11 @@ You cannot pipe input to this cmdlet.
 
 [Enable-PSSessionConfiguration](Enable-PSSessionConfiguration.md)
 
+[Get-PSSessionConfiguration](Get-PSSessionConfiguration.md)
+
 [New-PSSessionConfigurationFile](New-PSSessionConfigurationFile.md)
+
+[New-PSSessionOption](New-PSSessionOption.md)
 
 [Register-PSSessionConfiguration](Register-PSSessionConfiguration.md)
 
@@ -345,3 +421,9 @@ You cannot pipe input to this cmdlet.
 [Test-PSSessionConfigurationFile](Test-PSSessionConfigurationFile.md)
 
 [Unregister-PSSessionConfiguration](Unregister-PSSessionConfiguration.md)
+
+[WSMan Provider](../microsoft.wsman.management/about/about_WSMan_Provider.md)
+
+[about_Session_Configurations](About/about_Session_Configurations.md)
+
+[about_Session_Configuration_Files](About/about_Session_Configuration_Files.md)

--- a/reference/5.1/PowershellGet/Install-Module.md
+++ b/reference/5.1/PowershellGet/Install-Module.md
@@ -17,6 +17,7 @@ Downloads one or more modules from an online gallery, and installs them on the l
 ## SYNTAX
 
 ### NameParameterSet (Default)
+
 ```
 Install-Module [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <String>]
  [-RequiredVersion <String>] [-Repository <String[]>] [-Credential <PSCredential>] [-Scope <String>]
@@ -25,6 +26,7 @@ Install-Module [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <S
 ```
 
 ### InputObject
+
 ```
 Install-Module [-InputObject] <PSObject[]> [-Credential <PSCredential>] [-Scope <String>] [-Proxy <Uri>]
  [-ProxyCredential <PSCredential>] [-AllowClobber] [-SkipPublisherCheck] [-Force] [-AcceptLicense] [-WhatIf]
@@ -32,7 +34,10 @@ Install-Module [-InputObject] <PSObject[]> [-Credential <PSCredential>] [-Scope 
 ```
 
 ## DESCRIPTION
-The **Install-Module** cmdlet gets one or more modules that meet specified criteria from an online gallery, verifies that search results are valid modules, and copies module folders to the installation location.
+
+The `Install-Module` cmdlet gets one or more modules that meet specified criteria from an online
+gallery, verifies that search results are valid modules, and copies module folders to the
+installation location.
 
 You can filter your results based on minimum and exact versions of specified modules.
 
@@ -40,52 +45,59 @@ You can filter your results based on minimum and exact versions of specified mod
 
 ### Example 1: Find a module and install it
 
-```powershell
-PS C:\> Find-Module -Name "MyDSC*" | Install-Module
-```
+In this example, modules with a name that starts with MyDSC that are found by `Find-Module` in the
+online gallery are installed to the default folder, `C:\ProgramFiles\WindowsPowerShell\Modules`.
 
-In this example, modules with a name that starts with MyDSC that are found by Find-Module in the online gallery are installed to the default folder, C:\ProgramFiles\WindowsPowerShell\Modules.
+```powershell
+Find-Module -Name "MyDSC*" | Install-Module
+```
 
 ### Example 2: Install a module by name
 
-```powershell
-PS C:\> Install-Module -Name "MyDscModule"
-```
+In this example, the newest version of the module MyDscModule from the online gallery is installed
+to the default folder.
 
-In this example, the newest version of the module MyDscModule from the online gallery is installed to the default folder, Program Files.
+```powershell
+Install-Module -Name "MyDscModule"
+```
 
 If no module named MyDscModule exists, an error occurs.
 
 ### Example 3: Install a module using its minimum version
 
+In this example, the most current version of the module ContosoServer is installed that matches the
+specified minimum version.
+
 ```powershell
-PS C:\> Install-Module -Name "ContosoServer" -MinimumVersion 1.0
+Install-Module -Name "ContosoServer" -MinimumVersion 1.0
 ```
 
-In this example, the most current version of the module ContosoServer is installed that matches the specified minimum version.
 If the most current version of the module is a lower number than 1.0, the command returns errors.
 
 ### Example 4: Install a specific version of a module
 
+This example installs version 1.1.3 of the module ContosoServer to the Program Files folder.
+
 ```powershell
-PS C:\> Install-Module -Name "ContosoServer" -RequiredVersion 1.1.3
+Install-Module -Name "ContosoServer" -RequiredVersion 1.1.3
 ```
 
-This example installs version 1.1.3 of the module ContosoServer to the Program Files folder.
 If version 1.1.3 is not available, an error occurs.
 
 ### Example 5: Install the current version of a module
 
-```powershell
-PS C:\> Install-Module -Name "ContosoServer" -Scope "CurrentUser"
-```
+This example installs the newest version of the module ContosoServer to
+`$home\Documents\WindowsPowerShell\Modules`.
 
-This example installs the newest version of the module ContosoServer to $home\Documents\WindowsPowerShell\Modules.
+```powershell
+Install-Module -Name "ContosoServer" -Scope "CurrentUser"
+```
 
 ## PARAMETERS
 
 ### -AcceptLicense
-{{Fill AcceptLicense Description}}
+
+Automatically accept the license agreement during installation if the module requires it.
 
 ```yaml
 Type: SwitchParameter
@@ -101,19 +113,6 @@ Accept wildcard characters: False
 
 ### -AllowClobber
 
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -AllowClobber
 Allows you to install a different version of a module that already exists on your computer.
 
 ```yaml
@@ -129,6 +128,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowPrerelease
+
 Allows you to install a module marked as a prerelease.
 
 ```yaml
@@ -144,7 +144,9 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies a user account that has rights to install a module for a specified package provider or source.
+
+Specifies a user account that has rights to install a module for a specified package provider or
+source.
 
 ```yaml
 Type: PSCredential
@@ -159,8 +161,10 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Forces the installation of modules.
-If a module of the same name and version already exists on the computer, this parameter overwrites the existing module with one of the same name that was found by the command.
+
+Forces the installation of modules. If a module of the same name and version already exists on the
+computer, this parameter overwrites the existing module with one of the same name that was found by
+the command.
 
 ```yaml
 Type: SwitchParameter
@@ -175,7 +179,8 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-{{Fill InputObject Description}}
+
+Used for pipeline input.
 
 ```yaml
 Type: PSObject[]
@@ -190,9 +195,10 @@ Accept wildcard characters: False
 ```
 
 ### -MaximumVersion
-Specifies the maximum version of a single module to install.
-You cannot add this parameter if you are attempting to install multiple modules.
-The *MaximumVersion* and the *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the maximum version of a single module to install. You cannot add this parameter if you
+are attempting to install multiple modules. The **MaximumVersion** and the **RequiredVersion**
+parameters are mutually exclusive; you cannot use both parameters in the same command.
 
 ```yaml
 Type: String
@@ -207,12 +213,17 @@ Accept wildcard characters: False
 ```
 
 ### -MinimumVersion
-Specifies the minimum version of a single module to install.
-You cannot add this parameter if you are attempting to install multiple modules.
-The *MinimumVersion* and the *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
 
-If you are installing multiple modules in a single command, and a specified minimum version for a module is not available for installation, the **Install-Module** command silently continues without installing the unavailable module.
-For example, if you try to install the ContosoServer module with a minimum version of 2.0, but the latest version of the ContosoServer module is 1.5, the **Install-Module** command does not install the ContosoServer module; it goes to install the next specified module, and Windows PowerShell display errors when the command is finished.
+Specifies the minimum version of a single module to install. You cannot add this parameter if you
+are attempting to install multiple modules. The **MinimumVersion** and the **RequiredVersion**
+parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+If you are installing multiple modules in a single command, and a specified minimum version for a
+module is not available for installation, the `Install-Module` command silently continues without
+installing the unavailable module. For example, if you try to install the ContosoServer module with
+a minimum version of 2.0, but the latest version of the ContosoServer module is 1.5, the
+`Install-Module` command does not install the ContosoServer module; it goes to install the next
+specified module, and PowerShell display errors when the command is finished.
 
 ```yaml
 Type: String
@@ -227,11 +238,12 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies the exact names of modules to install from the online gallery.
-This parameter supports wildcard characters.
-If wildcard characters are not specified, only modules that exactly match the specified names are returned.
-If no matches are found, and you have not used any wildcard characters, the command returns an error.
-If you use wildcard characters, but do not find matching results, no error is returned.
+
+Specifies the exact names of modules to install from the online gallery. This parameter supports
+wildcard characters. If wildcard characters are not specified, only modules that exactly match the
+specified names are returned. If no matches are found, and you have not used any wildcard
+characters, the command returns an error. If you use wildcard characters, but do not find matching
+results, no error is returned.
 
 ```yaml
 Type: String[]
@@ -246,6 +258,7 @@ Accept wildcard characters: False
 ```
 
 ### -Proxy
+
 Specifies a proxy server for the request, rather than connecting directly to the Internet resource.
 
 ```yaml
@@ -261,7 +274,9 @@ Accept wildcard characters: False
 ```
 
 ### -ProxyCredential
-Specifies a user account that has permission to use the proxy server that is specified by the **Proxy** parameter.
+
+Specifies a user account that has permission to use the proxy server that is specified by the
+**Proxy** parameter.
 
 ```yaml
 Type: PSCredential
@@ -276,7 +291,9 @@ Accept wildcard characters: False
 ```
 
 ### -Repository
-Specifies the friendly name of a repository that has been registered by running Register-PSRepository.
+
+Specifies the friendly name of a repository that has been registered by running
+`Register-PSRepository`.
 
 ```yaml
 Type: String[]
@@ -291,9 +308,10 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredVersion
-Specifies the exact version of a single module to install.
-You cannot add this parameter if you are attempting to install multiple modules.
-The *MinimumVersion* and the *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the exact version of a single module to install. You cannot add this parameter if you are
+attempting to install multiple modules. The **MinimumVersion** and the **RequiredVersion**
+parameters are mutually exclusive; you cannot use both parameters in the same command.
 
 ```yaml
 Type: String
@@ -308,17 +326,22 @@ Accept wildcard characters: False
 ```
 
 ### -Scope
-Specifies the installation scope of the module.
-The acceptable values for this parameter are: AllUsers and CurrentUser.
 
-When no *Scope* is defined, the default will be set based on the current session:
-* For an elevated PowerShell session, *Scope* will default to AllUsers;
-* For non-elevated PowerShell sessions in [PowerShellGet versions 2.0.0](https://www.powershellgallery.com/packages/PowerShellGet) and above, *Scope* will be CurrentUser;
-* For non-elevated PowerShell sessions in PowerShellGet versions 1.6.7 and earlier, *Scope* will be undefined, and Install-Module will fail.
+Specifies the installation scope of the module. The acceptable values for this parameter are:
+AllUsers and CurrentUser.
 
-The AllUsers scope lets modules be installed in a location that is accessible to all users of the computer, that is, %systemdrive%:\ProgramFiles\WindowsPowerShell\Modules.
+The AllUsers scope lets modules be installed in a location that is accessible to all users of the
+computer, that is, `$env:ProgramFiles\WindowsPowerShell\Modules`.
 
-The CurrentUser scope lets modules be installed only to $home\Documents\WindowsPowerShell\Modules, so that the module is available only to the current user.
+The CurrentUser scope lets modules be installed only to `$home\Documents\WindowsPowerShell\Modules`,
+so that the module is available only to the current user.
+
+When no **Scope** is defined, the default will be set based on the current session:
+- For an elevated PowerShell session, **Scope** defaults to AllUsers;
+- For non-elevated PowerShell sessions in [PowerShellGet versions 2.0.0](https://www.powershellgallery.com/packages/PowerShellGet)
+  and above, **Scope** is CurrentUser;
+- For non-elevated PowerShell sessions in PowerShellGet versions 1.6.7 and earlier, **Scope** is
+  undefined, and `Install-Module` will fail.
 
 ```yaml
 Type: String
@@ -334,7 +357,10 @@ Accept wildcard characters: False
 ```
 
 ### -SkipPublisherCheck
-Allows you to install a newer version of a module that already exists on your computer in the case when a newer one is not digitally signed by a trusted publisher and the newest existing module is digitally signed by a trusted publisher.
+
+Allows you to install a newer version of a module that already exists on your computer in the case
+when a newer one is not digitally signed by a trusted publisher and the newest existing module is
+digitally signed by a trusted publisher.
 
 ```yaml
 Type: SwitchParameter
@@ -349,6 +375,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -364,8 +391,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -380,7 +407,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -389,24 +420,43 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
-* This cmdlet runs on Windows PowerShell 5.0 or later releases of Windows PowerShell, on Windows 7 or Windows 2008 R2 and later releases of Windows.
 
-  If an installed module cannot be imported (that is, if it does not have a .psm1, .psd1, or .dll of the same name within the folder), installation fails unless you add the *Force* parameter to your command.
+This cmdlet runs on PowerShell 5.0 or later releases, on Windows 7 or Windows 2008 R2 and later
+releases of Windows.
 
-  If a version of the module on the computer matches the value specified for the *Name* parameter, and you have not added the *MinimumVersion* or *RequiredVersion* parameter, **Install-Module** silently continues without installing that module.
-If the *MinimumVersion* or *RequiredVersion* parameters are specified, and the existing module does not match the values in that parameter, then an error occurs.
-To be more specific: if the version of the currently-installed module is either lower than the value of the *MinimumVersion* parameter, or not equal to the value of the *RequiredVersion* parameter, an error occurs.
-If the version of the installed module is greater than the value of the *MinimumVersion* parameter, or equal to the value of the *RequiredVersion* parameter, **Install-Module** silently continues without installing that module.
+If an installed module cannot be imported (that is, if it does not have a .psm1, .psd1, or .dll of
+the same name within the folder), installation fails unless you add the *Force* parameter to your
+command.
 
-  **Install-Module** returns an error if no module exists in the online gallery that matches the specified name.
+If a version of the module on the computer matches the value specified for the **Name** parameter,
+and you have not added the **MinimumVersion** or **RequiredVersion** parameter, `Install-Module`
+silently continues without installing that module.
 
-  To install multiple modules, specify an array of the module names, separated by commas.
-You cannot add *MinimumVersion* or *RequiredVersion* if you specify multiple module names.
+If the **MinimumVersion** or **RequiredVersion** parameters are specified, and the existing module
+does not match the values in that parameter, then an error occurs. To be more specific: if the
+version of the currently-installed module is either lower than the value of the **MinimumVersion**
+parameter, or not equal to the value of the **RequiredVersion** parameter, an error occurs.
 
-  By default, modules are installed to the Program Files folder, to prevent confusion when you are installing Windows PowerShell Desired State Configuration (DSC) resources.You can pipe multiple **PSGetItemInfo** objects to **Install-Module**; this is another way of specifying multiple modules to install in a single command.
+If the version of the installed module is greater than the value of the **MinimumVersion**
+parameter, or equal to the value of the **RequiredVersion** parameter, `Install-Module` silently
+continues without installing that module.
 
-  To help prevent running modules that contain malicious code, installed modules are not automatically imported by installation.
-As a security best practice, evaluate module code before running any cmdlets or functions in a module for the first time.
+`Install-Module` returns an error if no module exists in the online gallery that matches the
+specified name.
+
+To install multiple modules, specify an array of the module names, separated by commas. You cannot
+add **MinimumVersion** or **RequiredVersion** if you specify multiple module names.
+
+By default, modules are installed to the Program Files folder, to prevent confusion when you are
+installing Windows PowerShell Desired State Configuration (DSC) resources.You can pipe multiple
+**PSGetItemInfo** objects to `Install-Module`; this is another way of specifying multiple modules
+to install in a single command.
+
+To help prevent running modules that contain malicious code, installed modules are not
+automatically imported by installation.
+
+As a security best practice, evaluate module code before running any cmdlets or functions in a
+module for the first time.
 
 ## RELATED LINKS
 

--- a/reference/5.1/PowershellGet/Install-Script.md
+++ b/reference/5.1/PowershellGet/Install-Script.md
@@ -17,43 +17,56 @@ Installs a script.
 ## SYNTAX
 
 ### NameParameterSet (Default)
+
 ```
 Install-Script [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <String>]
  [-RequiredVersion <String>] [-Repository <String[]>] [-Scope <String>] [-NoPathUpdate] [-Proxy <Uri>]
- [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease] [-AcceptLicense]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease]
+ [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
+
 ```
 
 ### InputObject
+
 ```
 Install-Script [-InputObject] <PSObject[]> [-Scope <String>] [-NoPathUpdate] [-Proxy <Uri>]
- [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Install-Script** cmdlet acquires a script payload from a repository, verifies that the payload is a valid PowerShell script, and copies the script file to a specified installation location.
 
-The default repositories **Install-Script** operates against are configurable through the Register-PSRepository, Set-PSRepository, Unregister-PSRepository, and Get-PSRepository cmdlets.
-When operating against multiple repositories, **Install-Script** installs the first script that matches the specified search criteria (*Name*, *MinimumVersion*, or *MaximumVersion*) from the first repository without any error.
+The `Install-Script` cmdlet acquires a script payload from a repository, verifies that the
+payload is a valid PowerShell script, and copies the script file to a specified installation
+location.
+
+The default repositories `Install-Script` operates against are configurable through the
+`Register-PSRepository`, `Set-PSRepository`, `Unregister-PSRepository`, and `Get-PSRepository`
+cmdlets. When operating against multiple repositories, `Install-Script` installs the first script
+that matches the specified search criteria (**Name**, **MinimumVersion**, or **MaximumVersion**)
+from the first repository without any error.
 
 ## EXAMPLES
 
 ### Example 1: Find a script and install it
+
 ```
 PS C:\> Find-Script -Repository "Local1" -Name "Required-Script2"
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.5        Required-Script2                    Script     local1               Description for the Required-Script2 script
+Version    Name                           Type       Repository           Description
+-------    ----                           ----       ----------           -----------
+2.5        Required-Script2               Script     local1               Description for the Required-Script2 script
+
 PS C:\> Find-Script -Repository "Local1" -Name "Required-Script2" | Install-Script
 PS C:\> Get-Command -Name "Required-Script2"
-CommandType     Name                                               Version    Source
------------     ----                                               -------    ------
-ExternalScript  Required-Script2.ps1                                2.0       C:\Users\pattif\Documents\WindowsPowerShell\Scripts\Required-Script2.ps1
+CommandType     Name                      Version    Source
+-----------     ----                      -------    ------
+ExternalScript  Required-Script2.ps1      2.0       C:\Users\pattif\Documents\WindowsPowerShell\Scripts\Required-Script2.ps1
+
 PS C:\> Get-InstalledScript -Name "Required-Script2"
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.5        Required-Script2                    Script     local1               Description for the Required-Script2 script
+Version    Name                  Type     Repository           Description
+-------    ----                  ----     ----------           -----------
+2.5        Required-Script2      Script   local1               Description for the Required-Script2 script
+
 PS C:\> Get-InstalledScript -Name "Required-Script2" | Format-List *
 Name                       : Required-Script2
 Version                    : 2.5
@@ -77,23 +90,30 @@ PackageManagementProvider  : NuGet
 InstalledLocation          : C:\Users\pattif\Documents\WindowsPowerShell\Scripts
 ```
 
-The first command finds the script named Required-Script2 from the Local1 repository and displays the results.
+The first command finds the script named `Required-Script2` from the Local1 repository and displays
+the results.
 
-The second command finds the Required-Script2 script, and then uses the pipeline operator to pass it to the Install-Script cmdlet to install it.
+The second command finds the `Required-Script2` script, and then uses the pipeline operator to pass
+it to the `Install-Script` cmdlet to install it.
 
-The third command uses the Get-Command cmdlet to get Required-Script2, and then displays the results.
+The third command uses the `Get-Command` cmdlet to get `Required-Script2`, and then displays the
+results.
 
-The fourth command uses the Get-InstalledScript cmdlet to get Required-Script2 and display the results.
+The fourth command uses the `Get-InstalledScript` cmdlet to get `Required-Script2` and display the
+results.
 
-The fifth command gets RequiredScript2 and uses the pipeline operator to pass it to the Format-List cmdlet to format the output.
+The fifth command gets `Required-Script2` and uses the pipeline operator to pass it to the
+`Format-List` cmdlet to format the output.
 
 ### Example 2: Install a script with AllUsers scope
+
 ```
 PS C:\> Install-Script -Repository "Local1" -Name "Required-Script3" -Scope "AllUsers"
 PS C:\> Get-InstalledScript -Name "Required-Script3"
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.5        Required-Script3                    Script     local1               Description for the Required-Script3 script
+Version    Name                  Type       Repository    Description
+-------    ----                  ----       ----------    -----------
+2.5        Required-Script3      Script     local1        Description for the Required-Script3 script
+
 PS C:\> Get-InstalledScript -Name "Required-Script3" | Format-List *
 Name                       : Required-Script3
 Version                    : 2.5
@@ -117,71 +137,83 @@ PackageManagementProvider  : NuGet
 InstalledLocation          : C:\Program Files\WindowsPowerShell\Scripts
 ```
 
-The first command installs the script named Required-Script3 and assigns it AllUsers scope.
+The first command installs the script named `Required-Script3` and assigns it AllUsers scope.
 
-The second command gets the installed script Required-Script3 and displays information about it.
+The second command gets the installed script `Required-Script3` and displays information about it.
 
-The third command gets Required-Script3 and uses the pipeline operator to pass it to the Format-List cmdlet to format the output.
+The third command gets `Required-Script3` and uses the pipeline operator to pass it to the
+`Format-List` cmdlet to format the output.
 
 ### Example 3: Install a script with its dependent scripts and modules
+
 ```
 PS C:\> Find-Script -Repository "Local1" -Name "Script-WithDependencies2" -IncludeDependencies
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.0        Script-WithDependencies2            Script     local1               Description for the Script-WithDependencies2 script
-2.5        RequiredModule1                     Module     local1               RequiredModule1 module
-2.5        RequiredModule2                     Module     local1               RequiredModule2 module
-2.5        RequiredModule3                     Module     local1               RequiredModule3 module
-2.5        Required-Script1                    Script     local1               Description for the Required-Script1 script
-2.5        Required-Script2                    Script     local1               Description for the Required-Script2 script
-2.5        Required-Script3                    Script     local1               Description for the Required-Script3 script
+Version    Name                        Type       Repository    Description
+-------    ----                        ----       ----------    -----------
+2.0        Script-WithDependencies2    Script     local1        Description for the Script-WithDependencies2 script
+2.5        RequiredModule1             Module     local1        RequiredModule1 module
+2.5        RequiredModule2             Module     local1        RequiredModule2 module
+2.5        RequiredModule3             Module     local1        RequiredModule3 module
+2.5        Required-Script1            Script     local1        Description for the Required-Script1 script
+2.5        Required-Script2            Script     local1        Description for the Required-Script2 script
+2.5        Required-Script3            Script     local1        Description for the Required-Script3 script
+
 PS C:\> Install-Script -Repository "Local1" -Name "Script-WithDependencies2"
 PS C:\> Get-InstalledScript
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.5        Required-Script1                    Script     local1               Description for the Required-Script1 script
-2.5        Required-Script2                    Script     local1               Description for the Required-Script2 script
-2.5        Required-Script3                    Script     local1               Description for the Required-Script3 script
-2.0        Script-WithDependencies2            Script     local1               Description for the Script-WithDependencies2 script
+Version    Name                        Type       Repository    Description
+-------    ----                        ----       ----------    -----------
+2.5        Required-Script1            Script     local1        Description for the Required-Script1 script
+2.5        Required-Script2            Script     local1        Description for the Required-Script2 script
+2.5        Required-Script3            Script     local1        Description for the Required-Script3 script
+2.0        Script-WithDependencies2    Script     local1        Description for the Script-WithDependencies2 script
+
 PS C:\> Get-InstalledModule
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.5        RequiredModule1                     Module     local1               RequiredModule1 module
-2.5        RequiredModule2                     Module     local1               RequiredModule2 module
-2.5        RequiredModule3                     Module     local1               RequiredModule3 module
+Version    Name                        Type       Repository    Description
+-------    ----                        ----       ----------    -----------
+2.5        RequiredModule1             Module     local1        RequiredModule1 module
+2.5        RequiredModule2             Module     local1        RequiredModule2 module
+2.5        RequiredModule3             Module     local1        RequiredModule3 module
+
 PS C:\> Find-Script -Repository "Local1" -Name "Required-Script*"
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.5        Required-Script1                    Script     local1               Description for the Required-Script1 script
-2.5        Required-Script2                    Script     local1               Description for the Required-Script2 script
-2.5        Required-Script3                    Script     local1               Description for the Required-Script3 script
+Version    Name                        Type       Repository    Description
+-------    ----                        ----       ----------    -----------
+2.5        Required-Script1            Script     local1        Description for the Required-Script1 script
+2.5        Required-Script2            Script     local1        Description for the Required-Script2 script
+2.5        Required-Script3            Script     local1        Description for the Required-Script3 script
+
 PS C:\> Install-Script -Repository "Local1" -Name "Required-Script*"
 PS C:\> Get-InstalledScript
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.5        Required-Script1                    Script     local1               Description for the Required-Script1 script
-2.5        Required-Script2                    Script     local1               Description for the Required-Script2 script
-2.5        Required-Script3                    Script     local1               Description for the Required-Script3 script
+Version    Name                        Type       Repository    Description
+-------    ----                        ----       ----------    -----------
+2.5        Required-Script1            Script     local1        Description for the Required-Script1 script
+2.5        Required-Script2            Script     local1        Description for the Required-Script2 script
+2.5        Required-Script3            Script     local1        Description for the Required-Script3 script
 ```
 
-The first command finds the script named Script-WithDependencies2 and its dependencies in the Local1 repository and displays the results.
+The first command finds the script named `Script-WithDependencies2` and its dependencies in the
+Local1 repository and displays the results.
 
-The second command installs Script-WithDependencies2.
+The second command installs `Script-WithDependencies2`.
 
-The third command uses the Get-InstalledScript script cmdlet to get installed scripts and display the results.
+The third command uses the `Get-InstalledScript` script cmdlet to get installed scripts and display
+the results.
 
-The fourth command uses the Get-InstalledModule cmdlet to get installed modules and display the results.
+The fourth command uses the `Get-InstalledModule` cmdlet to get installed modules and display the
+results.
 
-The fifth command uses the Find-Script cmdlet to find scripts where the name begins with Required-Script and display the results.
+The fifth command uses the `Find-Script` cmdlet to find scripts where the name begins with
+`Required-Script` and display the results.
 
-The sixth command installs the scripts where the name begins with Required-Script in the Local1 repository.
+The sixth command installs the scripts where the name begins with `Required-Script` in the Local1
+repository.
 
 The final command gets installed scripts and displays the results.
 
 ## PARAMETERS
 
 ### -AcceptLicense
-{{Fill AcceptLicense Description}}
+
+Automatically accept the license agreement during installation if the module requires it.
 
 ```yaml
 Type: SwitchParameter
@@ -196,6 +228,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowPrerelease
+
 Allows you to install a script marked as a prerelease.
 
 ```yaml
@@ -211,7 +244,9 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Specifies a user account that has rights to install a script for a specified package provider or source.
+
+Specifies a user account that has rights to install a script for a specified package provider or
+source.
 
 ```yaml
 Type: PSCredential
@@ -226,6 +261,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 Forces the command to run without asking for user confirmation.
 
 ```yaml
@@ -241,7 +277,8 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-{{Fill InputObject Description}}
+
+Used for pipeline input.
 
 ```yaml
 Type: PSObject[]
@@ -256,9 +293,11 @@ Accept wildcard characters: False
 ```
 
 ### -MaximumVersion
-Specifies the maximum, or newest, version of the script to install.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
-This parameter accepts the wildcard character (*).
+
+Specifies the maximum version of a single scripts to install. You cannot add this parameter if you
+are attempting to install multiple scripts. The **MaximumVersion** and the **RequiredVersion**
+parameters are mutually exclusive; you cannot use both parameters in the same command.
+
 
 ```yaml
 Type: String
@@ -273,8 +312,10 @@ Accept wildcard characters: False
 ```
 
 ### -MinimumVersion
-Specifies the minimum version of the script to install.
-The *MinimumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the minimum version of a single script to install. You cannot add this parameter if you
+are attempting to install multiple scripts. The **MinimumVersion** and the **RequiredVersion**
+parameters are mutually exclusive; you cannot use both parameters in the same command.
 
 ```yaml
 Type: String
@@ -289,6 +330,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Specifies an array of names of scripts to install.
 
 ```yaml
@@ -318,6 +360,7 @@ Accept wildcard characters: False
 ```
 
 ### -Proxy
+
 Specifies a proxy server for the request, rather than connecting directly to the Internet resource.
 
 ```yaml
@@ -333,7 +376,9 @@ Accept wildcard characters: False
 ```
 
 ### -ProxyCredential
-Specifies a user account that has permission to use the proxy server that is specified by the **Proxy** parameter.
+
+Specifies a user account that has permission to use the proxy server that is specified by the
+**Proxy** parameter.
 
 ```yaml
 Type: PSCredential
@@ -348,8 +393,9 @@ Accept wildcard characters: False
 ```
 
 ### -Repository
-Specifies the friendly name of a repository that has been registered with the Register-PSRepository cmdlet.
-The default is all registered repositories.
+
+Specifies the friendly name of a repository that has been registered with the
+`Register-PSRepository` cmdlet. The default is all registered repositories.
 
 ```yaml
 Type: String[]
@@ -364,6 +410,7 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredVersion
+
 Specifies the exact version number of the script to install.
 
 ```yaml
@@ -379,16 +426,23 @@ Accept wildcard characters: False
 ```
 
 ### -Scope
+
 Specifies the installation scope of the script.
 Valid values are: AllUsers and CurrentUser.
 
-When no *Scope* is defined, the default will be set based on the current session:
-* For an elevated PowerShell session, *Scope* will default to AllUsers;
-* For non-elevated PowerShell sessions in [PowerShellGet versions 2.0.0](https://www.powershellgallery.com/packages/PowerShellGet) and above, *Scope* will default to CurrentUser;
-* For non-elevated PowerShell sessions in PowerShellGet versions 1.6.7 and earlier, *Scope* will be undefined, and Install-Script will fail.
+The AllUsers scope lets modules be installed in a location that is accessible to all users of the
+computer, that is, `$env:ProgramFiles\WindowsPowerShell\Scripts`.
 
-The AllUsers scope specifies to install a script to %systemdrive%:\ProgramFiles\WindowsPowerShell\Scripts so that the script is available to all users.
-The CurrentUser scope specifies to install the script in $home\Documents\WindowsPowerShell\Scripts so that the script is available only to the current user.
+The CurrentUser scope lets modules be installed only to
+`$home\Documents\WindowsPowerShell\Scripts`, so that the module is available only to the current
+user.
+
+When no **Scope** is defined, the default will be set based on the current session:
+- For an elevated PowerShell session, **Scope** defaults to AllUsers;
+- For non-elevated PowerShell sessions in [PowerShellGet versions 2.0.0](https://www.powershellgallery.com/packages/PowerShellGet)
+  and above, **Scope** is CurrentUser;
+- For non-elevated PowerShell sessions in PowerShellGet versions 1.6.7 and earlier, **Scope** is
+  undefined, and `Install-Module` fails.
 
 ```yaml
 Type: String
@@ -404,6 +458,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -419,8 +474,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -435,7 +490,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/reference/6/Microsoft.PowerShell.Core/Get-PSSessionConfiguration.md
+++ b/reference/6/Microsoft.PowerShell.Core/Get-PSSessionConfiguration.md
@@ -8,7 +8,6 @@ online version: http://go.microsoft.com/fwlink/?LinkId=821490
 schema: 2.0.0
 title: Get-PSSessionConfiguration
 ---
-
 # Get-PSSessionConfiguration
 
 ## SYNOPSIS
@@ -21,43 +20,55 @@ Get-PSSessionConfiguration [[-Name] <String[]>] [-Force] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Get-PSSessionConfiguration** cmdlet gets the session configurations that have been registered on the local computer.
-This is an advanced cmdlet is designed for system administrators to manage customized session configurations your users.
 
-Starting in Windows PowerShell 3.0, you can define the properties of a session configuration by using a session configuration (.pssc) file.
-This feature lets you create customized and restricted sessions without writing a computer program.
-For more information about session configuration files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
+The `Get-PSSessionConfiguration` cmdlet gets the session configurations that have been registered
+on the local computer. This is an advanced cmdlet that is designed to be used by system
+administrators to manage customized session configurations for their users.
 
-Starting in Windows PowerShell 3.0, new note properties have been added to the session configuration object that **Get-PSSessionConfiguration** returns.
-These properties make it easier for users and session configuration authors to examine and compare session configurations.
+Beginning in Windows PowerShell 3.0, you can define the properties of a session configuration by
+using a session configuration (.pssc) file. This feature lets you create customized and restricted
+sessions without writing a computer program. For more information about session configuration
+files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
 
-To create and register a session configuration, use the Register-PSSessionConfiguration cmdlet.
-For more information about session configurations, see [about_Session_Configurations](About/about_Session_Configurations.md).
+Also, beginning in Windows PowerShell 3.0, new note properties have been added to the session
+configuration object that `Get-PSSessionConfiguration` returns. These properties make it easier
+for users and session configuration authors to examine and compare session configurations.
+
+To create and register a session configuration, use the `Register-PSSessionConfiguration` cmdlet. For
+more information about session configurations, see
+[about_Session_Configurations](About/about_Session_Configurations.md).
 
 ## EXAMPLES
 
-### Example 1: Get session configurations for the local computer
+### Example 1 - Get session configurations on the local computer
+
 ```
-PS C:\> Get-PSSessionConfiguration
+PS> Get-PSSessionConfiguration
 ```
 
-This command gets the session configurations on the local computer.
+### Example 2 - Get the two default session configurations
 
-### Example 2: Get default session configurations
+The command uses the **Name** parameter of `Get-PSSessionConfiguration` to get only the session
+configurations with names that begin with "Microsoft".
+
 ```
-PS C:\> Get-PSSessionConfiguration -Name Microsoft*
+PS> Get-PSSessionConfiguration -Name Microsoft*
+
 Name                      PSVersion  StartupScript        Permission
 ----                      ---------  -------------        ----------
 microsoft.powershell      2.0                             BUILTIN\Administrators AccessAll...
 microsoft.powershell32    2.0                             BUILTIN\Administrators AccessAll...
 ```
 
-This command gets the two default session configurations that come with Windows PowerShell.
-The command uses the *Name* parameter of **Get-PSSessionConfiguration** to get only the session configurations with names that begin with "Microsoft".
+### Example 3 - Get the properties and values of a session configuration
 
-### Example 3: Display properties of a session configuration created from a file
+This example shows the properties and property values of a session configuration that was created
+by using a session configuration file.
+
 ```
-PS C:\> Get-PSSessionConfiguration -Name Full | Format-List -Property *
+PS> Get-PSSessionConfiguration -Name Full  | Format-List -Property *
+
+
 Copyright                     : (c) 2011 User01. All rights reserved.
 AliasDefinitions              : {System.Collections.Hashtable}
 SessionType                   : Default
@@ -98,86 +109,94 @@ MaxShellsPerUser              : 30
 Permission                    :
 ```
 
-This example shows the properties and property values of a session configuration that was created by using a session configuration file.
+The example uses the `Get-PSSessionConfiguration` cmdlet to get the full session configuration.
+A pipeline operator sends the Full session configuration to the `Format-List` cmdlet. The
+**Property** parameter with a value of `*` (all) directs `Format-List` to display all of the
+properties and property values of the object in a list.
 
-The command uses the **Get-PSSessionConfiguration** command to get the Full session configuration.
-A pipeline operator sends the Full session configuration to the Format-List cmdlet.
-The *Property* parameter with a value of * (all) directs **Format-List** to display all of the properties and property values of the object in a list.
+The output of this command has useful information, including the author of the session
+configuration, the session type, language mode, and execution policy of sessions that are created
+with this session configuration, session quotas, and the full path to the session configuration
+file.
 
-The output of this command has very useful information.
-This includes the author of the session configuration, the session type, language mode, and execution policy of sessions that are created by using this session configuration, session quotas, and the full path of the session configuration file.
+This view of a session configuration is used for sessions that include a session configuration
+file. For more information about session configuration files, see
+[about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
 
-This view of a session configuration is used for sessions that include a session configuration file.
-For more information about session configuration files, see [about_Session_Configuration_Files](About/about_Session_Configuration_Files.md).
+### Example 4 - Get the configuration of a workflow session
 
-### Example 4: Get and sort properties of a session configuration
+This command gets the properties of the Microsoft.PowerShell.Worfklow session configuration and
+sorts them into alphabetical order for easy reading. You can use this command format in a function
+to get this display for any session configuration.
+
 ```
-PS C:\> (Get-PSSessionConfiguration Microsoft.PowerShell.Workflow).PSObject.Properties | Select-Object Name,Value | Sort-Object Name
-
-Name                                                                                                              Value
-----                                                                                                              -----
-ActivityProcessIdleTimeoutSec                                                                                        60
-AllowedActivity                                                                                   {PSDefaultActivities}
-Architecture                                                                                                         64
-AssemblyName                                                ...licKeyToken=31bf3856ad364e35, processorArchitecture=MSIL
-AutoRestart                                                                                                       false
-Capability                                                                                                      {Shell}
-Enabled                                                                                                            true
-EnableValidation                                                                                                   true
-ExactMatch                                                                                                        False
-Filename                                                                              %windir%\system32\pwrshplugin.dll
-IdleTimeoutms                                                                                                   7200000
-lang                                                                                                              en-US
-MaxActivityProcesses                                                                                                  5
-MaxConcurrentCommandsPerShell                                                                                      1000
-MaxConcurrentUsers                                                                                                    5
-MaxConnectedSessions                                                                                                100
-MaxDisconnectedSessions                                                                                            1000
-MaxIdleTimeoutms                                                                                             2147483647
-MaxMemoryPerShellMB                                                                                                1024
-MaxPersistenceStoreSizeGB                                                                                            10
-MaxProcessesPerShell                                                                                                 15
-MaxRunningWorkflows                                                                                                  30
-MaxSessionsPerRemoteNode                                                                                              5
-MaxSessionsPerWorkflow                                                                                                5
-
-MaxShells                                                                                                            25
-MaxShellsPerUser                                                                                                     25
-ModulesToImport                                             %windir%\system32\windowspowershell\v1.0\Modules\PSWorkflow
-Name                                                                                      microsoft.powershell.workflow
-OutOfProcessActivity                                                                                     {InlineScript}
-OutputBufferingMode                                                                                               Block
-ParentResourceUri                                           ...s.microsoft.com/powershell/microsoft.powershell.workflow
-Permission                                                  ...ssAllowed, BUILTIN\Remote Management Users AccessAllowed
-PersistencePath                                             ...s\juneb\AppData\Local\Microsoft\Windows\PowerShell\WF\PS
-PersistWithEncryption                                                                                             False
-ProcessIdleTimeoutSec                                                                                             28800
-PSSessionConfigurationTypeName                              ...osoft.PowerShell.Workflow.PSWorkflowSessionConfiguration
-PSVersion                                                                                                           3.0
-RemoteNodeSessionIdleTimeoutSec                                                                                      60
-ResourceUri                                                 ...s.microsoft.com/powershell/microsoft.powershell.workflow
+PS> (Get-PSSessionConfiguration Microsoft.PowerShell.Workflow).PSObject.Properties |
+  Select-Object Name,Value | Sort-Object Name
+Name                                                                                                  Value
+----                                                                                                  -----
+ActivityProcessIdleTimeoutSec                                                                            60
+AllowedActivity                                                                       {PSDefaultActivities}
+Architecture                                                                                             64
+AssemblyName                                    ...licKeyToken=31bf3856ad364e35, processorArchitecture=MSIL
+AutoRestart                                                                                           false
+Capability                                                                                          {Shell}
+Enabled                                                                                                true
+EnableValidation                                                                                       true
+ExactMatch                                                                                            False
+Filename                                                                  %windir%\system32\pwrshplugin.dll
+IdleTimeoutms                                                                                       7200000
+lang                                                                                                  en-US
+MaxActivityProcesses                                                                                      5
+MaxConcurrentCommandsPerShell                                                                          1000
+MaxConcurrentUsers                                                                                        5
+MaxConnectedSessions                                                                                    100
+MaxDisconnectedSessions                                                                                1000
+MaxIdleTimeoutms                                                                                 2147483647
+MaxMemoryPerShellMB                                                                                    1024
+MaxPersistenceStoreSizeGB                                                                                10
+MaxProcessesPerShell                                                                                     15
+MaxRunningWorkflows                                                                                      30
+MaxSessionsPerRemoteNode                                                                                  5
+MaxSessionsPerWorkflow                                                                                    5
+MaxShells                                                                                                25
+MaxShellsPerUser                                                                                         25
+ModulesToImport                                 %windir%\system32\windowspowershell\v1.0\Modules\PSWorkflow
+Name                                                                          microsoft.powershell.workflow
+OutOfProcessActivity                                                                         {InlineScript}
+OutputBufferingMode                                                                                   Block
+ParentResourceUri                               ...s.microsoft.com/powershell/microsoft.powershell.workflow
+Permission                                      ...ssAllowed, BUILTIN\Remote Management Users AccessAllowed
+PersistencePath                                 ...s\juneb\AppData\Local\Microsoft\Windows\PowerShell\WF\PS
+PersistWithEncryption                                                                                 False
+ProcessIdleTimeoutSec                                                                                 28800
+PSSessionConfigurationTypeName                  ...osoft.PowerShell.Workflow.PSWorkflowSessionConfiguration
+PSVersion                                                                                               3.0
+RemoteNodeSessionIdleTimeoutSec                                                                          60
+ResourceUri                                     ...s.microsoft.com/powershell/microsoft.powershell.workflow
 RunAsPassword
 RunAsUser
-SDKVersion                                                                                                            2
-SecurityDescriptorSddl                                      ...;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)
-SessionConfigurationData                                    ...    </SessionConfigurationData>
-SessionThrottleLimit                                                                                                100
-SupportsOptions                                                                                                    true
-Uri                                                         ...s.microsoft.com/powershell/microsoft.powershell.workflow
-UseSharedProcess                                                                                                   true
-WorkflowShutdownTimeoutMSec                                                                                         500
-xmlns                                                       ...as.microsoft.com/wbem/wsman/1/config/PluginConfiguration
-XmlRenderingType                                                                                                   text
+SDKVersion                                                                                                2
+SecurityDescriptorSddl                          ...;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)
+SessionConfigurationData                                                 ...    </SessionConfigurationData>
+SessionThrottleLimit                                                                                    100
+SupportsOptions                                                                                        true
+Uri                                             ...s.microsoft.com/powershell/microsoft.powershell.workflow
+UseSharedProcess                                                                                       true
+WorkflowShutdownTimeoutMSec                                                                             500
+xmlns                                           ...as.microsoft.com/wbem/wsman/1/config/PluginConfiguration
+XmlRenderingType                                                                                       text
 ```
-
-This command gets the properties of the Microsoft.PowerShell.Worfklow session configuration and sorts them into alphabetical order for easy reading.
-You can use this command format in a function to get this display for any session configuration.
 
 This example was contributed by Shay Levy, a Windows PowerShell MVP from Sderot, Israel.
 
-### Example 5: Examine the contents of the Plugin node
+### Example 5 - Another way to look at the session configurations
+
+This command uses the `Get-ChildItem` cmdlet (alias = dir) in the WSMan: provider drive to look at
+the content of the Plugin node. This is another way to look at the session configurations on the
+computer.
+
 ```
-PS C:\> dir wsman:\localhost\plugin
+PS> dir wsman:\localhost\plugin
 Type            Keys                                Name
 ----            ----                                ----
 Container       {Name=Event Forwarding Plugin}      Event Forwarding Plugin
@@ -189,18 +208,20 @@ Container       {Name=microsoft.ServerManager}      microsoft.ServerManager
 Container       {Name=WMI Provider}                 WMI Provider
 ```
 
-This command uses the dir alias of the Get-ChildItem cmdlet in the WSMan: provider drive to examine the content of the **Plugin** node.
-This is another way to view the session configurations on the computer.
+The **PlugIn** node contains **ContainerElement** objects
+(Microsoft.WSMan.Management.WSManConfigContainerElement) that represent the registered PowerShell
+session configurations, along with other plug-ins for WS-Management.
 
-The **PlugIn** node contains **ContainerElement** objects (Microsoft.WSMan.Management.WSManConfigContainerElement) that represent the registered Windows PowerShell session configurations, together with other plug-ins for WS-Management.
+### Example 6 - View session configurations on a remote computer
 
-### Example 6: View session configuration on a remote computer
+This example shows how to use the WSMan provider to view the session configurations on a remote
+computer. This method does not provide as much information as a `Get-PSSessionConfiguration`
+command, but the user does not need to be a member of the Administrators group to run this command.
+
 ```
-The first command uses the Connect-WSMan cmdlet to connect to the WinRM service on the Server01 remote computer.
-PS C:\> Connect-WSMan -ComputerName Server01
+PS> Connect-WSMan -ComputerName Server01
 
-The second command uses dir in the WSMan: drive to get the items in the Server01\Plugin path.The output shows the items in the **Plugin** directory on the Server01 computer. The items include the session configurations, which are a type of WSMan plug-in, together with other types of plug-ins on the computer.
-PS C:\> dir WSMan:\Server01\Plugin
+PS> dir WSMan:\Server01\Plugin
    WSManConfig: Microsoft.WSMan.Management\WSMan::localhost\Plugin
 
 Type            Keys                                Name
@@ -219,8 +240,9 @@ Container       {Name=SEL Plugin}                   SEL Plugin
 Container       {Name=WithProfile}                  WithProfile
 Container       {Name=WMI Provider}                 WMI Provider
 
-The third command returns the names of the plugins that are session configurations. The command searches for a value of Shell in the **Capability** property, which is in the Plugin\Resources\<ResourceNumber> path in the WSMan: drive.
-PS C:\> dir WSMan:\Server01\Plugin\*\Resources\Resource*\Capability | where {$_.Value -eq "Shell"} | foreach {($_.PSPath.split("\"))[3] }
+PS> dir WSMan:\Server01\Plugin\*\Resources\Resource*\Capability |
+  where {$_.Value -eq "Shell"} |
+    foreach {($_.PSPath.split("\"))[3] }
 Empty
 Full
 microsoft.powershell
@@ -233,22 +255,34 @@ RRS
 WithProfile
 ```
 
-This example shows how to use the WSMan provider to view the session configurations on a remote computer.
-This method does not provide as much information as a **Get-PSSessionConfiguration** command, but the user does not have to be a member of the Administrators group to run this command.
+The first command uses the `Connect-WSMan` cmdlet to connect to the WinRM service on the Server01
+remote computer.
 
-### Example 7: Run this cmdlet on a remote computer
+The second command uses the `Get-ChildItem` cmdlet ("dir") in the WSMan: drive to get the items in
+the Server01\Plugin path.The output shows the items in the Plugin directory on the Server01
+computer. The items include the session configurations, which are a type of WSMan plug-in, along
+with other types of plug-ins on the computer.
+
+The third command returns the names of the plugins that are session configurations. The command
+searches for a value of **Shell** in the **Capability** property, which is in the
+`Plugin\Resources\<ResourceNumber>` path in the WSMan: drive.
+
+### Example 7 - Get detailed session configurations from a remote computer
+
+This example shows how to run a `Get-PSSessionConfiguration` command on a remote computer. The
+command requires that CredSSP delegation be enabled in the client settings on the local computer
+and in the service settings on the remote computer.
+
+To run the commands in this example, you must be a member of the Administrators group on the local
+computer and the remote computer and you must start Windows PowerShell with the "Run as
+administrator" option.
+
 ```
-The first command uses the Enable-WSManCredSSP cmdlet to enable **CredSSP** delegation from the Server01 local computer to the Server02 remote computer. This configures the **CredSSP** client setting on the local computer.
-PS C:\> Enable-WSManCredSSP -Delegate Server02
+PS> Enable-WSManCredSSP -Delegate Server02
+PS> Connect-WSMan Server02
+PS> Set-Item WSMan:\Server02*\Service\Auth\CredSSP -Value $true
+PS> Invoke-Command -ScriptBlock {Get-PSSessionConfiguration} -ComputerName Server02 -Authentication CredSSP -Credential Domain01\Admin01
 
-The second command uses the **Connect-WSMan** cmdlet to connect to the Server02 computer. This action adds a node for the Server02 computer to the WSMan: drive on the local computer. This lets you view and change the WS-Management settings on the Server02 computer.
-PS C:\> Connect-WSMan Server02
-
-The third command uses the Set-Item cmdlet to change the value of the **CredSSP** item in the Service node of the Server02 computer to True. This configures the service settings on the remote computer.
-PS C:\> Set-Item WSMan:\Server02*\Service\Auth\CredSSP -Value $true
-
-The fourth command uses the Invoke-Command cmdlet to run a **Get-PSSessionConfiguration** command on the Server02 computer. The command uses the *Credential* parameter, and it uses the *Authentication* parameter with a value of CredSSP.The output shows the session configurations on the Server02 remote computer.
-PS C:\> Invoke-Command -ScriptBlock {Get-PSSessionConfiguration} -ComputerName Server02 -Authentication CredSSP -Credential Domain01\Admin01
 Name                      PSVersion  StartupScript        Permission                          PSComputerName
 ----                      ---------  -------------        ----------                          --------------
 microsoft.powershell      2.0                             BUILTIN\Administrators AccessAll... server02.corp.fabrikam.com
@@ -256,24 +290,37 @@ microsoft.powershell32    2.0                             BUILTIN\Administrators
 MyX86Shell                2.0        c:\test\x86Shell.ps1 BUILTIN\Administrators AccessAll... server02.corp.fabrikam.com
 ```
 
-This example shows how to run a **Get-PSSessionConfiguration** command on a remote computer.
-The command requires that CredSSP delegation be enabled in the client settings on the local computer and in the service settings on the remote computer.
+The first command uses the `Enable-WSManCredSSP` cmdlet to enable **CredSSP** delegation from the
+Server01 local computer to the Server02 remote computer. This configures the **CredSSP** client
+setting on the local computer.
 
-To run the commands in this example, you must be a member of the Administrators group on the local computer and the remote computer and you must start Windows PowerShell by using the Run as administrator option.
+The second command uses the `Connect-WSMan` cmdlet to connect to the Server02 computer. This action
+adds a node for the Server02 computer to the WSMan: drive on the local computer, allowing you to
+view and change the WS-Management settings on the Server02 computer.
 
-### Example 8: Get the resource URI of a session configuration
+The third command uses the `Set-Item` cmdlet to change the value of the **CredSSP** item in the
+Service node of the Server02 computer to True. This configures the service settings on the remote
+computer.
+
+The fourth command uses the `Invoke-Command` cmdlet to run a `Get-PSSessionConfiguration` command
+on the Server02 computer. The command uses the **Credential** parameter, and it uses the
+**Authentication** parameter with a value of **CredSSP**.The output shows the session
+configurations on the Server02 remote computer.
+
+### Example 8 - Get the resource URI of a session configuration
+
+This command is useful when setting the value of the $PSSessionConfigurationName preference
+variable, which takes a resource URI.
+
 ```
-PS C:\> (Get-PSSessionConfiguration -Name CustomShell).resourceURI
+PS> (Get-PSSessionConfiguration -Name CustomShell).resourceURI
 http://schemas.microsoft.com/powershell/microsoft.CustomShell
 ```
 
-This command uses the **Get-PSSessionConfiguration** cmdlet to get the resource Uniform Resource Identifier (URI) of a session configuration.
-
-This command is useful when you set the value of the $PSSessionConfigurationName preference variable, which takes a resource URI.
-
-The $PSSessionConfiguationName variable specifies the default configuration that is used when you create a session.
-This variable is set on the local computer, but it specifies a configuration on the remote computer.
-For more information about the $PSSessionConfiguration variable, see [about_Preference_Variables](About/about_Preference_Variables.md).
+The `$PSSessionConfiguationName` variable specifies the default configuration that is used when you
+create a session. This variable is set on the local computer, but it specifies a configuration on
+the remote computer. For more information about the `$PSSessionConfiguration` variable, see
+[about_Preference_Variables](About/about_Preference_Variables.md).
 
 ## PARAMETERS
 
@@ -293,10 +340,9 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies an array of names.
-This cmdlet gets the session configurations with the specified name or name pattern.
-Enter one or more session configuration names.
-Wildcard characters are permitted.
+
+Gets only the session configurations with the specified name or name pattern. Enter one or more
+session configuration names. Wildcards are permitted.
 
 ```yaml
 Type: String[]
@@ -305,17 +351,22 @@ Aliases:
 
 Required: False
 Position: 0
-Default value: None
+Default value: All session configurations on the local computer
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### None
+
 You cannot pipe input to this cmdlet.
 
 ## OUTPUTS
@@ -323,12 +374,32 @@ You cannot pipe input to this cmdlet.
 ### Microsoft.PowerShell.Commands.PSSessionConfigurationCommands#PSSessionConfiguration
 
 ## NOTES
-* To run this cmdlet, start Windows PowerShell by using the Run as administrator option.
-* To view the session configurations on the computer, you must be a member of the Administrators group on the computer.
-* To run a **Get-PSSessionConfiguration** command on a remote computer, Credential Security Service Provider (CredSSP) authentication must be enabled in the client settings on the local computer by using the Enable-WSManCredSSP cmdlet, and in the service settings on the remote computer. You must also use the **CredSSP** value of the *Authentication* parameter when establishing the remote session. Otherwise, access is denied.
-* The note properties of the object that **Get-PSSessionConfiguration** returns appear on the object only when they have a value. Only session configurations that were created by using a session configuration file have all of the defined properties.
-* The properties of a session configuration object vary with the options set for the session configuration and the values of those options. Also, session configurations that use a session configuration file have additional properties.
-* You can use commands in the WSMan: drive to change the properties of session configurations. However, you cannot use the WSMan: drive in Windows PowerShell 2.0 to change session configuration properties that are introduced in Windows PowerShell 3.0, such as **OutputBufferingMode**. Windows PowerShell 2.0 commands do not generate an error, but they are ineffective. To change  properties introduced in Windows PowerShell 3.0, use the WSMan: drive in Windows PowerShell 3.0.
+
+- To run this cmdlet, start Windows PowerShell with the "Run as administrator" option.
+
+- To view the session configurations on the computer, you must be a member of the Administrators
+  group on the computer.
+
+- To run a `Get-PSSessionConfiguration` command on a remote computer, Credential Security Service
+  Provider (CredSSP) authentication must be enabled in the client settings on the local computer
+  (by using the `Enable-WSManCredSSP` cmdlet) and in the service settings on the remote computer,
+  and you must use the **CredSSP** value of the **Authentication** parameter when establishing the
+  remote session. Otherwise, access is denied.
+
+- The note properties of the object that `Get-PSSessionConfiguration` returns appear on the
+  object only when they have a value. Only session configurations that were created by using a
+  session configuration file have all of the defined properties.
+
+- The properties of a session configuration object vary with the options set for the session
+  configuration and the values of those options. Also, session configurations that use a session
+  configuration file have additional properties.
+
+- You can use commands in the WSMan: drive to change the properties of session configurations.
+  However, you cannot use the WSMan: drive in Windows PowerShell 2.0 to change session
+  configuration properties that are introduced in Windows PowerShell 3.0, such as
+  **OutputBufferingMode**. Windows PowerShell 2.0 commands do not generate an error, but they are
+  ineffective. To change properties introduced in Windows PowerShell 3.0, use the WSMan: drive in
+  Windows PowerShell 3.0.
 
 ## RELATED LINKS
 
@@ -336,7 +407,11 @@ You cannot pipe input to this cmdlet.
 
 [Enable-PSSessionConfiguration](Enable-PSSessionConfiguration.md)
 
+[Get-PSSessionConfiguration](Get-PSSessionConfiguration.md)
+
 [New-PSSessionConfigurationFile](New-PSSessionConfigurationFile.md)
+
+[New-PSSessionOption](New-PSSessionOption.md)
 
 [Register-PSSessionConfiguration](Register-PSSessionConfiguration.md)
 
@@ -345,3 +420,9 @@ You cannot pipe input to this cmdlet.
 [Test-PSSessionConfigurationFile](Test-PSSessionConfigurationFile.md)
 
 [Unregister-PSSessionConfiguration](Unregister-PSSessionConfiguration.md)
+
+[WSMan Provider](../microsoft.wsman.management/about/about_WSMan_Provider.md)
+
+[about_Session_Configurations](About/about_Session_Configurations.md)
+
+[about_Session_Configuration_Files](About/about_Session_Configuration_Files.md)

--- a/reference/6/PowerShellGet/Install-Module.md
+++ b/reference/6/PowerShellGet/Install-Module.md
@@ -17,6 +17,7 @@ Downloads one or more modules from an online gallery, and installs them on the l
 ## SYNTAX
 
 ### NameParameterSet (Default)
+
 ```
 Install-Module [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <String>]
  [-RequiredVersion <String>] [-Repository <String[]>] [-Credential <PSCredential>] [-Scope <String>]
@@ -25,6 +26,7 @@ Install-Module [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <S
 ```
 
 ### InputObject
+
 ```
 Install-Module [-InputObject] <PSObject[]> [-Credential <PSCredential>] [-Scope <String>] [-Proxy <Uri>]
  [-ProxyCredential <PSCredential>] [-AllowClobber] [-SkipPublisherCheck] [-Force] [-AcceptLicense] [-WhatIf]
@@ -32,58 +34,70 @@ Install-Module [-InputObject] <PSObject[]> [-Credential <PSCredential>] [-Scope 
 ```
 
 ## DESCRIPTION
-The **Install-Module** cmdlet gets one or more modules that meet specified criteria from an online gallery, verifies that search results are valid modules, and copies module folders to the installation location.
 
-When no scope is defined, or when the value of the *Scope* parameter is AllUsers, the module is installed to %systemdrive%:\Program Files\WindowsPowerShell\Modules.
-When the value of *Scope* is CurrentUser, the module is installed to $home\Documents\WindowsPowerShell\Modules.
+The `Install-Module` cmdlet gets one or more modules that meet specified criteria from an online
+gallery, verifies that search results are valid modules, and copies module folders to the
+installation location.
 
 You can filter your results based on minimum and exact versions of specified modules.
 
 ## EXAMPLES
 
 ### Example 1: Find a module and install it
-```
-PS C:\> Find-Module -Name "MyDSC*" | Install-Module
-```
 
-In this example, modules with a name that starts with MyDSC that are found by Find-Module in the online gallery are installed to the default folder, C:\ProgramFiles\WindowsPowerShell\Modules.
+In this example, modules with a name that starts with MyDSC that are found by `Find-Module` in the
+online gallery are installed to the default folder, `C:\ProgramFiles\WindowsPowerShell\Modules`.
+
+```powershell
+Find-Module -Name "MyDSC*" | Install-Module
+```
 
 ### Example 2: Install a module by name
-```
-PS C:\> Install-Module -Name "MyDscModule"
-```
 
-In this example, the newest version of the module MyDscModule from the online gallery is installed to the default folder, Program Files.
+In this example, the newest version of the module MyDscModule from the online gallery is installed
+to the default folder.
+
+```powershell
+Install-Module -Name "MyDscModule"
+```
 
 If no module named MyDscModule exists, an error occurs.
 
 ### Example 3: Install a module using its minimum version
-```
-PS C:\> Install-Module -Name "ContosoServer" -MinimumVersion 1.0
+
+In this example, the most current version of the module ContosoServer is installed that matches the
+specified minimum version.
+
+```powershell
+Install-Module -Name "ContosoServer" -MinimumVersion 1.0
 ```
 
-In this example, the most current version of the module ContosoServer is installed that matches the specified minimum version.
 If the most current version of the module is a lower number than 1.0, the command returns errors.
 
 ### Example 4: Install a specific version of a module
-```
-PS C:\> Install-Module -Name "ContosoServer" -RequiredVersion 1.1.3
-```
 
 This example installs version 1.1.3 of the module ContosoServer to the Program Files folder.
+
+```powershell
+Install-Module -Name "ContosoServer" -RequiredVersion 1.1.3
+```
+
 If version 1.1.3 is not available, an error occurs.
 
 ### Example 5: Install the current version of a module
-```
-PS C:\> Install-Module -Name "ContosoServer" -Scope "CurrentUser"
-```
 
-This example installs the newest version of the module ContosoServer to $home\Documents\WindowsPowerShell\Modules.
+This example installs the newest version of the module ContosoServer to
+`$home\Documents\WindowsPowerShell\Modules`.
+
+```powershell
+Install-Module -Name "ContosoServer" -Scope "CurrentUser"
+```
 
 ## PARAMETERS
 
 ### -AcceptLicense
-{{Fill AcceptLicense Description}}
+
+Automatically accept the license agreement during installation if the module requires it.
 
 ```yaml
 Type: SwitchParameter
@@ -114,6 +128,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowPrerelease
+
 Allows you to install a module marked as a prerelease.
 
 ```yaml
@@ -130,6 +145,9 @@ Accept wildcard characters: False
 
 ### -Credential
 
+Specifies a user account that has rights to install a module for a specified package provider or
+source.
+
 ```yaml
 Type: PSCredential
 Parameter Sets: (All)
@@ -143,8 +161,10 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-Forces the installation of modules.
-If a module of the same name and version already exists on the computer, this parameter overwrites the existing module with one of the same name that was found by the command.
+
+Forces the installation of modules. If a module of the same name and version already exists on the
+computer, this parameter overwrites the existing module with one of the same name that was found by
+the command.
 
 ```yaml
 Type: SwitchParameter
@@ -159,7 +179,8 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-{{Fill InputObject Description}}
+
+Used for pipeline input.
 
 ```yaml
 Type: PSObject[]
@@ -174,9 +195,10 @@ Accept wildcard characters: False
 ```
 
 ### -MaximumVersion
-Specifies the maximum version of a single module to install.
-You cannot add this parameter if you are attempting to install multiple modules.
-The *MaximumVersion* and the *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the maximum version of a single module to install. You cannot add this parameter if you
+are attempting to install multiple modules. The **MaximumVersion** and the **RequiredVersion**
+parameters are mutually exclusive; you cannot use both parameters in the same command.
 
 ```yaml
 Type: String
@@ -191,12 +213,17 @@ Accept wildcard characters: False
 ```
 
 ### -MinimumVersion
-Specifies the minimum version of a single module to install.
-You cannot add this parameter if you are attempting to install multiple modules.
-The *MinimumVersion* and the *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
 
-If you are installing multiple modules in a single command, and a specified minimum version for a module is not available for installation, the **Install-Module** command silently continues without installing the unavailable module.
-For example, if you try to install the ContosoServer module with a minimum version of 2.0, but the latest version of the ContosoServer module is 1.5, the **Install-Module** command does not install the ContosoServer module; it goes to install the next specified module, and Windows PowerShell display errors when the command is finished.
+Specifies the minimum version of a single module to install. You cannot add this parameter if you
+are attempting to install multiple modules. The **MinimumVersion** and the **RequiredVersion**
+parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+If you are installing multiple modules in a single command, and a specified minimum version for a
+module is not available for installation, the `Install-Module` command silently continues without
+installing the unavailable module. For example, if you try to install the ContosoServer module with
+a minimum version of 2.0, but the latest version of the ContosoServer module is 1.5, the
+`Install-Module` command does not install the ContosoServer module; it goes to install the next
+specified module, and PowerShell display errors when the command is finished.
 
 ```yaml
 Type: String
@@ -211,11 +238,12 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies the exact names of modules to install from the online gallery.
-This parameter supports wildcard characters.
-If wildcard characters are not specified, only modules that exactly match the specified names are returned.
-If no matches are found, and you have not used any wildcard characters, the command returns an error.
-If you use wildcard characters, but do not find matching results, no error is returned.
+
+Specifies the exact names of modules to install from the online gallery. This parameter supports
+wildcard characters. If wildcard characters are not specified, only modules that exactly match the
+specified names are returned. If no matches are found, and you have not used any wildcard
+characters, the command returns an error. If you use wildcard characters, but do not find matching
+results, no error is returned.
 
 ```yaml
 Type: String[]
@@ -231,6 +259,8 @@ Accept wildcard characters: False
 
 ### -Proxy
 
+Specifies a proxy server for the request, rather than connecting directly to the Internet resource.
+
 ```yaml
 Type: Uri
 Parameter Sets: (All)
@@ -245,6 +275,9 @@ Accept wildcard characters: False
 
 ### -ProxyCredential
 
+Specifies a user account that has permission to use the proxy server that is specified by the
+**Proxy** parameter.
+
 ```yaml
 Type: PSCredential
 Parameter Sets: (All)
@@ -258,7 +291,9 @@ Accept wildcard characters: False
 ```
 
 ### -Repository
-Specifies the friendly name of a repository that has been registered by running Register-PSRepository.
+
+Specifies the friendly name of a repository that has been registered by running
+`Register-PSRepository`.
 
 ```yaml
 Type: String[]
@@ -273,9 +308,10 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredVersion
-Specifies the exact version of a single module to install.
-You cannot add this parameter if you are attempting to install multiple modules.
-The *MinimumVersion* and the *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the exact version of a single module to install. You cannot add this parameter if you are
+attempting to install multiple modules. The **MinimumVersion** and the **RequiredVersion**
+parameters are mutually exclusive; you cannot use both parameters in the same command.
 
 ```yaml
 Type: String
@@ -290,12 +326,23 @@ Accept wildcard characters: False
 ```
 
 ### -Scope
-Specifies the installation scope of the module.
-The acceptable values for this parameter are: AllUsers and CurrentUser.
 
-The AllUsers scope lets modules be installed in a location that is accessible to all users of the computer, that is, %systemdrive%:\ProgramFiles\WindowsPowerShell\Modules.
+Specifies the installation scope of the module. The acceptable values for this parameter are:
+AllUsers and CurrentUser.
 
-The CurrentUser scope lets modules be installed only to $home\Documents\WindowsPowerShell\Modules, so that the module is available only to the current user.
+The AllUsers scope lets modules be installed in a location that is accessible to all users of the
+computer, that is, `$env:ProgramFiles\WindowsPowerShell\Modules`.
+
+The CurrentUser scope lets modules be installed only to
+`$home\Documents\WindowsPowerShell\Modules`, so that the module is available only to the current
+user.
+
+When no **Scope** is defined, the default will be set based on the current session:
+- For an elevated PowerShell session, **Scope** defaults to AllUsers;
+- For non-elevated PowerShell sessions in [PowerShellGet versions 2.0.0](https://www.powershellgallery.com/packages/PowerShellGet)
+  and above, **Scope** is CurrentUser;
+- For non-elevated PowerShell sessions in PowerShellGet versions 1.6.7 and earlier, **Scope** is
+  undefined, and `Install-Module` fails.
 
 ```yaml
 Type: String
@@ -312,6 +359,10 @@ Accept wildcard characters: False
 
 ### -SkipPublisherCheck
 
+Allows you to install a newer version of a module that already exists on your computer in the case
+when a newer one is not digitally signed by a trusted publisher and the newest existing module is
+digitally signed by a trusted publisher.
+
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
@@ -325,6 +376,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -340,8 +392,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -356,7 +408,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -365,24 +421,43 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
-* This cmdlet runs on Windows PowerShell 5.0 or later releases of Windows PowerShell, on Windows 7 or Windows 2008 R2 and later releases of Windows.
 
-  If an installed module cannot be imported (that is, if it does not have a .psm1, .psd1, or .dll of the same name within the folder), installation fails unless you add the *Force* parameter to your command.
+This cmdlet runs on PowerShell 5.0 or later releases, on Windows 7 or Windows 2008 R2 and later
+releases of Windows.
 
-  If a version of the module on the computer matches the value specified for the *Name* parameter, and you have not added the *MinimumVersion* or *RequiredVersion* parameter, **Install-Module** silently continues without installing that module.
-If the *MinimumVersion* or *RequiredVersion* parameters are specified, and the existing module does not match the values in that parameter, then an error occurs.
-To be more specific: if the version of the currently-installed module is either lower than the value of the *MinimumVersion* parameter, or not equal to the value of the *RequiredVersion* parameter, an error occurs.
-If the version of the installed module is greater than the value of the *MinimumVersion* parameter, or equal to the value of the *RequiredVersion* parameter, **Install-Module** silently continues without installing that module.
+If an installed module cannot be imported (that is, if it does not have a .psm1, .psd1, or .dll of
+the same name within the folder), installation fails unless you add the *Force* parameter to your
+command.
 
-  **Install-Module** returns an error if no module exists in the online gallery that matches the specified name.
+If a version of the module on the computer matches the value specified for the **Name** parameter,
+and you have not added the **MinimumVersion** or **RequiredVersion** parameter, `Install-Module`
+silently continues without installing that module.
 
-  To install multiple modules, specify an array of the module names, separated by commas.
-You cannot add *MinimumVersion* or *RequiredVersion* if you specify multiple module names.
+If the **MinimumVersion** or **RequiredVersion** parameters are specified, and the existing module
+does not match the values in that parameter, then an error occurs. To be more specific: if the
+version of the currently-installed module is either lower than the value of the **MinimumVersion**
+parameter, or not equal to the value of the **RequiredVersion** parameter, an error occurs.
 
-  By default, modules are installed to the Program Files folder, to prevent confusion when you are installing PowerShell Desired State Configuration (DSC) resources.You can pipe multiple **PSGetItemInfo** objects to **Install-Module**; this is another way of specifying multiple modules to install in a single command.
+If the version of the installed module is greater than the value of the **MinimumVersion**
+parameter, or equal to the value of the **RequiredVersion** parameter, `Install-Module` silently
+continues without installing that module.
 
-  To help prevent running modules that contain malicious code, installed modules are not automatically imported by installation.
-As a security best practice, evaluate module code before running any cmdlets or functions in a module for the first time.
+`Install-Module` returns an error if no module exists in the online gallery that matches the
+specified name.
+
+To install multiple modules, specify an array of the module names, separated by commas. You cannot
+add **MinimumVersion** or **RequiredVersion** if you specify multiple module names.
+
+By default, modules are installed to the Program Files folder, to prevent confusion when you are
+installing Windows PowerShell Desired State Configuration (DSC) resources.You can pipe multiple
+**PSGetItemInfo** objects to `Install-Module`; this is another way of specifying multiple modules
+to install in a single command.
+
+To help prevent running modules that contain malicious code, installed modules are not
+automatically imported by installation.
+
+As a security best practice, evaluate module code before running any cmdlets or functions in a
+module for the first time.
 
 ## RELATED LINKS
 

--- a/reference/6/PowerShellGet/Install-Script.md
+++ b/reference/6/PowerShellGet/Install-Script.md
@@ -17,41 +17,57 @@ Installs a script.
 ## SYNTAX
 
 ### NameParameterSet (Default)
+
 ```
 Install-Script [-Name] <String[]> [-MinimumVersion <String>] [-MaximumVersion <String>]
  [-RequiredVersion <String>] [-Repository <String[]>] [-Scope <String>] [-NoPathUpdate] [-Proxy <Uri>]
- [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease] [-AcceptLicense]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AllowPrerelease]
+ [-AcceptLicense] [-WhatIf] [-Confirm] [<CommonParameters>]
+
 ```
 
 ### InputObject
+
 ```
 Install-Script [-InputObject] <PSObject[]> [-Scope <String>] [-NoPathUpdate] [-Proxy <Uri>]
- [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-ProxyCredential <PSCredential>] [-Credential <PSCredential>] [-Force] [-AcceptLicense] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Install-Script** cmdlet acquires a script payload from a repository, verifies that the payload is a valid PowerShell script, and copies the script file to a specified installation location.
 
-The default repositories **Install-Script** operates against are configurable through the Register-PSRepository, Set-PSRepository, Unregister-PSRepository, and Get-PSRepository cmdlets.
-When operating against multiple repositories, **Install-Script** installs the first script that matches the specified search criteria (*Name*, *MinimumVersion*, or *MaximumVersion*) from the first repository without any error.
+The `Install-Script` cmdlet acquires a script payload from a repository, verifies that the
+payload is a valid PowerShell script, and copies the script file to a specified installation
+location.
+
+The default repositories `Install-Script` operates against are configurable through the
+`Register-PSRepository`, `Set-PSRepository`, `Unregister-PSRepository`, and `Get-PSRepository`
+cmdlets. When operating against multiple repositories, `Install-Script` installs the first script
+that matches the specified search criteria (**Name**, **MinimumVersion**, or **MaximumVersion**)
+from the first repository without any error.
 
 ## EXAMPLES
 
 ### Example 1: Find a script and install it
+
 ```
 PS C:\> Find-Script -Repository "Local1" -Name "Required-Script2"
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.5        Required-Script2                    Script     local1               Description for the Required-Script2 script PS C:\> Find-Script -Repository "Local1" -Name "Required-Script2" | Install-Script
+Version    Name                           Type       Repository           Description
+-------    ----                           ----       ----------           -----------
+2.5        Required-Script2               Script     local1               Description for the Required-Script2 script
+
+PS C:\> Find-Script -Repository "Local1" -Name "Required-Script2" | Install-Script
 PS C:\> Get-Command -Name "Required-Script2"
-CommandType     Name                                               Version    Source
------------     ----                                               -------    ------
-ExternalScript  Required-Script2.ps1                                2.0       C:\Users\pattif\Documents\WindowsPowerShell\Scripts\Required-Script2.ps1 PS C:\> Get-InstalledScript -Name "Required-Script2"
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.5        Required-Script2                    Script     local1               Description for the Required-Script2 script PS C:\> Get-InstalledScript -Name "Required-Script2" | Format-List *
+CommandType     Name                      Version    Source
+-----------     ----                      -------    ------
+ExternalScript  Required-Script2.ps1      2.0       C:\Users\pattif\Documents\WindowsPowerShell\Scripts\Required-Script2.ps1
+
+PS C:\> Get-InstalledScript -Name "Required-Script2"
+Version    Name                  Type     Repository           Description
+-------    ----                  ----     ----------           -----------
+2.5        Required-Script2      Script   local1               Description for the Required-Script2 script
+
+PS C:\> Get-InstalledScript -Name "Required-Script2" | Format-List *
 Name                       : Required-Script2
 Version                    : 2.5
 Type                       : Script
@@ -74,23 +90,31 @@ PackageManagementProvider  : NuGet
 InstalledLocation          : C:\Users\pattif\Documents\WindowsPowerShell\Scripts
 ```
 
-The first command finds the script named Required-Script2 from the Local1 repository and displays the results.
+The first command finds the script named `Required-Script2` from the Local1 repository and displays
+the results.
 
-The second command finds the Required-Script2 script, and then uses the pipeline operator to pass it to the Install-Script cmdlet to install it.
+The second command finds the `Required-Script2` script, and then uses the pipeline operator to pass
+it to the `Install-Script` cmdlet to install it.
 
-The third command uses the Get-Command cmdlet to get Required-Script2, and then displays the results.
+The third command uses the `Get-Command` cmdlet to get `Required-Script2`, and then displays the
+results.
 
-The fourth command uses the Get-InstalledScript cmdlet to get Required-Script2 and display the results.
+The fourth command uses the `Get-InstalledScript` cmdlet to get `Required-Script2` and display the
+results.
 
-The fifth command gets RequiredScript2 and uses the pipeline operator to pass it to the Format-List cmdlet to format the output.
+The fifth command gets `Required-Script2` and uses the pipeline operator to pass it to the
+`Format-List` cmdlet to format the output.
 
 ### Example 2: Install a script with AllUsers scope
+
 ```
 PS C:\> Install-Script -Repository "Local1" -Name "Required-Script3" -Scope "AllUsers"
 PS C:\> Get-InstalledScript -Name "Required-Script3"
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.5        Required-Script3                    Script     local1               Description for the Required-Script3 script PS C:\> Get-InstalledScript -Name "Required-Script3" | Format-List *
+Version    Name                  Type       Repository    Description
+-------    ----                  ----       ----------    -----------
+2.5        Required-Script3      Script     local1        Description for the Required-Script3 script
+
+PS C:\> Get-InstalledScript -Name "Required-Script3" | Format-List *
 Name                       : Required-Script3
 Version                    : 2.5
 Type                       : Script
@@ -113,67 +137,83 @@ PackageManagementProvider  : NuGet
 InstalledLocation          : C:\Program Files\WindowsPowerShell\Scripts
 ```
 
-The first command installs the script named Required-Script3 and assigns it AllUsers scope.
+The first command installs the script named `Required-Script3` and assigns it AllUsers scope.
 
-The second command gets the installed script Required-Script3 and displays information about it.
+The second command gets the installed script `Required-Script3` and displays information about it.
 
-The third command gets Required-Script3 and uses the pipeline operator to pass it to the Format-List cmdlet to format the output.
+The third command gets `Required-Script3` and uses the pipeline operator to pass it to the
+`Format-List` cmdlet to format the output.
 
 ### Example 3: Install a script with its dependent scripts and modules
+
 ```
 PS C:\> Find-Script -Repository "Local1" -Name "Script-WithDependencies2" -IncludeDependencies
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.0        Script-WithDependencies2            Script     local1               Description for the Script-WithDependencies2 script
-2.5        RequiredModule1                     Module     local1               RequiredModule1 module
-2.5        RequiredModule2                     Module     local1               RequiredModule2 module
-2.5        RequiredModule3                     Module     local1               RequiredModule3 module
-2.5        Required-Script1                    Script     local1               Description for the Required-Script1 script
-2.5        Required-Script2                    Script     local1               Description for the Required-Script2 script
-2.5        Required-Script3                    Script     local1               Description for the Required-Script3 script PS C:\> Install-Script -Repository "Local1" -Name "Script-WithDependencies2"
+Version    Name                        Type       Repository    Description
+-------    ----                        ----       ----------    -----------
+2.0        Script-WithDependencies2    Script     local1        Description for the Script-WithDependencies2 script
+2.5        RequiredModule1             Module     local1        RequiredModule1 module
+2.5        RequiredModule2             Module     local1        RequiredModule2 module
+2.5        RequiredModule3             Module     local1        RequiredModule3 module
+2.5        Required-Script1            Script     local1        Description for the Required-Script1 script
+2.5        Required-Script2            Script     local1        Description for the Required-Script2 script
+2.5        Required-Script3            Script     local1        Description for the Required-Script3 script
+
+PS C:\> Install-Script -Repository "Local1" -Name "Script-WithDependencies2"
 PS C:\> Get-InstalledScript
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.5        Required-Script1                    Script     local1               Description for the Required-Script1 script
-2.5        Required-Script2                    Script     local1               Description for the Required-Script2 script
-2.5        Required-Script3                    Script     local1               Description for the Required-Script3 script
-2.0        Script-WithDependencies2            Script     local1               Description for the Script-WithDependencies2 script PS C:\> Get-InstalledModule
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.5        RequiredModule1                     Module     local1               RequiredModule1 module
-2.5        RequiredModule2                     Module     local1               RequiredModule2 module
-2.5        RequiredModule3                     Module     local1               RequiredModule3 module PS C:\> Find-Script -Repository "Local1" -Name "Required-Script*"
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.5        Required-Script1                    Script     local1               Description for the Required-Script1 script
-2.5        Required-Script2                    Script     local1               Description for the Required-Script2 script
-2.5        Required-Script3                    Script     local1               Description for the Required-Script3 script PS C:\> Install-Script -Repository "Local1" -Name "Required-Script*"
+Version    Name                        Type       Repository    Description
+-------    ----                        ----       ----------    -----------
+2.5        Required-Script1            Script     local1        Description for the Required-Script1 script
+2.5        Required-Script2            Script     local1        Description for the Required-Script2 script
+2.5        Required-Script3            Script     local1        Description for the Required-Script3 script
+2.0        Script-WithDependencies2    Script     local1        Description for the Script-WithDependencies2 script
+
+PS C:\> Get-InstalledModule
+Version    Name                        Type       Repository    Description
+-------    ----                        ----       ----------    -----------
+2.5        RequiredModule1             Module     local1        RequiredModule1 module
+2.5        RequiredModule2             Module     local1        RequiredModule2 module
+2.5        RequiredModule3             Module     local1        RequiredModule3 module
+
+PS C:\> Find-Script -Repository "Local1" -Name "Required-Script*"
+Version    Name                        Type       Repository    Description
+-------    ----                        ----       ----------    -----------
+2.5        Required-Script1            Script     local1        Description for the Required-Script1 script
+2.5        Required-Script2            Script     local1        Description for the Required-Script2 script
+2.5        Required-Script3            Script     local1        Description for the Required-Script3 script
+
+PS C:\> Install-Script -Repository "Local1" -Name "Required-Script*"
 PS C:\> Get-InstalledScript
-Version    Name                                Type       Repository           Description
--------    ----                                ----       ----------           -----------
-2.5        Required-Script1                    Script     local1               Description for the Required-Script1 script
-2.5        Required-Script2                    Script     local1               Description for the Required-Script2 script
-2.5        Required-Script3                    Script     local1               Description for the Required-Script3 script
+Version    Name                        Type       Repository    Description
+-------    ----                        ----       ----------    -----------
+2.5        Required-Script1            Script     local1        Description for the Required-Script1 script
+2.5        Required-Script2            Script     local1        Description for the Required-Script2 script
+2.5        Required-Script3            Script     local1        Description for the Required-Script3 script
 ```
 
-The first command finds the script named Script-WithDependencies2 and its dependencies in the Local1 repository and displays the results.
+The first command finds the script named `Script-WithDependencies2` and its dependencies in the
+Local1 repository and displays the results.
 
-The second command installs Script-WithDependencies2.
+The second command installs `Script-WithDependencies2`.
 
-The third command uses the Get-InstalledScript script cmdlet to get installed scripts and display the results.
+The third command uses the `Get-InstalledScript` script cmdlet to get installed scripts and display
+the results.
 
-The fourth command uses the Get-InstalledModule cmdlet to get installed modules and display the results.
+The fourth command uses the `Get-InstalledModule` cmdlet to get installed modules and display the
+results.
 
-The fifth command uses the Find-Script cmdlet to find scripts where the name begins with Required-Script and display the results.
+The fifth command uses the `Find-Script` cmdlet to find scripts where the name begins with
+`Required-Script` and display the results.
 
-The sixth command installs the scripts where the name begins with Required-Script in the Local1 repository.
+The sixth command installs the scripts where the name begins with `Required-Script` in the Local1
+repository.
 
 The final command gets installed scripts and displays the results.
 
 ## PARAMETERS
 
 ### -AcceptLicense
-{{Fill AcceptLicense Description}}
+
+Automatically accept the license agreement during installation if the module requires it.
 
 ```yaml
 Type: SwitchParameter
@@ -188,6 +228,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowPrerelease
+
 Allows you to install a script marked as a prerelease.
 
 ```yaml
@@ -204,6 +245,9 @@ Accept wildcard characters: False
 
 ### -Credential
 
+Specifies a user account that has rights to install a script for a specified package provider or
+source.
+
 ```yaml
 Type: PSCredential
 Parameter Sets: (All)
@@ -217,6 +261,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 Forces the command to run without asking for user confirmation.
 
 ```yaml
@@ -232,7 +277,8 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-{{Fill InputObject Description}}
+
+Used for pipeline input.
 
 ```yaml
 Type: PSObject[]
@@ -247,9 +293,11 @@ Accept wildcard characters: False
 ```
 
 ### -MaximumVersion
-Specifies the maximum, or newest, version of the script to install.
-The *MaximumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
-This parameter accepts the wildcard character (*).
+
+Specifies the maximum version of a single scripts to install. You cannot add this parameter if you
+are attempting to install multiple scripts. The **MaximumVersion** and the **RequiredVersion**
+parameters are mutually exclusive; you cannot use both parameters in the same command.
+
 
 ```yaml
 Type: String
@@ -264,8 +312,10 @@ Accept wildcard characters: False
 ```
 
 ### -MinimumVersion
-Specifies the minimum version of the script to install.
-The *MinimumVersion* and *RequiredVersion* parameters are mutually exclusive; you cannot use both parameters in the same command.
+
+Specifies the minimum version of a single script to install. You cannot add this parameter if you
+are attempting to install multiple scripts. The **MinimumVersion** and the **RequiredVersion**
+parameters are mutually exclusive; you cannot use both parameters in the same command.
 
 ```yaml
 Type: String
@@ -280,6 +330,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Specifies an array of names of scripts to install.
 
 ```yaml
@@ -310,6 +361,8 @@ Accept wildcard characters: False
 
 ### -Proxy
 
+Specifies a proxy server for the request, rather than connecting directly to the Internet resource.
+
 ```yaml
 Type: Uri
 Parameter Sets: (All)
@@ -324,6 +377,9 @@ Accept wildcard characters: False
 
 ### -ProxyCredential
 
+Specifies a user account that has permission to use the proxy server that is specified by the
+**Proxy** parameter.
+
 ```yaml
 Type: PSCredential
 Parameter Sets: (All)
@@ -337,8 +393,9 @@ Accept wildcard characters: False
 ```
 
 ### -Repository
-Specifies the friendly name of a repository that has been registered with the Register-PSRepository cmdlet.
-The default is all registered repositories.
+
+Specifies the friendly name of a repository that has been registered with the
+`Register-PSRepository` cmdlet. The default is all registered repositories.
 
 ```yaml
 Type: String[]
@@ -353,6 +410,7 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredVersion
+
 Specifies the exact version number of the script to install.
 
 ```yaml
@@ -368,12 +426,23 @@ Accept wildcard characters: False
 ```
 
 ### -Scope
+
 Specifies the installation scope of the script.
 Valid values are: AllUsers and CurrentUser.
-The default is CurrentUser.
 
-The AllUsers scope specifies to install a script to %systemdrive%:\ProgramFiles\WindowsPowerShell\Scripts so that the script is available to all users.
-The CurrentUser scope specifies to install the script in $home\Documents\WindowsPowerShell\Scripts so that the script is available only to the current user.
+The AllUsers scope lets modules be installed in a location that is accessible to all users of the
+computer, that is, `$env:ProgramFiles\WindowsPowerShell\Scripts`.
+
+The CurrentUser scope lets modules be installed only to
+`$home\Documents\WindowsPowerShell\Scripts`, so that the module is available only to the current
+user.
+
+When no **Scope** is defined, the default will be set based on the current session:
+- For an elevated PowerShell session, **Scope** defaults to AllUsers;
+- For non-elevated PowerShell sessions in [PowerShellGet versions 2.0.0](https://www.powershellgallery.com/packages/PowerShellGet)
+  and above, **Scope** is CurrentUser;
+- For non-elevated PowerShell sessions in PowerShellGet versions 1.6.7 and earlier, **Scope** is
+  undefined, and `Install-Module` fails.
 
 ```yaml
 Type: String
@@ -389,6 +458,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -404,8 +474,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -420,7 +490,11 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
This is the first of several PRs to change references to environment variables from `%variablename%` to `$env:variablename`.

Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [x] This PR partially fixes the issue, and issue #3559 tracks the remaining work
