### PR TITLE
Add full title before using COM abbreviations in the overview doc.

### DIFF
--- a/reference/docs-conceptual/overview.md
+++ b/reference/docs-conceptual/overview.md
@@ -54,7 +54,7 @@ Get-Service | Get-Member
 ### Consistency
 
 Managing systems can be a complex task. Tools that have a consistent interface help to control the
-inherent complexity. Unfortunately, command-line tools and scriptable COM objects aren't known for
+inherent complexity. Unfortunately, command-line tools and scriptable Component Object Model (COM) objects aren't known for
 their consistency.
 
 The consistency of PowerShell is one of its primary assets. For example, if you learn how to use


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->

I've noticed multiple usage of `COM` in the following doc page, but wasn't sure what this abbreviation represented until having to lookup. I feel like it would be nice for new readers like me to be able to know the full title of `COM`.

Also noticed similar pattern in the other files so this can keep the consistency.

Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [ ] Impacts 6 document
- [ ] Impacts 5.1 document
- [ ] Impacts 5.0 document
- [ ] Impacts 4.0 document
- [ ] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [ ] This PR partially fixes the issue, and issue #<insert here> tracks the remaining work
