### PR TITLE
Fixes #3559 - removing %-style environment variables and other cleanup

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/3.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  01/22/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -10,232 +10,275 @@ title:  New-ModuleManifest
 # New-ModuleManifest
 
 ## SYNOPSIS
-
 Creates a new module manifest.
 
 ## SYNTAX
 
 ```
-New-ModuleManifest [-Path] <String> [-NestedModules <Object[]>] [-Guid <Guid>] [-Author <String>]
- [-CompanyName <String>] [-Copyright <String>] [-RootModule <String>] [-ModuleVersion <Version>]
- [-Description <String>] [-ProcessorArchitecture <ProcessorArchitecture>] [-PowerShellVersion <Version>]
- [-ClrVersion <Version>] [-DotNetFrameworkVersion <Version>] [-PowerShellHostName <String>]
- [-PowerShellHostVersion <Version>] [-RequiredModules <Object[]>] [-TypesToProcess <String[]>]
- [-FormatsToProcess <String[]>] [-ScriptsToProcess <String[]>] [-RequiredAssemblies <String[]>]
- [-FileList <String[]>] [-ModuleList <Object[]>] [-FunctionsToExport <String[]>] [-AliasesToExport <String[]>]
- [-VariablesToExport <String[]>] [-CmdletsToExport <String[]>] [-PrivateData <Object>] [-HelpInfoUri <String>]
- [-PassThru] [-DefaultCommandPrefix <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-ModuleManifest [-Path] <string> [-NestedModules <Object[]>] [-Guid <guid>] [-Author <string>]
+  [-CompanyName <string>] [-Copyright <string>] [-RootModule <string>] [-ModuleVersion <version>]
+  [-Description <string>] [-ProcessorArchitecture <ProcessorArchitecture>] [-PowerShellVersion <version>]
+  [-ClrVersion <version>] [-DotNetFrameworkVersion <version>] [-PowerShellHostName <string>]
+  [-PowerShellHostVersion <version>] [-RequiredModules <Object[]>] [-TypesToProcess <string[]>]
+  [-FormatsToProcess <string[]>] [-ScriptsToProcess <string[]>] [-RequiredAssemblies <string[]>]
+  [-FileList <string[]>] [-ModuleList <Object[]>] [-FunctionsToExport <string[]>]
+  [-AliasesToExport <string[]>] [-VariablesToExport <string[]>] [-CmdletsToExport <string[]>]
+  [-PrivateData <Object>] [-HelpInfoUri <string>] [-PassThru] [-DefaultCommandPrefix <string>]
+  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The **New-ModuleManifest** cmdlet creates a new module manifest (.psd1) file, populates its values, and saves the manifest file in the specified path.
+The `New-ModuleManifest` cmdlet creates a new module manifest (.psd1) file, populates its values,
+and saves the manifest file in the specified path.
 
-Module authors can use this cmdlet to create a manifest for their module.
-A module manifest is a .psd1 file that contains a hash table.
-The keys and values in the hash table describe the contents and attributes of the module, define the prerequisites, and determine how the components are processed.
-Manifests are not required for a module.
+Module authors can use this cmdlet to create a manifest for their module. A module manifest is a
+.psd1 file that contains a hash table. The keys and values in the hash table describe the contents
+and attributes of the module, define the prerequisites, and determine how the components are
+processed. Manifests are not required for a module.
 
-**New-ModuleManifest** creates a manifest that includes all of the commonly used manifest keys, so you can use the default output as a manifest template.
-To add or change values, or to add module keys that this cmdlet does not add, open the resulting file in a text editor.
+`New-ModuleManifest` creates a manifest that includes all of the commonly used manifest keys, so
+you can use the default output as a manifest template. To add or change values, or to add module
+keys that this cmdlet does not add, open the resulting file in a text editor.
 
-Each parameter of this cmdlet (except for **Path** and **PassThru**) creates a module manifest key and its value.
-In a module manifest, only the **ModuleVersion** key is required.
-Unless specified in the parameter description, if you omit a parameter from the command, **New-ModuleManifest** creates a comment string for the associated value that has no effect.
+Each parameter of this cmdlet (except for **Path** and **PassThru**) creates a module manifest key
+and its value. In a module manifest, only the **ModuleVersion** key is required. Unless specified
+in the parameter description, if you omit a parameter from the command, `New-ModuleManifest`
+creates a comment string for the associated value that has no effect.
 
-In Windows PowerShell 2.0, **New-ModuleManifest** prompts you for the values of commonly used parameters that are not specified in the command, in addition to required parameter values.
-Beginning in Windows PowerShell 3.0, it prompts only when required parameter values are not specified.
+In Windows PowerShell 2.0, `New-ModuleManifest` prompts you for the values of commonly used
+parameters that are not specified in the command, in addition to required parameter values.
+Beginning in Windows PowerShell 3.0, it prompts only when required parameter values are not
+specified.
 
 ## EXAMPLES
 
-### Example 1
+### Example 1 - Create a new module manifest
 
-```
-PS> New-ModuleManifest -Path C:\Users\User01\Documents\WindowsPowerShell\Modules\Test-Module\Test-Module.psd1 -PassThru
-
-## Module manifest for module 'TestModule'
-## Generated by: User01
-## Generated on: 1/24/2012
-#@{
-# Script module or binary module file associated with this manifest
-# RootModule = ''
-# Version number of this module.ModuleVersion = '1.0'
-# ID used to uniquely identify this moduleGUID = 'd0a9150d-b6a4-4b17-a325-e3a24fed0aa9'
-# Author of this moduleAuthor = 'User01'
-# Company or vendor of this moduleCompanyName = 'Unknown'
-# Copyright statement for this moduleCopyright = '(c) 2012 User01. All rights reserved.'
-# Description of the functionality provided by this module
-# Description = ''
-# Minimum version of the Windows PowerShell engine required by this module
-# PowerShellVersion = ''
-# Name of the Windows PowerShell host required by this module
-# PowerShellHostName = ''
-# Minimum version of the Windows PowerShell host required by this module
-# PowerShellHostVersion = ''
-# Minimum version of the .NET Framework required by this module
-# DotNetFrameworkVersion = ''
-# Minimum version of the common language runtime (CLR) required by this module
-# CLRVersion = ''
-# Processor architecture (None, X86, Amd64) required by this module
-# ProcessorArchitecture = ''
-# Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
-# Assemblies that must be loaded prior to importing this module
-# RequiredAssemblies = @()
-# Script files (.ps1) that are run in the caller's environment prior to importing this module
-# ScriptsToProcess = @()
-# Type files (.ps1xml) to be loaded when importing this module
-# TypesToProcess = @()
-# Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
-# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-# NestedModules = @()
-# Functions to export from this moduleFunctionsToExport = '*'
-# Cmdlets to export from this moduleCmdletsToExport = '*'
-# Variables to export from this moduleVariablesToExport = '*'
-# Aliases to export from this moduleAliasesToExport = '*'
-# List of all modules packaged with this module# ModuleList = @()
-# List of all files packaged with this module
-# FileList = @()
-# Private data to pass to the module specified in RootModule/ModuleToProcess
-# PrivateData = ''
-# HelpInfo URI of this module
-# HelpInfoURI = ''
-# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
-# DefaultCommandPrefix = ''}
-```
-
-This command creates a new module manifest in the file that is specified by the Path parameter.
-The **PassThru** parameter sends the output to the pipeline as well as to the file.
+This command creates a new module manifest in the file that is specified by the Path parameter. The
+**PassThru** parameter sends the output to the pipeline as well as to the file.
 
 The output shows the default values of all keys in the manifest.
 
-### Example 2
-
-```
-PS> New-ModuleManifest -PowerShellVersion 1.0 -AliasesToExport JKBC, DRC, TAC -Path C:\ps-test\ManifestTest.psd1
+```powershell
+New-ModuleManifest -Path C:\ps-test\Test-Module\Test-Module.psd1 -PassThru
 ```
 
-This command creates a new module manifest.
-It uses the **PowerShellVersion** and **AliasesToExport** parameters to add values to the corresponding manifest keys.
+```Output
+#
+# Module manifest for module 'Test-Module'
+#
+# Generated by: ContosoAdmin
+#
+# Generated on: 1/22/2019
+#
 
-### Example 3
+@{
 
+# Script module or binary module file associated with this manifest.
+# RootModule = ''
+
+# Version number of this module.
+ModuleVersion = '1.0'
+
+# ID used to uniquely identify this module
+GUID = '47179120-0bcb-4f14-8d80-f4560107f85c'
+
+# Author of this module
+Author = 'ContosoAdmin'
+
+# Company or vendor of this module
+CompanyName = 'Unknown'
+
+# Copyright statement for this module
+Copyright = '(c) 2019 ContosoAdmin. All rights reserved.'
+
+# Description of the functionality provided by this module
+# Description = ''
+
+# Minimum version of the Windows PowerShell engine required by this module
+# PowerShellVersion = ''
+
+# Name of the Windows PowerShell host required by this module
+# PowerShellHostName = ''
+
+# Minimum version of the Windows PowerShell host required by this module
+# PowerShellHostVersion = ''
+
+# Minimum version of the .NET Framework required by this module
+# DotNetFrameworkVersion = ''
+
+# Minimum version of the common language runtime (CLR) required by this module
+# CLRVersion = ''
+
+# Processor architecture (None, X86, Amd64) required by this module
+# ProcessorArchitecture = ''
+
+# Modules that must be imported into the global environment prior to importing this module
+# RequiredModules = @()
+
+# Assemblies that must be loaded prior to importing this module
+# RequiredAssemblies = @()
+
+# Script files (.ps1) that are run in the caller's environment prior to importing this module.
+# ScriptsToProcess = @()
+
+# Type files (.ps1xml) to be loaded when importing this module
+# TypesToProcess = @()
+
+# Format files (.ps1xml) to be loaded when importing this module
+# FormatsToProcess = @()
+
+# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+# NestedModules = @()
+
+# Functions to export from this module
+FunctionsToExport = '*'
+
+# Cmdlets to export from this module
+CmdletsToExport = '*'
+
+# Variables to export from this module
+VariablesToExport = '*'
+
+# Aliases to export from this module
+AliasesToExport = '*'
+
+# List of all modules packaged with this module.
+# ModuleList = @()
+
+# List of all files packaged with this module
+# FileList = @()
+
+# Private data to pass to the module specified in RootModule/ModuleToProcess
+# PrivateData = ''
+
+# HelpInfo URI of this module
+# HelpInfoURI = ''
+
+# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+# DefaultCommandPrefix = ''
+
+}
 ```
-PS> New-ModuleManifest -RequiredModules BitsTransfer,@{ModuleName="PSScheduledJob";ModuleVersion="1.0.0.0";GUID="50cdb55f-5ab7-489f-9e94-4ec21ff51e59"}
+
+### Example 2 - Create a new manifest with some prepopulated settings
+
+This command creates a new module manifest. It uses the **PowerShellVersion** and
+**AliasesToExport** parameters to add values to the corresponding manifest keys.
+
+```powershell
+New-ModuleManifest -PowerShellVersion 1.0 -AliasesToExport JKBC, DRC, TAC -Path C:\ps-test\ManifestTest.psd1
 ```
 
-This example shows how to use the string and hash table formats of the  **ModuleList**, **RequiredModules**, and **NestedModules** parameter.
-You can combine strings and hash tables in the same parameter value.
+### Example 3 - Create a manifest that requires other modules
 
-This command commands creates a module manifest for a module that requires the **BitsTransfer**  and **PSScheduledJob** modules.
+The example uses a string format to specify the name of the **BitsTransfer** module and the hash
+table format to specify the name, a GUID, and a version of the **PSScheduledJob** module.
 
-The command uses a string format to specify the name of the **BitsTransfer** module and the hash table format to specify the name, a GUID, and a version of the **PSScheduledJob** module.
-
-### Example 4
-
+```powershell
+$moduleSettings = @{
+  RequiredModules = (BitsTransfer, @{
+    ModuleName="PSScheduledJob"
+    ModuleVersion="1.0.0.0";
+    GUID="50cdb55f-5ab7-489f-9e94-4ec21ff51e59"
+  }
+  Path = 'C:\ps-test\ManifestTest.psd1'
+}
+New-ModuleManifest @moduleSettings
 ```
-PS> New-ModuleManifest -HelpInfoUri "http://http://go.microsoft.com/fwlink/?LinkID=603"
+
+This example shows how to use the string and hash table formats of the **ModuleList**,
+**RequiredModules**, and **NestedModules** parameter. You can combine strings and hash tables in
+the same parameter value.
+
+### Example 4 - Create a manifest that supports updateable help
+
+This example uses the **HelpInfoUri** parameter to create a **HelpInfoUri** key in the module
+manifest. The value of the parameter and the key must begin with "http" or "https". This value
+tells the Updatable Help system where to find the HelpInfo XML updatable help information file for
+the module.
+
+```powershell
+$moduleSettings = @{
+  HelpInfoUri = 'http://http://go.microsoft.com/fwlink/?LinkID=603'
+  Path = 'C:\ps-test\ManifestTest.psd1'
+}
+New-ModuleManifest @moduleSettings
 ```
-
-This example shows creates a module manifest for a module that supports the Updatable Help feature.
-This feature allows users to use the Update-Help and Save-Help cmdlets, which download help files for the module from the Internet and install them in the module.
-
-The command uses the **HelpInfoUri** parameter to create a **HelpInfoUri** key in the module manifest.
-The value of the parameter and the key must begin with "http" or "https".
-This value tells the Updatable Help system where to find the HelpInfo XML updatable help information file for the module.
 
 For information about Updatable Help, see [about_Updatable_Help](./About/about_Updatable_Help.md).
-For information about the HelpInfo XML file, see "Supporting Updatable Help" in MSDN.
+For information about the HelpInfo XML file, see [Supporting Updatable Help](/powershell/developer/module/supporting-updatable-help).
 
-### Example 5
+### Example 5 - Getting module information
 
+This example shows how to get the configuration values of a module. The values in the module
+manifest are reflected in the values of properties of the module object.
+
+The `Get-Module` cmdlet is used to get the **Microsoft.PowerShell.Diagnostics** module using the
+**List** parameter. The command sends the module to the `Format-List` cmdlet to display all
+properties and values of the module object.
+
+```powershell
+Get-Module Microsoft.PowerShell.Diagnostics -List | Format-List -Property *
 ```
-PS> Get-Module PSScheduledJob -List | Format-List -Property *
 
-LogPipelineExecutionDetails :
-FalseName                        :
-PSScheduledJobPath                        : C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.psd1
+```Output
+LogPipelineExecutionDetails : False
+Name                        : Microsoft.PowerShell.Diagnostics
+Path                        : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Diagnostics\Micro
+                              soft.PowerShell.Diagnostics.psd1
 Definition                  :
 Description                 :
-Guid                        : 50cdb55f-5ab7-489f-9e94-4ec21ff51e59
-HelpInfoUri                 : http://go.microsoft.com/fwlink/?LinkID=223911
-ModuleBase                  : C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob
+Guid                        : ca046f10-ca64-4740-8ff9-2565dba61a4f
+HelpInfoUri                 : http://go.microsoft.com/fwlink/?LinkID=210596
+ModuleBase                  : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Diagnostics
 PrivateData                 :
-Version                     : 1.0.0.0
-ModuleType                  :
-BinaryAuthor                      : Microsoft Corporation
+Version                     : 3.0.0.0
+ModuleType                  : Manifest
+Author                      : Microsoft Corporation
 AccessMode                  : ReadWrite
 ClrVersion                  : 4.0
 CompanyName                 : Microsoft Corporation
-Copyright                   : c Microsoft Corporation. All rights reserved.
+Copyright                   : © Microsoft Corporation. All rights reserved.
 DotNetFrameworkVersion      :
 ExportedFunctions           : {}
-ExportedCmdlets             : {[New-JobTrigger, New-JobTrigger], [Add-JobTrigger, Add-JobTrigger], [Remove-JobTrigger, Remove-JobTrigger], [Get-JobTrigger, Get-JobTrigger]...}
-ExportedCommands            : {[New-JobTrigger, New-JobTrigger], [Add-JobTrigger, Add-JobTrigger], [Remove-JobTrigger, Remove-JobTrigger], [Get-JobTrigger, Get-JobTrigger]...}
+ExportedCmdlets             : {[Get-WinEvent, Get-WinEvent], [Get-Counter, Get-Counter], [Import-Counter,
+                              Import-Counter], [Export-Counter, Export-Counter]...}
+ExportedCommands            : {[Get-WinEvent, Get-WinEvent], [Get-Counter, Get-Counter], [Import-Counter,
+                              Import-Counter], [Export-Counter, Export-Counter]...}
 FileList                    : {}
 ModuleList                  : {}
 NestedModules               : {}
 PowerShellHostName          :
 PowerShellHostVersion       :
-PowerShellVersion           : 4.0
+PowerShellVersion           : 3.0
 ProcessorArchitecture       : None
 Scripts                     : {}
 RequiredAssemblies          : {}
 RequiredModules             : {}
-RootModule                  : Microsoft.PowerShell.ScheduledJob.dll
+RootModule                  :
 ExportedVariables           : {}
 ExportedAliases             : {}
 ExportedWorkflows           : {}
 SessionState                :
 OnRemove                    :
-ExportedFormatFiles         : {C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.Format.ps1xml}
-ExportedTypeFiles           : {C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.types.ps1xml}
-
-PS> Get-Module -List | Format-Table -Property Name, PowerShellVersion
-
-Name                                                        PowerShellVersion
-----                                                        -----------------
-ADDeploymentWF                                              4.0
-AppLocker                                                   4.0
-Appx                                                        4.0
-BestPractices                                               4.0
-BitsTransfer                                                4.0
-BranchCache                                                 4.0
-CimCmdlets                                                  4.0
-DirectAccessClientComponents                                4.0
-Dism                                                        4.0
-DnsClient                                                   4.0
-International                                               4.0
-iSCSI                                                       4.0
-IscsiTarget                                                 4.0
-Kds                                                         4.0
-Microsoft.PowerShell.Diagnostics                            4.0
-Microsoft.PowerShell.Host                                   4.0
-Microsoft.PowerShell.Management                             4.0â€¦
+ExportedFormatFiles         : {C:\Windows\system32\WindowsPowerShell\v1.0\Event.format.ps1xml,
+                              C:\Windows\system32\WindowsPowerShell\v1.0\Diagnostics.format.ps1xml}
+ExportedTypeFiles           : {C:\Windows\system32\WindowsPowerShell\v1.0\GetEvent.types.ps1xml}
 ```
-
-This example shows how to get the module manifest values of a module -- essentially a "Get-ModuleManifest" command.
-Because the values in the module manifest are reflected in the values of properties of the module object, you can get the module manifest values by displaying the module object properties.
-
-The first command uses the **Get-Module** cmdlet to get the PSScheduledJob module.
-The command uses the List parameter, because the module is installed, but not imported into the session.
-The command sends the module to the Format-List cmdlet, which displays all properties and values of the module object in a list.
-
-The second command uses the Format-Table cmdlet to display the PowerShellVersion property of all installed modules in a table.
-The PowerShellVersion property is defined in the module manifest.
 
 ## PARAMETERS
 
 ### -AliasesToExport
 
-Specifies the aliases that the module exports.
-Wildcards are permitted.
+Specifies the aliases that the module exports. Wildcards are permitted.
 
-You can use this parameter to restrict the aliases that are exported by the module.
-It can remove aliases from the list of exported aliases, but it cannot add aliases to the list.
+You can use this parameter to restrict the aliases that are exported by the module. It can remove
+aliases from the list of exported aliases, but it cannot add aliases to the list.
 
-If you omit this parameter, **New-ModuleManifest** creates an **AliasesToExport** key with a value of * (all), meaning that all aliases that are exported by the module are exported by the manifest.
+If you omit this parameter, `New-ModuleManifest` creates an **AliasesToExport** key with a value
+of `*` (all), meaning that all aliases defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -253,7 +296,8 @@ Accept wildcard characters: True
 
 Specifies the module author.
 
-If you omit this parameter, **New-ModuleManifest** creates an **Author** key with the name of the current user.
+If you omit this parameter, `New-ModuleManifest` creates an **Author** key with the name of the
+current user.
 
 ```yaml
 Type: String
@@ -269,7 +313,8 @@ Accept wildcard characters: False
 
 ### -ClrVersion
 
-Specifies the minimum version of the Common Language Runtime (CLR) of the Microsoft .NET Framework that the module requires.
+Specifies the minimum version of the Common Language Runtime (CLR) of the Microsoft .NET Framework
+that the module requires.
 
 ```yaml
 Type: Version
@@ -285,13 +330,13 @@ Accept wildcard characters: False
 
 ### -CmdletsToExport
 
-Specifies the cmdlets that the module exports.
-Wildcards are permitted.
+Specifies the cmdlets that the module exports. Wildcards are permitted.
 
-You can use this parameter to restrict the cmdlets that are exported by the module.
-It can remove cmdlets from the list of exported cmdlets, but it cannot add cmdlets to the list.
+You can use this parameter to restrict the cmdlets that are exported by the module. It can remove
+cmdlets from the list of exported cmdlets, but it cannot add cmdlets to the list.
 
-If you omit this parameter, **New-ModuleManifest** creates a **CmdletsToExport** key with a value of * (all), meaning that all cmdlets that are exported by the module are exported by the manifest.
+If you omit this parameter, `New-ModuleManifest` creates a **CmdletsToExport** key with a value
+of `*` (all), meaning that all cmdlets defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -309,7 +354,8 @@ Accept wildcard characters: True
 
 Identifies the company or vendor who created the module.
 
-If you omit this parameter, **New-ModuleManifest** creates a **CompanyName** key with a value of "Unknown".
+If you omit this parameter, `New-ModuleManifest` creates a **CompanyName** key with a value of
+"Unknown".
 
 ```yaml
 Type: String
@@ -323,12 +369,29 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Copyright
 
 Specifies a copyright statement for the module.
 
-If you omit this parameter, **New-ModuleManifest** creates a **Copyright** key with a value of  "(c) \<year\> \<username\>.
-All rights reserved." where \<year\> is the current year and \<username\> is the value of the **Author** key (if one is specified) or the name of the current user.
+If you omit this parameter, `New-ModuleManifest` creates a **Copyright** key with a value of
+`(c) <year> <username>. All rights reserved.` where `<year>` is the current year and `<username>`
+is the value of the **Author** key.
 
 ```yaml
 Type: String
@@ -378,7 +441,8 @@ Accept wildcard characters: False
 
 Specifies all items that are included in the module.
 
-This key is designed to act as a module inventory. The files listed in the key are included when the module is published, but any functions are not automatically exported.
+This key is designed to act as a module inventory. The files listed in the key are included when
+the module is published, but any functions are not automatically exported.
 
 ```yaml
 Type: String[]
@@ -396,8 +460,8 @@ Accept wildcard characters: False
 
 Specifies the formatting files (.ps1xml) that run when the module is imported.
 
-When you import a module, Windows PowerShell runs the Update-FormatData cmdlet with the specified files.
-Because formatting files are not scoped, they affect all session states in the session.
+When you import a module, Windows PowerShell runs the `Update-FormatData` cmdlet with the specified
+files. Because formatting files are not scoped, they affect all session states in the session.
 
 ```yaml
 Type: String[]
@@ -413,13 +477,13 @@ Accept wildcard characters: False
 
 ### -FunctionsToExport
 
-Specifies the functions that the module exports.
-Wildcards are permitted.
+Specifies the functions that the module exports. Wildcards are permitted.
 
-You can use this parameter to restrict the functions that are exported by the module.
-It can remove functions from the list of exported aliases, but it cannot add functions to the list.
+You can use this parameter to restrict the functions that are exported by the module. It can remove
+functions from the list of exported aliases, but it cannot add functions to the list.
 
-If you omit this parameter, **New-ModuleManifest** creates an **FunctionsToExport** key with a value of * (all), meaning that all functions that are exported by the module are exported by the manifest.
+If you omit this parameter, `New-ModuleManifest` creates an **FunctionsToExport** key with a
+value of `*` (all), meaning that all functions defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -435,10 +499,11 @@ Accept wildcard characters: True
 
 ### -Guid
 
-Specifies a unique identifier for the module.
-The GUID can be used to distinguish among modules with the same name.
+Specifies a unique identifier for the module. The GUID can be used to distinguish among modules
+with the same name.
 
-If you omit this parameter, **New-ModuleManifest** creates a **GUID** key in the manifest and generates a GUID for the value.
+If you omit this parameter, `New-ModuleManifest` creates a **GUID** key in the manifest and
+generates a GUID for the value.
 
 To create a new GUID in Windows PowerShell, type "\[guid\]::NewGuid()".
 
@@ -456,15 +521,17 @@ Accept wildcard characters: False
 
 ### -HelpInfoUri
 
-Specifies the Internet address of the HelpInfo XML file for the module.
-Enter an Uniform Resource Identifier (URI) that begins with "http" or "https".
+Specifies the Internet address of the HelpInfo XML file for the module. Enter an Uniform Resource
+Identifier (URI) that begins with "http" or "https".
 
-The   HelpInfo XML file supports the Updatable Help feature that was introduced in Windows PowerShell 3.0.
-It contains information about the location of downloadable help files for the module and the version numbers of the newest help files for each supported locale.
+The HelpInfo XML file supports the Updatable Help feature that was introduced in Windows PowerShell
+3.0. It contains information about the location of downloadable help files for the module and the
+version numbers of the newest help files for each supported locale.
+
 For information about Updatable Help, see [about_Updatable_Help](./About/about_Updatable_Help.md).
-For information about the HelpInfo XML file, see "Supporting Updatable Help" in MSDN.
+For information about the HelpInfo XML file, see [Supporting Updatable Help](/powershell/developer/module/supporting-updatable-help).
 
-This parameter is introduced in Windows PowerShell 3.0.
+This parameter was introduced in Windows PowerShell 3.0.
 
 ```yaml
 Type: String
@@ -482,13 +549,12 @@ Accept wildcard characters: False
 
 Lists all modules that are included in this module.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
 
-This key is designed to act as a module inventory.
-The modules that are listed in the value of this key are not automatically processed.
+This key is designed to act as a module inventory. The modules that are listed in the value of this
+key are not automatically processed.
 
 ```yaml
 Type: Object[]
@@ -506,8 +572,9 @@ Accept wildcard characters: False
 
 Specifies the version of the module.
 
-This parameter is not required by the cmdlet, but a **ModuleVersion** key is required in the manifest.
-If you omit this parameter, **New-ModuleManifest** creates a **ModuleVersion** key with a value of "1.0".
+This parameter is not required by the cmdlet, but a **ModuleVersion** key is required in the
+manifest. If you omit this parameter, `New-ModuleManifest` creates a **ModuleVersion** key with a
+value of "1.0".
 
 ```yaml
 Type: Version
@@ -523,21 +590,25 @@ Accept wildcard characters: False
 
 ### -NestedModules
 
-Specifies script modules (.psm1) and binary modules (.dll) that are imported into the module's session state.
-The files in the **NestedModules** key run in the order in which they are listed in the value.
+Specifies script modules (.psm1) and binary modules (.dll) that are imported into the module's
+session state. The files in the **NestedModules** key run in the order in which they are listed in
+the value.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
 
 Typically, nested modules contain commands that the root module needs for its internal processing.
-By default, the commands in nested modules are exported from the module's session state into the caller's session state, but the root module can restrict the commands that it exports (for example, by using an Export-ModuleMembercommand).
+By default, the commands in nested modules are exported from the module's session state into the
+caller's session state, but the root module can restrict the commands that it exports (for example,
+by using an Export-ModuleMember command).
 
-Nested modules in the module session state are available to the root module, but they are not returned by a Get-Module command in the caller's session state.
+Nested modules in the module session state are available to the root module, but they are not
+returned by a `Get-Module` command in the caller's session state.
 
-Scripts (.ps1) that are listed in the **NestedModules** key are run in the module's session state, not in the caller's session state.
-To run a script in the caller's session state, list the script file name in the value of the **ScriptsToProcess** key in the manifest.
+Scripts (.ps1) that are listed in the **NestedModules** key are run in the module's session state,
+not in the caller's session state. To run a script in the caller's session state, list the script
+file name in the value of the **ScriptsToProcess** key in the manifest.
 
 ```yaml
 Type: Object[]
@@ -553,8 +624,8 @@ Accept wildcard characters: False
 
 ### -PassThru
 
-Writes the resulting module manifest to the console, in addition to creating a .psd1 file.
-By default, this cmdlet does not generate any output.
+Writes the resulting module manifest to the console, in addition to creating a .psd1 file. By
+default, this cmdlet does not generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -570,16 +641,19 @@ Accept wildcard characters: False
 
 ### -Path
 
-Specifies the path and file name of the new module manifest.
-Enter a path and file name with a .psd1 file name extension, such as "$pshome\Modules\MyModule\MyModule.psd1".
-This parameter is required.
+Specifies the path and file name of the new module manifest. Enter a path and file name with a
+.psd1 file name extension, such as `$pshome\Modules\MyModule\MyModule.psd1`. This parameter is
+required.
 
-If you specify the path to an existing file, **New-ModuleManifest** replaces the file without warning unless the file has the read-only attribute.
+If you specify the path to an existing file, `New-ModuleManifest` replaces the file without
+warning unless the file has the read-only attribute.
 
-The manifest should be located in the module's directory, and the manifest file name should be the same as the module directory name, but with a .psd1 file name extension.
+The manifest should be located in the module's directory, and the manifest file name should be the
+same as the module directory name, but with a .psd1 file name extension.
 
-Note: You cannot use variables, such as $pshome or $home, in response to a prompt for a **Path** parameter value.
-To use a variable, include the **Path** parameter in the command.
+> [!NOTE]
+> You cannot use variables, such as `$PSHOME` or `$HOME`, in response to a prompt for a **Path**
+> parameter value. To use a variable, include the **Path** parameter in the command.
 
 ```yaml
 Type: String
@@ -595,11 +669,10 @@ Accept wildcard characters: False
 
 ### -PowerShellHostName
 
-Specifies the name of the Windows PowerShell host program that the module requires.
-Enter the name of the host program, such as "Windows PowerShell ISE Host" or "ConsoleHost".
-Wildcards are not permitted.
+Specifies the name of the PowerShell host program that the module requires. Enter the name of the
+host program, such as "Windows PowerShell ISE Host" or "ConsoleHost". Wildcards are not permitted.
 
-To find the name of a host program, in the program, type "$host.name".
+To find the name of a host program, in the program, type `$Host.Name`.
 
 ```yaml
 Type: String
@@ -615,8 +688,8 @@ Accept wildcard characters: False
 
 ### -PowerShellHostVersion
 
-Specifies the minimum version of the Windows PowerShell host program that works with the module.
-Enter a version number, such as 1.1.
+Specifies the minimum version of the PowerShell host program that works with the module. Enter a
+version number, such as 1.1.
 
 ```yaml
 Type: Version
@@ -632,8 +705,8 @@ Accept wildcard characters: False
 
 ### -PowerShellVersion
 
-Specifies the minimum version of Windows PowerShell that will work with this module.
-For example, you can enter 1.0, 2.0, or 3.0 as the value of this parameter.
+Specifies the minimum version of Windows PowerShell that will work with this module. For example,
+you can enter 1.0, 2.0, or 3.0 as the value of this parameter.
 
 ```yaml
 Type: Version
@@ -665,13 +738,14 @@ Accept wildcard characters: False
 
 ### -ProcessorArchitecture
 
-Specifies the processor architecture that the module requires.
-Valid values are x86, AMD64, IA64, and None (unknown or unspecified).
+Specifies the processor architecture that the module requires. Valid values are x86, AMD64, IA64, MSIL,
+and None (unknown or unspecified).
 
 ```yaml
 Type: ProcessorArchitecture
 Parameter Sets: (All)
 Aliases:
+Accepted values: None, MSIL, X86, IA64, Amd64, Arm
 
 Required: False
 Position: Named
@@ -682,11 +756,14 @@ Accept wildcard characters: False
 
 ### -RequiredAssemblies
 
-Specifies the assembly (.dll) files that the module requires.
-Enter the assembly file names.
-Windows PowerShell loads the specified assemblies before updating types or formats, importing nested modules, or importing the module file that is specified in the value of the **RootModule** key.
+Specifies the assembly (.dll) files that the module requires. Enter the assembly file names.
+PowerShell loads the specified assemblies before updating types or formats, importing nested
+modules, or importing the module file that is specified in the value of the **RootModule** key.
 
-Use this parameter to list all the assemblies that the module requires, including assemblies that must be loaded to update any formatting or type files that are listed in the **FormatsToProcess** or **TypesToProcess** keys, even if those assemblies are also listed as binary modules in the **NestedModules** key.
+Use this parameter to list all the assemblies that the module requires, including assemblies that
+must be loaded to update any formatting or type files that are listed in the **FormatsToProcess**
+or **TypesToProcess** keys, even if those assemblies are also listed as binary modules in the
+**NestedModules** key.
 
 ```yaml
 Type: String[]
@@ -702,17 +779,16 @@ Accept wildcard characters: False
 
 ### -RequiredModules
 
-Specifies modules that must be in the global session state.
-If the required modules are not in the global session state, Windows PowerShell imports them.
-If the required modules are not available, the Import-Module command fails.
+Specifies modules that must be in the global session state. If the required modules are not in the
+global session state, Windows PowerShell imports them. If the required modules are not available,
+the `Import-Module` command fails.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
 
-In Windows PowerShell 2.0, **Import-Module** does not import required modules automatically.
-It just verifies that the required modules are in the global session state.
+In Windows PowerShell 2.0, `Import-Module` does not import required modules automatically. It
+just verifies that the required modules are in the global session state.
 
 ```yaml
 Type: Object[]
@@ -749,8 +825,8 @@ Accept wildcard characters: False
 
 Specifies the type files (.ps1xml) that run when the module is imported.
 
-When you import the module, Windows PowerShell runs the Update-TypeData cmdlet with the specified files.
-Because type files are not scoped, they affect all session states in the session.
+When you import the module, Windows PowerShell runs the `Update-TypeData` cmdlet with the specified
+files. Because type files are not scoped, they affect all session states in the session.
 
 ```yaml
 Type: String[]
@@ -766,13 +842,13 @@ Accept wildcard characters: False
 
 ### -VariablesToExport
 
-Specifies the variables that the module exports.
-Wildcards are permitted.
+Specifies the variables that the module exports. Wildcards are permitted.
 
-You can use this parameter to restrict the variables that are exported by the module.
-It can remove variables from the list of exported variables, but it cannot add variables to the list.
+You can use this parameter to restrict the variables that are exported by the module. It can remove
+variables from the list of exported variables, but it cannot add variables to the list.
 
-If you omit this parameter, **New-ModuleManifest** creates a **VariablesToExport** key with a value of * (all), meaning that all variables that are exported by the module are exported by the manifest.
+If you omit this parameter, `New-ModuleManifest` creates a **VariablesToExport** key with a value
+of `*` (all), meaning that all variables defined int the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -788,11 +864,12 @@ Accept wildcard characters: True
 
 ### -DefaultCommandPrefix
 
-Specifies a prefix that is prepended to the nouns of all commands in the module when they are imported into a session.
-Enter a prefix string.
-Prefixes prevent command name conflicts in a user's session.
+Specifies a prefix that is prepended to the nouns of all commands in the module when they are
+imported into a session. Enter a prefix string. Prefixes prevent command name conflicts in a user's
+session.
 
-Module users can override this prefix by specifying the **Prefix** parameter of the Import-Module cmdlet.
+Module users can override this prefix by specifying the **Prefix** parameter of the `Import-Module`
+cmdlet.
 
 This parameter is introduced in Windows PowerShell 3.0.
 
@@ -810,16 +887,22 @@ Accept wildcard characters: False
 
 ### -RootModule
 
-Specifies the primary or "root" file of the module.
-Enter the file name of a script (.ps1), a script module (.psm1), a module manifest(.psd1), an assembly (.dll), a cmdlet definition XML file (.cdxml), or a workflow (.xaml).
-When the module is imported, the members that are exported from the root module file are imported into the caller's session state.
+Specifies the primary or "root" file of the module. Enter the file name of a script (.ps1), a
+script module (.psm1), a module manifest(.psd1), an assembly (.dll), a cmdlet definition XML file
+(.cdxml), or a workflow (.xaml). When the module is imported, the members that are exported from
+the root module file are imported into the caller's session state.
 
-If a module has a manifest file and no root file has been designated in the **RootModule** key, the manifest becomes the primary file for the module, and the module becomes a "manifest module" (ModuleType = Manifest).
+If a module has a manifest file and no root file has been designated in the **RootModule** key, the
+manifest becomes the primary file for the module, and the module becomes a "manifest module"
+(ModuleType = Manifest).
 
-To export members from .psm1 or .dll files in a module that has a manifest, the names of those files must be specified in the values of the **RootModule** or **NestedModules** keys in the manifest.
-Otherwise, their members are not exported.
+To export members from .psm1 or .dll files in a module that has a manifest, the names of those
+files must be specified in the values of the **RootModule** or **NestedModules** keys in the
+manifest. Otherwise, their members are not exported.
 
-Note: In Windows PowerShell 2.0, this key was called "ModuleToProcess." You can use the "RootModule" parameter name or its "ModuleToProcess" alias.
+> [!NOTE]
+> In PowerShell 2.0, this key was called **ModuleToProcess**. You can use the "RootModule" parameter
+> name or its **ModuleToProcess** alias.
 
 ```yaml
 Type: String
@@ -833,26 +916,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -868,7 +934,10 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](./About/about_CommonParameters.md).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
@@ -880,18 +949,28 @@ You cannot pipe input to this cmdlet.
 
 ### None or System.String
 
-By default, New-ModuleManifest does not generate any output.
-However, if you use the PassThru parameter, it generates a System.String object representing the module manifest..
+By default, `New-ModuleManifest` does not generate any output. However, if you use the **PassThru**
+parameter, it generates a **System.String** object representing the module manifest.
 
 ## NOTES
 
-- Module manifests are usually optional. However, a module manifest is required to export an assembly that is installed in the global assembly cache.
-- To add or change files in the $pshome\Modules directory (%Windir%\System32\WindowsPowerShell\v1.0\Modules), start Windows PowerShell with the "Run as administrator" option.
-- In Windows PowerShell 2.0, many parameters of **New-ModuleManifest** are mandatory, even though they are not required in a module manifest. In Windows PowerShell 3.0, only the **Path** parameter is  mandatory.
-- A "session" is an instance of the Windows PowerShell execution environment. A session can have one or more session states. By default, a session has only a global session state, but each imported module has its own session state. Session states allow the commands in a module to run without affecting the global session state.
+Module manifests are usually optional. However, a module manifest is required to export an assembly
+that is installed in the global assembly cache.
 
-  The "caller's session state" is the session state into which a module is imported.
-Typically, it refers to the global session state, but when a module imports nested modules, the "caller" is the module and the "caller's session state" is the module's session state.
+To add or change files in the `$pshome\Modules` directory, start PowerShell with the "Run as
+administrator" option.
+
+In PowerShell 2.0, many parameters of `New-ModuleManifest` are mandatory, even though they are not
+required in a module manifest. In Windows PowerShell 3.0, only the **Path** parameter is mandatory.
+
+A "session" is an instance of the PowerShell execution environment. A session can have one or more
+session states. By default, a session has only a global session state, but each imported module has
+its own session state. Session states allow the commands in a module to run without affecting the
+global session state.
+
+The "caller's session state" is the session state into which a module is imported. Typically, it
+refers to the global session state, but when a module imports nested modules, the "caller" is the
+module and the "caller's session state" is the module's session state.
 
 ## RELATED LINKS
 

--- a/reference/3.0/Microsoft.PowerShell.Management/New-EventLog.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/New-EventLog.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  01/22/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -9,46 +9,58 @@ title:  New-EventLog
 ---
 
 # New-EventLog
+
 ## SYNOPSIS
 Creates a new event log and a new event source on a local or remote computer.
+
 ## SYNTAX
 
 ```
-New-EventLog [-CategoryResourceFile <String>] [[-ComputerName] <String[]>] [-LogName] <String>
- [-MessageResourceFile <String>] [-ParameterResourceFile <String>] [-Source] <String[]> [<CommonParameters>]
+New-EventLog [-LogName] <string> [-Source] <string[]> [[-ComputerName] <string[]>]
+  [-CategoryResourceFile <string>] [-MessageResourceFile <string>] [-ParameterResourceFile <string>]
+  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet creates a new classic event log on a local or remote computer.
-It can also register an event source that writes to the new log or to an existing log.
+
+This cmdlet creates a new classic event log on a local or remote computer. It can also register an
+event source that writes to the new log or to an existing log.
 
 The cmdlets that contain the EventLog noun (the Event log cmdlets) work only on classic event logs.
-To get events from logs that use the Windows Event Log technology in Windows Vista and later versions of Windows, use Get-WinEvent.
+To get events from logs that use the Windows Event Log technology in Windows Vista and later
+versions of Windows, use `Get-WinEvent`.
+
 ## EXAMPLES
 
-### Example 1
-```
-PS C:\> new-eventlog -source TestApp -logname TestLog -MessageResourceFile C:\Test\TestApp.dll
-```
+### Example 1 - create a new event log
 
 This command creates the TestLog event log on the local computer and registers a new source for it.
-### Example 2
-```
-PS C:\> $file = "C:\Program Files\TestApps\NewTestApp.dll"
-PS C:\> new-eventlog -computername Server01 -source NewTestApp -logname Application -MessageResourceFile $file -CategoryResourceFile $file
+
+```powershell
+New-EventLog -source TestApp -LogName TestLog -MessageResourceFile C:\Test\TestApp.dll
 ```
 
-This command adds a new event source, NewTestApp, to the Application log on the Server01 remote computer.
+### Example 2 - add a new event source to an existing log
+
+This command adds a new event source, NewTestApp, to the Application log on the Server01 remote
+computer.
+
+```powershell
+$file = "C:\Program Files\TestApps\NewTestApp.dll"
+New-EventLog -ComputerName Server01 -Source NewTestApp -LogName Application -MessageResourceFile $file -CategoryResourceFile $file
+```
 
 The command requires that the NewTestApp.dll file is located on the Server01 computer.
+
 ## PARAMETERS
 
 ### -CategoryResourceFile
-Specifies the path to the file that contains category strings for the source events.
-This file is also known as the Category Message File.
 
-The file must be present on the computer on which the event log is being created.
-This parameter does not create or move files.
+Specifies the path to the file that contains category strings for the source events. This file is
+also known as the Category Message File.
+
+The file must be present on the computer on which the event log is being created. This parameter
+does not create or move files.
 
 ```yaml
 Type: String
@@ -63,14 +75,14 @@ Accept wildcard characters: False
 ```
 
 ### -ComputerName
-Creates the new event logs on the specified computers.
-The default is the local computer.
 
-Type the NetBIOS name, an Internet Protocol (IP) address, or a fully qualified domain name of a remote computer.
+Creates the new event logs on the specified computers. The default is the local computer.
+
+The NetBIOS name, IP address, or fully qualified domain name of a remote computer.
 To specify the local computer, type the computer name, a dot (.), or "localhost".
 
-This parameter does not rely on Windows PowerShell remoting.
-You can use the ComputerName parameter of Get-EventLog even if your computer is not configured to run remote commands.
+This parameter does not rely on PowerShell remoting. You can use the **ComputerName**
+parameter of `Get-EventLog` even if your computer is not configured to run remote commands.
 
 ```yaml
 Type: String[]
@@ -85,10 +97,12 @@ Accept wildcard characters: False
 ```
 
 ### -LogName
+
 Specifies the name of the event log.
 
-If the log does not exist, New-EventLog creates the log and uses this value for the Log and LogDisplayName properties of the new event log.
-If the log exists, New-EventLog registers a new source for the event log.
+If the log does not exist, `New-EventLog` creates the log and uses this value for the **Log** and
+**LogDisplayName** properties of the new event log. If the log exists, `New-EventLog` registers a new
+source for the event log.
 
 ```yaml
 Type: String
@@ -103,6 +117,7 @@ Accept wildcard characters: False
 ```
 
 ### -MessageResourceFile
+
 Specifies the path to the file that contains message formatting strings for the source events.
 This file is also known as the Event Message File.
 
@@ -122,8 +137,9 @@ Accept wildcard characters: False
 ```
 
 ### -ParameterResourceFile
-Specifies the path to the file that contains strings used for parameter substitutions in event descriptions.
-This file is also known as the Parameter Message File.
+
+Specifies the path to the file that contains strings used for parameter substitutions in event
+descriptions. This file is also known as the Parameter Message File.
 
 The file must be present on the computer on which the event log is being created.
 This parameter does not create or move files.
@@ -141,8 +157,9 @@ Accept wildcard characters: False
 ```
 
 ### -Source
-Specifies the names of the event log sources, such as application programs that write to the event log.
-This parameter is required.
+
+Specifies the names of the event log sources, such as application programs that write to the event
+log. This parameter is required.
 
 ```yaml
 Type: String[]
@@ -157,27 +174,41 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
 ## INPUTS
 
 ### None
+
 You cannot pipe input to this cmdlet.
+
 ## OUTPUTS
 
 ### System.Diagnostics.EventLogEntry
 
 ## NOTES
-* To use New-EventLog on Windows Vista and later versions of Windows, open Windows PowerShell with the "Run as administrator" option.
 
-  To create an event source in Windows Vista, Windows XP Professional, or Windows Server 2003, you must be a member of the Administrators group on the computer.
+To use `New-EventLog` on Windows Vista and later versions of Windows, open PowerShell with
+the "Run as administrator" option.
 
-  When you create a new event log and a new event source, the system registers the new source for the new log, but the log is not created until the first entry is written to it.
+To create an event source in Windows Vista, Windows XP Professional, or Windows Server 2003, you
+must be a member of the Administrators group on the computer.
 
-  The operating system stores event logs as files.
-When you create a new event log, the associated file is stored in the %SystemRoot%\System32\Config directory on the specified computer.
-The file name is the first eight characters of the Log property with an .evt file name extension.
+When you create a new event log and a new event source, the system registers the new source for the
+new log, but the log is not created until the first entry is written to it.
 
-*
+The operating system stores event logs as files.
+
+When you create a new event log, the associated file is stored in the
+`$env:SystemRoot\System32\Config` directory on the specified computer.
+
+The file name is the first eight characters of the **Log** property with an .evt file name
+extension.
+
 ## RELATED LINKS
 
 [Clear-EventLog](Clear-EventLog.md)

--- a/reference/3.0/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/3.0/Microsoft.PowerShell.Management/Push-Location.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  01/22/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -9,75 +9,95 @@ title:  Push-Location
 ---
 
 # Push-Location
+
 ## SYNOPSIS
 Adds the current location to the top of a location stack.
+
 ## SYNTAX
 
 ### Path (Default)
+
 ```
 Push-Location [[-Path] <String>] [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### LiteralPath
+
 ```
 Push-Location [-LiteralPath <String>] [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Push-Location cmdlet adds ("pushes") the current location onto a location stack.
-If you specify a path, Push-Location pushes the current location onto a location stack and then changes the current location to the location specified by the path.
-You can use the Pop-Location cmdlet to get locations from the location stack.
 
-By default, the Push-Location cmdlet pushes the current location onto the current location stack, but you can use the StackName parameter to specify an alternate location stack.
-If the stack does not exist, Push-Location creates it.
+The `Push-Location` cmdlet adds ("pushes") the current location onto a location stack. If you
+specify a path, `Push-Location` pushes the current location onto a location stack and then changes
+the current location to the location specified by the path. You can use the `Pop-Location` cmdlet
+to get locations from the location stack.
+
+By default, the `Push-Location` cmdlet pushes the current location onto the current location stack,
+but you can use the StackName parameter to specify an alternate location stack. If the stack does
+not exist, `Push-Location` creates it.
 
 For more information about location stacks, see the Notes.
+
 ## EXAMPLES
 
 ### Example 1
+
+This example pushes the current location onto the default location stack and then changes the location to `C:\Windows`.
+
 ```
-PS C:\> push-location C:\Windows
+PS C:\> Push-Location C:\Windows
 ```
 
-This command pushes the current location onto the default location stack and then changes the location to C:\Windows.
 ### Example 2
+
+This example pushes the current location onto the RegFunction stack and changes the current location to the `HKLM:\Software\Policies` location.
+
 ```
-PS C:\> push-location HKLM:\Software\Policies -stackname RegFunction
+PS C:\> Push-Location HKLM:\Software\Policies -StackName RegFunction
 ```
 
-This command pushes the current location onto the RegFunction stack and changes the current location to the HKLM:\Software\Policies location.
-You can use the Location cmdlets in any Windows PowerShell drive (PSDrive).
+You can use the Location cmdlets in any PowerShell drive (PSDrive).
+
 ### Example 3
-```
-PS C:\> push-location
-```
 
 This command pushes the current location onto the default stack.
 It does not change the location.
-### Example 4
+
 ```
-PS C:\> push-location ~ -stackname Stack2
-PS C:\Users\User01> pop-location -stackname Stack2
-PS C:\>
+PS C:\> Push-Location
 ```
+
+### Example 4 - Create and use a named stack
 
 These commands show how to create and use a named location stack.
 
-The first command pushes the current location onto a new stack named Stack2, and then changes the current location to the home directory (%USERPROFILE%), which is represented in the command by the tilde symbol (~) or $home.
-If Stack2 does not already exist in the session, Push-Location creates it.
+```
+PS C:\> Push-Location ~ -StackName Stack2
+PS C:\Users\User01> Pop-Location -StackName Stack2
+PS C:\>
+```
 
-The second command uses the Pop-Location cmdlet to pop the original location (PS C:\\\>) from the Stack2 stack.
-Without the StackName parameter, Pop-Location would pop the location from the unnamed default stack.
+The first command pushes the current location onto a new stack named Stack2, and then changes the
+current location to the home directory, which is represented in the command by the tilde symbol (~)
+(same as `$env:USERPROFILE` or `$HOME`).
 
-For more information about location stacks, see the Notes.
+If Stack2 does not already exist in the session, `Push-Location` creates it. The second command
+uses the `Pop-Location` cmdlet to pop the original location (PS C:\\\>) from the Stack2 stack.
+Without the StackName parameter, `Pop-Location` would pop the location from the unnamed default
+stack.
+
+For more information about location stacks, see the [Notes](#notes).
+
 ## PARAMETERS
 
 ### -LiteralPath
-Specifies the path to the new location.
-Unlike the Path parameter, the value of the LiteralPath parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+
+Specifies the path to the new location. Unlike the **Path** parameter, the value of the
+**LiteralPath** parameter is used exactly as it is typed. No characters are interpreted as
+wildcards. If the path includes escape characters, enclose it in single quotation marks. Single
+quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -92,8 +112,9 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Passes an object representing the location to the pipeline.
-By default, this cmdlet does not generate any output.
+
+Passes an object representing the location to the pipeline. By default, this cmdlet does not
+generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -108,10 +129,10 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Changes your location to the location specified by this path after it adds (pushes) the current location onto the top of the stack.
-Enter a path to any location whose provider supports this cmdlet.
-Wildcards are permitted.
-The parameter name ("Path") is optional.
+
+Changes your location to the location specified by this path after it adds (pushes) the current
+location onto the top of the stack. Enter a path to any location whose provider supports this
+cmdlet. Wildcards are permitted. The parameter name is optional.
 
 ```yaml
 Type: String
@@ -126,16 +147,18 @@ Accept wildcard characters: True
 ```
 
 ### -StackName
-Specifies the location stack to which the current location is added.
-Enter a location stack name.
-If the stack does not exist, Push-Location creates it.
 
-Without this parameter, Push-Location adds the location to the current location stack.
-By default, the current location stack is the unnamed default location stack that Windows PowerShell creates.
-To make a location stack the current location stack, use the StackName parameter of the Set-Location cmdlet.
-For more information about location stacks, see the Notes.
+Specifies the location stack to which the current location is added. Enter a location stack name.
+If the stack does not exist, `Push-Location` creates it.
 
-NOTE: Push-Location cannot add a location to the unnamed default stack unless it is the current location stack.
+Without this parameter, `Push-Location` adds the location to the current location stack. By
+default, the current location stack is the unnamed default location stack that PowerShell creates.
+To make a location stack the current location stack, use the StackName parameter of the
+`Set-Location` cmdlet. For more information about location stacks, see the [Notes](#notes).
+
+> [!NOTE]
+> `Push-Location` cannot add a location to the unnamed default stack unless it is the current
+> location stack.
 
 ```yaml
 Type: String
@@ -150,9 +173,9 @@ Accept wildcard characters: False
 ```
 
 ### -UseTransaction
-Includes the command in the active transaction.
-This parameter is valid only when a transaction is in progress.
-For more information, see about_transactions.
+
+Includes the command in the active transaction. This parameter is valid only when a transaction is
+in progress. For more information, see [about_Transactions](../Microsoft.PowerShell.Core/About/about_transactions.md).
 
 ```yaml
 Type: SwitchParameter
@@ -167,49 +190,66 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains a path (but not a literal path) to Push-Location.
+
+You can pipe a string that contains a path (but not a literal path) to `Push-Location`.
+
 ## OUTPUTS
 
 ### None or System.Management.Automation.PathInfo
-When you use the PassThru parameter, Push-Location generates a System.Management.Automation.PathInfo object that represents the location.
-Otherwise, this cmdlet does not generate any output.
+
+When you use the PassThru parameter, `Push-Location` generates a
+**System.Management.Automation.PathInfo** object that represents the location. Otherwise, this
+cmdlet does not generate any output.
+
 ## NOTES
-* A "stack" is a last-in, first-out list in which only the most recently added item is accessible. You add items to a stack in the order that you use them, and then retrieve them for use in the reverse order.  Windows PowerShell lets you store provider locations in location stacks.
 
-  Windows PowerShell creates an unnamed default location stack and you can create multiple named location stacks.
-If you do not specify a stack name, Windows PowerShell uses the current location stack.
-By default, the unnamed default location is the current location stack, but you can use the Set-Location cmdlet to change the current location stack.
+A "stack" is a last-in, first-out list in which only the most recently added item is accessible.
+You add items to a stack in the order that you use them, and then retrieve them for use in the
+reverse order. PowerShell lets you store provider locations in location stacks.
 
-  To manage location stacks, use the Windows PowerShell Location cmdlets, as follows.
+PowerShell creates an unnamed default location stack and you can create multiple named location
+stacks. If you do not specify a stack name, Windows PowerShell uses the current location stack. By
+default, the unnamed default location is the current location stack, but you can use the
+`Set-Location` cmdlet to change the current location stack.
 
-  - To add a location to a location stack, use the Push-Location cmdlet.
+To manage location stacks, use the PowerShell Location cmdlets, as follows.
 
-  - To get a location from a location stack, use the Pop-Location cmdlet.
+- To add a location to a location stack, use the `Push-Location` cmdlet.
+- To get a location from a location stack, use the `Pop-Location` cmdlet.
+- To display the locations in the current location stack, use the **Stack** parameter of the
+  `Get-Location` cmdlet.
 
-  - To display the locations in the current location stack, use the Stack parameter of the Get-Location cmdlet.
-To display the locations in a named location stack, use the StackName parameter of the Get-Location cmdlet.
+To display the locations in a named location stack, use the **StackName** parameter of the
+`Get-Location` cmdlet.
 
-  - To create a new location stack, use the StackName parameter of the Push-Location cmdlet.
-If you specify a stack that does not exist, Push-Location creates the stack.
+- To create a new location stack, use the StackName parameter of the `Push-Location` cmdlet. If you
+  specify a stack that does not exist, `Push-Location` creates the stack.
+- To make a location stack the current location stack, use the StackName parameter of the
+  `Set-Location` cmdlet.
 
-  - To make a location stack the current location stack, use the StackName parameter of the Set-Location cmdlet.
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you can no longer use
+`Push-Location` or `Pop-Location` cmdlets add or get items from the default stack or use
+`Get-Location` command to display the locations in the unnamed stack. To make the unnamed stack the
+current stack, use the StackName parameter of the `Set-Location` cmdlet with a value of $null or an
+empty string ("").
 
-  The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you cannot no longer use Push-Location or Pop-Location cmdlets add or get items from the default stack or use Get-Location command to display the locations in the unnamed stack.
-To make the unnamed stack the current stack, use the StackName parameter of the Set-Location cmdlet with a value of $null or an empty string ("").
+You can also refer to `Push-Location` by its built-in alias, `pushd`. For more information, see
+[about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).
 
-  You can also refer to Push-Location by its built-in alias, "pushd".
-For more information, see about_Aliases.
+The `Push-Location` cmdlet is designed to work with the data exposed by any provider. To list the
+providers available in your session, type `Get-PSProvider`. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
-  The Push-Location cmdlet is designed to work with the data exposed by any provider.
-To list the providers available in your session, type "Get-PSProvider".
-For more information, see about_Providers.
-
-*
 ## RELATED LINKS
 
 [Get-Location](Get-Location.md)

--- a/reference/4.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/4.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  01/22/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -7,7 +7,6 @@ online version:  http://go.microsoft.com/fwlink/p/?linkid=289595
 external help file:  System.Management.Automation.dll-Help.xml
 title:  New-ModuleManifest
 ---
-
 # New-ModuleManifest
 
 ## SYNOPSIS
@@ -16,219 +15,270 @@ Creates a new module manifest.
 ## SYNTAX
 
 ```
-New-ModuleManifest [-Path] <String> [-NestedModules <Object[]>] [-Guid <Guid>] [-Author <String>]
- [-CompanyName <String>] [-Copyright <String>] [-RootModule <String>] [-ModuleVersion <Version>]
- [-Description <String>] [-ProcessorArchitecture <ProcessorArchitecture>] [-PowerShellVersion <Version>]
- [-ClrVersion <Version>] [-DotNetFrameworkVersion <Version>] [-PowerShellHostName <String>]
- [-PowerShellHostVersion <Version>] [-RequiredModules <Object[]>] [-TypesToProcess <String[]>]
- [-FormatsToProcess <String[]>] [-ScriptsToProcess <String[]>] [-RequiredAssemblies <String[]>]
- [-FileList <String[]>] [-ModuleList <Object[]>] [-FunctionsToExport <String[]>] [-AliasesToExport <String[]>]
- [-VariablesToExport <String[]>] [-CmdletsToExport <String[]>] [-PrivateData <Object>] [-HelpInfoUri <String>]
- [-PassThru] [-DefaultCommandPrefix <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-ModuleManifest [-Path] <string> [-NestedModules <Object[]>] [-Guid <guid>] [-Author <string>]
+  [-CompanyName <string>] [-Copyright <string>] [-RootModule <string>] [-ModuleVersion <version>]
+  [-Description <string>] [-ProcessorArchitecture <ProcessorArchitecture>] [-PowerShellVersion <version>]
+  [-ClrVersion <version>] [-DotNetFrameworkVersion <version>] [-PowerShellHostName <string>]
+  [-PowerShellHostVersion <version>] [-RequiredModules <Object[]>] [-TypesToProcess <string[]>]
+  [-FormatsToProcess <string[]>] [-ScriptsToProcess <string[]>] [-RequiredAssemblies <string[]>]
+  [-FileList <string[]>] [-ModuleList <Object[]>] [-FunctionsToExport <string[]>]
+  [-AliasesToExport <string[]>] [-VariablesToExport <string[]>] [-CmdletsToExport <string[]>]
+  [-PrivateData <Object>] [-HelpInfoUri <string>] [-PassThru] [-DefaultCommandPrefix <string>]
+  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **New-ModuleManifest** cmdlet creates a new module manifest (.psd1) file, populates its values, and saves the manifest file in the specified path.
 
-Module authors can use this cmdlet to create a manifest for their module.
-A module manifest is a .psd1 file that contains a hash table.
-The keys and values in the hash table describe the contents and attributes of the module, define the prerequisites, and determine how the components are processed.
-Manifests are not required for a module.
+The `New-ModuleManifest` cmdlet creates a new module manifest (.psd1) file, populates its values,
+and saves the manifest file in the specified path.
 
-**New-ModuleManifest** creates a manifest that includes all of the commonly used manifest keys, so you can use the default output as a manifest template.
-To add or change values, or to add module keys that this cmdlet does not add, open the resulting file in a text editor.
+Module authors can use this cmdlet to create a manifest for their module. A module manifest is a
+.psd1 file that contains a hash table. The keys and values in the hash table describe the contents
+and attributes of the module, define the prerequisites, and determine how the components are
+processed. Manifests are not required for a module.
 
-Each parameter of this cmdlet (except for **Path** and **PassThru**) creates a module manifest key and its value.
-In a module manifest, only the **ModuleVersion** key is required.
-Unless specified in the parameter description, if you omit a parameter from the command, **New-ModuleManifest** creates a comment string for the associated value that has no effect.
+`New-ModuleManifest` creates a manifest that includes all of the commonly used manifest keys, so
+you can use the default output as a manifest template. To add or change values, or to add module
+keys that this cmdlet does not add, open the resulting file in a text editor.
 
-In Windows PowerShell 2.0, **New-ModuleManifest** prompts you for the values of commonly used parameters that are not specified in the command, in addition to required parameter values.
-Beginning in Windows PowerShell 3.0, it prompts only when required parameter values are not specified.
+Each parameter of this cmdlet (except for **Path** and **PassThru**) creates a module manifest key
+and its value. In a module manifest, only the **ModuleVersion** key is required. Unless specified
+in the parameter description, if you omit a parameter from the command, `New-ModuleManifest`
+creates a comment string for the associated value that has no effect.
+
+In Windows PowerShell 2.0, `New-ModuleManifest` prompts you for the values of commonly used
+parameters that are not specified in the command, in addition to required parameter values.
+Beginning in Windows PowerShell 3.0, it prompts only when required parameter values are not
+specified.
 
 ## EXAMPLES
 
-### Example 1
-```
-PS C:\> New-ModuleManifest -Path C:\Users\User01\Documents\WindowsPowerShell\Modules\Test-Module\Test-Module.psd1 -PassThru
+### Example 1 - Create a new module manifest
 
-## Module manifest for module 'TestModule'
-## Generated by: User01
-## Generated on: 1/24/2012
-#@{
-# Script module or binary module file associated with this manifest
-# RootModule = ''
-# Version number of this module.ModuleVersion = '1.0'
-# ID used to uniquely identify this moduleGUID = 'd0a9150d-b6a4-4b17-a325-e3a24fed0aa9'
-# Author of this moduleAuthor = 'User01'
-# Company or vendor of this moduleCompanyName = 'Unknown'
-# Copyright statement for this moduleCopyright = '(c) 2012 User01. All rights reserved.'
-# Description of the functionality provided by this module
-# Description = ''
-# Minimum version of the Windows PowerShell engine required by this module
-# PowerShellVersion = ''
-# Name of the Windows PowerShell host required by this module
-# PowerShellHostName = ''
-# Minimum version of the Windows PowerShell host required by this module
-# PowerShellHostVersion = ''
-# Minimum version of the .NET Framework required by this module
-# DotNetFrameworkVersion = ''
-# Minimum version of the common language runtime (CLR) required by this module
-# CLRVersion = ''
-# Processor architecture (None, X86, Amd64) required by this module
-# ProcessorArchitecture = ''
-# Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
-# Assemblies that must be loaded prior to importing this module
-# RequiredAssemblies = @()
-# Script files (.ps1) that are run in the caller's environment prior to importing this module
-# ScriptsToProcess = @()
-# Type files (.ps1xml) to be loaded when importing this module
-# TypesToProcess = @()
-# Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
-# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-# NestedModules = @()
-# Functions to export from this moduleFunctionsToExport = '*'
-# Cmdlets to export from this moduleCmdletsToExport = '*'
-# Variables to export from this moduleVariablesToExport = '*'
-# Aliases to export from this moduleAliasesToExport = '*'
-# List of all modules packaged with this module# ModuleList = @()
-# List of all files packaged with this module
-# FileList = @()
-# Private data to pass to the module specified in RootModule/ModuleToProcess
-# PrivateData = ''
-# HelpInfo URI of this module
-# HelpInfoURI = ''
-# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
-# DefaultCommandPrefix = ''}
-```
-
-This command creates a new module manifest in the file that is specified by the Path parameter.
-The **PassThru** parameter sends the output to the pipeline as well as to the file.
+This command creates a new module manifest in the file that is specified by the Path parameter. The
+**PassThru** parameter sends the output to the pipeline as well as to the file.
 
 The output shows the default values of all keys in the manifest.
 
-### Example 2
-```
-PS C:\> New-ModuleManifest -PowerShellVersion 1.0 -AliasesToExport JKBC, DRC, TAC -Path C:\ps-test\ManifestTest.psd1
-```
-
-This command creates a new module manifest.
-It uses the **PowerShellVersion** and **AliasesToExport** parameters to add values to the corresponding manifest keys.
-
-### Example 3
-```
-PS C:\> New-ModuleManifest -RequiredModules BitsTransfer,@{ModuleName="PSScheduledJob";ModuleVersion="1.0.0.0";GUID="50cdb55f-5ab7-489f-9e94-4ec21ff51e59"}
+```powershell
+New-ModuleManifest -Path C:\ps-test\Test-Module\Test-Module.psd1 -PassThru
 ```
 
-This example shows how to use the string and hash table formats of the  **ModuleList**, **RequiredModules**, and **NestedModules** parameter.
-You can combine strings and hash tables in the same parameter value.
+```Output
+#
+# Module manifest for module 'Test-Module'
+#
+# Generated by: ContosoAdmin
+#
+# Generated on: 1/22/2019
+#
 
-This command commands creates a module manifest for a module that requires the **BitsTransfer**  and **PSScheduledJob** modules.
+@{
 
-The command uses a string format to specify the name of the **BitsTransfer** module and the hash table format to specify the name, a GUID, and a version of the **PSScheduledJob** module.
+# Script module or binary module file associated with this manifest.
+# RootModule = ''
 
-### Example 4
+# Version number of this module.
+ModuleVersion = '1.0'
+
+# ID used to uniquely identify this module
+GUID = '47179120-0bcb-4f14-8d80-f4560107f85c'
+
+# Author of this module
+Author = 'ContosoAdmin'
+
+# Company or vendor of this module
+CompanyName = 'Unknown'
+
+# Copyright statement for this module
+Copyright = '(c) 2019 ContosoAdmin. All rights reserved.'
+
+# Description of the functionality provided by this module
+# Description = ''
+
+# Minimum version of the Windows PowerShell engine required by this module
+# PowerShellVersion = ''
+
+# Name of the Windows PowerShell host required by this module
+# PowerShellHostName = ''
+
+# Minimum version of the Windows PowerShell host required by this module
+# PowerShellHostVersion = ''
+
+# Minimum version of the .NET Framework required by this module
+# DotNetFrameworkVersion = ''
+
+# Minimum version of the common language runtime (CLR) required by this module
+# CLRVersion = ''
+
+# Processor architecture (None, X86, Amd64) required by this module
+# ProcessorArchitecture = ''
+
+# Modules that must be imported into the global environment prior to importing this module
+# RequiredModules = @()
+
+# Assemblies that must be loaded prior to importing this module
+# RequiredAssemblies = @()
+
+# Script files (.ps1) that are run in the caller's environment prior to importing this module.
+# ScriptsToProcess = @()
+
+# Type files (.ps1xml) to be loaded when importing this module
+# TypesToProcess = @()
+
+# Format files (.ps1xml) to be loaded when importing this module
+# FormatsToProcess = @()
+
+# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+# NestedModules = @()
+
+# Functions to export from this module
+FunctionsToExport = '*'
+
+# Cmdlets to export from this module
+CmdletsToExport = '*'
+
+# Variables to export from this module
+VariablesToExport = '*'
+
+# Aliases to export from this module
+AliasesToExport = '*'
+
+# List of all modules packaged with this module.
+# ModuleList = @()
+
+# List of all files packaged with this module
+# FileList = @()
+
+# Private data to pass to the module specified in RootModule/ModuleToProcess
+# PrivateData = ''
+
+# HelpInfo URI of this module
+# HelpInfoURI = ''
+
+# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+# DefaultCommandPrefix = ''
+
+}
 ```
-PS C:\> New-ModuleManifest -HelpInfoUri "http://http://go.microsoft.com/fwlink/?LinkID=603"
+
+### Example 2 - Create a new manifest with some prepopulated settings
+
+This command creates a new module manifest. It uses the **PowerShellVersion** and
+**AliasesToExport** parameters to add values to the corresponding manifest keys.
+
+```powershell
+New-ModuleManifest -PowerShellVersion 1.0 -AliasesToExport JKBC, DRC, TAC -Path C:\ps-test\ManifestTest.psd1
 ```
 
-This example shows creates a module manifest for a module that supports the Updatable Help feature.
-This feature allows users to use the Update-Help and Save-Help cmdlets, which download help files for the module from the Internet and install them in the module.
+### Example 3 - Create a manifest that requires other modules
 
-The command uses the **HelpInfoUri** parameter to create a **HelpInfoUri** key in the module manifest.
-The value of the parameter and the key must begin with "http" or "https".
-This value tells the Updatable Help system where to find the HelpInfo XML updatable help information file for the module.
+The example uses a string format to specify the name of the **BitsTransfer** module and the hash
+table format to specify the name, a GUID, and a version of the **PSScheduledJob** module.
 
-For information about Updatable Help, see about_Updatable_Help (http://go.microsoft.com/fwlink/?LinkID=235801).
-For information about the HelpInfo XML file, see "Supporting Updatable Help" in MSDN.
-
-### Example 5
+```powershell
+$moduleSettings = @{
+  RequiredModules = (BitsTransfer, @{
+    ModuleName="PSScheduledJob"
+    ModuleVersion="1.0.0.0";
+    GUID="50cdb55f-5ab7-489f-9e94-4ec21ff51e59"
+  }
+  Path = 'C:\ps-test\ManifestTest.psd1'
+}
+New-ModuleManifest @moduleSettings
 ```
-PS C:\> Get-Module PSScheduledJob -List | Format-List -Property *
 
-LogPipelineExecutionDetails :
-FalseName                        :
-PSScheduledJobPath                        : C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.psd1
+This example shows how to use the string and hash table formats of the **ModuleList**,
+**RequiredModules**, and **NestedModules** parameter. You can combine strings and hash tables in
+the same parameter value.
+
+### Example 4 - Create a manifest that supports updateable help
+
+This example uses the **HelpInfoUri** parameter to create a **HelpInfoUri** key in the module
+manifest. The value of the parameter and the key must begin with "http" or "https". This value
+tells the Updatable Help system where to find the HelpInfo XML updatable help information file for
+the module.
+
+```powershell
+$moduleSettings = @{
+  HelpInfoUri = 'http://http://go.microsoft.com/fwlink/?LinkID=603'
+  Path = 'C:\ps-test\ManifestTest.psd1'
+}
+New-ModuleManifest @moduleSettings
+```
+
+For information about Updatable Help, see [about_Updatable_Help](./About/about_Updatable_Help.md).
+For information about the HelpInfo XML file, see [Supporting Updatable Help](/powershell/developer/module/supporting-updatable-help).
+
+### Example 5 - Getting module information
+
+This example shows how to get the configuration values of a module. The values in the module
+manifest are reflected in the values of properties of the module object.
+
+The `Get-Module` cmdlet is used to get the **Microsoft.PowerShell.Diagnostics** module using the
+**List** parameter. The command sends the module to the `Format-List` cmdlet to display all
+properties and values of the module object.
+
+```powershell
+Get-Module Microsoft.PowerShell.Diagnostics -List | Format-List -Property *
+```
+
+```Output
+LogPipelineExecutionDetails : False
+Name                        : Microsoft.PowerShell.Diagnostics
+Path                        : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Diagnostics\Micro
+                              soft.PowerShell.Diagnostics.psd1
 Definition                  :
 Description                 :
-Guid                        : 50cdb55f-5ab7-489f-9e94-4ec21ff51e59
-HelpInfoUri                 : http://go.microsoft.com/fwlink/?LinkID=223911
-ModuleBase                  : C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob
+Guid                        : ca046f10-ca64-4740-8ff9-2565dba61a4f
+HelpInfoUri                 : http://go.microsoft.com/fwlink/?LinkID=210596
+ModuleBase                  : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Diagnostics
 PrivateData                 :
-Version                     : 1.0.0.0
-ModuleType                  :
-BinaryAuthor                      : Microsoft Corporation
+Version                     : 3.0.0.0
+ModuleType                  : Manifest
+Author                      : Microsoft Corporation
 AccessMode                  : ReadWrite
 ClrVersion                  : 4.0
 CompanyName                 : Microsoft Corporation
-Copyright                   : c Microsoft Corporation. All rights reserved.
+Copyright                   : © Microsoft Corporation. All rights reserved.
 DotNetFrameworkVersion      :
 ExportedFunctions           : {}
-ExportedCmdlets             : {[New-JobTrigger, New-JobTrigger], [Add-JobTrigger, Add-JobTrigger], [Remove-JobTrigger, Remove-JobTrigger], [Get-JobTrigger, Get-JobTrigger]...}
-ExportedCommands            : {[New-JobTrigger, New-JobTrigger], [Add-JobTrigger, Add-JobTrigger], [Remove-JobTrigger, Remove-JobTrigger], [Get-JobTrigger, Get-JobTrigger]...}
+ExportedCmdlets             : {[Get-WinEvent, Get-WinEvent], [Get-Counter, Get-Counter], [Import-Counter,
+                              Import-Counter], [Export-Counter, Export-Counter]...}
+ExportedCommands            : {[Get-WinEvent, Get-WinEvent], [Get-Counter, Get-Counter], [Import-Counter,
+                              Import-Counter], [Export-Counter, Export-Counter]...}
 FileList                    : {}
 ModuleList                  : {}
 NestedModules               : {}
 PowerShellHostName          :
 PowerShellHostVersion       :
-PowerShellVersion           : 4.0
+PowerShellVersion           : 3.0
 ProcessorArchitecture       : None
 Scripts                     : {}
 RequiredAssemblies          : {}
 RequiredModules             : {}
-RootModule                  : Microsoft.PowerShell.ScheduledJob.dll
+RootModule                  :
 ExportedVariables           : {}
 ExportedAliases             : {}
 ExportedWorkflows           : {}
 SessionState                :
 OnRemove                    :
-ExportedFormatFiles         : {C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.Format.ps1xml}
-ExportedTypeFiles           : {C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.types.ps1xml}
-
-PS C:\> Get-Module -List | Format-Table -Property Name, PowerShellVersion
-
-Name                                                        PowerShellVersion
-----                                                        -----------------
-ADDeploymentWF                                              4.0
-AppLocker                                                   4.0
-Appx                                                        4.0
-BestPractices                                               4.0
-BitsTransfer                                                4.0
-BranchCache                                                 4.0
-CimCmdlets                                                  4.0
-DirectAccessClientComponents                                4.0
-Dism                                                        4.0
-DnsClient                                                   4.0
-International                                               4.0
-iSCSI                                                       4.0
-IscsiTarget                                                 4.0
-Kds                                                         4.0
-Microsoft.PowerShell.Diagnostics                            4.0
-Microsoft.PowerShell.Host                                   4.0
-Microsoft.PowerShell.Management                             4.0â€¦
+ExportedFormatFiles         : {C:\Windows\system32\WindowsPowerShell\v1.0\Event.format.ps1xml,
+                              C:\Windows\system32\WindowsPowerShell\v1.0\Diagnostics.format.ps1xml}
+ExportedTypeFiles           : {C:\Windows\system32\WindowsPowerShell\v1.0\GetEvent.types.ps1xml}
 ```
-
-This example shows how to get the module manifest values of a module -- essentially a "Get-ModuleManifest" command.
-Because the values in the module manifest are reflected in the values of properties of the module object, you can get the module manifest values by displaying the module object properties.
-
-The first command uses the **Get-Module** cmdlet to get the PSScheduledJob module.
-The command uses the List parameter, because the module is installed, but not imported into the session.
-The command sends the module to the Format-List cmdlet, which displays all properties and values of the module object in a list.
-
-The second command uses the Format-Table cmdlet to display the PowerShellVersion property of all installed modules in a table.
-The PowerShellVersion property is defined in the module manifest.
 
 ## PARAMETERS
 
 ### -AliasesToExport
-Specifies the aliases that the module exports.
-Wildcards are permitted.
 
-You can use this parameter to restrict the aliases that are exported by the module.
-It can remove aliases from the list of exported aliases, but it cannot add aliases to the list.
+Specifies the aliases that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates an **AliasesToExport** key with a value of * (all), meaning that all aliases that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the aliases that are exported by the module. It can remove
+aliases from the list of exported aliases, but it cannot add aliases to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates an **AliasesToExport** key with a value
+of `*` (all), meaning that all aliases defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -239,13 +289,15 @@ Required: False
 Position: Named
 Default value: * (all)
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Author
+
 Specifies the module author.
 
-If you omit this parameter, **New-ModuleManifest** creates an **Author** key with the name of the current user.
+If you omit this parameter, `New-ModuleManifest` creates an **Author** key with the name of the
+current user.
 
 ```yaml
 Type: String
@@ -260,7 +312,9 @@ Accept wildcard characters: False
 ```
 
 ### -ClrVersion
-Specifies the minimum version of the Common Language Runtime (CLR) of the Microsoft .NET Framework that the module requires.
+
+Specifies the minimum version of the Common Language Runtime (CLR) of the Microsoft .NET Framework
+that the module requires.
 
 ```yaml
 Type: Version
@@ -275,13 +329,14 @@ Accept wildcard characters: False
 ```
 
 ### -CmdletsToExport
-Specifies the cmdlets that the module exports.
-Wildcards are permitted.
 
-You can use this parameter to restrict the cmdlets that are exported by the module.
-It can remove cmdlets from the list of exported cmdlets, but it cannot add cmdlets to the list.
+Specifies the cmdlets that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates a **CmdletsToExport** key with a value of * (all), meaning that all cmdlets that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the cmdlets that are exported by the module. It can remove
+cmdlets from the list of exported cmdlets, but it cannot add cmdlets to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates a **CmdletsToExport** key with a value
+of `*` (all), meaning that all cmdlets defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -292,13 +347,15 @@ Required: False
 Position: Named
 Default value: * (all)
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -CompanyName
+
 Identifies the company or vendor who created the module.
 
-If you omit this parameter, **New-ModuleManifest** creates a **CompanyName** key with a value of "Unknown".
+If you omit this parameter, `New-ModuleManifest` creates a **CompanyName** key with a value of
+"Unknown".
 
 ```yaml
 Type: String
@@ -313,6 +370,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -328,10 +386,12 @@ Accept wildcard characters: False
 ```
 
 ### -Copyright
+
 Specifies a copyright statement for the module.
 
-If you omit this parameter, **New-ModuleManifest** creates a **Copyright** key with a value of  "(c) \<year\> \<username\>.
-All rights reserved." where \<year\> is the current year and \<username\> is the value of the **Author** key (if one is specified) or the name of the current user.
+If you omit this parameter, `New-ModuleManifest` creates a **Copyright** key with a value of
+`(c) <year> <username>. All rights reserved.` where `<year>` is the current year and `<username>`
+is the value of the **Author** key.
 
 ```yaml
 Type: String
@@ -345,28 +405,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DefaultCommandPrefix
-Specifies a prefix that is prepended to the nouns of all commands in the module when they are imported into a session.
-Enter a prefix string.
-Prefixes prevent command name conflicts in a user's session.
-
-Module users can override this prefix by specifying the **Prefix** parameter of the Import-Module cmdlet.
-
-This parameter is introduced in Windows PowerShell 3.0.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Description
+
 Describes the contents of the module.
 
 ```yaml
@@ -382,6 +422,7 @@ Accept wildcard characters: False
 ```
 
 ### -DotNetFrameworkVersion
+
 Specifies the minimum version of the Microsoft .NET Framework that the module requires.
 
 ```yaml
@@ -397,9 +438,11 @@ Accept wildcard characters: False
 ```
 
 ### -FileList
+
 Specifies all items that are included in the module.
 
-This key is designed to act as a module inventory. The files listed in the key are included when the module is published, but any functions are not automatically exported.
+This key is designed to act as a module inventory. The files listed in the key are included when
+the module is published, but any functions are not automatically exported.
 
 ```yaml
 Type: String[]
@@ -414,10 +457,11 @@ Accept wildcard characters: False
 ```
 
 ### -FormatsToProcess
+
 Specifies the formatting files (.ps1xml) that run when the module is imported.
 
-When you import a module, Windows PowerShell runs the Update-FormatData cmdlet with the specified files.
-Because formatting files are not scoped, they affect all session states in the session.
+When you import a module, Windows PowerShell runs the `Update-FormatData` cmdlet with the specified
+files. Because formatting files are not scoped, they affect all session states in the session.
 
 ```yaml
 Type: String[]
@@ -432,13 +476,14 @@ Accept wildcard characters: False
 ```
 
 ### -FunctionsToExport
-Specifies the functions that the module exports.
-Wildcards are permitted.
 
-You can use this parameter to restrict the functions that are exported by the module.
-It can remove functions from the list of exported aliases, but it cannot add functions to the list.
+Specifies the functions that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates an **FunctionsToExport** key with a value of * (all), meaning that all functions that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the functions that are exported by the module. It can remove
+functions from the list of exported aliases, but it cannot add functions to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates an **FunctionsToExport** key with a
+value of `*` (all), meaning that all functions defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -449,14 +494,16 @@ Required: False
 Position: Named
 Default value: * (all)
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Guid
-Specifies a unique identifier for the module.
-The GUID can be used to distinguish among modules with the same name.
 
-If you omit this parameter, **New-ModuleManifest** creates a **GUID** key in the manifest and generates a GUID for the value.
+Specifies a unique identifier for the module. The GUID can be used to distinguish among modules
+with the same name.
+
+If you omit this parameter, `New-ModuleManifest` creates a **GUID** key in the manifest and
+generates a GUID for the value.
 
 To create a new GUID in Windows PowerShell, type "\[guid\]::NewGuid()".
 
@@ -473,15 +520,18 @@ Accept wildcard characters: False
 ```
 
 ### -HelpInfoUri
-Specifies the Internet address of the HelpInfo XML file for the module.
-Enter an Uniform Resource Identifier (URI) that begins with "http" or "https".
 
-The   HelpInfo XML file supports the Updatable Help feature that was introduced in Windows PowerShell 3.0.
-It contains information about the location of downloadable help files for the module and the version numbers of the newest help files for each supported locale.
-For information about Updatable Help, see about_Updatable_Help (http://go.microsoft.com/fwlink/?LinkID=235801).
-For information about the HelpInfo XML file, see "Supporting Updatable Help" in MSDN.
+Specifies the Internet address of the HelpInfo XML file for the module. Enter an Uniform Resource
+Identifier (URI) that begins with "http" or "https".
 
-This parameter is introduced in Windows PowerShell 3.0.
+The HelpInfo XML file supports the Updatable Help feature that was introduced in Windows PowerShell
+3.0. It contains information about the location of downloadable help files for the module and the
+version numbers of the newest help files for each supported locale.
+
+For information about Updatable Help, see [about_Updatable_Help](./About/about_Updatable_Help.md).
+For information about the HelpInfo XML file, see [Supporting Updatable Help](/powershell/developer/module/supporting-updatable-help).
+
+This parameter was introduced in Windows PowerShell 3.0.
 
 ```yaml
 Type: String
@@ -496,15 +546,15 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleList
+
 Lists all modules that are included in this module.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
 
-This key is designed to act as a module inventory.
-The modules that are listed in the value of this key are not automatically processed.
+This key is designed to act as a module inventory. The modules that are listed in the value of this
+key are not automatically processed.
 
 ```yaml
 Type: Object[]
@@ -519,10 +569,12 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleVersion
+
 Specifies the version of the module.
 
-This parameter is not required by the cmdlet, but a **ModuleVersion** key is required in the manifest.
-If you omit this parameter, **New-ModuleManifest** creates a **ModuleVersion** key with a value of "1.0".
+This parameter is not required by the cmdlet, but a **ModuleVersion** key is required in the
+manifest. If you omit this parameter, `New-ModuleManifest` creates a **ModuleVersion** key with a
+value of "1.0".
 
 ```yaml
 Type: Version
@@ -537,21 +589,26 @@ Accept wildcard characters: False
 ```
 
 ### -NestedModules
-Specifies script modules (.psm1) and binary modules (.dll) that are imported into the module's session state.
-The files in the **NestedModules** key run in the order in which they are listed in the value.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Specifies script modules (.psm1) and binary modules (.dll) that are imported into the module's
+session state. The files in the **NestedModules** key run in the order in which they are listed in
+the value.
+
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
 
 Typically, nested modules contain commands that the root module needs for its internal processing.
-By default, the commands in nested modules are exported from the module's session state into the caller's session state, but the root module can restrict the commands that it exports (for example, by using an Export-ModuleMembercommand).
+By default, the commands in nested modules are exported from the module's session state into the
+caller's session state, but the root module can restrict the commands that it exports (for example,
+by using an Export-ModuleMember command).
 
-Nested modules in the module session state are available to the root module, but they are not returned by a Get-Module command in the caller's session state.
+Nested modules in the module session state are available to the root module, but they are not
+returned by a `Get-Module` command in the caller's session state.
 
-Scripts (.ps1) that are listed in the **NestedModules** key are run in the module's session state, not in the caller's session state.
-To run a script in the caller's session state, list the script file name in the value of the **ScriptsToProcess** key in the manifest.
+Scripts (.ps1) that are listed in the **NestedModules** key are run in the module's session state,
+not in the caller's session state. To run a script in the caller's session state, list the script
+file name in the value of the **ScriptsToProcess** key in the manifest.
 
 ```yaml
 Type: Object[]
@@ -566,8 +623,9 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Writes the resulting module manifest to the console, in addition to creating a .psd1 file.
-By default, this cmdlet does not generate any output.
+
+Writes the resulting module manifest to the console, in addition to creating a .psd1 file. By
+default, this cmdlet does not generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -582,16 +640,20 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies the path and file name of the new module manifest.
-Enter a path and file name with a .psd1 file name extension, such as "$pshome\Modules\MyModule\MyModule.psd1".
-This parameter is required.
 
-If you specify the path to an existing file, **New-ModuleManifest** replaces the file without warning unless the file has the read-only attribute.
+Specifies the path and file name of the new module manifest. Enter a path and file name with a
+.psd1 file name extension, such as `$pshome\Modules\MyModule\MyModule.psd1`. This parameter is
+required.
 
-The manifest should be located in the module's directory, and the manifest file name should be the same as the module directory name, but with a .psd1 file name extension.
+If you specify the path to an existing file, `New-ModuleManifest` replaces the file without
+warning unless the file has the read-only attribute.
 
-Note: You cannot use variables, such as $pshome or $home, in response to a prompt for a **Path** parameter value.
-To use a variable, include the **Path** parameter in the command.
+The manifest should be located in the module's directory, and the manifest file name should be the
+same as the module directory name, but with a .psd1 file name extension.
+
+> [!NOTE]
+> You cannot use variables, such as `$PSHOME` or `$HOME`, in response to a prompt for a **Path**
+> parameter value. To use a variable, include the **Path** parameter in the command.
 
 ```yaml
 Type: String
@@ -599,18 +661,18 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -PowerShellHostName
-Specifies the name of the Windows PowerShell host program that the module requires.
-Enter the name of the host program, such as "Windows PowerShell ISE Host" or "ConsoleHost".
-Wildcards are not permitted.
 
-To find the name of a host program, in the program, type "$host.name".
+Specifies the name of the PowerShell host program that the module requires. Enter the name of the
+host program, such as "Windows PowerShell ISE Host" or "ConsoleHost". Wildcards are not permitted.
+
+To find the name of a host program, in the program, type `$Host.Name`.
 
 ```yaml
 Type: String
@@ -625,8 +687,9 @@ Accept wildcard characters: False
 ```
 
 ### -PowerShellHostVersion
-Specifies the minimum version of the Windows PowerShell host program that works with the module.
-Enter a version number, such as 1.1.
+
+Specifies the minimum version of the PowerShell host program that works with the module. Enter a
+version number, such as 1.1.
 
 ```yaml
 Type: Version
@@ -641,8 +704,9 @@ Accept wildcard characters: False
 ```
 
 ### -PowerShellVersion
-Specifies the minimum version of Windows PowerShell that will work with this module.
-For example, you can enter 2.0, 3.0, or 4.0 as the value of this parameter.
+
+Specifies the minimum version of Windows PowerShell that will work with this module. For example,
+you can enter 1.0, 2.0, or 3.0 as the value of this parameter.
 
 ```yaml
 Type: Version
@@ -657,6 +721,7 @@ Accept wildcard characters: False
 ```
 
 ### -PrivateData
+
 Specifies data that is passed to the module when it is imported.
 
 ```yaml
@@ -672,8 +737,9 @@ Accept wildcard characters: False
 ```
 
 ### -ProcessorArchitecture
-Specifies the processor architecture that the module requires.
-Valid values are x86, AMD64, IA64, and None (unknown or unspecified).
+
+Specifies the processor architecture that the module requires. Valid values are x86, AMD64, IA64, MSIL,
+and None (unknown or unspecified).
 
 ```yaml
 Type: ProcessorArchitecture
@@ -689,11 +755,15 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredAssemblies
-Specifies the assembly (.dll) files that the module requires.
-Enter the assembly file names.
-Windows PowerShell loads the specified assemblies before updating types or formats, importing nested modules, or importing the module file that is specified in the value of the **RootModule** key.
 
-Use this parameter to list all the assemblies that the module requires, including assemblies that must be loaded to update any formatting or type files that are listed in the **FormatsToProcess** or **TypesToProcess** keys, even if those assemblies are also listed as binary modules in the **NestedModules** key.
+Specifies the assembly (.dll) files that the module requires. Enter the assembly file names.
+PowerShell loads the specified assemblies before updating types or formats, importing nested
+modules, or importing the module file that is specified in the value of the **RootModule** key.
+
+Use this parameter to list all the assemblies that the module requires, including assemblies that
+must be loaded to update any formatting or type files that are listed in the **FormatsToProcess**
+or **TypesToProcess** keys, even if those assemblies are also listed as binary modules in the
+**NestedModules** key.
 
 ```yaml
 Type: String[]
@@ -708,17 +778,17 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredModules
-Specifies modules that must be in the global session state.
-If the required modules are not in the global session state, Windows PowerShell imports them.
-If the required modules are not available, the Import-Module command fails.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Specifies modules that must be in the global session state. If the required modules are not in the
+global session state, Windows PowerShell imports them. If the required modules are not available,
+the `Import-Module` command fails.
 
-In Windows PowerShell 2.0, **Import-Module** does not import required modules automatically.
-It just verifies that the required modules are in the global session state.
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
+
+In Windows PowerShell 2.0, `Import-Module` does not import required modules automatically. It
+just verifies that the required modules are in the global session state.
 
 ```yaml
 Type: Object[]
@@ -732,31 +802,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RootModule
-Specifies the primary or "root" file of the module.
-Enter the file name of a script (.ps1), a script module (.psm1), a module manifest(.psd1), an assembly (.dll), a cmdlet definition XML file (.cdxml), or a workflow (.xaml).
-When the module is imported, the members that are exported from the root module file are imported into the caller's session state.
-
-If a module has a manifest file and no root file has been designated in the **RootModule** key, the manifest becomes the primary file for the module, and the module becomes a "manifest module" (ModuleType = Manifest).
-
-To export members from .psm1 or .dll files in a module that has a manifest, the names of those files must be specified in the values of the **RootModule** or **NestedModules** keys in the manifest.
-Otherwise, their members are not exported.
-
-Note: In Windows PowerShell 2.0, this key was called "ModuleToProcess." You can use the "RootModule" parameter name or its "ModuleToProcess" alias.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: ModuleToProcess
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -ScriptsToProcess
+
 Specifies script (.ps1) files that run in the caller's session state when the module is imported.
 You can use these scripts to prepare an environment, just as you might use a login script.
 
@@ -775,10 +822,11 @@ Accept wildcard characters: False
 ```
 
 ### -TypesToProcess
+
 Specifies the type files (.ps1xml) that run when the module is imported.
 
-When you import the module, Windows PowerShell runs the Update-TypeData cmdlet with the specified files.
-Because type files are not scoped, they affect all session states in the session.
+When you import the module, Windows PowerShell runs the `Update-TypeData` cmdlet with the specified
+files. Because type files are not scoped, they affect all session states in the session.
 
 ```yaml
 Type: String[]
@@ -793,13 +841,14 @@ Accept wildcard characters: False
 ```
 
 ### -VariablesToExport
-Specifies the variables that the module exports.
-Wildcards are permitted.
 
-You can use this parameter to restrict the variables that are exported by the module.
-It can remove variables from the list of exported variables, but it cannot add variables to the list.
+Specifies the variables that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates a **VariablesToExport** key with a value of * (all), meaning that all variables that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the variables that are exported by the module. It can remove
+variables from the list of exported variables, but it cannot add variables to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates a **VariablesToExport** key with a value
+of `*` (all), meaning that all variables defined int the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -810,12 +859,66 @@ Required: False
 Position: Named
 Default value: * (all)
 Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -DefaultCommandPrefix
+
+Specifies a prefix that is prepended to the nouns of all commands in the module when they are
+imported into a session. Enter a prefix string. Prefixes prevent command name conflicts in a user's
+session.
+
+Module users can override this prefix by specifying the **Prefix** parameter of the `Import-Module`
+cmdlet.
+
+This parameter is introduced in Windows PowerShell 3.0.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RootModule
+
+Specifies the primary or "root" file of the module. Enter the file name of a script (.ps1), a
+script module (.psm1), a module manifest(.psd1), an assembly (.dll), a cmdlet definition XML file
+(.cdxml), or a workflow (.xaml). When the module is imported, the members that are exported from
+the root module file are imported into the caller's session state.
+
+If a module has a manifest file and no root file has been designated in the **RootModule** key, the
+manifest becomes the primary file for the module, and the module becomes a "manifest module"
+(ModuleType = Manifest).
+
+To export members from .psm1 or .dll files in a module that has a manifest, the names of those
+files must be specified in the values of the **RootModule** or **NestedModules** keys in the
+manifest. Otherwise, their members are not exported.
+
+> [!NOTE]
+> In PowerShell 2.0, this key was called **ModuleToProcess**. You can use the "RootModule" parameter
+> name or its **ModuleToProcess** alias.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: ModuleToProcess
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -830,27 +933,44 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### None
+
 You cannot pipe input to this cmdlet.
 
 ## OUTPUTS
 
 ### None or System.String
-By default, New-ModuleManifest does not generate any output.
-However, if you use the PassThru parameter, it generates a System.String object representing the module manifest..
+
+By default, `New-ModuleManifest` does not generate any output. However, if you use the **PassThru**
+parameter, it generates a **System.String** object representing the module manifest.
 
 ## NOTES
-* Module manifests are usually optional. However, a module manifest is required to export an assembly that is installed in the global assembly cache.
-* To add or change files in the $pshome\Modules directory (%Windir%\System32\WindowsPowerShell\v1.0\Modules), start Windows PowerShell with the "Run as administrator" option.
-* In Windows PowerShell 2.0, many parameters of **New-ModuleManifest** are mandatory, even though they are not required in a module manifest. In Windows PowerShell 3.0, only the **Path** parameter is  mandatory.
-* A "session" is an instance of the Windows PowerShell execution environment. A session can have one or more session states. By default, a session has only a global session state, but each imported module has its own session state. Session states allow the commands in a module to run without affecting the global session state.
 
-  The "caller's session state" is the session state into which a module is imported.
-Typically, it refers to the global session state, but when a module imports nested modules, the "caller" is the module and the "caller's session state" is the module's session state.
+Module manifests are usually optional. However, a module manifest is required to export an assembly
+that is installed in the global assembly cache.
+
+To add or change files in the `$pshome\Modules` directory, start PowerShell with the "Run as
+administrator" option.
+
+In PowerShell 2.0, many parameters of `New-ModuleManifest` are mandatory, even though they are not
+required in a module manifest. In Windows PowerShell 3.0, only the **Path** parameter is mandatory.
+
+A "session" is an instance of the PowerShell execution environment. A session can have one or more
+session states. By default, a session has only a global session state, but each imported module has
+its own session state. Session states allow the commands in a module to run without affecting the
+global session state.
+
+The "caller's session state" is the session state into which a module is imported. Typically, it
+refers to the global session state, but when a module imports nested modules, the "caller" is the
+module and the "caller's session state" is the module's session state.
 
 ## RELATED LINKS
 

--- a/reference/4.0/Microsoft.PowerShell.Management/New-EventLog.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/New-EventLog.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  01/22/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -16,44 +16,51 @@ Creates a new event log and a new event source on a local or remote computer.
 ## SYNTAX
 
 ```
-New-EventLog [-CategoryResourceFile <String>] [[-ComputerName] <String[]>] [-LogName] <String>
- [-MessageResourceFile <String>] [-ParameterResourceFile <String>] [-Source] <String[]> [<CommonParameters>]
+New-EventLog [-LogName] <string> [-Source] <string[]> [[-ComputerName] <string[]>]
+  [-CategoryResourceFile <string>] [-MessageResourceFile <string>] [-ParameterResourceFile <string>]
+  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet creates a new classic event log on a local or remote computer.
-It can also register an event source that writes to the new log or to an existing log.
+
+This cmdlet creates a new classic event log on a local or remote computer. It can also register an
+event source that writes to the new log or to an existing log.
 
 The cmdlets that contain the EventLog noun (the Event log cmdlets) work only on classic event logs.
-To get events from logs that use the Windows Event Log technology in Windows Vista and later versions of Windows, use Get-WinEvent.
+To get events from logs that use the Windows Event Log technology in Windows Vista and later
+versions of Windows, use `Get-WinEvent`.
 
 ## EXAMPLES
 
-### Example 1
-```
-PS C:\> new-eventlog -source TestApp -logname TestLog -MessageResourceFile C:\Test\TestApp.dll
-```
+### Example 1 - create a new event log
 
 This command creates the TestLog event log on the local computer and registers a new source for it.
 
-### Example 2
-```
-PS C:\> $file = "C:\Program Files\TestApps\NewTestApp.dll"
-PS C:\> new-eventlog -computername Server01 -source NewTestApp -logname Application -MessageResourceFile $file -CategoryResourceFile $file
+```powershell
+New-EventLog -source TestApp -LogName TestLog -MessageResourceFile C:\Test\TestApp.dll
 ```
 
-This command adds a new event source, NewTestApp, to the Application log on the Server01 remote computer.
+### Example 2 - add a new event source to an existing log
+
+This command adds a new event source, NewTestApp, to the Application log on the Server01 remote
+computer.
+
+```powershell
+$file = "C:\Program Files\TestApps\NewTestApp.dll"
+New-EventLog -ComputerName Server01 -Source NewTestApp -LogName Application -MessageResourceFile $file -CategoryResourceFile $file
+```
 
 The command requires that the NewTestApp.dll file is located on the Server01 computer.
 
 ## PARAMETERS
 
 ### -CategoryResourceFile
-Specifies the path to the file that contains category strings for the source events.
-This file is also known as the Category Message File.
 
-The file must be present on the computer on which the event log is being created.
-This parameter does not create or move files.
+Specifies the path to the file that contains category strings for the source events. This file is
+also known as the Category Message File.
+
+The file must be present on the computer on which the event log is being created. This parameter
+does not create or move files.
 
 ```yaml
 Type: String
@@ -68,14 +75,14 @@ Accept wildcard characters: False
 ```
 
 ### -ComputerName
-Creates the new event logs on the specified computers.
-The default is the local computer.
 
-Type the NetBIOS name, an Internet Protocol (IP) address, or a fully qualified domain name of a remote computer.
+Creates the new event logs on the specified computers. The default is the local computer.
+
+The NetBIOS name, IP address, or fully qualified domain name of a remote computer.
 To specify the local computer, type the computer name, a dot (.), or "localhost".
 
-This parameter does not rely on Windows PowerShell remoting.
-You can use the ComputerName parameter of Get-EventLog even if your computer is not configured to run remote commands.
+This parameter does not rely on PowerShell remoting. You can use the **ComputerName**
+parameter of `Get-EventLog` even if your computer is not configured to run remote commands.
 
 ```yaml
 Type: String[]
@@ -90,10 +97,12 @@ Accept wildcard characters: False
 ```
 
 ### -LogName
+
 Specifies the name of the event log.
 
-If the log does not exist, New-EventLog creates the log and uses this value for the Log and LogDisplayName properties of the new event log.
-If the log exists, New-EventLog registers a new source for the event log.
+If the log does not exist, `New-EventLog` creates the log and uses this value for the **Log** and
+**LogDisplayName** properties of the new event log. If the log exists, `New-EventLog` registers a new
+source for the event log.
 
 ```yaml
 Type: String
@@ -108,6 +117,7 @@ Accept wildcard characters: False
 ```
 
 ### -MessageResourceFile
+
 Specifies the path to the file that contains message formatting strings for the source events.
 This file is also known as the Event Message File.
 
@@ -127,8 +137,9 @@ Accept wildcard characters: False
 ```
 
 ### -ParameterResourceFile
-Specifies the path to the file that contains strings used for parameter substitutions in event descriptions.
-This file is also known as the Parameter Message File.
+
+Specifies the path to the file that contains strings used for parameter substitutions in event
+descriptions. This file is also known as the Parameter Message File.
 
 The file must be present on the computer on which the event log is being created.
 This parameter does not create or move files.
@@ -146,8 +157,9 @@ Accept wildcard characters: False
 ```
 
 ### -Source
-Specifies the names of the event log sources, such as application programs that write to the event log.
-This parameter is required.
+
+Specifies the names of the event log sources, such as application programs that write to the event
+log. This parameter is required.
 
 ```yaml
 Type: String[]
@@ -162,11 +174,16 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None
+
 You cannot pipe input to this cmdlet.
 
 ## OUTPUTS
@@ -174,23 +191,31 @@ You cannot pipe input to this cmdlet.
 ### System.Diagnostics.EventLogEntry
 
 ## NOTES
-* To use New-EventLog on Windows Vista and later versions of Windows, open Windows PowerShell with the "Run as administrator" option.
 
-  To create an event source in Windows Vista, Windows XP Professional, or Windows Server 2003, you must be a member of the Administrators group on the computer.
+To use `New-EventLog` on Windows Vista and later versions of Windows, open PowerShell with
+the "Run as administrator" option.
 
-  When you create a new event log and a new event source, the system registers the new source for the new log, but the log is not created until the first entry is written to it.
+To create an event source in Windows Vista, Windows XP Professional, or Windows Server 2003, you
+must be a member of the Administrators group on the computer.
 
-  The operating system stores event logs as files.
-When you create a new event log, the associated file is stored in the %SystemRoot%\System32\Config directory on the specified computer.
-The file name is the first eight characters of the Log property with an .evt file name extension.
+When you create a new event log and a new event source, the system registers the new source for the
+new log, but the log is not created until the first entry is written to it.
 
-*
+The operating system stores event logs as files.
+
+When you create a new event log, the associated file is stored in the
+`$env:SystemRoot\System32\Config` directory on the specified computer.
+
+The file name is the first eight characters of the **Log** property with an .evt file name
+extension.
 
 ## RELATED LINKS
 
 [Clear-EventLog](Clear-EventLog.md)
 
 [Get-EventLog](Get-EventLog.md)
+
+[Get-WinEvent](../Microsoft.PowerShell.Diagnostics/Get-WinEvent.md)
 
 [Limit-EventLog](Limit-EventLog.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/4.0/Microsoft.PowerShell.Management/Push-Location.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  01/22/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -16,75 +16,88 @@ Adds the current location to the top of a location stack.
 ## SYNTAX
 
 ### Path (Default)
+
 ```
 Push-Location [[-Path] <String>] [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### LiteralPath
+
 ```
 Push-Location [-LiteralPath <String>] [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Push-Location cmdlet adds ("pushes") the current location onto a location stack.
-If you specify a path, Push-Location pushes the current location onto a location stack and then changes the current location to the location specified by the path.
-You can use the Pop-Location cmdlet to get locations from the location stack.
 
-By default, the Push-Location cmdlet pushes the current location onto the current location stack, but you can use the StackName parameter to specify an alternate location stack.
-If the stack does not exist, Push-Location creates it.
+The `Push-Location` cmdlet adds ("pushes") the current location onto a location stack. If you
+specify a path, `Push-Location` pushes the current location onto a location stack and then changes
+the current location to the location specified by the path. You can use the `Pop-Location` cmdlet
+to get locations from the location stack.
+
+By default, the `Push-Location` cmdlet pushes the current location onto the current location stack,
+but you can use the StackName parameter to specify an alternate location stack. If the stack does
+not exist, `Push-Location` creates it.
 
 For more information about location stacks, see the Notes.
 
 ## EXAMPLES
 
 ### Example 1
-```
-PS C:\> push-location C:\Windows
-```
 
-This command pushes the current location onto the default location stack and then changes the location to C:\Windows.
+This example pushes the current location onto the default location stack and then changes the location to `C:\Windows`.
+
+```
+PS C:\> Push-Location C:\Windows
+```
 
 ### Example 2
+
+This example pushes the current location onto the RegFunction stack and changes the current location to the `HKLM:\Software\Policies` location.
+
 ```
-PS C:\> push-location HKLM:\Software\Policies -stackname RegFunction
+PS C:\> Push-Location HKLM:\Software\Policies -StackName RegFunction
 ```
 
-This command pushes the current location onto the RegFunction stack and changes the current location to the HKLM:\Software\Policies location.
-You can use the Location cmdlets in any Windows PowerShell drive (PSDrive).
+You can use the Location cmdlets in any PowerShell drive (PSDrive).
 
 ### Example 3
-```
-PS C:\> push-location
-```
 
 This command pushes the current location onto the default stack.
 It does not change the location.
 
-### Example 4
 ```
-PS C:\> push-location ~ -stackname Stack2
-PS C:\Users\User01> pop-location -stackname Stack2
-PS C:\>
+PS C:\> Push-Location
 ```
+
+### Example 4 - Create and use a named stack
 
 These commands show how to create and use a named location stack.
 
-The first command pushes the current location onto a new stack named Stack2, and then changes the current location to the home directory (%USERPROFILE%), which is represented in the command by the tilde symbol (~) or $home.
-If Stack2 does not already exist in the session, Push-Location creates it.
+```
+PS C:\> Push-Location ~ -StackName Stack2
+PS C:\Users\User01> Pop-Location -StackName Stack2
+PS C:\>
+```
 
-The second command uses the Pop-Location cmdlet to pop the original location (PS C:\\\>) from the Stack2 stack.
-Without the StackName parameter, Pop-Location would pop the location from the unnamed default stack.
+The first command pushes the current location onto a new stack named Stack2, and then changes the
+current location to the home directory, which is represented in the command by the tilde symbol (~)
+(same as `$env:USERPROFILE` or `$HOME`).
 
-For more information about location stacks, see the Notes.
+If Stack2 does not already exist in the session, `Push-Location` creates it. The second command
+uses the `Pop-Location` cmdlet to pop the original location (PS C:\\\>) from the Stack2 stack.
+Without the StackName parameter, `Pop-Location` would pop the location from the unnamed default
+stack.
+
+For more information about location stacks, see the [Notes](#notes).
 
 ## PARAMETERS
 
 ### -LiteralPath
-Specifies the path to the new location.
-Unlike the Path parameter, the value of the LiteralPath parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+
+Specifies the path to the new location. Unlike the **Path** parameter, the value of the
+**LiteralPath** parameter is used exactly as it is typed. No characters are interpreted as
+wildcards. If the path includes escape characters, enclose it in single quotation marks. Single
+quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -99,8 +112,9 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Passes an object representing the location to the pipeline.
-By default, this cmdlet does not generate any output.
+
+Passes an object representing the location to the pipeline. By default, this cmdlet does not
+generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -115,10 +129,10 @@ Accept wildcard characters: False
 ```
 
 ### -Path
-Changes your location to the location specified by this path after it adds (pushes) the current location onto the top of the stack.
-Enter a path to any location whose provider supports this cmdlet.
-Wildcards are permitted.
-The parameter name ("Path") is optional.
+
+Changes your location to the location specified by this path after it adds (pushes) the current
+location onto the top of the stack. Enter a path to any location whose provider supports this
+cmdlet. Wildcards are permitted. The parameter name is optional.
 
 ```yaml
 Type: String
@@ -133,16 +147,18 @@ Accept wildcard characters: True
 ```
 
 ### -StackName
-Specifies the location stack to which the current location is added.
-Enter a location stack name.
-If the stack does not exist, Push-Location creates it.
 
-Without this parameter, Push-Location adds the location to the current location stack.
-By default, the current location stack is the unnamed default location stack that Windows PowerShell creates.
-To make a location stack the current location stack, use the StackName parameter of the Set-Location cmdlet.
-For more information about location stacks, see the Notes.
+Specifies the location stack to which the current location is added. Enter a location stack name.
+If the stack does not exist, `Push-Location` creates it.
 
-NOTE: Push-Location cannot add a location to the unnamed default stack unless it is the current location stack.
+Without this parameter, `Push-Location` adds the location to the current location stack. By
+default, the current location stack is the unnamed default location stack that PowerShell creates.
+To make a location stack the current location stack, use the StackName parameter of the
+`Set-Location` cmdlet. For more information about location stacks, see the [Notes](#notes).
+
+> [!NOTE]
+> `Push-Location` cannot add a location to the unnamed default stack unless it is the current
+> location stack.
 
 ```yaml
 Type: String
@@ -157,9 +173,9 @@ Accept wildcard characters: False
 ```
 
 ### -UseTransaction
-Includes the command in the active transaction.
-This parameter is valid only when a transaction is in progress.
-For more information, see about_transactions.
+
+Includes the command in the active transaction. This parameter is valid only when a transaction is
+in progress. For more information, see [about_Transactions](../Microsoft.PowerShell.Core/About/about_transactions.md).
 
 ```yaml
 Type: SwitchParameter
@@ -174,52 +190,65 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains a path (but not a literal path) to Push-Location.
+
+You can pipe a string that contains a path (but not a literal path) to `Push-Location`.
 
 ## OUTPUTS
 
 ### None or System.Management.Automation.PathInfo
-When you use the PassThru parameter, Push-Location generates a System.Management.Automation.PathInfo object that represents the location.
-Otherwise, this cmdlet does not generate any output.
+
+When you use the PassThru parameter, `Push-Location` generates a
+**System.Management.Automation.PathInfo** object that represents the location. Otherwise, this
+cmdlet does not generate any output.
 
 ## NOTES
-* A "stack" is a last-in, first-out list in which only the most recently added item is accessible. You add items to a stack in the order that you use them, and then retrieve them for use in the reverse order.  Windows PowerShell lets you store provider locations in location stacks.
 
-  Windows PowerShell creates an unnamed default location stack and you can create multiple named location stacks.
-If you do not specify a stack name, Windows PowerShell uses the current location stack.
-By default, the unnamed default location is the current location stack, but you can use the Set-Location cmdlet to change the current location stack.
+A "stack" is a last-in, first-out list in which only the most recently added item is accessible.
+You add items to a stack in the order that you use them, and then retrieve them for use in the
+reverse order. PowerShell lets you store provider locations in location stacks.
 
-  To manage location stacks, use the Windows PowerShell Location cmdlets, as follows.
+PowerShell creates an unnamed default location stack and you can create multiple named location
+stacks. If you do not specify a stack name, Windows PowerShell uses the current location stack. By
+default, the unnamed default location is the current location stack, but you can use the
+`Set-Location` cmdlet to change the current location stack.
 
-  - To add a location to a location stack, use the Push-Location cmdlet.
+To manage location stacks, use the PowerShell Location cmdlets, as follows.
 
-  - To get a location from a location stack, use the Pop-Location cmdlet.
+- To add a location to a location stack, use the `Push-Location` cmdlet.
+- To get a location from a location stack, use the `Pop-Location` cmdlet.
+- To display the locations in the current location stack, use the **Stack** parameter of the
+  `Get-Location` cmdlet.
 
-  - To display the locations in the current location stack, use the Stack parameter of the Get-Location cmdlet.
-To display the locations in a named location stack, use the StackName parameter of the Get-Location cmdlet.
+To display the locations in a named location stack, use the **StackName** parameter of the
+`Get-Location` cmdlet.
 
-  - To create a new location stack, use the StackName parameter of the Push-Location cmdlet.
-If you specify a stack that does not exist, Push-Location creates the stack.
+- To create a new location stack, use the StackName parameter of the `Push-Location` cmdlet. If you
+  specify a stack that does not exist, `Push-Location` creates the stack.
+- To make a location stack the current location stack, use the StackName parameter of the
+  `Set-Location` cmdlet.
 
-  - To make a location stack the current location stack, use the StackName parameter of the Set-Location cmdlet.
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you can no longer use
+`Push-Location` or `Pop-Location` cmdlets add or get items from the default stack or use
+`Get-Location` command to display the locations in the unnamed stack. To make the unnamed stack the
+current stack, use the StackName parameter of the `Set-Location` cmdlet with a value of $null or an
+empty string ("").
 
-  The unnamed default location stack is fully accessible only when it is the current location stack.
-If you make a named location stack the current location stack, you cannot no longer use Push-Location or Pop-Location cmdlets add or get items from the default stack or use Get-Location command to display the locations in the unnamed stack.
-To make the unnamed stack the current stack, use the StackName parameter of the Set-Location cmdlet with a value of $null or an empty string ("").
+You can also refer to `Push-Location` by its built-in alias, `pushd`. For more information, see
+[about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).
 
-  You can also refer to Push-Location by its built-in alias, "pushd".
-For more information, see about_Aliases.
-
-  The Push-Location cmdlet is designed to work with the data exposed by any provider.
-To list the providers available in your session, type "Get-PSProvider".
-For more information, see about_Providers.
-
-*
+The `Push-Location` cmdlet is designed to work with the data exposed by any provider. To list the
+providers available in your session, type `Get-PSProvider`. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS
 

--- a/reference/5.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/5.0/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  01/22/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -16,222 +16,271 @@ Creates a new module manifest.
 ## SYNTAX
 
 ```
-New-ModuleManifest [-Path] <String> [-NestedModules <Object[]>] [-Guid <Guid>] [-Author <String>]
- [-CompanyName <String>] [-Copyright <String>] [-RootModule <String>] [-ModuleVersion <Version>]
- [-Description <String>] [-ProcessorArchitecture <ProcessorArchitecture>] [-PowerShellVersion <Version>]
- [-ClrVersion <Version>] [-DotNetFrameworkVersion <Version>] [-PowerShellHostName <String>]
- [-PowerShellHostVersion <Version>] [-RequiredModules <Object[]>] [-TypesToProcess <String[]>]
- [-FormatsToProcess <String[]>] [-ScriptsToProcess <String[]>] [-RequiredAssemblies <String[]>]
- [-FileList <String[]>] [-ModuleList <Object[]>] [-FunctionsToExport <String[]>] [-AliasesToExport <String[]>]
- [-VariablesToExport <String[]>] [-CmdletsToExport <String[]>] [-DscResourcesToExport <String[]>]
- [-PrivateData <Object>] [-Tags <String[]>] [-ProjectUri <Uri>] [-LicenseUri <Uri>] [-IconUri <Uri>]
- [-ReleaseNotes <String>] [-HelpInfoUri <String>] [-PassThru] [-DefaultCommandPrefix <String>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+New-ModuleManifest [-Path] <string> [-NestedModules <Object[]>] [-Guid <guid>] [-Author <string>]
+  [-CompanyName <string>] [-Copyright <string>] [-RootModule <string>] [-ModuleVersion <version>]
+  [-Description <string>] [-ProcessorArchitecture <ProcessorArchitecture>] [-PowerShellVersion <version>]
+  [-ClrVersion <version>] [-DotNetFrameworkVersion <version>] [-PowerShellHostName <string>]
+  [-PowerShellHostVersion <version>] [-RequiredModules <Object[]>] [-TypesToProcess <string[]>]
+  [-FormatsToProcess <string[]>] [-ScriptsToProcess <string[]>] [-RequiredAssemblies <string[]>]
+  [-FileList <string[]>] [-ModuleList <Object[]>] [-FunctionsToExport <string[]>]
+  [-AliasesToExport <string[]>] [-VariablesToExport <string[]>] [-CmdletsToExport <string[]>]
+  [-DscResourcesToExport <string[]>] [-PrivateData <Object>] [-Tags <string[]>] [-ProjectUri <uri>]
+  [-LicenseUri <uri>] [-IconUri <uri>] [-ReleaseNotes <string>] [-HelpInfoUri <string>] [-PassThru]
+  [-DefaultCommandPrefix <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **New-ModuleManifest** cmdlet creates a new module manifest (.psd1) file, populates its values, and saves the manifest file in the specified path.
 
-Module authors can use this cmdlet to create a manifest for their module.
-A module manifest is a .psd1 file that contains a hash table.
-The keys and values in the hash table describe the contents and attributes of the module, define the prerequisites, and determine how the components are processed.
-Manifests are not required for a module.
+The `New-ModuleManifest` cmdlet creates a new module manifest (.psd1) file, populates its values,
+and saves the manifest file in the specified path.
 
-**New-ModuleManifest** creates a manifest that includes all of the frequently used manifest keys, so that you can use the default output as a manifest template.
-To add or change values, or to add module keys that this cmdlet does not add, open the resulting file in a text editor.
+Module authors can use this cmdlet to create a manifest for their module. A module manifest is a
+.psd1 file that contains a hash table. The keys and values in the hash table describe the contents
+and attributes of the module, define the prerequisites, and determine how the components are
+processed. Manifests are not required for a module.
 
-Each parameter of this cmdlet, except for *Path* and *PassThru*, creates a module manifest key and its value.
-In a module manifest, only the **ModuleVersion** key is required.
-Unless specified in the parameter description, if you omit a parameter from the command, **New-ModuleManifest** creates a comment string for the associated value that has no effect.
+`New-ModuleManifest` creates a manifest that includes all of the commonly used manifest keys, so
+you can use the default output as a manifest template. To add or change values, or to add module
+keys that this cmdlet does not add, open the resulting file in a text editor.
 
-In Windows PowerShell 2.0, **New-ModuleManifest** prompts you for the values of frequently used parameters that are not specified in the command, in addition to required parameter values.
-Starting in Windows PowerShell 3.0, it prompts only when required parameter values are not specified.
+Each parameter of this cmdlet (except for **Path** and **PassThru**) creates a module manifest key
+and its value. In a module manifest, only the **ModuleVersion** key is required. Unless specified
+in the parameter description, if you omit a parameter from the command, `New-ModuleManifest`
+creates a comment string for the associated value that has no effect.
+
+In Windows PowerShell 2.0, `New-ModuleManifest` prompts you for the values of commonly used
+parameters that are not specified in the command, in addition to required parameter values.
+Beginning in Windows PowerShell 3.0, it prompts only when required parameter values are not
+specified.
 
 ## EXAMPLES
 
-### Example 1: Create a manifest
-```
-PS C:\> New-ModuleManifest -Path C:\Users\User01\Documents\WindowsPowerShell\Modules\Test-Module\Test-Module.psd1 -PassThru
+### Example 1 - Create a new module manifest
 
-## Module manifest for module 'TestModule'
-## Generated by: User01
-## Generated on: 1/24/2012
-#@{
-# Script module or binary module file associated with this manifest
-# RootModule = ''
-# Version number of this module.ModuleVersion = '1.0'
-# ID used to uniquely identify this moduleGUID = 'd0a9150d-b6a4-4b17-a325-e3a24fed0aa9'
-# Author of this moduleAuthor = 'User01'
-# Company or vendor of this moduleCompanyName = 'Unknown'
-# Copyright statement for this moduleCopyright = '(c) 2012 User01. All rights reserved.'
-# Description of the functionality provided by this module
-# Description = ''
-# Minimum version of the Windows PowerShell engine required by this module
-# PowerShellVersion = ''
-# Name of the Windows PowerShell host required by this module
-# PowerShellHostName = ''
-# Minimum version of the Windows PowerShell host required by this module
-# PowerShellHostVersion = ''
-# Minimum version of the .NET Framework required by this module
-# DotNetFrameworkVersion = ''
-# Minimum version of the common language runtime (CLR) required by this module
-# CLRVersion = ''
-# Processor architecture (None, X86, Amd64) required by this module
-# ProcessorArchitecture = ''
-# Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
-# Assemblies that must be loaded prior to importing this module
-# RequiredAssemblies = @()
-# Script files (.ps1) that are run in the caller's environment prior to importing this module
-# ScriptsToProcess = @()
-# Type files (.ps1xml) to be loaded when importing this module
-# TypesToProcess = @()
-# Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
-# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-# NestedModules = @()
-# Functions to export from this moduleFunctionsToExport = '*'
-# Cmdlets to export from this moduleCmdletsToExport = '*'
-# Variables to export from this moduleVariablesToExport = '*'
-# Aliases to export from this moduleAliasesToExport = '*'
-# List of all modules packaged with this module# ModuleList = @()
-# List of all files packaged with this module
-# FileList = @()
-# Private data to pass to the module specified in RootModule/ModuleToProcess
-# PrivateData = ''
-# HelpInfo URI of this module
-# HelpInfoURI = ''
-# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
-# DefaultCommandPrefix = ''}
-```
-
-This command creates a module manifest in the file that is specified by the *Path* parameter.
-The *PassThru* parameter sends the output to the pipeline in addition to the file.
+This command creates a new module manifest in the file that is specified by the Path parameter. The
+**PassThru** parameter sends the output to the pipeline as well as to the file.
 
 The output shows the default values of all keys in the manifest.
 
-### Example 2: Create a manifest and add values to keys
-```
-PS C:\> New-ModuleManifest -PowerShellVersion 1.0 -AliasesToExport JKBC, DRC, TAC -Path C:\ps-test\ManifestTest.psd1
-```
-
-This command creates a new module manifest.
-It uses the *PowerShellVersion* and *AliasesToExport* parameters to add values to the corresponding manifest keys.
-
-### Example 3: Create a manifest by using strings and hash tables
-```
-PS C:\> New-ModuleManifest -RequiredModules BitsTransfer,@{ModuleName="PSScheduledJob";ModuleVersion="1.0.0.0";GUID="50cdb55f-5ab7-489f-9e94-4ec21ff51e59"}
+```powershell
+New-ModuleManifest -Path C:\ps-test\Test-Module\Test-Module.psd1 -PassThru
 ```
 
-This example shows how to use the string and hash table formats of the *ModuleList*, *RequiredModules*, and *NestedModules* parameter.
-You can combine strings and hash tables in the same parameter value.
+```Output
+#
+# Module manifest for module 'Test-Module'
+#
+# Generated by: ContosoAdmin
+#
+# Generated on: 1/22/2019
+#
 
-This command commands creates a module manifest for a module that requires the **BitsTransfer** and **PSScheduledJob** modules.
+@{
 
-The command uses a string format to specify the name of the **BitsTransfer** module and the hash table format to specify the name, a GUID, and a version of the **PSScheduledJob** module.
+# Script module or binary module file associated with this manifest.
+# RootModule = ''
 
-### Example 4: Create a manifest for a module that support updatable help
+# Version number of this module.
+ModuleVersion = '1.0'
+
+# ID used to uniquely identify this module
+GUID = '47179120-0bcb-4f14-8d80-f4560107f85c'
+
+# Author of this module
+Author = 'ContosoAdmin'
+
+# Company or vendor of this module
+CompanyName = 'Unknown'
+
+# Copyright statement for this module
+Copyright = '(c) 2019 ContosoAdmin. All rights reserved.'
+
+# Description of the functionality provided by this module
+# Description = ''
+
+# Minimum version of the Windows PowerShell engine required by this module
+# PowerShellVersion = ''
+
+# Name of the Windows PowerShell host required by this module
+# PowerShellHostName = ''
+
+# Minimum version of the Windows PowerShell host required by this module
+# PowerShellHostVersion = ''
+
+# Minimum version of the .NET Framework required by this module
+# DotNetFrameworkVersion = ''
+
+# Minimum version of the common language runtime (CLR) required by this module
+# CLRVersion = ''
+
+# Processor architecture (None, X86, Amd64) required by this module
+# ProcessorArchitecture = ''
+
+# Modules that must be imported into the global environment prior to importing this module
+# RequiredModules = @()
+
+# Assemblies that must be loaded prior to importing this module
+# RequiredAssemblies = @()
+
+# Script files (.ps1) that are run in the caller's environment prior to importing this module.
+# ScriptsToProcess = @()
+
+# Type files (.ps1xml) to be loaded when importing this module
+# TypesToProcess = @()
+
+# Format files (.ps1xml) to be loaded when importing this module
+# FormatsToProcess = @()
+
+# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+# NestedModules = @()
+
+# Functions to export from this module
+FunctionsToExport = '*'
+
+# Cmdlets to export from this module
+CmdletsToExport = '*'
+
+# Variables to export from this module
+VariablesToExport = '*'
+
+# Aliases to export from this module
+AliasesToExport = '*'
+
+# List of all modules packaged with this module.
+# ModuleList = @()
+
+# List of all files packaged with this module
+# FileList = @()
+
+# Private data to pass to the module specified in RootModule/ModuleToProcess
+# PrivateData = ''
+
+# HelpInfo URI of this module
+# HelpInfoURI = ''
+
+# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+# DefaultCommandPrefix = ''
+
+}
 ```
-PS C:\> New-ModuleManifest -HelpInfoUri "http://http://go.microsoft.com/fwlink/?LinkID=603"
+
+### Example 2 - Create a new manifest with some prepopulated settings
+
+This command creates a new module manifest. It uses the **PowerShellVersion** and
+**AliasesToExport** parameters to add values to the corresponding manifest keys.
+
+```powershell
+New-ModuleManifest -PowerShellVersion 1.0 -AliasesToExport JKBC, DRC, TAC -Path C:\ps-test\ManifestTest.psd1
 ```
 
-This example shows creates a module manifest for a module that supports the Updatable Help feature.
-This feature lets users use the Update-Help and Save-Help cmdlets, which download help files for the module from the Internet and install them in the module.
+### Example 3 - Create a manifest that requires other modules
 
-The command uses the *HelpInfoUri* parameter to create a **HelpInfoUri** key in the module manifest.
-The value of the parameter and the key must begin with http or https.
-This value tells the Updatable Help system where to find the HelpInfo XML updatable help information file for the module.
+The example uses a string format to specify the name of the **BitsTransfer** module and the hash
+table format to specify the name, a GUID, and a version of the **PSScheduledJob** module.
 
-For information about Updatable Help, see about_Updatable_Help (http://go.microsoft.com/fwlink/?LinkID=235801).
-For information about the HelpInfo XML file, see "Supporting Updatable Help" in the Microsoft Developer Library (MSDN) library.
-
-### Example 5: Get the module manifest values of a module
+```powershell
+$moduleSettings = @{
+  RequiredModules = (BitsTransfer, @{
+    ModuleName="PSScheduledJob"
+    ModuleVersion="1.0.0.0";
+    GUID="50cdb55f-5ab7-489f-9e94-4ec21ff51e59"
+  }
+  Path = 'C:\ps-test\ManifestTest.psd1'
+}
+New-ModuleManifest @moduleSettings
 ```
-PS C:\> Get-Module PSScheduledJob -List | Format-List -Property *
 
-LogPipelineExecutionDetails :
-FalseName                        :
-PSScheduledJobPath                        : C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.psd1
+This example shows how to use the string and hash table formats of the **ModuleList**,
+**RequiredModules**, and **NestedModules** parameter. You can combine strings and hash tables in
+the same parameter value.
+
+### Example 4 - Create a manifest that supports updateable help
+
+This example uses the **HelpInfoUri** parameter to create a **HelpInfoUri** key in the module
+manifest. The value of the parameter and the key must begin with "http" or "https". This value
+tells the Updatable Help system where to find the HelpInfo XML updatable help information file for
+the module.
+
+```powershell
+$moduleSettings = @{
+  HelpInfoUri = 'http://http://go.microsoft.com/fwlink/?LinkID=603'
+  Path = 'C:\ps-test\ManifestTest.psd1'
+}
+New-ModuleManifest @moduleSettings
+```
+
+For information about Updatable Help, see [about_Updatable_Help](./About/about_Updatable_Help.md).
+For information about the HelpInfo XML file, see [Supporting Updatable Help](/powershell/developer/module/supporting-updatable-help).
+
+### Example 5 - Getting module information
+
+This example shows how to get the configuration values of a module. The values in the module
+manifest are reflected in the values of properties of the module object.
+
+The `Get-Module` cmdlet is used to get the **Microsoft.PowerShell.Diagnostics** module using the
+**List** parameter. The command sends the module to the `Format-List` cmdlet to display all
+properties and values of the module object.
+
+```powershell
+Get-Module Microsoft.PowerShell.Diagnostics -List | Format-List -Property *
+```
+
+```Output
+LogPipelineExecutionDetails : False
+Name                        : Microsoft.PowerShell.Diagnostics
+Path                        : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Diagnostics\Micro
+                              soft.PowerShell.Diagnostics.psd1
 Definition                  :
 Description                 :
-Guid                        : 50cdb55f-5ab7-489f-9e94-4ec21ff51e59
-HelpInfoUri                 : http://go.microsoft.com/fwlink/?LinkID=223911
-ModuleBase                  : C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob
+Guid                        : ca046f10-ca64-4740-8ff9-2565dba61a4f
+HelpInfoUri                 : http://go.microsoft.com/fwlink/?LinkID=210596
+ModuleBase                  : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Diagnostics
 PrivateData                 :
-Version                     : 1.0.0.0
-ModuleType                  :
-BinaryAuthor                      : Microsoft Corporation
+Version                     : 3.0.0.0
+ModuleType                  : Manifest
+Author                      : Microsoft Corporation
 AccessMode                  : ReadWrite
 ClrVersion                  : 4.0
 CompanyName                 : Microsoft Corporation
-Copyright                   : c Microsoft Corporation. All rights reserved.
+Copyright                   : © Microsoft Corporation. All rights reserved.
 DotNetFrameworkVersion      :
 ExportedFunctions           : {}
-ExportedCmdlets             : {[New-JobTrigger, New-JobTrigger], [Add-JobTrigger, Add-JobTrigger], [Remove-JobTrigger, Remove-JobTrigger], [Get-JobTrigger, Get-JobTrigger]...}
-ExportedCommands            : {[New-JobTrigger, New-JobTrigger], [Add-JobTrigger, Add-JobTrigger], [Remove-JobTrigger, Remove-JobTrigger], [Get-JobTrigger, Get-JobTrigger]...}
+ExportedCmdlets             : {[Get-WinEvent, Get-WinEvent], [Get-Counter, Get-Counter], [Import-Counter,
+                              Import-Counter], [Export-Counter, Export-Counter]...}
+ExportedCommands            : {[Get-WinEvent, Get-WinEvent], [Get-Counter, Get-Counter], [Import-Counter,
+                              Import-Counter], [Export-Counter, Export-Counter]...}
 FileList                    : {}
 ModuleList                  : {}
 NestedModules               : {}
 PowerShellHostName          :
 PowerShellHostVersion       :
-PowerShellVersion           : 4.0
+PowerShellVersion           : 3.0
 ProcessorArchitecture       : None
 Scripts                     : {}
 RequiredAssemblies          : {}
 RequiredModules             : {}
-RootModule                  : Microsoft.PowerShell.ScheduledJob.dll
+RootModule                  :
 ExportedVariables           : {}
 ExportedAliases             : {}
 ExportedWorkflows           : {}
 SessionState                :
 OnRemove                    :
-ExportedFormatFiles         : {C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.Format.ps1xml}
-ExportedTypeFiles           : {C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.types.ps1xml}
-
-PS C:\> Get-Module -List | Format-Table -Property Name, PowerShellVersion
-
-Name                                                        PowerShellVersion
-----                                                        -----------------
-ADDeploymentWF                                              4.0
-AppLocker                                                   4.0
-Appx                                                        4.0
-BestPractices                                               4.0
-BitsTransfer                                                4.0
-BranchCache                                                 4.0
-CimCmdlets                                                  4.0
-DirectAccessClientComponents                                4.0
-Dism                                                        4.0
-DnsClient                                                   4.0
-International                                               4.0
-iSCSI                                                       4.0
-IscsiTarget                                                 4.0
-Kds                                                         4.0
-Microsoft.PowerShell.Diagnostics                            4.0
-Microsoft.PowerShell.Host                                   4.0
-Microsoft.PowerShell.Management                             4.0â€¦
+ExportedFormatFiles         : {C:\Windows\system32\WindowsPowerShell\v1.0\Event.format.ps1xml,
+                              C:\Windows\system32\WindowsPowerShell\v1.0\Diagnostics.format.ps1xml}
+ExportedTypeFiles           : {C:\Windows\system32\WindowsPowerShell\v1.0\GetEvent.types.ps1xml}
 ```
-
-This example shows how to get the module manifest values of a module.
-This is essentially a "Get-ModuleManifest" command.
-Because the values in the module manifest are reflected in the values of properties of the module object, you can get the module manifest values by displaying the module object properties.
-
-The first command uses the **Get-Module** cmdlet to get the *PSScheduledJob* module.
-The command uses the *List* parameter, because the module is installed, but not imported into the session.
-The command sends the module to the Format-List cmdlet, which displays all properties and values of the module object in a list.
-
-The second command uses the Format-Table cmdlet to display the **PowerShellVersion** property of all installed modules in a table.
-The **PowerShellVersion** property is defined in the module manifest.
 
 ## PARAMETERS
 
 ### -AliasesToExport
-Specifies the aliases that the module exports.
-Wildcard characters are permitted.
 
-You can use this parameter to restrict the aliases that are exported by the module.
-It can remove aliases from the list of exported aliases, but it cannot add aliases to the list.
+Specifies the aliases that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates an **AliasesToExport** key with a value of * (all), meaning that all aliases that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the aliases that are exported by the module. It can remove
+aliases from the list of exported aliases, but it cannot add aliases to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates an **AliasesToExport** key with a value
+of `*` (all), meaning that all aliases defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -240,15 +289,17 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: * (all)
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Author
+
 Specifies the module author.
 
-If you omit this parameter, **New-ModuleManifest** creates an **Author** key with the name of the current user.
+If you omit this parameter, `New-ModuleManifest` creates an **Author** key with the name of the
+current user.
 
 ```yaml
 Type: String
@@ -257,13 +308,15 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: Name of the current user
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -ClrVersion
-Specifies the minimum version of the Common Language Runtime (CLR) of the Microsoft .NET Framework that the module requires.
+
+Specifies the minimum version of the Common Language Runtime (CLR) of the Microsoft .NET Framework
+that the module requires.
 
 ```yaml
 Type: Version
@@ -278,13 +331,14 @@ Accept wildcard characters: False
 ```
 
 ### -CmdletsToExport
-Specifies the cmdlets that the module exports.
-Wildcard characters are permitted.
 
-You can use this parameter to restrict the cmdlets that are exported by the module.
-It can remove cmdlets from the list of exported cmdlets, but it cannot add cmdlets to the list.
+Specifies the cmdlets that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates a **CmdletsToExport** key with a value of * (all), meaning that all cmdlets that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the cmdlets that are exported by the module. It can remove
+cmdlets from the list of exported cmdlets, but it cannot add cmdlets to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates a **CmdletsToExport** key with a value
+of `*` (all), meaning that all cmdlets defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -293,15 +347,17 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: * (all)
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -CompanyName
+
 Identifies the company or vendor who created the module.
 
-If you omit this parameter, **New-ModuleManifest** creates a **CompanyName** key with a value of "Unknown".
+If you omit this parameter, `New-ModuleManifest` creates a **CompanyName** key with a value of
+"Unknown".
 
 ```yaml
 Type: String
@@ -310,12 +366,13 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: "Unknown"
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -331,10 +388,12 @@ Accept wildcard characters: False
 ```
 
 ### -Copyright
+
 Specifies a copyright statement for the module.
 
-If you omit this parameter, **New-ModuleManifest** creates a **Copyright** key with a value of  "(c) \<year\> \<username\>.
-All rights reserved." where \<year\> is the current year and \<username\> is the value of the **Author** key (if one is specified) or the name of the current user.
+If you omit this parameter, `New-ModuleManifest` creates a **Copyright** key with a value of
+`(c) <year> <username>. All rights reserved.` where `<year>` is the current year and `<username>`
+is the value of the **Author** key.
 
 ```yaml
 Type: String
@@ -343,32 +402,13 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DefaultCommandPrefix
-Specifies a prefix that is prepended to the nouns of all commands in the module when they are imported into a session.
-Prefixes prevent command name conflicts in a user's session.
-
-Module users can override this prefix by specifying the *Prefix* parameter of the Import-Module cmdlet.
-
-This parameter was introduced in Windows PowerShell 3.0.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
+Default value: (c) <year> <username>. All rights reserved.
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Description
+
 Describes the contents of the module.
 
 ```yaml
@@ -384,6 +424,7 @@ Accept wildcard characters: False
 ```
 
 ### -DotNetFrameworkVersion
+
 Specifies the minimum version of the Microsoft .NET Framework that the module requires.
 
 ```yaml
@@ -399,6 +440,7 @@ Accept wildcard characters: False
 ```
 
 ### -DscResourcesToExport
+
 Specifies the DSC resources that the module exports.
 Wildcards are permitted.
 
@@ -415,9 +457,11 @@ Accept wildcard characters: True
 ```
 
 ### -FileList
+
 Specifies all items that are included in the module.
 
-This key is designed to act as a module inventory. The files listed in the key are included when the module is published, but any functions are not automatically exported.
+This key is designed to act as a module inventory. The files listed in the key are included when
+the module is published, but any functions are not automatically exported.
 
 ```yaml
 Type: String[]
@@ -432,10 +476,11 @@ Accept wildcard characters: False
 ```
 
 ### -FormatsToProcess
+
 Specifies the formatting files (.ps1xml) that run when the module is imported.
 
-When you import a module, Windows PowerShell runs the Update-FormatData cmdlet with the specified files.
-Because formatting files are not scoped, they affect all session states in the session.
+When you import a module, Windows PowerShell runs the `Update-FormatData` cmdlet with the specified
+files. Because formatting files are not scoped, they affect all session states in the session.
 
 ```yaml
 Type: String[]
@@ -450,13 +495,14 @@ Accept wildcard characters: False
 ```
 
 ### -FunctionsToExport
-Specifies the functions that the module exports.
-Wildcard characters are permitted.
 
-You can use this parameter to restrict the functions that are exported by the module.
-It can remove functions from the list of exported aliases, but it cannot add functions to the list.
+Specifies the functions that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates an **FunctionsToExport** key with a value of * (all), meaning that all functions that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the functions that are exported by the module. It can remove
+functions from the list of exported aliases, but it cannot add functions to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates an **FunctionsToExport** key with a
+value of `*` (all), meaning that all functions defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -465,16 +511,18 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: * (all)
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Guid
-Specifies a unique identifier for the module.
-The GUID can be used to distinguish among modules with the same name.
 
-If you omit this parameter, **New-ModuleManifest** creates a **GUID** key in the manifest and generates a GUID for the value.
+Specifies a unique identifier for the module. The GUID can be used to distinguish among modules
+with the same name.
+
+If you omit this parameter, `New-ModuleManifest` creates a **GUID** key in the manifest and
+generates a GUID for the value.
 
 To create a new GUID in Windows PowerShell, type "\[guid\]::NewGuid()".
 
@@ -485,19 +533,22 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: A GUID generated for the module
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -HelpInfoUri
-Specifies the Internet address of the HelpInfo XML file for the module.
-Enter an Uniform Resource Identifier (URI) that starts with "http" or "https".
 
-The HelpInfo XML file supports the Updatable Help feature that was introduced in Windows PowerShell 3.0.
-It contains information about the location of downloadable help files for the module and the version numbers of the newest help files for each supported locale.
-For information about Updatable Help, see about_Updatable_Help (http://go.microsoft.com/fwlink/?LinkID=235801).
-For information about the HelpInfo XML file, see "Supporting Updatable Help" in the Microsoft Developer Network (MSDN) library.
+Specifies the Internet address of the HelpInfo XML file for the module. Enter an Uniform Resource
+Identifier (URI) that begins with "http" or "https".
+
+The HelpInfo XML file supports the Updatable Help feature that was introduced in Windows PowerShell
+3.0. It contains information about the location of downloadable help files for the module and the
+version numbers of the newest help files for each supported locale.
+
+For information about Updatable Help, see [about_Updatable_Help](./About/about_Updatable_Help.md).
+For information about the HelpInfo XML file, see [Supporting Updatable Help](/powershell/developer/module/supporting-updatable-help).
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -514,6 +565,7 @@ Accept wildcard characters: False
 ```
 
 ### -IconUri
+
 Specifies the URL of an icon for the module. The specified icon is displayed on the gallery web page for the module.
 
 ```yaml
@@ -529,6 +581,7 @@ Accept wildcard characters: False
 ```
 
 ### -LicenseUri
+
 Specifies the URL of licensing terms for the module.
 
 ```yaml
@@ -544,15 +597,15 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleList
+
 Lists all modules that are included in this module.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
 
-This key is designed to act as a module inventory.
-The modules that are listed in the value of this key are not automatically processed.
+This key is designed to act as a module inventory. The modules that are listed in the value of this
+key are not automatically processed.
 
 ```yaml
 Type: Object[]
@@ -567,10 +620,12 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleVersion
+
 Specifies the version of the module.
 
-This parameter is not required by the cmdlet, but a **ModuleVersion** key is required in the manifest.
-If you omit this parameter, **New-ModuleManifest** creates a **ModuleVersion** key with a value of "1.0".
+This parameter is not required by the cmdlet, but a **ModuleVersion** key is required in the
+manifest. If you omit this parameter, `New-ModuleManifest` creates a **ModuleVersion** key with a
+value of "1.0".
 
 ```yaml
 Type: Version
@@ -579,27 +634,32 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 1.0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -NestedModules
-Specifies script modules (.psm1) and binary modules (.dll) that are imported into the module's session state.
-The files in the **NestedModules** key run in the order in which they are listed in the value.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Specifies script modules (.psm1) and binary modules (.dll) that are imported into the module's
+session state. The files in the **NestedModules** key run in the order in which they are listed in
+the value.
+
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
 
 Typically, nested modules contain commands that the root module needs for its internal processing.
-By default, the commands in nested modules are exported from the module's session state into the caller's session state, but the root module can restrict the commands that it exports, for example, by using an Export-ModuleMember command.
+By default, the commands in nested modules are exported from the module's session state into the
+caller's session state, but the root module can restrict the commands that it exports (for example,
+by using an Export-ModuleMember command).
 
-Nested modules in the module session state are available to the root module, but they are not returned by a Get-Module command in the caller's session state.
+Nested modules in the module session state are available to the root module, but they are not
+returned by a `Get-Module` command in the caller's session state.
 
-Scripts (.ps1) that are listed in the **NestedModules** key are run in the module's session state, not in the caller's session state.
-To run a script in the caller's session state, list the script file name in the value of the **ScriptsToProcess** key in the manifest.
+Scripts (.ps1) that are listed in the **NestedModules** key are run in the module's session state,
+not in the caller's session state. To run a script in the caller's session state, list the script
+file name in the value of the **ScriptsToProcess** key in the manifest.
 
 ```yaml
 Type: Object[]
@@ -614,8 +674,9 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Indicates that this cmdlet writes the resulting module manifest to the console, in addition to creating a .psd1 file.
-By default, this cmdlet does not generate any output.
+
+Writes the resulting module manifest to the console, in addition to creating a .psd1 file. By
+default, this cmdlet does not generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -624,22 +685,26 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies the path and file name of the new module manifest.
-Enter a path and file name with a .psd1 file name extension, such as `$pshome\Modules\MyModule\MyModule.psd1`.
-This parameter is required.
 
-If you specify the path of an existing file, **New-ModuleManifest** replaces the file without warning unless the file has the read-only attribute.
+Specifies the path and file name of the new module manifest. Enter a path and file name with a
+.psd1 file name extension, such as `$pshome\Modules\MyModule\MyModule.psd1`. This parameter is
+required.
 
-The manifest should be located in the module's directory, and the manifest file name should be the same as the module directory name, but with a .psd1 file name extension.
+If you specify the path to an existing file, `New-ModuleManifest` replaces the file without
+warning unless the file has the read-only attribute.
 
-You cannot use variables, such as $pshome or $home, in response to a prompt for a **Path** parameter value.
-To use a variable, include the **Path** parameter in the command.
+The manifest should be located in the module's directory, and the manifest file name should be the
+same as the module directory name, but with a .psd1 file name extension.
+
+> [!NOTE]
+> You cannot use variables, such as `$PSHOME` or `$HOME`, in response to a prompt for a **Path**
+> parameter value. To use a variable, include the **Path** parameter in the command.
 
 ```yaml
 Type: String
@@ -647,18 +712,18 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -PowerShellHostName
-Specifies the name of the Windows PowerShell host program that the module requires.
-Enter the name of the host program, such as `Windows PowerShell ISE Host` or `ConsoleHost`.
-Wildcard characters are not permitted.
 
-To find the name of a host program, in the program, type `$host.name`.
+Specifies the name of the PowerShell host program that the module requires. Enter the name of the
+host program, such as "Windows PowerShell ISE Host" or "ConsoleHost". Wildcards are not permitted.
+
+To find the name of a host program, in the program, type `$Host.Name`.
 
 ```yaml
 Type: String
@@ -673,8 +738,9 @@ Accept wildcard characters: False
 ```
 
 ### -PowerShellHostVersion
-Specifies the minimum version of the Windows PowerShell host program that works with the module.
-Enter a version number, such as 1.1.
+
+Specifies the minimum version of the PowerShell host program that works with the module. Enter a
+version number, such as 1.1.
 
 ```yaml
 Type: Version
@@ -689,8 +755,9 @@ Accept wildcard characters: False
 ```
 
 ### -PowerShellVersion
-Specifies the minimum version of Windows PowerShell that works with this module.
-For example, you can enter 3.0, 4.0, or 5.0 as the value of this parameter.
+
+Specifies the minimum version of Windows PowerShell that will work with this module. For example,
+you can enter 1.0, 2.0, or 3.0 as the value of this parameter.
 
 ```yaml
 Type: Version
@@ -705,6 +772,7 @@ Accept wildcard characters: False
 ```
 
 ### -PrivateData
+
 Specifies data that is passed to the module when it is imported.
 
 ```yaml
@@ -720,9 +788,9 @@ Accept wildcard characters: False
 ```
 
 ### -ProcessorArchitecture
-Specifies the processor architecture that the module requires.
-The acceptable values for this parameter are: x86, AMD64, IA64, and None.
-None indicates unknown or unspecified.
+
+Specifies the processor architecture that the module requires. Valid values are x86, AMD64, IA64, MSIL,
+and None (unknown or unspecified).
 
 ```yaml
 Type: ProcessorArchitecture
@@ -768,12 +836,15 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredAssemblies
-Specifies the assembly (.dll) files that the module requires.
-Enter the assembly file names.
-Windows PowerShell loads the specified assemblies before updating types or formats, importing nested modules, or importing the module file that is specified in the value of the **RootModule** key.
 
-Use this parameter to list all the assemblies that the module requires.
-This includes assemblies that must be loaded to update any formatting or type files that are listed in the **FormatsToProcess** or **TypesToProcess** keys, even if those assemblies are also listed as binary modules in the **NestedModules** key.
+Specifies the assembly (.dll) files that the module requires. Enter the assembly file names.
+PowerShell loads the specified assemblies before updating types or formats, importing nested
+modules, or importing the module file that is specified in the value of the **RootModule** key.
+
+Use this parameter to list all the assemblies that the module requires, including assemblies that
+must be loaded to update any formatting or type files that are listed in the **FormatsToProcess**
+or **TypesToProcess** keys, even if those assemblies are also listed as binary modules in the
+**NestedModules** key.
 
 ```yaml
 Type: String[]
@@ -788,17 +859,17 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredModules
-Specifies modules that must be in the global session state.
-If the required modules are not in the global session state, Windows PowerShell imports them.
-If the required modules are not available, the Import-Module command fails.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Specifies modules that must be in the global session state. If the required modules are not in the
+global session state, Windows PowerShell imports them. If the required modules are not available,
+the `Import-Module` command fails.
 
-In Windows PowerShell 2.0, **Import-Module** does not import required modules automatically.
-It just verifies that the required modules are in the global session state.
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
+
+In Windows PowerShell 2.0, `Import-Module` does not import required modules automatically. It
+just verifies that the required modules are in the global session state.
 
 ```yaml
 Type: Object[]
@@ -812,34 +883,10 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RootModule
-Specifies the primary or root file of the module.
-Enter the file name of a script (.ps1), a script module (.psm1), a module manifest (.psd1), an assembly (.dll), a cmdlet definition XML file (.cdxml), or a workflow (.xaml).
-When the module is imported, the members that are exported from the root module file are imported into the caller's session state.
-
-If a module has a manifest file and no root file has been designated in the **RootModule** key, the manifest becomes the primary file for the module, and the module becomes a manifest module (ModuleType = Manifest).
-
-To export members from .psm1 or .dll files in a module that has a manifest, the names of those files must be specified in the values of the **RootModule** or **NestedModules** keys in the manifest.
-Otherwise, their members are not exported.
-
-In Windows PowerShell 2.0, this key was called **ModuleToProcess**.
-You can use the *RootModule* parameter name or its *ModuleToProcess* alias.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: ModuleToProcess
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -ScriptsToProcess
+
 Specifies script (.ps1) files that run in the caller's session state when the module is imported.
-You can use these scripts to prepare an environment, just as you might use a logon script.
+You can use these scripts to prepare an environment, just as you might use a login script.
 
 To specify scripts that run in the module's session state, use the **NestedModules** key.
 
@@ -871,10 +918,11 @@ Accept wildcard characters: False
 ```
 
 ### -TypesToProcess
+
 Specifies the type files (.ps1xml) that run when the module is imported.
 
-When you import the module, Windows PowerShell runs the Update-TypeData cmdlet with the specified files.
-Because type files are not scoped, they affect all session states in the session.
+When you import the module, Windows PowerShell runs the `Update-TypeData` cmdlet with the specified
+files. Because type files are not scoped, they affect all session states in the session.
 
 ```yaml
 Type: String[]
@@ -889,16 +937,40 @@ Accept wildcard characters: False
 ```
 
 ### -VariablesToExport
-Specifies the variables that the module exports.
-Wildcard characters are permitted.
 
-You can use this parameter to restrict the variables that are exported by the module.
-It can remove variables from the list of exported variables, but it cannot add variables to the list.
+Specifies the variables that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates a **VariablesToExport** key with a value of * (all), meaning that all variables that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the variables that are exported by the module. It can remove
+variables from the list of exported variables, but it cannot add variables to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates a **VariablesToExport** key with a value
+of `*` (all), meaning that all variables defined int the module are exported by the manifest.
 
 ```yaml
 Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: * (all)
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -DefaultCommandPrefix
+
+Specifies a prefix that is prepended to the nouns of all commands in the module when they are
+imported into a session. Enter a prefix string. Prefixes prevent command name conflicts in a user's
+session.
+
+Module users can override this prefix by specifying the **Prefix** parameter of the `Import-Module`
+cmdlet.
+
+This parameter is introduced in Windows PowerShell 3.0.
+
+```yaml
+Type: String
 Parameter Sets: (All)
 Aliases:
 
@@ -909,9 +981,40 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RootModule
+
+Specifies the primary or "root" file of the module. Enter the file name of a script (.ps1), a
+script module (.psm1), a module manifest(.psd1), an assembly (.dll), a cmdlet definition XML file
+(.cdxml), or a workflow (.xaml). When the module is imported, the members that are exported from
+the root module file are imported into the caller's session state.
+
+If a module has a manifest file and no root file has been designated in the **RootModule** key, the
+manifest becomes the primary file for the module, and the module becomes a "manifest module"
+(ModuleType = Manifest).
+
+To export members from .psm1 or .dll files in a module that has a manifest, the names of those
+files must be specified in the values of the **RootModule** or **NestedModules** keys in the
+manifest. Otherwise, their members are not exported.
+
+> [!NOTE]
+> In PowerShell 2.0, this key was called **ModuleToProcess**. You can use the "RootModule" parameter
+> name or its **ModuleToProcess** alias.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: ModuleToProcess
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -926,27 +1029,44 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### None
+
 You cannot pipe input to this cmdlet.
 
 ## OUTPUTS
 
 ### None or System.String
-This cmdlet does not generate any output by default.
-However, if you use the *PassThru* parameter, it generates a **System.String** object that represents the module manifest.
+
+By default, `New-ModuleManifest` does not generate any output. However, if you use the **PassThru**
+parameter, it generates a **System.String** object representing the module manifest.
 
 ## NOTES
-* Module manifests are usually optional. However, a module manifest is required to export an assembly that is installed in the global assembly cache.
-* To add or change files in the $pshome\Modules directory (%Windir%\System32\WindowsPowerShell\v1.0\Modules), start Windows PowerShell by using the Run as administrator option.
-* In Windows PowerShell 2.0, many parameters of **New-ModuleManifest** are mandatory, even though they are not required in a module manifest. In Windows PowerShell 3.0, only the *Path* parameter is mandatory.
-* A session is an instance of the Windows PowerShell run environment. A session can have one or more session states. By default, a session has only a global session state, but each imported module has its own session state. Session states allow the commands in a module to run without affecting the global session state.
 
-  The caller's session state is the session state into which a module is imported.
-Typically, it refers to the global session state, but when a module imports nested modules, the caller is the module and the caller's session state is the module's session state.
+Module manifests are usually optional. However, a module manifest is required to export an assembly
+that is installed in the global assembly cache.
+
+To add or change files in the `$pshome\Modules` directory, start PowerShell with the "Run as
+administrator" option.
+
+In PowerShell 2.0, many parameters of `New-ModuleManifest` are mandatory, even though they are not
+required in a module manifest. In Windows PowerShell 3.0, only the **Path** parameter is mandatory.
+
+A "session" is an instance of the PowerShell execution environment. A session can have one or more
+session states. By default, a session has only a global session state, but each imported module has
+its own session state. Session states allow the commands in a module to run without affecting the
+global session state.
+
+The "caller's session state" is the session state into which a module is imported. Typically, it
+refers to the global session state, but when a module imports nested modules, the "caller" is the
+module and the "caller's session state" is the module's session state.
 
 ## RELATED LINKS
 

--- a/reference/5.0/Microsoft.PowerShell.Management/New-EventLog.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/New-EventLog.md
@@ -1,11 +1,11 @@
 ---
-ms.date:  06/09/2017
+ms.date:  01/22/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
 online version:  http://go.microsoft.com/fwlink/?LinkId=821603
 external help file:  Microsoft.PowerShell.Commands.Management.dll-Help.xml
-title:  New-EventLog
+title: New-EventLog
 ---
 
 # New-EventLog
@@ -16,44 +16,51 @@ Creates a new event log and a new event source on a local or remote computer.
 ## SYNTAX
 
 ```
-New-EventLog [-CategoryResourceFile <String>] [[-ComputerName] <String[]>] [-LogName] <String>
- [-MessageResourceFile <String>] [-ParameterResourceFile <String>] [-Source] <String[]> [<CommonParameters>]
+New-EventLog [-LogName] <string> [-Source] <string[]> [[-ComputerName] <string[]>]
+  [-CategoryResourceFile <string>] [-MessageResourceFile <string>] [-ParameterResourceFile <string>]
+  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **New-EventLog** cmdlet creates a new classic event log on a local or remote computer.
-It can also register an event source that writes to the new log or to an existing log.
 
-The cmdlets that contain the **EventLog** noun (the **EventLog** cmdlets) work only on classic event logs.
-To get events from logs that use the Windows Event Log technology in Windows Vista and later versions of the Windows operating system, use the Get-WinEvent cmdlet.
+This cmdlet creates a new classic event log on a local or remote computer. It can also register an
+event source that writes to the new log or to an existing log.
+
+The cmdlets that contain the EventLog noun (the Event log cmdlets) work only on classic event logs.
+To get events from logs that use the Windows Event Log technology in Windows Vista and later
+versions of Windows, use `Get-WinEvent`.
 
 ## EXAMPLES
 
-### Example 1: Create an event log and register its source
-```
-PS C:\> New-EventLog -Source "TestApp" -LogName "TestLog" -MessageResourceFile "C:\Test\TestApp.dll"
-```
+### Example 1 - create a new event log
 
 This command creates the TestLog event log on the local computer and registers a new source for it.
 
-### Example 2: Add an event source to the Application log
-```
-PS C:\> $file = "C:\Program Files\TestApps\NewTestApp.dll"
-PS C:\> New-EventLog -ComputerName "Server01" -Source "NewTestApp" -LogName "Application" -MessageResourceFile $file -CategoryResourceFile $file
+```powershell
+New-EventLog -source TestApp -LogName TestLog -MessageResourceFile C:\Test\TestApp.dll
 ```
 
-This command adds a new event source, NewTestApp, to the Application log on the Server01 remote computer.
+### Example 2 - add a new event source to an existing log
+
+This command adds a new event source, NewTestApp, to the Application log on the Server01 remote
+computer.
+
+```powershell
+$file = "C:\Program Files\TestApps\NewTestApp.dll"
+New-EventLog -ComputerName Server01 -Source NewTestApp -LogName Application -MessageResourceFile $file -CategoryResourceFile $file
+```
 
 The command requires that the NewTestApp.dll file is located on the Server01 computer.
 
 ## PARAMETERS
 
 ### -CategoryResourceFile
-Specifies the path of the file that contains category strings for the source events.
-This file is also known as the Category Message File.
 
-The file must be present on the computer on which the event log is being created.
-This parameter does not create or move files.
+Specifies the path to the file that contains category strings for the source events. This file is
+also known as the Category Message File.
+
+The file must be present on the computer on which the event log is being created. This parameter
+does not create or move files.
 
 ```yaml
 Type: String
@@ -68,14 +75,14 @@ Accept wildcard characters: False
 ```
 
 ### -ComputerName
-Specifies the computers on which this cmdlet creates new event logs.
-The default is the local computer.
 
-Type the NetBIOS name, an IP address or a fully qualified domain name of a remote computer.
-To specify the local computer, type the computer name, a dot (.), or localhost.
+Creates the new event logs on the specified computers. The default is the local computer.
 
-This parameter does not rely on Windows PowerShell remoting.
-You can use the *ComputerName* parameter of **New-EventLog** even if your computer is not configured to run remote commands.
+The NetBIOS name, IP address, or fully qualified domain name of a remote computer.
+To specify the local computer, type the computer name, a dot (.), or "localhost".
+
+This parameter does not rely on PowerShell remoting. You can use the **ComputerName**
+parameter of `Get-EventLog` even if your computer is not configured to run remote commands.
 
 ```yaml
 Type: String[]
@@ -83,17 +90,19 @@ Parameter Sets: (All)
 Aliases: CN
 
 Required: False
-Position: 2
-Default value: None
+Position: 3
+Default value: Local computer
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -LogName
+
 Specifies the name of the event log.
 
-If the log does not exist, **New-EventLog** creates the log and uses this value for the **Log** and **LogDisplayName** properties of the new event log.
-If the log exists, **New-EventLog** registers a new source for the event log.
+If the log does not exist, `New-EventLog` creates the log and uses this value for the **Log** and
+**LogDisplayName** properties of the new event log. If the log exists, `New-EventLog` registers a new
+source for the event log.
 
 ```yaml
 Type: String
@@ -101,14 +110,15 @@ Parameter Sets: (All)
 Aliases: LN
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -MessageResourceFile
-Specifies the path of the file that contains message formatting strings for the source events.
+
+Specifies the path to the file that contains message formatting strings for the source events.
 This file is also known as the Event Message File.
 
 The file must be present on the computer on which the event log is being created.
@@ -127,8 +137,9 @@ Accept wildcard characters: False
 ```
 
 ### -ParameterResourceFile
-Specifies the path of the file that contains strings used for parameter substitutions in event descriptions.
-This file is also known as the Parameter Message File.
+
+Specifies the path to the file that contains strings used for parameter substitutions in event
+descriptions. This file is also known as the Parameter Message File.
 
 The file must be present on the computer on which the event log is being created.
 This parameter does not create or move files.
@@ -146,8 +157,9 @@ Accept wildcard characters: False
 ```
 
 ### -Source
-Specifies the names of the event log sources, such as application programs that write to the event log.
-This parameter is required.
+
+Specifies the names of the event log sources, such as application programs that write to the event
+log. This parameter is required.
 
 ```yaml
 Type: String[]
@@ -155,18 +167,23 @@ Parameter Sets: (All)
 Aliases: SRC
 
 Required: True
-Position: 1
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None
+
 You cannot pipe input to this cmdlet.
 
 ## OUTPUTS
@@ -174,23 +191,31 @@ You cannot pipe input to this cmdlet.
 ### System.Diagnostics.EventLogEntry
 
 ## NOTES
-* To use **New-EventLog** on Windows Vista and later versions of the Windows operating system, open Windows PowerShell by using Run as administrator option.
 
-  To create an event source in Windows Vista, Windows XP Professional, or Windows Server 2003, you must be a member of the Administrators group on the computer.
+To use `New-EventLog` on Windows Vista and later versions of Windows, open PowerShell with
+the "Run as administrator" option.
 
-  When you create a new event log and a new event source, the system registers the new source for the new log, but the log is not created until the first entry is written to it.
+To create an event source in Windows Vista, Windows XP Professional, or Windows Server 2003, you
+must be a member of the Administrators group on the computer.
 
-  The operating system stores event logs as files.
-When you create a new event log, the associated file is stored in the %SystemRoot%\System32\Config directory on the specified computer.
-The file name is the first eight characters of the Log property that has an .evt file name extension.
+When you create a new event log and a new event source, the system registers the new source for the
+new log, but the log is not created until the first entry is written to it.
 
-*
+The operating system stores event logs as files.
+
+When you create a new event log, the associated file is stored in the
+`$env:SystemRoot\System32\Config` directory on the specified computer.
+
+The file name is the first eight characters of the **Log** property with an .evt file name
+extension.
 
 ## RELATED LINKS
 
 [Clear-EventLog](Clear-EventLog.md)
 
 [Get-EventLog](Get-EventLog.md)
+
+[Get-WinEvent](../Microsoft.PowerShell.Diagnostics/Get-WinEvent.md)
 
 [Limit-EventLog](Limit-EventLog.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/5.0/Microsoft.PowerShell.Management/Push-Location.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  01/22/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -16,73 +16,88 @@ Adds the current location to the top of a location stack.
 ## SYNTAX
 
 ### Path (Default)
+
 ```
 Push-Location [[-Path] <String>] [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### LiteralPath
+
 ```
 Push-Location [-LiteralPath <String>] [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Push-Location** cmdlet adds, or pushes, the current location onto a location stack.
-If you specify a path, this cmdlet pushes the current location onto a location stack and then changes the current location to the location specified by the path.
-You can use the Pop-Location cmdlet to get locations from the location stack.
 
-By default, **Push-Location** pushes the current location onto the current location stack, but you can use the *StackName* parameter to specify another location stack.
-If the stack does not exist, **Push-Location** creates it.
+The `Push-Location` cmdlet adds ("pushes") the current location onto a location stack. If you
+specify a path, `Push-Location` pushes the current location onto a location stack and then changes
+the current location to the location specified by the path. You can use the `Pop-Location` cmdlet
+to get locations from the location stack.
+
+By default, the `Push-Location` cmdlet pushes the current location onto the current location stack,
+but you can use the StackName parameter to specify an alternate location stack. If the stack does
+not exist, `Push-Location` creates it.
 
 For more information about location stacks, see the Notes.
 
 ## EXAMPLES
 
-### Example 1: Change location
+### Example 1
+
+This example pushes the current location onto the default location stack and then changes the location to `C:\Windows`.
+
 ```
-PS C:\> Push-Location -Path "C:\Windows"
+PS C:\> Push-Location C:\Windows
 ```
 
-This command pushes the current location onto the default location stack and then changes the location to C:\Windows.
+### Example 2
 
-### Example 2: Change location in a named stack
+This example pushes the current location onto the RegFunction stack and changes the current location to the `HKLM:\Software\Policies` location.
+
 ```
-PS C:\> Push-Location -Path "HKLM:\Software\Policies" -StackName RegFunction
+PS C:\> Push-Location HKLM:\Software\Policies -StackName RegFunction
 ```
 
-This command pushes the current location onto the RegFunction stack and changes the current location to the HKLM:\Software\Policies location.
-You can use the **Location** cmdlets in any Windows PowerShell drive (PSDrive).
+You can use the Location cmdlets in any PowerShell drive (PSDrive).
 
-### Example 3: Push the current location onto the default stack
-```
-PS C:\> Push-Location
-```
+### Example 3
 
 This command pushes the current location onto the default stack.
 It does not change the location.
 
-### Example 4: Create and use a named stack
 ```
-PS C:\> Push-Location ~ -StackName "Stack2"
-PS C:\Users\User01> Pop-Location -StackName "Stack2"
-PS C:\>
+PS C:\> Push-Location
 ```
+
+### Example 4 - Create and use a named stack
 
 These commands show how to create and use a named location stack.
 
-The first command pushes the current location onto a new stack named Stack2, and then changes the current location to the root directory (%USERPROFILE%), which is represented in the command by the tilde symbol (~) or $home.
-If Stack2 does not already occur in the session, **Push-Location** creates it.
+```
+PS C:\> Push-Location ~ -StackName Stack2
+PS C:\Users\User01> Pop-Location -StackName Stack2
+PS C:\>
+```
 
-The second command uses **Pop-Location** to pop the original location (PS C:\\\>) from the Stack2 stack.
-Without *StackName*, **Pop-Location** would pop the location from the unnamed default stack.
+The first command pushes the current location onto a new stack named Stack2, and then changes the
+current location to the home directory, which is represented in the command by the tilde symbol (~)
+(same as `$env:USERPROFILE` or `$HOME`).
+
+If Stack2 does not already exist in the session, `Push-Location` creates it. The second command
+uses the `Pop-Location` cmdlet to pop the original location (PS C:\\\>) from the Stack2 stack.
+Without the StackName parameter, `Pop-Location` would pop the location from the unnamed default
+stack.
+
+For more information about location stacks, see the [Notes](#notes).
 
 ## PARAMETERS
 
 ### -LiteralPath
-Specifies the path of the new location.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is typed.
-No characters are interpreted as wildcard characters.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+
+Specifies the path to the new location. Unlike the **Path** parameter, the value of the
+**LiteralPath** parameter is used exactly as it is typed. No characters are interpreted as
+wildcards. If the path includes escape characters, enclose it in single quotation marks. Single
+quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -97,8 +112,9 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Passes an object that represents the location to the pipeline.
-By default, this cmdlet does not generate any output.
+
+Passes an object representing the location to the pipeline. By default, this cmdlet does not
+generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -107,16 +123,16 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies the path of the new location.
-This cmdlet your location to the location specified by this path after it adds, or pushes, the current location onto the top of the stack.
-Enter a path of any location whose provider supports this cmdlet.
-Wildcard characters are permitted.
+
+Changes your location to the location specified by this path after it adds (pushes) the current
+location onto the top of the stack. Enter a path to any location whose provider supports this
+cmdlet. Wildcards are permitted. The parameter name is optional.
 
 ```yaml
 Type: String
@@ -124,23 +140,25 @@ Parameter Sets: Path
 Aliases:
 
 Required: False
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -StackName
-Specifies the location stack to which the current location is added.
-Enter a location stack name.
-If the stack does not exist, **Push-Location** creates it.
 
-Without this parameter, **Push-Location** adds the location to the current location stack.
-By default, the current location stack is the unnamed default location stack that Windows PowerShell creates.
-To make a location stack the current location stack, use the *StackName* parameter of the Set-Location cmdlet.
-For more information about location stacks, see the Notes.
+Specifies the location stack to which the current location is added. Enter a location stack name.
+If the stack does not exist, `Push-Location` creates it.
 
-**Push-Location** cannot add a location to the unnamed default stack unless it is the current location stack.
+Without this parameter, `Push-Location` adds the location to the current location stack. By
+default, the current location stack is the unnamed default location stack that PowerShell creates.
+To make a location stack the current location stack, use the StackName parameter of the
+`Set-Location` cmdlet. For more information about location stacks, see the [Notes](#notes).
+
+> [!NOTE]
+> `Push-Location` cannot add a location to the unnamed default stack unless it is the current
+> location stack.
 
 ```yaml
 Type: String
@@ -149,15 +167,15 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: Default stack
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
 ### -UseTransaction
-Includes the command in the active transaction.
-This parameter is valid only when a transaction is in progress.
-For more information, see about_Transactions.
+
+Includes the command in the active transaction. This parameter is valid only when a transaction is
+in progress. For more information, see [about_Transactions](../Microsoft.PowerShell.Core/About/about_transactions.md).
 
 ```yaml
 Type: SwitchParameter
@@ -172,33 +190,65 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains a path, but not a literal path, to this cmdlet.
+
+You can pipe a string that contains a path (but not a literal path) to `Push-Location`.
 
 ## OUTPUTS
 
-### None, System.Management.Automation.PathInfo
-This cmdlet generates a **System.Management.Automation.PathInfo** object that represents the location, if you specify the *PassThru* parameter.
-Otherwise, this cmdlet does not generate any output.
+### None or System.Management.Automation.PathInfo
+
+When you use the PassThru parameter, `Push-Location` generates a
+**System.Management.Automation.PathInfo** object that represents the location. Otherwise, this
+cmdlet does not generate any output.
 
 ## NOTES
-* A stack is a last-in, first-out list in which only the most recently added item can be accessed. You add items to a stack in the order that you use them, and then retrieve them for use in the reverse order. Windows PowerShell lets you store provider locations in location stacks.
-* Windows PowerShell creates an unnamed default location stack and you can create multiple named location stacks. If you do not specify a stack name, Windows PowerShell uses the current location stack. By default, the unnamed default location is the current location stack, but you can use **Set-Location** to change the current location stack.
-* To manage location stacks, use the Windows PowerShell**Location** cmdlets, as follows:
 
-- To add a location to a location stack, use the **Push-Location** cmdlet.
-- To get a location from a location stack, use the **Pop-Location** cmdlet.
-- To display the locations in the current location stack, use the *Stack* parameter of the **Get-Location** cmdlet.
-- To display the locations in a named location stack, use the *StackName* parameter of the **Get-Location** cmdlet.
-- To create a new location stack, use the *StackName* parameter of the **Push-Location** cmdlet. If you specify a stack that does not exist, **Push-Location** creates the stack.
-- To make a location stack the current location stack, use the *StackName* parameter of the **Set-Location** cmdlet.
-* The unnamed default location stack is fully available only when it is the current location stack. If you make a named location stack the current location stack, you can no longer use **Push-Location** or **Pop-Location** cmdlets add or get items from the default stack or use a **Get-Location** command to display the locations in the unnamed stack. To make the unnamed stack the current stack, use the *StackName* parameter of **Set-Location** with a value of $Null or an empty string ("").
-* You can also refer to **Push-Location** by its built-in alias, **pushd**. For more information, see about_Aliases.
-* **Push-Location** is designed to work with the data exposed by any provider. To list the providers available in your session, type `Get-PSProvider`. For more information, see about_Providers.
+A "stack" is a last-in, first-out list in which only the most recently added item is accessible.
+You add items to a stack in the order that you use them, and then retrieve them for use in the
+reverse order. PowerShell lets you store provider locations in location stacks.
+
+PowerShell creates an unnamed default location stack and you can create multiple named location
+stacks. If you do not specify a stack name, Windows PowerShell uses the current location stack. By
+default, the unnamed default location is the current location stack, but you can use the
+`Set-Location` cmdlet to change the current location stack.
+
+To manage location stacks, use the PowerShell Location cmdlets, as follows.
+
+- To add a location to a location stack, use the `Push-Location` cmdlet.
+- To get a location from a location stack, use the `Pop-Location` cmdlet.
+- To display the locations in the current location stack, use the **Stack** parameter of the
+  `Get-Location` cmdlet.
+
+To display the locations in a named location stack, use the **StackName** parameter of the
+`Get-Location` cmdlet.
+
+- To create a new location stack, use the StackName parameter of the `Push-Location` cmdlet. If you
+  specify a stack that does not exist, `Push-Location` creates the stack.
+- To make a location stack the current location stack, use the StackName parameter of the
+  `Set-Location` cmdlet.
+
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you can no longer use
+`Push-Location` or `Pop-Location` cmdlets add or get items from the default stack or use
+`Get-Location` command to display the locations in the unnamed stack. To make the unnamed stack the
+current stack, use the StackName parameter of the `Set-Location` cmdlet with a value of $null or an
+empty string ("").
+
+You can also refer to `Push-Location` by its built-in alias, `pushd`. For more information, see
+[about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).
+
+The `Push-Location` cmdlet is designed to work with the data exposed by any provider. To list the
+providers available in your session, type `Get-PSProvider`. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS
 
@@ -207,3 +257,5 @@ Otherwise, this cmdlet does not generate any output.
 [Pop-Location](Pop-Location.md)
 
 [Set-Location](Set-Location.md)
+
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md)

--- a/reference/5.1/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/5.1/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 01/22/2019
 online version: http://go.microsoft.com/fwlink/?LinkId=821496
 schema: 2.0.0
 title: New-ModuleManifest
@@ -17,222 +17,271 @@ Creates a new module manifest.
 ## SYNTAX
 
 ```
-New-ModuleManifest [-Path] <String> [-NestedModules <Object[]>] [-Guid <Guid>] [-Author <String>]
- [-CompanyName <String>] [-Copyright <String>] [-RootModule <String>] [-ModuleVersion <Version>]
- [-Description <String>] [-ProcessorArchitecture <ProcessorArchitecture>] [-PowerShellVersion <Version>]
- [-ClrVersion <Version>] [-DotNetFrameworkVersion <Version>] [-PowerShellHostName <String>]
- [-PowerShellHostVersion <Version>] [-RequiredModules <Object[]>] [-TypesToProcess <String[]>]
- [-FormatsToProcess <String[]>] [-ScriptsToProcess <String[]>] [-RequiredAssemblies <String[]>]
- [-FileList <String[]>] [-ModuleList <Object[]>] [-FunctionsToExport <String[]>] [-AliasesToExport <String[]>]
- [-VariablesToExport <String[]>] [-CmdletsToExport <String[]>] [-DscResourcesToExport <String[]>]
- [-CompatiblePSEditions <String[]>] [-PrivateData <Object>] [-Tags <String[]>] [-ProjectUri <Uri>]
- [-LicenseUri <Uri>] [-IconUri <Uri>] [-ReleaseNotes <String>] [-HelpInfoUri <String>] [-PassThru]
- [-DefaultCommandPrefix <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-ModuleManifest [-Path] <string> [-NestedModules <Object[]>] [-Guid <guid>] [-Author <string>]
+ [-CompanyName <string>] [-Copyright <string>] [-RootModule <string>] [-ModuleVersion <version>]
+ [-Description <string>] [-ProcessorArchitecture <ProcessorArchitecture>] [-PowerShellVersion <version>]
+ [-ClrVersion <version>] [-DotNetFrameworkVersion <version>] [-PowerShellHostName <string>]
+ [-PowerShellHostVersion <version>] [-RequiredModules <Object[]>] [-TypesToProcess <string[]>]
+ [-FormatsToProcess <string[]>] [-ScriptsToProcess <string[]>] [-RequiredAssemblies <string[]>]
+ [-FileList <string[]>] [-ModuleList <Object[]>] [-FunctionsToExport <string[]>] [-AliasesToExport <string[]>]
+ [-VariablesToExport <string[]>] [-CmdletsToExport <string[]>] [-DscResourcesToExport <string[]>]
+ [-CompatiblePSEditions <string[]>] [-PrivateData <Object>] [-Tags <string[]>] [-ProjectUri <uri>]
+ [-LicenseUri <uri>] [-IconUri <uri>] [-ReleaseNotes <string>] [-HelpInfoUri <string>] [-PassThru]
+ [-DefaultCommandPrefix <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **New-ModuleManifest** cmdlet creates a new module manifest (.psd1) file, populates its values, and saves the manifest file in the specified path.
 
-Module authors can use this cmdlet to create a manifest for their module.
-A module manifest is a .psd1 file that contains a hash table.
-The keys and values in the hash table describe the contents and attributes of the module, define the prerequisites, and determine how the components are processed.
-Manifests are not required for a module.
+The `New-ModuleManifest` cmdlet creates a new module manifest (.psd1) file, populates its values,
+and saves the manifest file in the specified path.
 
-**New-ModuleManifest** creates a manifest that includes all of the frequently used manifest keys, so that you can use the default output as a manifest template.
-To add or change values, or to add module keys that this cmdlet does not add, open the resulting file in a text editor.
+Module authors can use this cmdlet to create a manifest for their module. A module manifest is a
+.psd1 file that contains a hash table. The keys and values in the hash table describe the contents
+and attributes of the module, define the prerequisites, and determine how the components are
+processed. Manifests are not required for a module.
 
-Each parameter of this cmdlet, except for *Path* and *PassThru*, creates a module manifest key and its value.
-In a module manifest, only the **ModuleVersion** key is required.
-Unless specified in the parameter description, if you omit a parameter from the command, **New-ModuleManifest** creates a comment string for the associated value that has no effect.
+`New-ModuleManifest` creates a manifest that includes all of the commonly used manifest keys, so
+you can use the default output as a manifest template. To add or change values, or to add module
+keys that this cmdlet does not add, open the resulting file in a text editor.
 
-In Windows PowerShell 2.0, **New-ModuleManifest** prompts you for the values of frequently used parameters that are not specified in the command, in addition to required parameter values.
-Starting in Windows PowerShell 3.0, it prompts only when required parameter values are not specified.
+Each parameter of this cmdlet (except for **Path** and **PassThru**) creates a module manifest key
+and its value. In a module manifest, only the **ModuleVersion** key is required. Unless specified
+in the parameter description, if you omit a parameter from the command, `New-ModuleManifest`
+creates a comment string for the associated value that has no effect.
+
+In Windows PowerShell 2.0, `New-ModuleManifest` prompts you for the values of commonly used
+parameters that are not specified in the command, in addition to required parameter values.
+Beginning in Windows PowerShell 3.0, it prompts only when required parameter values are not
+specified.
 
 ## EXAMPLES
 
-### Example 1: Create a manifest
-```
-PS C:\> New-ModuleManifest -Path C:\Users\User01\Documents\WindowsPowerShell\Modules\Test-Module\Test-Module.psd1 -PassThru
+### Example 1 - Create a new module manifest
 
-## Module manifest for module 'TestModule'
-## Generated by: User01
-## Generated on: 1/24/2012
-#@{
-# Script module or binary module file associated with this manifest
-# RootModule = ''
-# Version number of this module.ModuleVersion = '1.0'
-# ID used to uniquely identify this moduleGUID = 'd0a9150d-b6a4-4b17-a325-e3a24fed0aa9'
-# Author of this moduleAuthor = 'User01'
-# Company or vendor of this moduleCompanyName = 'Unknown'
-# Copyright statement for this moduleCopyright = '(c) 2012 User01. All rights reserved.'
-# Description of the functionality provided by this module
-# Description = ''
-# Minimum version of the Windows PowerShell engine required by this module
-# PowerShellVersion = ''
-# Name of the Windows PowerShell host required by this module
-# PowerShellHostName = ''
-# Minimum version of the Windows PowerShell host required by this module
-# PowerShellHostVersion = ''
-# Minimum version of the .NET Framework required by this module
-# DotNetFrameworkVersion = ''
-# Minimum version of the common language runtime (CLR) required by this module
-# CLRVersion = ''
-# Processor architecture (None, X86, Amd64) required by this module
-# ProcessorArchitecture = ''
-# Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
-# Assemblies that must be loaded prior to importing this module
-# RequiredAssemblies = @()
-# Script files (.ps1) that are run in the caller's environment prior to importing this module
-# ScriptsToProcess = @()
-# Type files (.ps1xml) to be loaded when importing this module
-# TypesToProcess = @()
-# Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
-# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-# NestedModules = @()
-# Functions to export from this moduleFunctionsToExport = '*'
-# Cmdlets to export from this moduleCmdletsToExport = '*'
-# Variables to export from this moduleVariablesToExport = '*'
-# Aliases to export from this moduleAliasesToExport = '*'
-# List of all modules packaged with this module# ModuleList = @()
-# List of all files packaged with this module
-# FileList = @()
-# Private data to pass to the module specified in RootModule/ModuleToProcess
-# PrivateData = ''
-# HelpInfo URI of this module
-# HelpInfoURI = ''
-# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
-# DefaultCommandPrefix = ''}
-```
-
-This command creates a module manifest in the file that is specified by the *Path* parameter.
-The *PassThru* parameter sends the output to the pipeline in addition to the file.
+This command creates a new module manifest in the file that is specified by the Path parameter. The
+**PassThru** parameter sends the output to the pipeline as well as to the file.
 
 The output shows the default values of all keys in the manifest.
 
-### Example 2: Create a manifest and add values to keys
-```
-PS C:\> New-ModuleManifest -PowerShellVersion 1.0 -AliasesToExport JKBC, DRC, TAC -Path C:\ps-test\ManifestTest.psd1
-```
-
-This command creates a new module manifest.
-It uses the *PowerShellVersion* and *AliasesToExport* parameters to add values to the corresponding manifest keys.
-
-### Example 3: Create a manifest by using strings and hash tables
-```
-PS C:\> New-ModuleManifest -RequiredModules BitsTransfer,@{ModuleName="PSScheduledJob";ModuleVersion="1.0.0.0";GUID="50cdb55f-5ab7-489f-9e94-4ec21ff51e59"}
+```powershell
+New-ModuleManifest -Path C:\ps-test\Test-Module\Test-Module.psd1 -PassThru
 ```
 
-This example shows how to use the string and hash table formats of the *ModuleList*, *RequiredModules*, and *NestedModules* parameter.
-You can combine strings and hash tables in the same parameter value.
+```Output
+#
+# Module manifest for module 'Test-Module'
+#
+# Generated by: ContosoAdmin
+#
+# Generated on: 1/22/2019
+#
 
-This command commands creates a module manifest for a module that requires the **BitsTransfer** and **PSScheduledJob** modules.
+@{
 
-The command uses a string format to specify the name of the **BitsTransfer** module and the hash table format to specify the name, a GUID, and a version of the **PSScheduledJob** module.
+# Script module or binary module file associated with this manifest.
+# RootModule = ''
 
-### Example 4: Create a manifest for a module that support updatable help
+# Version number of this module.
+ModuleVersion = '1.0'
+
+# ID used to uniquely identify this module
+GUID = '47179120-0bcb-4f14-8d80-f4560107f85c'
+
+# Author of this module
+Author = 'ContosoAdmin'
+
+# Company or vendor of this module
+CompanyName = 'Unknown'
+
+# Copyright statement for this module
+Copyright = '(c) 2019 ContosoAdmin. All rights reserved.'
+
+# Description of the functionality provided by this module
+# Description = ''
+
+# Minimum version of the Windows PowerShell engine required by this module
+# PowerShellVersion = ''
+
+# Name of the Windows PowerShell host required by this module
+# PowerShellHostName = ''
+
+# Minimum version of the Windows PowerShell host required by this module
+# PowerShellHostVersion = ''
+
+# Minimum version of the .NET Framework required by this module
+# DotNetFrameworkVersion = ''
+
+# Minimum version of the common language runtime (CLR) required by this module
+# CLRVersion = ''
+
+# Processor architecture (None, X86, Amd64) required by this module
+# ProcessorArchitecture = ''
+
+# Modules that must be imported into the global environment prior to importing this module
+# RequiredModules = @()
+
+# Assemblies that must be loaded prior to importing this module
+# RequiredAssemblies = @()
+
+# Script files (.ps1) that are run in the caller's environment prior to importing this module.
+# ScriptsToProcess = @()
+
+# Type files (.ps1xml) to be loaded when importing this module
+# TypesToProcess = @()
+
+# Format files (.ps1xml) to be loaded when importing this module
+# FormatsToProcess = @()
+
+# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+# NestedModules = @()
+
+# Functions to export from this module
+FunctionsToExport = '*'
+
+# Cmdlets to export from this module
+CmdletsToExport = '*'
+
+# Variables to export from this module
+VariablesToExport = '*'
+
+# Aliases to export from this module
+AliasesToExport = '*'
+
+# List of all modules packaged with this module.
+# ModuleList = @()
+
+# List of all files packaged with this module
+# FileList = @()
+
+# Private data to pass to the module specified in RootModule/ModuleToProcess
+# PrivateData = ''
+
+# HelpInfo URI of this module
+# HelpInfoURI = ''
+
+# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+# DefaultCommandPrefix = ''
+
+}
 ```
-PS C:\> New-ModuleManifest -HelpInfoUri "http://http://go.microsoft.com/fwlink/?LinkID=603"
+
+### Example 2 - Create a new manifest with some prepopulated settings
+
+This command creates a new module manifest. It uses the **PowerShellVersion** and
+**AliasesToExport** parameters to add values to the corresponding manifest keys.
+
+```powershell
+New-ModuleManifest -PowerShellVersion 1.0 -AliasesToExport JKBC, DRC, TAC -Path C:\ps-test\ManifestTest.psd1
 ```
 
-This example shows creates a module manifest for a module that supports the Updatable Help feature.
-This feature lets users use the Update-Help and Save-Help cmdlets, which download help files for the module from the Internet and install them in the module.
+### Example 3 - Create a manifest that requires other modules
 
-The command uses the *HelpInfoUri* parameter to create a **HelpInfoUri** key in the module manifest.
-The value of the parameter and the key must begin with http or https.
-This value tells the Updatable Help system where to find the HelpInfo XML updatable help information file for the module.
+The example uses a string format to specify the name of the **BitsTransfer** module and the hash
+table format to specify the name, a GUID, and a version of the **PSScheduledJob** module.
 
-For information about Updatable Help, see about_Updatable_Help (http://go.microsoft.com/fwlink/?LinkID=235801).
-For information about the HelpInfo XML file, see "Supporting Updatable Help" in the Microsoft Developer Library (MSDN) library.
-
-### Example 5: Get the module manifest values of a module
+```powershell
+$moduleSettings = @{
+  RequiredModules = (BitsTransfer, @{
+    ModuleName="PSScheduledJob"
+    ModuleVersion="1.0.0.0";
+    GUID="50cdb55f-5ab7-489f-9e94-4ec21ff51e59"
+  }
+  Path = 'C:\ps-test\ManifestTest.psd1'
+}
+New-ModuleManifest @moduleSettings
 ```
-PS C:\> Get-Module PSScheduledJob -List | Format-List -Property *
 
-LogPipelineExecutionDetails :
-FalseName                        :
-PSScheduledJobPath                        : C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.psd1
+This example shows how to use the string and hash table formats of the **ModuleList**,
+**RequiredModules**, and **NestedModules** parameter. You can combine strings and hash tables in
+the same parameter value.
+
+### Example 4 - Create a manifest that supports updateable help
+
+This example uses the **HelpInfoUri** parameter to create a **HelpInfoUri** key in the module
+manifest. The value of the parameter and the key must begin with "http" or "https". This value
+tells the Updatable Help system where to find the HelpInfo XML updatable help information file for
+the module.
+
+```powershell
+$moduleSettings = @{
+  HelpInfoUri = 'http://http://go.microsoft.com/fwlink/?LinkID=603'
+  Path = 'C:\ps-test\ManifestTest.psd1'
+}
+New-ModuleManifest @moduleSettings
+```
+
+For information about Updatable Help, see [about_Updatable_Help](./About/about_Updatable_Help.md).
+For information about the HelpInfo XML file, see [Supporting Updatable Help](/powershell/developer/module/supporting-updatable-help).
+
+### Example 5 - Getting module information
+
+This example shows how to get the configuration values of a module. The values in the module
+manifest are reflected in the values of properties of the module object.
+
+The `Get-Module` cmdlet is used to get the **Microsoft.PowerShell.Diagnostics** module using the
+**List** parameter. The command sends the module to the `Format-List` cmdlet to display all
+properties and values of the module object.
+
+```powershell
+Get-Module Microsoft.PowerShell.Diagnostics -List | Format-List -Property *
+```
+
+```Output
+LogPipelineExecutionDetails : False
+Name                        : Microsoft.PowerShell.Diagnostics
+Path                        : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Diagnostics\Micro
+                              soft.PowerShell.Diagnostics.psd1
 Definition                  :
 Description                 :
-Guid                        : 50cdb55f-5ab7-489f-9e94-4ec21ff51e59
-HelpInfoUri                 : http://go.microsoft.com/fwlink/?LinkID=223911
-ModuleBase                  : C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob
+Guid                        : ca046f10-ca64-4740-8ff9-2565dba61a4f
+HelpInfoUri                 : http://go.microsoft.com/fwlink/?LinkID=210596
+ModuleBase                  : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Diagnostics
 PrivateData                 :
-Version                     : 1.0.0.0
-ModuleType                  :
-BinaryAuthor                      : Microsoft Corporation
+Version                     : 3.0.0.0
+ModuleType                  : Manifest
+Author                      : Microsoft Corporation
 AccessMode                  : ReadWrite
 ClrVersion                  : 4.0
 CompanyName                 : Microsoft Corporation
-Copyright                   : c Microsoft Corporation. All rights reserved.
+Copyright                   : © Microsoft Corporation. All rights reserved.
 DotNetFrameworkVersion      :
 ExportedFunctions           : {}
-ExportedCmdlets             : {[New-JobTrigger, New-JobTrigger], [Add-JobTrigger, Add-JobTrigger], [Remove-JobTrigger, Remove-JobTrigger], [Get-JobTrigger, Get-JobTrigger]...}
-ExportedCommands            : {[New-JobTrigger, New-JobTrigger], [Add-JobTrigger, Add-JobTrigger], [Remove-JobTrigger, Remove-JobTrigger], [Get-JobTrigger, Get-JobTrigger]...}
+ExportedCmdlets             : {[Get-WinEvent, Get-WinEvent], [Get-Counter, Get-Counter], [Import-Counter,
+                              Import-Counter], [Export-Counter, Export-Counter]...}
+ExportedCommands            : {[Get-WinEvent, Get-WinEvent], [Get-Counter, Get-Counter], [Import-Counter,
+                              Import-Counter], [Export-Counter, Export-Counter]...}
 FileList                    : {}
 ModuleList                  : {}
 NestedModules               : {}
 PowerShellHostName          :
 PowerShellHostVersion       :
-PowerShellVersion           : 4.0
+PowerShellVersion           : 3.0
 ProcessorArchitecture       : None
 Scripts                     : {}
 RequiredAssemblies          : {}
 RequiredModules             : {}
-RootModule                  : Microsoft.PowerShell.ScheduledJob.dll
+RootModule                  :
 ExportedVariables           : {}
 ExportedAliases             : {}
 ExportedWorkflows           : {}
 SessionState                :
 OnRemove                    :
-ExportedFormatFiles         : {C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.Format.ps1xml}
-ExportedTypeFiles           : {C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.types.ps1xml}
-
-PS C:\> Get-Module -List | Format-Table -Property Name, PowerShellVersion
-
-Name                                                        PowerShellVersion
-----                                                        -----------------
-ADDeploymentWF                                              4.0
-AppLocker                                                   4.0
-Appx                                                        4.0
-BestPractices                                               4.0
-BitsTransfer                                                4.0
-BranchCache                                                 4.0
-CimCmdlets                                                  4.0
-DirectAccessClientComponents                                4.0
-Dism                                                        4.0
-DnsClient                                                   4.0
-International                                               4.0
-iSCSI                                                       4.0
-IscsiTarget                                                 4.0
-Kds                                                         4.0
-Microsoft.PowerShell.Diagnostics                            4.0
-Microsoft.PowerShell.Host                                   4.0
-Microsoft.PowerShell.Management                             4.0â€¦
+ExportedFormatFiles         : {C:\Windows\system32\WindowsPowerShell\v1.0\Event.format.ps1xml,
+                              C:\Windows\system32\WindowsPowerShell\v1.0\Diagnostics.format.ps1xml}
+ExportedTypeFiles           : {C:\Windows\system32\WindowsPowerShell\v1.0\GetEvent.types.ps1xml}
 ```
-
-This example shows how to get the module manifest values of a module.
-This is essentially a "Get-ModuleManifest" command.
-Because the values in the module manifest are reflected in the values of properties of the module object, you can get the module manifest values by displaying the module object properties.
-
-The first command uses the **Get-Module** cmdlet to get the *PSScheduledJob* module.
-The command uses the *List* parameter, because the module is installed, but not imported into the session.
-The command sends the module to the Format-List cmdlet, which displays all properties and values of the module object in a list.
-
-The second command uses the Format-Table cmdlet to display the **PowerShellVersion** property of all installed modules in a table.
-The **PowerShellVersion** property is defined in the module manifest.
 
 ## PARAMETERS
 
 ### -AliasesToExport
-Specifies the aliases that the module exports.
-Wildcard characters are permitted.
 
-You can use this parameter to restrict the aliases that are exported by the module.
-It can remove aliases from the list of exported aliases, but it cannot add aliases to the list.
+Specifies the aliases that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates an **AliasesToExport** key with a value of * (all), meaning that all aliases that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the aliases that are exported by the module. It can remove
+aliases from the list of exported aliases, but it cannot add aliases to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates an **AliasesToExport** key with a value
+of `*` (all), meaning that all aliases defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -241,15 +290,17 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: * (all)
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Author
+
 Specifies the module author.
 
-If you omit this parameter, **New-ModuleManifest** creates an **Author** key with the name of the current user.
+If you omit this parameter, `New-ModuleManifest` creates an **Author** key with the name of the
+current user.
 
 ```yaml
 Type: String
@@ -258,13 +309,15 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: Name of the current user
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -ClrVersion
-Specifies the minimum version of the Common Language Runtime (CLR) of the Microsoft .NET Framework that the module requires.
+
+Specifies the minimum version of the Common Language Runtime (CLR) of the Microsoft .NET Framework
+that the module requires.
 
 ```yaml
 Type: Version
@@ -279,13 +332,14 @@ Accept wildcard characters: False
 ```
 
 ### -CmdletsToExport
-Specifies the cmdlets that the module exports.
-Wildcard characters are permitted.
 
-You can use this parameter to restrict the cmdlets that are exported by the module.
-It can remove cmdlets from the list of exported cmdlets, but it cannot add cmdlets to the list.
+Specifies the cmdlets that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates a **CmdletsToExport** key with a value of * (all), meaning that all cmdlets that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the cmdlets that are exported by the module. It can remove
+cmdlets from the list of exported cmdlets, but it cannot add cmdlets to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates a **CmdletsToExport** key with a value
+of `*` (all), meaning that all cmdlets defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -294,15 +348,17 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: * (all)
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -CompanyName
+
 Identifies the company or vendor who created the module.
 
-If you omit this parameter, **New-ModuleManifest** creates a **CompanyName** key with a value of "Unknown".
+If you omit this parameter, `New-ModuleManifest` creates a **CompanyName** key with a value of
+"Unknown".
 
 ```yaml
 Type: String
@@ -311,14 +367,31 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: "Unknown"
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -CompatiblePSEditions
-Specifies the compatible PSEditions of the module.
-For information about PSEdition, see [Modules with compatible PowerShell Editions](https://msdn.microsoft.com/en-us/powershell/gallery/psget/module/modulewithpseditionsupport).
+
+Specifies the compatible PSEditions of the module. For information about PSEdition, see
+[Modules with compatible PowerShell Editions](/powershell/gallery/concepts/module-psedition-support).
 
 ```yaml
 Type: String[]
@@ -334,10 +407,12 @@ Accept wildcard characters: False
 ```
 
 ### -Copyright
+
 Specifies a copyright statement for the module.
 
-If you omit this parameter, **New-ModuleManifest** creates a **Copyright** key with a value of  "(c) \<year\> \<username\>.
-All rights reserved." where \<year\> is the current year and \<username\> is the value of the **Author** key (if one is specified) or the name of the current user.
+If you omit this parameter, `New-ModuleManifest` creates a **Copyright** key with a value of
+`(c) <year> <username>. All rights reserved.` where `<year>` is the current year and `<username>`
+is the value of the **Author** key.
 
 ```yaml
 Type: String
@@ -346,32 +421,13 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DefaultCommandPrefix
-Specifies a prefix that is prepended to the nouns of all commands in the module when they are imported into a session.
-Prefixes prevent command name conflicts in a user's session.
-
-Module users can override this prefix by specifying the *Prefix* parameter of the Import-Module cmdlet.
-
-This parameter was introduced in Windows PowerShell 3.0.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
+Default value: (c) <year> <username>. All rights reserved.
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Description
+
 Describes the contents of the module.
 
 ```yaml
@@ -387,6 +443,7 @@ Accept wildcard characters: False
 ```
 
 ### -DotNetFrameworkVersion
+
 Specifies the minimum version of the Microsoft .NET Framework that the module requires.
 
 ```yaml
@@ -402,6 +459,7 @@ Accept wildcard characters: False
 ```
 
 ### -DscResourcesToExport
+
 Specifies the DSC resources that the module exports.
 Wildcards are permitted.
 
@@ -414,14 +472,15 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -FileList
+
 Specifies all items that are included in the module.
 
-This key is designed to act as a module inventory.
-The files listed in the key are included when the module is published, but any functions are not automatically exported.
+This key is designed to act as a module inventory. The files listed in the key are included when
+the module is published, but any functions are not automatically exported.
 
 ```yaml
 Type: String[]
@@ -436,10 +495,11 @@ Accept wildcard characters: False
 ```
 
 ### -FormatsToProcess
+
 Specifies the formatting files (.ps1xml) that run when the module is imported.
 
-When you import a module, Windows PowerShell runs the Update-FormatData cmdlet with the specified files.
-Because formatting files are not scoped, they affect all session states in the session.
+When you import a module, Windows PowerShell runs the `Update-FormatData` cmdlet with the specified
+files. Because formatting files are not scoped, they affect all session states in the session.
 
 ```yaml
 Type: String[]
@@ -454,13 +514,14 @@ Accept wildcard characters: False
 ```
 
 ### -FunctionsToExport
-Specifies the functions that the module exports.
-Wildcard characters are permitted.
 
-You can use this parameter to restrict the functions that are exported by the module.
-It can remove functions from the list of exported aliases, but it cannot add functions to the list.
+Specifies the functions that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates an **FunctionsToExport** key with a value of * (all), meaning that all functions that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the functions that are exported by the module. It can remove
+functions from the list of exported aliases, but it cannot add functions to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates an **FunctionsToExport** key with a
+value of `*` (all), meaning that all functions defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -469,16 +530,18 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: * (all)
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Guid
-Specifies a unique identifier for the module.
-The GUID can be used to distinguish among modules with the same name.
 
-If you omit this parameter, **New-ModuleManifest** creates a **GUID** key in the manifest and generates a GUID for the value.
+Specifies a unique identifier for the module. The GUID can be used to distinguish among modules
+with the same name.
+
+If you omit this parameter, `New-ModuleManifest` creates a **GUID** key in the manifest and
+generates a GUID for the value.
 
 To create a new GUID in Windows PowerShell, type "\[guid\]::NewGuid()".
 
@@ -489,19 +552,22 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: A GUID generated for the module
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -HelpInfoUri
-Specifies the Internet address of the HelpInfo XML file for the module.
-Enter an Uniform Resource Identifier (URI) that starts with "http" or "https".
 
-The HelpInfo XML file supports the Updatable Help feature that was introduced in Windows PowerShell 3.0.
-It contains information about the location of downloadable help files for the module and the version numbers of the newest help files for each supported locale.
-For information about Updatable Help, see about_Updatable_Help (http://go.microsoft.com/fwlink/?LinkID=235801).
-For information about the HelpInfo XML file, see "Supporting Updatable Help" in the Microsoft Developer Network (MSDN) library.
+Specifies the Internet address of the HelpInfo XML file for the module. Enter an Uniform Resource
+Identifier (URI) that begins with "http" or "https".
+
+The HelpInfo XML file supports the Updatable Help feature that was introduced in Windows PowerShell
+3.0. It contains information about the location of downloadable help files for the module and the
+version numbers of the newest help files for each supported locale.
+
+For information about Updatable Help, see [about_Updatable_Help](./About/about_Updatable_Help.md).
+For information about the HelpInfo XML file, see [Supporting Updatable Help](/powershell/developer/module/supporting-updatable-help).
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -518,8 +584,8 @@ Accept wildcard characters: False
 ```
 
 ### -IconUri
-Specifies the URL of an icon for the module.
-The specified icon is displayed on the gallery web page for the module.
+
+Specifies the URL of an icon for the module. The specified icon is displayed on the gallery web page for the module.
 
 ```yaml
 Type: Uri
@@ -534,6 +600,7 @@ Accept wildcard characters: False
 ```
 
 ### -LicenseUri
+
 Specifies the URL of licensing terms for the module.
 
 ```yaml
@@ -549,15 +616,15 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleList
+
 Lists all modules that are included in this module.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
 
-This key is designed to act as a module inventory.
-The modules that are listed in the value of this key are not automatically processed.
+This key is designed to act as a module inventory. The modules that are listed in the value of this
+key are not automatically processed.
 
 ```yaml
 Type: Object[]
@@ -572,10 +639,12 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleVersion
+
 Specifies the version of the module.
 
-This parameter is not required by the cmdlet, but a **ModuleVersion** key is required in the manifest.
-If you omit this parameter, **New-ModuleManifest** creates a **ModuleVersion** key with a value of "1.0".
+This parameter is not required by the cmdlet, but a **ModuleVersion** key is required in the
+manifest. If you omit this parameter, `New-ModuleManifest` creates a **ModuleVersion** key with a
+value of "1.0".
 
 ```yaml
 Type: Version
@@ -584,27 +653,32 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 1.0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -NestedModules
-Specifies script modules (.psm1) and binary modules (.dll) that are imported into the module's session state.
-The files in the **NestedModules** key run in the order in which they are listed in the value.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Specifies script modules (.psm1) and binary modules (.dll) that are imported into the module's
+session state. The files in the **NestedModules** key run in the order in which they are listed in
+the value.
+
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
 
 Typically, nested modules contain commands that the root module needs for its internal processing.
-By default, the commands in nested modules are exported from the module's session state into the caller's session state, but the root module can restrict the commands that it exports, for example, by using an Export-ModuleMember command.
+By default, the commands in nested modules are exported from the module's session state into the
+caller's session state, but the root module can restrict the commands that it exports (for example,
+by using an Export-ModuleMember command).
 
-Nested modules in the module session state are available to the root module, but they are not returned by a Get-Module command in the caller's session state.
+Nested modules in the module session state are available to the root module, but they are not
+returned by a `Get-Module` command in the caller's session state.
 
-Scripts (.ps1) that are listed in the **NestedModules** key are run in the module's session state, not in the caller's session state.
-To run a script in the caller's session state, list the script file name in the value of the **ScriptsToProcess** key in the manifest.
+Scripts (.ps1) that are listed in the **NestedModules** key are run in the module's session state,
+not in the caller's session state. To run a script in the caller's session state, list the script
+file name in the value of the **ScriptsToProcess** key in the manifest.
 
 ```yaml
 Type: Object[]
@@ -619,8 +693,9 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Indicates that this cmdlet writes the resulting module manifest to the console, in addition to creating a .psd1 file.
-By default, this cmdlet does not generate any output.
+
+Writes the resulting module manifest to the console, in addition to creating a .psd1 file. By
+default, this cmdlet does not generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -629,22 +704,26 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies the path and file name of the new module manifest.
-Enter a path and file name with a .psd1 file name extension, such as `$pshome\Modules\MyModule\MyModule.psd1`.
-This parameter is required.
 
-If you specify the path of an existing file, **New-ModuleManifest** replaces the file without warning unless the file has the read-only attribute.
+Specifies the path and file name of the new module manifest. Enter a path and file name with a
+.psd1 file name extension, such as `$pshome\Modules\MyModule\MyModule.psd1`. This parameter is
+required.
 
-The manifest should be located in the module's directory, and the manifest file name should be the same as the module directory name, but with a .psd1 file name extension.
+If you specify the path to an existing file, `New-ModuleManifest` replaces the file without
+warning unless the file has the read-only attribute.
 
-You cannot use variables, such as $pshome or $home, in response to a prompt for a **Path** parameter value.
-To use a variable, include the **Path** parameter in the command.
+The manifest should be located in the module's directory, and the manifest file name should be the
+same as the module directory name, but with a .psd1 file name extension.
+
+> [!NOTE]
+> You cannot use variables, such as `$PSHOME` or `$HOME`, in response to a prompt for a **Path**
+> parameter value. To use a variable, include the **Path** parameter in the command.
 
 ```yaml
 Type: String
@@ -652,18 +731,18 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -PowerShellHostName
-Specifies the name of the Windows PowerShell host program that the module requires.
-Enter the name of the host program, such as `Windows PowerShell ISE Host` or `ConsoleHost`.
-Wildcard characters are not permitted.
 
-To find the name of a host program, in the program, type `$host.name`.
+Specifies the name of the PowerShell host program that the module requires. Enter the name of the
+host program, such as "Windows PowerShell ISE Host" or "ConsoleHost". Wildcards are not permitted.
+
+To find the name of a host program, in the program, type `$Host.Name`.
 
 ```yaml
 Type: String
@@ -678,8 +757,9 @@ Accept wildcard characters: False
 ```
 
 ### -PowerShellHostVersion
-Specifies the minimum version of the Windows PowerShell host program that works with the module.
-Enter a version number, such as 1.1.
+
+Specifies the minimum version of the PowerShell host program that works with the module. Enter a
+version number, such as 1.1.
 
 ```yaml
 Type: Version
@@ -694,6 +774,7 @@ Accept wildcard characters: False
 ```
 
 ### -PowerShellVersion
+
 Specifies the minimum version of Windows PowerShell that works with this module.
 For example, you can enter 3.0, 4.0, or 5.0 as the value of this parameter.
 
@@ -710,6 +791,7 @@ Accept wildcard characters: False
 ```
 
 ### -PrivateData
+
 Specifies data that is passed to the module when it is imported.
 
 ```yaml
@@ -725,9 +807,9 @@ Accept wildcard characters: False
 ```
 
 ### -ProcessorArchitecture
-Specifies the processor architecture that the module requires.
-The acceptable values for this parameter are: x86, AMD64, IA64, and None.
-None indicates unknown or unspecified.
+
+Specifies the processor architecture that the module requires. Valid values are x86, AMD64, IA64, MSIL,
+and None (unknown or unspecified).
 
 ```yaml
 Type: ProcessorArchitecture
@@ -773,12 +855,15 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredAssemblies
-Specifies the assembly (.dll) files that the module requires.
-Enter the assembly file names.
-Windows PowerShell loads the specified assemblies before updating types or formats, importing nested modules, or importing the module file that is specified in the value of the **RootModule** key.
 
-Use this parameter to list all the assemblies that the module requires.
-This includes assemblies that must be loaded to update any formatting or type files that are listed in the **FormatsToProcess** or **TypesToProcess** keys, even if those assemblies are also listed as binary modules in the **NestedModules** key.
+Specifies the assembly (.dll) files that the module requires. Enter the assembly file names.
+PowerShell loads the specified assemblies before updating types or formats, importing nested
+modules, or importing the module file that is specified in the value of the **RootModule** key.
+
+Use this parameter to list all the assemblies that the module requires, including assemblies that
+must be loaded to update any formatting or type files that are listed in the **FormatsToProcess**
+or **TypesToProcess** keys, even if those assemblies are also listed as binary modules in the
+**NestedModules** key.
 
 ```yaml
 Type: String[]
@@ -793,17 +878,17 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredModules
-Specifies modules that must be in the global session state.
-If the required modules are not in the global session state, Windows PowerShell imports them.
-If the required modules are not available, the Import-Module command fails.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Specifies modules that must be in the global session state. If the required modules are not in the
+global session state, Windows PowerShell imports them. If the required modules are not available,
+the `Import-Module` command fails.
 
-In Windows PowerShell 2.0, **Import-Module** does not import required modules automatically.
-It just verifies that the required modules are in the global session state.
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
+
+In Windows PowerShell 2.0, `Import-Module` does not import required modules automatically. It
+just verifies that the required modules are in the global session state.
 
 ```yaml
 Type: Object[]
@@ -817,34 +902,10 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RootModule
-Specifies the primary or root file of the module.
-Enter the file name of a script (.ps1), a script module (.psm1), a module manifest (.psd1), an assembly (.dll), a cmdlet definition XML file (.cdxml), or a workflow (.xaml).
-When the module is imported, the members that are exported from the root module file are imported into the caller's session state.
-
-If a module has a manifest file and no root file has been designated in the **RootModule** key, the manifest becomes the primary file for the module, and the module becomes a manifest module (ModuleType = Manifest).
-
-To export members from .psm1 or .dll files in a module that has a manifest, the names of those files must be specified in the values of the **RootModule** or **NestedModules** keys in the manifest.
-Otherwise, their members are not exported.
-
-In Windows PowerShell 2.0, this key was called **ModuleToProcess**.
-You can use the *RootModule* parameter name or its *ModuleToProcess* alias.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: ModuleToProcess
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -ScriptsToProcess
+
 Specifies script (.ps1) files that run in the caller's session state when the module is imported.
-You can use these scripts to prepare an environment, just as you might use a logon script.
+You can use these scripts to prepare an environment, just as you might use a login script.
 
 To specify scripts that run in the module's session state, use the **NestedModules** key.
 
@@ -876,10 +937,11 @@ Accept wildcard characters: False
 ```
 
 ### -TypesToProcess
+
 Specifies the type files (.ps1xml) that run when the module is imported.
 
-When you import the module, Windows PowerShell runs the Update-TypeData cmdlet with the specified files.
-Because type files are not scoped, they affect all session states in the session.
+When you import the module, Windows PowerShell runs the `Update-TypeData` cmdlet with the specified
+files. Because type files are not scoped, they affect all session states in the session.
 
 ```yaml
 Type: String[]
@@ -894,16 +956,40 @@ Accept wildcard characters: False
 ```
 
 ### -VariablesToExport
-Specifies the variables that the module exports.
-Wildcard characters are permitted.
 
-You can use this parameter to restrict the variables that are exported by the module.
-It can remove variables from the list of exported variables, but it cannot add variables to the list.
+Specifies the variables that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates a **VariablesToExport** key with a value of * (all), meaning that all variables that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the variables that are exported by the module. It can remove
+variables from the list of exported variables, but it cannot add variables to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates a **VariablesToExport** key with a value
+of `*` (all), meaning that all variables defined int the module are exported by the manifest.
 
 ```yaml
 Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: * (all)
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -DefaultCommandPrefix
+
+Specifies a prefix that is prepended to the nouns of all commands in the module when they are
+imported into a session. Enter a prefix string. Prefixes prevent command name conflicts in a user's
+session.
+
+Module users can override this prefix by specifying the **Prefix** parameter of the `Import-Module`
+cmdlet.
+
+This parameter is introduced in Windows PowerShell 3.0.
+
+```yaml
+Type: String
 Parameter Sets: (All)
 Aliases:
 
@@ -914,24 +1000,40 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
+### -RootModule
+
+Specifies the primary or "root" file of the module. Enter the file name of a script (.ps1), a
+script module (.psm1), a module manifest(.psd1), an assembly (.dll), a cmdlet definition XML file
+(.cdxml), or a workflow (.xaml). When the module is imported, the members that are exported from
+the root module file are imported into the caller's session state.
+
+If a module has a manifest file and no root file has been designated in the **RootModule** key, the
+manifest becomes the primary file for the module, and the module becomes a "manifest module"
+(ModuleType = Manifest).
+
+To export members from .psm1 or .dll files in a module that has a manifest, the names of those
+files must be specified in the values of the **RootModule** or **NestedModules** keys in the
+manifest. Otherwise, their members are not exported.
+
+> [!NOTE]
+> In PowerShell 2.0, this key was called **ModuleToProcess**. You can use the "RootModule" parameter
+> name or its **ModuleToProcess** alias.
 
 ```yaml
-Type: SwitchParameter
+Type: String
 Parameter Sets: (All)
-Aliases: cf
+Aliases: ModuleToProcess
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -946,27 +1048,44 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### None
+
 You cannot pipe input to this cmdlet.
 
 ## OUTPUTS
 
 ### None or System.String
-This cmdlet does not generate any output by default.
-However, if you use the *PassThru* parameter, it generates a **System.String** object that represents the module manifest.
+
+By default, `New-ModuleManifest` does not generate any output. However, if you use the **PassThru**
+parameter, it generates a **System.String** object representing the module manifest.
 
 ## NOTES
-* Module manifests are usually optional. However, a module manifest is required to export an assembly that is installed in the global assembly cache.
-* To add or change files in the $pshome\Modules directory (%Windir%\System32\WindowsPowerShell\v1.0\Modules), start Windows PowerShell by using the Run as administrator option.
-* In Windows PowerShell 2.0, many parameters of **New-ModuleManifest** are mandatory, even though they are not required in a module manifest. In Windows PowerShell 3.0, only the *Path* parameter is mandatory.
-* A session is an instance of the Windows PowerShell run environment. A session can have one or more session states. By default, a session has only a global session state, but each imported module has its own session state. Session states allow the commands in a module to run without affecting the global session state.
 
-  The caller's session state is the session state into which a module is imported.
-Typically, it refers to the global session state, but when a module imports nested modules, the caller is the module and the caller's session state is the module's session state.
+Module manifests are usually optional. However, a module manifest is required to export an assembly
+that is installed in the global assembly cache.
+
+To add or change files in the `$pshome\Modules` directory, start PowerShell with the "Run as
+administrator" option.
+
+In PowerShell 2.0, many parameters of `New-ModuleManifest` are mandatory, even though they are not
+required in a module manifest. In Windows PowerShell 3.0, only the **Path** parameter is mandatory.
+
+A "session" is an instance of the PowerShell execution environment. A session can have one or more
+session states. By default, a session has only a global session state, but each imported module has
+its own session state. Session states allow the commands in a module to run without affecting the
+global session state.
+
+The "caller's session state" is the session state into which a module is imported. Typically, it
+refers to the global session state, but when a module imports nested modules, the "caller" is the
+module and the "caller's session state" is the module's session state.
 
 ## RELATED LINKS
 
@@ -981,3 +1100,5 @@ Typically, it refers to the global session state, but when a module imports nest
 [Remove-Module](Remove-Module.md)
 
 [Test-ModuleManifest](Test-ModuleManifest.md)
+
+[about_Modules](About/about_Modules.md)

--- a/reference/5.1/Microsoft.PowerShell.Management/New-EventLog.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/New-EventLog.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/09/2017
+ms.date:  01/22/2019
 online version: http://go.microsoft.com/fwlink/?LinkId=821603
 schema: 2.0.0
 title: New-EventLog
@@ -17,44 +17,51 @@ Creates a new event log and a new event source on a local or remote computer.
 ## SYNTAX
 
 ```
-New-EventLog [-CategoryResourceFile <String>] [[-ComputerName] <String[]>] [-LogName] <String>
- [-MessageResourceFile <String>] [-ParameterResourceFile <String>] [-Source] <String[]> [<CommonParameters>]
+New-EventLog [-LogName] <string> [-Source] <string[]> [[-ComputerName] <string[]>]
+  [-CategoryResourceFile <string>] [-MessageResourceFile <string>] [-ParameterResourceFile <string>]
+  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **New-EventLog** cmdlet creates a new classic event log on a local or remote computer.
-It can also register an event source that writes to the new log or to an existing log.
 
-The cmdlets that contain the **EventLog** noun (the **EventLog** cmdlets) work only on classic event logs.
-To get events from logs that use the Windows Event Log technology in Windows Vista and later versions of the Windows operating system, use the Get-WinEvent cmdlet.
+This cmdlet creates a new classic event log on a local or remote computer. It can also register an
+event source that writes to the new log or to an existing log.
+
+The cmdlets that contain the EventLog noun (the Event log cmdlets) work only on classic event logs.
+To get events from logs that use the Windows Event Log technology in Windows Vista and later
+versions of Windows, use `Get-WinEvent`.
 
 ## EXAMPLES
 
-### Example 1: Create an event log and register its source
-```
-PS C:\> New-EventLog -Source "TestApp" -LogName "TestLog" -MessageResourceFile "C:\Test\TestApp.dll"
-```
+### Example 1 - create a new event log
 
 This command creates the TestLog event log on the local computer and registers a new source for it.
 
-### Example 2: Add an event source to the Application log
-```
-PS C:\> $file = "C:\Program Files\TestApps\NewTestApp.dll"
-PS C:\> New-EventLog -ComputerName "Server01" -Source "NewTestApp" -LogName "Application" -MessageResourceFile $file -CategoryResourceFile $file
+```powershell
+New-EventLog -source TestApp -LogName TestLog -MessageResourceFile C:\Test\TestApp.dll
 ```
 
-This command adds a new event source, NewTestApp, to the Application log on the Server01 remote computer.
+### Example 2 - add a new event source to an existing log
+
+This command adds a new event source, NewTestApp, to the Application log on the Server01 remote
+computer.
+
+```powershell
+$file = "C:\Program Files\TestApps\NewTestApp.dll"
+New-EventLog -ComputerName Server01 -Source NewTestApp -LogName Application -MessageResourceFile $file -CategoryResourceFile $file
+```
 
 The command requires that the NewTestApp.dll file is located on the Server01 computer.
 
 ## PARAMETERS
 
 ### -CategoryResourceFile
-Specifies the path of the file that contains category strings for the source events.
-This file is also known as the Category Message File.
 
-The file must be present on the computer on which the event log is being created.
-This parameter does not create or move files.
+Specifies the path to the file that contains category strings for the source events. This file is
+also known as the Category Message File.
+
+The file must be present on the computer on which the event log is being created. This parameter
+does not create or move files.
 
 ```yaml
 Type: String
@@ -69,14 +76,14 @@ Accept wildcard characters: False
 ```
 
 ### -ComputerName
-Specifies the computers on which this cmdlet creates new event logs.
-The default is the local computer.
 
-Type the NetBIOS name, an IP address or a fully qualified domain name of a remote computer.
-To specify the local computer, type the computer name, a dot (.), or localhost.
+Creates the new event logs on the specified computers. The default is the local computer.
 
-This parameter does not rely on Windows PowerShell remoting.
-You can use the *ComputerName* parameter of **New-EventLog** even if your computer is not configured to run remote commands.
+The NetBIOS name, IP address, or fully qualified domain name of a remote computer.
+To specify the local computer, type the computer name, a dot (.), or "localhost".
+
+This parameter does not rely on PowerShell remoting. You can use the **ComputerName**
+parameter of `Get-EventLog` even if your computer is not configured to run remote commands.
 
 ```yaml
 Type: String[]
@@ -84,17 +91,19 @@ Parameter Sets: (All)
 Aliases: CN
 
 Required: False
-Position: 2
-Default value: None
+Position: 3
+Default value: Local computer
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -LogName
+
 Specifies the name of the event log.
 
-If the log does not exist, **New-EventLog** creates the log and uses this value for the **Log** and **LogDisplayName** properties of the new event log.
-If the log exists, **New-EventLog** registers a new source for the event log.
+If the log does not exist, `New-EventLog` creates the log and uses this value for the **Log** and
+**LogDisplayName** properties of the new event log. If the log exists, `New-EventLog` registers a new
+source for the event log.
 
 ```yaml
 Type: String
@@ -102,14 +111,15 @@ Parameter Sets: (All)
 Aliases: LN
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -MessageResourceFile
-Specifies the path of the file that contains message formatting strings for the source events.
+
+Specifies the path to the file that contains message formatting strings for the source events.
 This file is also known as the Event Message File.
 
 The file must be present on the computer on which the event log is being created.
@@ -128,8 +138,9 @@ Accept wildcard characters: False
 ```
 
 ### -ParameterResourceFile
-Specifies the path of the file that contains strings used for parameter substitutions in event descriptions.
-This file is also known as the Parameter Message File.
+
+Specifies the path to the file that contains strings used for parameter substitutions in event
+descriptions. This file is also known as the Parameter Message File.
 
 The file must be present on the computer on which the event log is being created.
 This parameter does not create or move files.
@@ -147,8 +158,9 @@ Accept wildcard characters: False
 ```
 
 ### -Source
-Specifies the names of the event log sources, such as application programs that write to the event log.
-This parameter is required.
+
+Specifies the names of the event log sources, such as application programs that write to the event
+log. This parameter is required.
 
 ```yaml
 Type: String[]
@@ -156,18 +168,23 @@ Parameter Sets: (All)
 Aliases: SRC
 
 Required: True
-Position: 1
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None
+
 You cannot pipe input to this cmdlet.
 
 ## OUTPUTS
@@ -175,23 +192,31 @@ You cannot pipe input to this cmdlet.
 ### System.Diagnostics.EventLogEntry
 
 ## NOTES
-* To use **New-EventLog** on Windows Vista and later versions of the Windows operating system, open Windows PowerShell by using Run as administrator option.
 
-  To create an event source in Windows Vista, Windows XP Professional, or Windows Server 2003, you must be a member of the Administrators group on the computer.
+To use `New-EventLog` on Windows Vista and later versions of Windows, open PowerShell with
+the "Run as administrator" option.
 
-  When you create a new event log and a new event source, the system registers the new source for the new log, but the log is not created until the first entry is written to it.
+To create an event source in Windows Vista, Windows XP Professional, or Windows Server 2003, you
+must be a member of the Administrators group on the computer.
 
-  The operating system stores event logs as files.
-When you create a new event log, the associated file is stored in the %SystemRoot%\System32\Config directory on the specified computer.
-The file name is the first eight characters of the Log property that has an .evt file name extension.
+When you create a new event log and a new event source, the system registers the new source for the
+new log, but the log is not created until the first entry is written to it.
 
-*
+The operating system stores event logs as files.
+
+When you create a new event log, the associated file is stored in the
+`$env:SystemRoot\System32\Config` directory on the specified computer.
+
+The file name is the first eight characters of the **Log** property with an .evt file name
+extension.
 
 ## RELATED LINKS
 
 [Clear-EventLog](Clear-EventLog.md)
 
 [Get-EventLog](Get-EventLog.md)
+
+[Get-WinEvent](../Microsoft.PowerShell.Diagnostics/Get-WinEvent.md)
 
 [Limit-EventLog](Limit-EventLog.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/5.1/Microsoft.PowerShell.Management/Push-Location.md
@@ -1,9 +1,9 @@
 ---
-external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
+ms.date:  01/22/2019
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/09/2017
+external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 online version: http://go.microsoft.com/fwlink/?LinkId=821612
 schema: 2.0.0
 title: Push-Location
@@ -17,77 +17,88 @@ Adds the current location to the top of a location stack.
 ## SYNTAX
 
 ### Path (Default)
+
 ```
 Push-Location [[-Path] <String>] [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ### LiteralPath
+
 ```
 Push-Location [-LiteralPath <String>] [-PassThru] [-StackName <String>] [-UseTransaction] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Push-Location** cmdlet adds, or pushes, the current location onto a location stack. A location stack basically functions like your location history. If you specify a path, this cmdlet pushes the current location onto a location stack and then changes the current location to the location specified by the path. You can use the Pop-Location cmdlet to get locations from the location stack.
 
-By default, **Push-Location** pushes the current location onto the current location stack, but you can use the *StackName* parameter to specify another location stack. If the stack does not exist, **Push-Location** creates it. The stack that is being created is named **default**.
+The `Push-Location` cmdlet adds ("pushes") the current location onto a location stack. If you
+specify a path, `Push-Location` pushes the current location onto a location stack and then changes
+the current location to the location specified by the path. You can use the `Pop-Location` cmdlet
+to get locations from the location stack.
+
+By default, the `Push-Location` cmdlet pushes the current location onto the current location stack,
+but you can use the StackName parameter to specify an alternate location stack. If the stack does
+not exist, `Push-Location` creates it.
 
 For more information about location stacks, see the Notes.
 
 ## EXAMPLES
 
-### Example 1: Change location
+### Example 1
+
+This example pushes the current location onto the default location stack and then changes the location to `C:\Windows`.
+
 ```
-PS C:\> Push-Location -Path "C:\Windows"
+PS C:\> Push-Location C:\Windows
 ```
 
-This command pushes the current location onto the default location stack and then changes the location to C:\Windows.
+### Example 2
 
-### Example 2: Change location in a named stack
+This example pushes the current location onto the RegFunction stack and changes the current location to the `HKLM:\Software\Policies` location.
+
 ```
-PS C:\> Push-Location -Path "HKLM:\Software\Policies" -StackName RegFunction
+PS C:\> Push-Location HKLM:\Software\Policies -StackName RegFunction
 ```
 
-This command pushes the current location onto the RegFunction stack and changes the current location to the HKLM:\Software\Policies location.
-You can use the **Location** cmdlets in any Windows PowerShell drive (PSDrive).
+You can use the Location cmdlets in any PowerShell drive (PSDrive).
 
-### Example 3: Push the current location onto the default stack
-```
-PS C:\> Push-Location
-```
+### Example 3
 
 This command pushes the current location onto the default stack.
 It does not change the location.
 
-### Example 4: Create and use a named stack
 ```
-PS C:\> Push-Location ~ -StackName "Stack2"
-PS C:\Users\User01> Pop-Location -StackName "Stack2"
-PS C:\>
+PS C:\> Push-Location
 ```
+
+### Example 4 - Create and use a named stack
 
 These commands show how to create and use a named location stack.
 
-The first command pushes the current location onto a new stack named Stack2, and then changes the current location to the root directory (%USERPROFILE%), which is represented in the command by the tilde symbol (~) or $home.
-If Stack2 does not already occur in the session, **Push-Location** creates it.
-
-The second command uses **Pop-Location** to pop the original location (PS C:\\\>) from the Stack2 stack.
-Without *StackName*, **Pop-Location** would pop the location from the unnamed default stack.
-
-### Example 5: Show the current stack
 ```
-PS C:\> Get-Location -Stack
+PS C:\> Push-Location ~ -StackName Stack2
+PS C:\Users\User01> Pop-Location -StackName Stack2
+PS C:\>
 ```
 
-This commmand shows the current location stack.
+The first command pushes the current location onto a new stack named Stack2, and then changes the
+current location to the home directory, which is represented in the command by the tilde symbol (~)
+(same as `$env:USERPROFILE` or `$HOME`).
+
+If Stack2 does not already exist in the session, `Push-Location` creates it. The second command
+uses the `Pop-Location` cmdlet to pop the original location (PS C:\\\>) from the Stack2 stack.
+Without the StackName parameter, `Pop-Location` would pop the location from the unnamed default
+stack.
+
+For more information about location stacks, see the [Notes](#notes).
 
 ## PARAMETERS
 
 ### -LiteralPath
-Specifies the path of the new location.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is typed.
-No characters are interpreted as wildcard characters.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+
+Specifies the path to the new location. Unlike the **Path** parameter, the value of the
+**LiteralPath** parameter is used exactly as it is typed. No characters are interpreted as
+wildcards. If the path includes escape characters, enclose it in single quotation marks. Single
+quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -102,8 +113,9 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Passes an object that represents the location to the pipeline.
-By default, this cmdlet does not generate any output.
+
+Passes an object representing the location to the pipeline. By default, this cmdlet does not
+generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -112,16 +124,16 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies the path of the new location.
-This cmdlet your location to the location specified by this path after it adds, or pushes, the current location onto the top of the stack.
-Enter a path of any location whose provider supports this cmdlet.
-Wildcard characters are permitted.
+
+Changes your location to the location specified by this path after it adds (pushes) the current
+location onto the top of the stack. Enter a path to any location whose provider supports this
+cmdlet. Wildcards are permitted. The parameter name is optional.
 
 ```yaml
 Type: String
@@ -129,23 +141,25 @@ Parameter Sets: Path
 Aliases:
 
 Required: False
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -StackName
-Specifies the location stack to which the current location is added.
-Enter a location stack name.
-If the stack does not exist, **Push-Location** creates it.
 
-Without this parameter, **Push-Location** adds the location to the current location stack.
-By default, the current location stack is the unnamed default location stack that Windows PowerShell creates.
-To make a location stack the current location stack, use the *StackName* parameter of the Set-Location cmdlet.
-For more information about location stacks, see the Notes.
+Specifies the location stack to which the current location is added. Enter a location stack name.
+If the stack does not exist, `Push-Location` creates it.
 
-**Push-Location** cannot add a location to the unnamed default stack unless it is the current location stack.
+Without this parameter, `Push-Location` adds the location to the current location stack. By
+default, the current location stack is the unnamed default location stack that PowerShell creates.
+To make a location stack the current location stack, use the StackName parameter of the
+`Set-Location` cmdlet. For more information about location stacks, see the [Notes](#notes).
+
+> [!NOTE]
+> `Push-Location` cannot add a location to the unnamed default stack unless it is the current
+> location stack.
 
 ```yaml
 Type: String
@@ -154,15 +168,15 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: Default stack
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
 ### -UseTransaction
-Includes the command in the active transaction.
-This parameter is valid only when a transaction is in progress.
-For more information, see about_transactions.
+
+Includes the command in the active transaction. This parameter is valid only when a transaction is
+in progress. For more information, see [about_Transactions](../Microsoft.PowerShell.Core/About/about_transactions.md).
 
 ```yaml
 Type: SwitchParameter
@@ -177,34 +191,65 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains a path, but not a literal path, to this cmdlet.
+
+You can pipe a string that contains a path (but not a literal path) to `Push-Location`.
 
 ## OUTPUTS
 
-### None, System.Management.Automation.PathInfo
-This cmdlet generates a **System.Management.Automation.PathInfo** object that represents the location, if you specify the *PassThru* parameter.
-Otherwise, this cmdlet does not generate any output.
+### None or System.Management.Automation.PathInfo
+
+When you use the PassThru parameter, `Push-Location` generates a
+**System.Management.Automation.PathInfo** object that represents the location. Otherwise, this
+cmdlet does not generate any output.
 
 ## NOTES
-* A stack is a last-in, first-out list in which only the most recently added item can be accessed. You add items to a stack in the order that you use them, and then retrieve them for use in the reverse order. Windows PowerShell lets you store provider locations in location stacks.
-* Windows PowerShell creates an unnamed default location stack and you can create multiple named location stacks. If you do not specify a stack name, Windows PowerShell uses the current location stack. By default, the unnamed default location is the current location stack, but you can use **Set-Location** to change the current location stack.
-* To manage location stacks, use the Windows PowerShell **Location** cmdlets, as follows:
 
-- To add a location to a location stack, use the **Push-Location** cmdlet.
-- To get a location from a location stack, use the **Pop-Location** cmdlet.
-- To display the locations in the current location stack, use the *Stack* parameter of the **Get-Location** cmdlet.
-- To display the locations in a named location stack, use the *StackName* parameter of the **Get-Location** cmdlet.
-- To create a new location stack, use the *StackName* parameter of the **Push-Location** cmdlet. If you specify a stack that does not exist, **Push-Location** creates the stack.
-- To make a location stack the current location stack, use the *StackName* parameter of the **Set-Location** cmdlet.
-* The unnamed default location stack is fully available only when it is the current location stack. If you make a named location stack the current location stack, you can no longer use **Push-Location** or **Pop-Location** cmdlets add or get items from the default stack or use a **Get-Location** command to display the locations in the unnamed stack. To make the unnamed stack the current stack, use the *StackName* parameter of **Set-Location** with a value of $Null or an empty string ("").
-* To view more properties of the stack, use **Get-Location -Stack | Select-Object **.
-* You can also refer to **Push-Location** by its built-in alias, **pushd**. For more information, see about_Aliases.
-* **Push-Location** is designed to work with the data exposed by any provider. To list the providers available in your session, type `Get-PSProvider`. For more information, see about_Providers.
+A "stack" is a last-in, first-out list in which only the most recently added item is accessible.
+You add items to a stack in the order that you use them, and then retrieve them for use in the
+reverse order. PowerShell lets you store provider locations in location stacks.
+
+PowerShell creates an unnamed default location stack and you can create multiple named location
+stacks. If you do not specify a stack name, Windows PowerShell uses the current location stack. By
+default, the unnamed default location is the current location stack, but you can use the
+`Set-Location` cmdlet to change the current location stack.
+
+To manage location stacks, use the PowerShell Location cmdlets, as follows.
+
+- To add a location to a location stack, use the `Push-Location` cmdlet.
+- To get a location from a location stack, use the `Pop-Location` cmdlet.
+- To display the locations in the current location stack, use the **Stack** parameter of the
+  `Get-Location` cmdlet.
+
+To display the locations in a named location stack, use the **StackName** parameter of the
+`Get-Location` cmdlet.
+
+- To create a new location stack, use the StackName parameter of the `Push-Location` cmdlet. If you
+  specify a stack that does not exist, `Push-Location` creates the stack.
+- To make a location stack the current location stack, use the StackName parameter of the
+  `Set-Location` cmdlet.
+
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you can no longer use
+`Push-Location` or `Pop-Location` cmdlets add or get items from the default stack or use
+`Get-Location` command to display the locations in the unnamed stack. To make the unnamed stack the
+current stack, use the StackName parameter of the `Set-Location` cmdlet with a value of $null or an
+empty string ("").
+
+You can also refer to `Push-Location` by its built-in alias, `pushd`. For more information, see
+[about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).
+
+The `Push-Location` cmdlet is designed to work with the data exposed by any provider. To list the
+providers available in your session, type `Get-PSProvider`. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS
 
@@ -213,3 +258,5 @@ Otherwise, this cmdlet does not generate any output.
 [Pop-Location](Pop-Location.md)
 
 [Set-Location](Set-Location.md)
+
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md)

--- a/reference/6/Microsoft.PowerShell.Core/New-ModuleManifest.md
+++ b/reference/6/Microsoft.PowerShell.Core/New-ModuleManifest.md
@@ -3,7 +3,7 @@ external help file: System.Management.Automation.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Core
-ms.date: 06/09/2017
+ms.date: 01/22/2019
 online version: http://go.microsoft.com/fwlink/?LinkId=821496
 schema: 2.0.0
 title: New-ModuleManifest
@@ -17,224 +17,271 @@ Creates a new module manifest.
 ## SYNTAX
 
 ```
-New-ModuleManifest [-Path] <String> [-NestedModules <Object[]>] [-Guid <Guid>] [-Author <String>]
- [-CompanyName <String>] [-Copyright <String>] [-RootModule <String>] [-ModuleVersion <Version>]
- [-Description <String>] [-ProcessorArchitecture <ProcessorArchitecture>] [-PowerShellVersion <Version>]
- [-ClrVersion <Version>] [-DotNetFrameworkVersion <Version>] [-PowerShellHostName <String>]
- [-PowerShellHostVersion <Version>] [-RequiredModules <Object[]>] [-TypesToProcess <String[]>]
- [-FormatsToProcess <String[]>] [-ScriptsToProcess <String[]>] [-RequiredAssemblies <String[]>]
- [-FileList <String[]>] [-ModuleList <Object[]>] [-FunctionsToExport <String[]>] [-AliasesToExport <String[]>]
- [-VariablesToExport <String[]>] [-CmdletsToExport <String[]>] [-DscResourcesToExport <String[]>]
- [-CompatiblePSEditions <String[]>] [-PrivateData <Object>] [-Tags <String[]>] [-ProjectUri <Uri>]
- [-LicenseUri <Uri>] [-IconUri <Uri>] [-ReleaseNotes <String>] [-HelpInfoUri <String>] [-PassThru]
- [-DefaultCommandPrefix <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-ModuleManifest [-Path] <string> [-NestedModules <Object[]>] [-Guid <guid>] [-Author <string>]
+ [-CompanyName <string>] [-Copyright <string>] [-RootModule <string>] [-ModuleVersion <version>]
+ [-Description <string>] [-ProcessorArchitecture <ProcessorArchitecture>] [-PowerShellVersion <version>]
+ [-ClrVersion <version>] [-DotNetFrameworkVersion <version>] [-PowerShellHostName <string>]
+ [-PowerShellHostVersion <version>] [-RequiredModules <Object[]>] [-TypesToProcess <string[]>]
+ [-FormatsToProcess <string[]>] [-ScriptsToProcess <string[]>] [-RequiredAssemblies <string[]>]
+ [-FileList <string[]>] [-ModuleList <Object[]>] [-FunctionsToExport <string[]>] [-AliasesToExport <string[]>]
+ [-VariablesToExport <string[]>] [-CmdletsToExport <string[]>] [-DscResourcesToExport <string[]>]
+ [-CompatiblePSEditions <string[]>] [-PrivateData <Object>] [-Tags <string[]>] [-ProjectUri <uri>]
+ [-LicenseUri <uri>] [-IconUri <uri>] [-ReleaseNotes <string>] [-HelpInfoUri <string>] [-PassThru]
+ [-DefaultCommandPrefix <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **New-ModuleManifest** cmdlet creates a new module manifest (.psd1) file, populates its values, and saves the manifest file in the specified path.
 
-Module authors can use this cmdlet to create a manifest for their module.
-A module manifest is a .psd1 file that contains a hash table.
-The keys and values in the hash table describe the contents and attributes of the module, define the prerequisites, and determine how the components are processed.
-Manifests are not required for a module.
+The `New-ModuleManifest` cmdlet creates a new module manifest (.psd1) file, populates its values,
+and saves the manifest file in the specified path.
 
-**New-ModuleManifest** creates a manifest that includes all of the frequently used manifest keys, so that you can use the default output as a manifest template.
-To add or change values, or to add module keys that this cmdlet does not add, open the resulting file in a text editor.
+Module authors can use this cmdlet to create a manifest for their module. A module manifest is a
+.psd1 file that contains a hash table. The keys and values in the hash table describe the contents
+and attributes of the module, define the prerequisites, and determine how the components are
+processed. Manifests are not required for a module.
 
-Each parameter of this cmdlet, except for *Path* and *PassThru*, creates a module manifest key and its value.
-In a module manifest, only the **ModuleVersion** key is required.
-Unless specified in the parameter description, if you omit a parameter from the command, **New-ModuleManifest** creates a comment string for the associated value that has no effect.
+`New-ModuleManifest` creates a manifest that includes all of the commonly used manifest keys, so
+you can use the default output as a manifest template. To add or change values, or to add module
+keys that this cmdlet does not add, open the resulting file in a text editor.
 
-In Windows PowerShell 2.0, **New-ModuleManifest** prompts you for the values of frequently used parameters that are not specified in the command, in addition to required parameter values.
-Starting in Windows PowerShell 3.0, it prompts only when required parameter values are not specified.
+Each parameter of this cmdlet (except for **Path** and **PassThru**) creates a module manifest key
+and its value. In a module manifest, only the **ModuleVersion** key is required. Unless specified
+in the parameter description, if you omit a parameter from the command, `New-ModuleManifest`
+creates a comment string for the associated value that has no effect.
 
-Module manifest (.psd1) file encoding is UTF-8 (no BOM) on all platforms.
+In Windows PowerShell 2.0, `New-ModuleManifest` prompts you for the values of commonly used
+parameters that are not specified in the command, in addition to required parameter values.
+Beginning in Windows PowerShell 3.0, it prompts only when required parameter values are not
+specified.
 
 ## EXAMPLES
 
-### Example 1: Create a manifest
-```
-PS C:\> New-ModuleManifest -Path C:\Users\User01\Documents\WindowsPowerShell\Modules\Test-Module\Test-Module.psd1 -PassThru
+### Example 1 - Create a new module manifest
 
-## Module manifest for module 'TestModule'
-## Generated by: User01
-## Generated on: 1/24/2012
-#@{
-# Script module or binary module file associated with this manifest
-# RootModule = ''
-# Version number of this module.ModuleVersion = '1.0'
-# ID used to uniquely identify this moduleGUID = 'd0a9150d-b6a4-4b17-a325-e3a24fed0aa9'
-# Author of this moduleAuthor = 'User01'
-# Company or vendor of this moduleCompanyName = 'Unknown'
-# Copyright statement for this moduleCopyright = '(c) 2012 User01. All rights reserved.'
-# Description of the functionality provided by this module
-# Description = ''
-# Minimum version of the PowerShell engine required by this module
-# PowerShellVersion = ''
-# Name of the PowerShell host required by this module
-# PowerShellHostName = ''
-# Minimum version of the PowerShell host required by this module
-# PowerShellHostVersion = ''
-# Minimum version of the .NET Framework required by this module
-# DotNetFrameworkVersion = ''
-# Minimum version of the common language runtime (CLR) required by this module
-# CLRVersion = ''
-# Processor architecture (None, X86, Amd64) required by this module
-# ProcessorArchitecture = ''
-# Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
-# Assemblies that must be loaded prior to importing this module
-# RequiredAssemblies = @()
-# Script files (.ps1) that are run in the caller's environment prior to importing this module
-# ScriptsToProcess = @()
-# Type files (.ps1xml) to be loaded when importing this module
-# TypesToProcess = @()
-# Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
-# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-# NestedModules = @()
-# Functions to export from this moduleFunctionsToExport = '*'
-# Cmdlets to export from this moduleCmdletsToExport = '*'
-# Variables to export from this moduleVariablesToExport = '*'
-# Aliases to export from this moduleAliasesToExport = '*'
-# List of all modules packaged with this module# ModuleList = @()
-# List of all files packaged with this module
-# FileList = @()
-# Private data to pass to the module specified in RootModule/ModuleToProcess
-# PrivateData = ''
-# HelpInfo URI of this module
-# HelpInfoURI = ''
-# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
-# DefaultCommandPrefix = ''}
-```
-
-This command creates a module manifest in the file that is specified by the *Path* parameter.
-The *PassThru* parameter sends the output to the pipeline in addition to the file.
+This command creates a new module manifest in the file that is specified by the Path parameter. The
+**PassThru** parameter sends the output to the pipeline as well as to the file.
 
 The output shows the default values of all keys in the manifest.
 
-### Example 2: Create a manifest and add values to keys
-```
-PS C:\> New-ModuleManifest -PowerShellVersion 1.0 -AliasesToExport JKBC, DRC, TAC -Path C:\ps-test\ManifestTest.psd1
-```
-
-This command creates a new module manifest.
-It uses the *PowerShellVersion* and *AliasesToExport* parameters to add values to the corresponding manifest keys.
-
-### Example 3: Create a manifest by using strings and hash tables
-```
-PS C:\> New-ModuleManifest -RequiredModules BitsTransfer,@{ModuleName="PSScheduledJob";ModuleVersion="1.0.0.0";GUID="50cdb55f-5ab7-489f-9e94-4ec21ff51e59"}
+```powershell
+New-ModuleManifest -Path C:\ps-test\Test-Module\Test-Module.psd1 -PassThru
 ```
 
-This example shows how to use the string and hash table formats of the *ModuleList*, *RequiredModules*, and *NestedModules* parameter.
-You can combine strings and hash tables in the same parameter value.
+```Output
+#
+# Module manifest for module 'Test-Module'
+#
+# Generated by: ContosoAdmin
+#
+# Generated on: 1/22/2019
+#
 
-This command commands creates a module manifest for a module that requires the **BitsTransfer** and **PSScheduledJob** modules.
+@{
 
-The command uses a string format to specify the name of the **BitsTransfer** module and the hash table format to specify the name, a GUID, and a version of the **PSScheduledJob** module.
+# Script module or binary module file associated with this manifest.
+# RootModule = ''
 
-### Example 4: Create a manifest for a module that support updatable help
+# Version number of this module.
+ModuleVersion = '1.0'
+
+# ID used to uniquely identify this module
+GUID = '47179120-0bcb-4f14-8d80-f4560107f85c'
+
+# Author of this module
+Author = 'ContosoAdmin'
+
+# Company or vendor of this module
+CompanyName = 'Unknown'
+
+# Copyright statement for this module
+Copyright = '(c) 2019 ContosoAdmin. All rights reserved.'
+
+# Description of the functionality provided by this module
+# Description = ''
+
+# Minimum version of the Windows PowerShell engine required by this module
+# PowerShellVersion = ''
+
+# Name of the Windows PowerShell host required by this module
+# PowerShellHostName = ''
+
+# Minimum version of the Windows PowerShell host required by this module
+# PowerShellHostVersion = ''
+
+# Minimum version of the .NET Framework required by this module
+# DotNetFrameworkVersion = ''
+
+# Minimum version of the common language runtime (CLR) required by this module
+# CLRVersion = ''
+
+# Processor architecture (None, X86, Amd64) required by this module
+# ProcessorArchitecture = ''
+
+# Modules that must be imported into the global environment prior to importing this module
+# RequiredModules = @()
+
+# Assemblies that must be loaded prior to importing this module
+# RequiredAssemblies = @()
+
+# Script files (.ps1) that are run in the caller's environment prior to importing this module.
+# ScriptsToProcess = @()
+
+# Type files (.ps1xml) to be loaded when importing this module
+# TypesToProcess = @()
+
+# Format files (.ps1xml) to be loaded when importing this module
+# FormatsToProcess = @()
+
+# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+# NestedModules = @()
+
+# Functions to export from this module
+FunctionsToExport = '*'
+
+# Cmdlets to export from this module
+CmdletsToExport = '*'
+
+# Variables to export from this module
+VariablesToExport = '*'
+
+# Aliases to export from this module
+AliasesToExport = '*'
+
+# List of all modules packaged with this module.
+# ModuleList = @()
+
+# List of all files packaged with this module
+# FileList = @()
+
+# Private data to pass to the module specified in RootModule/ModuleToProcess
+# PrivateData = ''
+
+# HelpInfo URI of this module
+# HelpInfoURI = ''
+
+# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+# DefaultCommandPrefix = ''
+
+}
 ```
-PS C:\> New-ModuleManifest -HelpInfoUri "http://http://go.microsoft.com/fwlink/?LinkID=603"
+
+### Example 2 - Create a new manifest with some prepopulated settings
+
+This command creates a new module manifest. It uses the **PowerShellVersion** and
+**AliasesToExport** parameters to add values to the corresponding manifest keys.
+
+```powershell
+New-ModuleManifest -PowerShellVersion 1.0 -AliasesToExport JKBC, DRC, TAC -Path C:\ps-test\ManifestTest.psd1
 ```
 
-This example shows creates a module manifest for a module that supports the Updatable Help feature.
-This feature lets users use the Update-Help and Save-Help cmdlets, which download help files for the module from the Internet and install them in the module.
+### Example 3 - Create a manifest that requires other modules
 
-The command uses the *HelpInfoUri* parameter to create a **HelpInfoUri** key in the module manifest.
-The value of the parameter and the key must begin with http or https.
-This value tells the Updatable Help system where to find the HelpInfo XML updatable help information file for the module.
+The example uses a string format to specify the name of the **BitsTransfer** module and the hash
+table format to specify the name, a GUID, and a version of the **PSScheduledJob** module.
 
-For information about Updatable Help, see [about_Updatable_Help](about/about_Updatable_Help.md).
-For information about the HelpInfo XML file, see "Supporting Updatable Help" in the Microsoft Developer Library (MSDN) library.
-
-### Example 5: Get the module manifest values of a module
+```powershell
+$moduleSettings = @{
+  RequiredModules = (BitsTransfer, @{
+    ModuleName="PSScheduledJob"
+    ModuleVersion="1.0.0.0";
+    GUID="50cdb55f-5ab7-489f-9e94-4ec21ff51e59"
+  }
+  Path = 'C:\ps-test\ManifestTest.psd1'
+}
+New-ModuleManifest @moduleSettings
 ```
-PS C:\> Get-Module PSScheduledJob -List | Format-List -Property *
 
-LogPipelineExecutionDetails :
-FalseName                        :
-PSScheduledJobPath                        : C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.psd1
+This example shows how to use the string and hash table formats of the **ModuleList**,
+**RequiredModules**, and **NestedModules** parameter. You can combine strings and hash tables in
+the same parameter value.
+
+### Example 4 - Create a manifest that supports updateable help
+
+This example uses the **HelpInfoUri** parameter to create a **HelpInfoUri** key in the module
+manifest. The value of the parameter and the key must begin with "http" or "https". This value
+tells the Updatable Help system where to find the HelpInfo XML updatable help information file for
+the module.
+
+```powershell
+$moduleSettings = @{
+  HelpInfoUri = 'http://http://go.microsoft.com/fwlink/?LinkID=603'
+  Path = 'C:\ps-test\ManifestTest.psd1'
+}
+New-ModuleManifest @moduleSettings
+```
+
+For information about Updatable Help, see [about_Updatable_Help](./About/about_Updatable_Help.md).
+For information about the HelpInfo XML file, see [Supporting Updatable Help](/powershell/developer/module/supporting-updatable-help).
+
+### Example 5 - Getting module information
+
+This example shows how to get the configuration values of a module. The values in the module
+manifest are reflected in the values of properties of the module object.
+
+The `Get-Module` cmdlet is used to get the **Microsoft.PowerShell.Diagnostics** module using the
+**List** parameter. The command sends the module to the `Format-List` cmdlet to display all
+properties and values of the module object.
+
+```powershell
+Get-Module Microsoft.PowerShell.Diagnostics -List | Format-List -Property *
+```
+
+```Output
+LogPipelineExecutionDetails : False
+Name                        : Microsoft.PowerShell.Diagnostics
+Path                        : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Diagnostics\Micro
+                              soft.PowerShell.Diagnostics.psd1
 Definition                  :
 Description                 :
-Guid                        : 50cdb55f-5ab7-489f-9e94-4ec21ff51e59
-HelpInfoUri                 : http://go.microsoft.com/fwlink/?LinkID=223911
-ModuleBase                  : C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob
+Guid                        : ca046f10-ca64-4740-8ff9-2565dba61a4f
+HelpInfoUri                 : http://go.microsoft.com/fwlink/?LinkID=210596
+ModuleBase                  : C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Diagnostics
 PrivateData                 :
-Version                     : 1.0.0.0
-ModuleType                  :
-BinaryAuthor                      : Microsoft Corporation
+Version                     : 3.0.0.0
+ModuleType                  : Manifest
+Author                      : Microsoft Corporation
 AccessMode                  : ReadWrite
 ClrVersion                  : 4.0
 CompanyName                 : Microsoft Corporation
-Copyright                   : c Microsoft Corporation. All rights reserved.
+Copyright                   : © Microsoft Corporation. All rights reserved.
 DotNetFrameworkVersion      :
 ExportedFunctions           : {}
-ExportedCmdlets             : {[New-JobTrigger, New-JobTrigger], [Add-JobTrigger, Add-JobTrigger], [Remove-JobTrigger, Remove-JobTrigger], [Get-JobTrigger, Get-JobTrigger]...}
-ExportedCommands            : {[New-JobTrigger, New-JobTrigger], [Add-JobTrigger, Add-JobTrigger], [Remove-JobTrigger, Remove-JobTrigger], [Get-JobTrigger, Get-JobTrigger]...}
+ExportedCmdlets             : {[Get-WinEvent, Get-WinEvent], [Get-Counter, Get-Counter], [Import-Counter,
+                              Import-Counter], [Export-Counter, Export-Counter]...}
+ExportedCommands            : {[Get-WinEvent, Get-WinEvent], [Get-Counter, Get-Counter], [Import-Counter,
+                              Import-Counter], [Export-Counter, Export-Counter]...}
 FileList                    : {}
 ModuleList                  : {}
 NestedModules               : {}
 PowerShellHostName          :
 PowerShellHostVersion       :
-PowerShellVersion           : 4.0
+PowerShellVersion           : 3.0
 ProcessorArchitecture       : None
 Scripts                     : {}
 RequiredAssemblies          : {}
 RequiredModules             : {}
-RootModule                  : Microsoft.PowerShell.ScheduledJob.dll
+RootModule                  :
 ExportedVariables           : {}
 ExportedAliases             : {}
 ExportedWorkflows           : {}
 SessionState                :
 OnRemove                    :
-ExportedFormatFiles         : {C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.Format.ps1xml}
-ExportedTypeFiles           : {C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\PSScheduledJob\PSScheduledJob.types.ps1xml}
-
-PS C:\> Get-Module -List | Format-Table -Property Name, PowerShellVersion
-
-Name                                                        PowerShellVersion
-----                                                        -----------------
-ADDeploymentWF                                              4.0
-AppLocker                                                   4.0
-Appx                                                        4.0
-BestPractices                                               4.0
-BitsTransfer                                                4.0
-BranchCache                                                 4.0
-CimCmdlets                                                  4.0
-DirectAccessClientComponents                                4.0
-Dism                                                        4.0
-DnsClient                                                   4.0
-International                                               4.0
-iSCSI                                                       4.0
-IscsiTarget                                                 4.0
-Kds                                                         4.0
-Microsoft.PowerShell.Diagnostics                            4.0
-Microsoft.PowerShell.Host                                   4.0
-Microsoft.PowerShell.Management                             4.0
+ExportedFormatFiles         : {C:\Windows\system32\WindowsPowerShell\v1.0\Event.format.ps1xml,
+                              C:\Windows\system32\WindowsPowerShell\v1.0\Diagnostics.format.ps1xml}
+ExportedTypeFiles           : {C:\Windows\system32\WindowsPowerShell\v1.0\GetEvent.types.ps1xml}
 ```
-
-This example shows how to get the module manifest values of a module.
-This is essentially a "Get-ModuleManifest" command.
-Because the values in the module manifest are reflected in the values of properties of the module object, you can get the module manifest values by displaying the module object properties.
-
-The first command uses the **Get-Module** cmdlet to get the *PSScheduledJob* module.
-The command uses the *List* parameter, because the module is installed, but not imported into the session.
-The command sends the module to the Format-List cmdlet, which displays all properties and values of the module object in a list.
-
-The second command uses the Format-Table cmdlet to display the **PowerShellVersion** property of all installed modules in a table.
-The **PowerShellVersion** property is defined in the module manifest.
 
 ## PARAMETERS
 
 ### -AliasesToExport
-Specifies the aliases that the module exports.
-Wildcard characters are permitted.
 
-You can use this parameter to restrict the aliases that are exported by the module.
-It can remove aliases from the list of exported aliases, but it cannot add aliases to the list.
+Specifies the aliases that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates an **AliasesToExport** key with a value of * (all), meaning that all aliases that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the aliases that are exported by the module. It can remove
+aliases from the list of exported aliases, but it cannot add aliases to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates an **AliasesToExport** key with a value
+of `*` (all), meaning that all aliases defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -243,15 +290,17 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: * (all)
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Author
+
 Specifies the module author.
 
-If you omit this parameter, **New-ModuleManifest** creates an **Author** key with the name of the current user.
+If you omit this parameter, `New-ModuleManifest` creates an **Author** key with the name of the
+current user.
 
 ```yaml
 Type: String
@@ -260,13 +309,15 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: Name of the current user
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -ClrVersion
-Specifies the minimum version of the Common Language Runtime (CLR) of the Microsoft .NET Framework that the module requires.
+
+Specifies the minimum version of the Common Language Runtime (CLR) of the Microsoft .NET Framework
+that the module requires.
 
 ```yaml
 Type: Version
@@ -281,13 +332,14 @@ Accept wildcard characters: False
 ```
 
 ### -CmdletsToExport
-Specifies the cmdlets that the module exports.
-Wildcard characters are permitted.
 
-You can use this parameter to restrict the cmdlets that are exported by the module.
-It can remove cmdlets from the list of exported cmdlets, but it cannot add cmdlets to the list.
+Specifies the cmdlets that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates a **CmdletsToExport** key with a value of * (all), meaning that all cmdlets that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the cmdlets that are exported by the module. It can remove
+cmdlets from the list of exported cmdlets, but it cannot add cmdlets to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates a **CmdletsToExport** key with a value
+of `*` (all), meaning that all cmdlets defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -296,15 +348,17 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: * (all)
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -CompanyName
+
 Identifies the company or vendor who created the module.
 
-If you omit this parameter, **New-ModuleManifest** creates a **CompanyName** key with a value of "Unknown".
+If you omit this parameter, `New-ModuleManifest` creates a **CompanyName** key with a value of
+"Unknown".
 
 ```yaml
 Type: String
@@ -313,14 +367,31 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: "Unknown"
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -CompatiblePSEditions
-Specifies the compatible PSEditions of the module.
-For information about PSEdition, see [Modules with compatible PowerShell Editions](https://msdn.microsoft.com/en-us/powershell/gallery/psget/module/modulewithpseditionsupport).
+
+Specifies the compatible PSEditions of the module. For information about PSEdition, see
+[Modules with compatible PowerShell Editions](/powershell/gallery/concepts/module-psedition-support).
 
 ```yaml
 Type: String[]
@@ -336,10 +407,12 @@ Accept wildcard characters: False
 ```
 
 ### -Copyright
+
 Specifies a copyright statement for the module.
 
-If you omit this parameter, **New-ModuleManifest** creates a **Copyright** key with a value of  "(c) \<year\> \<username\>.
-All rights reserved." where \<year\> is the current year and \<username\> is the value of the **Author** key (if one is specified) or the name of the current user.
+If you omit this parameter, `New-ModuleManifest` creates a **Copyright** key with a value of
+`(c) <year> <username>. All rights reserved.` where `<year>` is the current year and `<username>`
+is the value of the **Author** key.
 
 ```yaml
 Type: String
@@ -348,32 +421,13 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DefaultCommandPrefix
-Specifies a prefix that is prepended to the nouns of all commands in the module when they are imported into a session.
-Prefixes prevent command name conflicts in a user's session.
-
-Module users can override this prefix by specifying the *Prefix* parameter of the Import-Module cmdlet.
-
-This parameter was introduced in Windows PowerShell 3.0.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
+Default value: (c) <year> <username>. All rights reserved.
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Description
+
 Describes the contents of the module.
 
 ```yaml
@@ -389,6 +443,7 @@ Accept wildcard characters: False
 ```
 
 ### -DotNetFrameworkVersion
+
 Specifies the minimum version of the Microsoft .NET Framework that the module requires.
 
 ```yaml
@@ -405,6 +460,9 @@ Accept wildcard characters: False
 
 ### -DscResourcesToExport
 
+Specifies the DSC resources that the module exports.
+Wildcards are permitted.
+
 ```yaml
 Type: String[]
 Parameter Sets: (All)
@@ -414,14 +472,15 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -FileList
+
 Specifies all items that are included in the module.
 
-This key is designed to act as a module inventory.
-The files listed in the key are not automatically exported with the module.
+This key is designed to act as a module inventory. The files listed in the key are included when
+the module is published, but any functions are not automatically exported.
 
 ```yaml
 Type: String[]
@@ -436,10 +495,11 @@ Accept wildcard characters: False
 ```
 
 ### -FormatsToProcess
+
 Specifies the formatting files (.ps1xml) that run when the module is imported.
 
-When you import a module, PowerShell runs the Update-FormatData cmdlet with the specified files.
-Because formatting files are not scoped, they affect all session states in the session.
+When you import a module, Windows PowerShell runs the `Update-FormatData` cmdlet with the specified
+files. Because formatting files are not scoped, they affect all session states in the session.
 
 ```yaml
 Type: String[]
@@ -454,13 +514,14 @@ Accept wildcard characters: False
 ```
 
 ### -FunctionsToExport
-Specifies the functions that the module exports.
-Wildcard characters are permitted.
 
-You can use this parameter to restrict the functions that are exported by the module.
-It can remove functions from the list of exported aliases, but it cannot add functions to the list.
+Specifies the functions that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates an **FunctionsToExport** key with a value of * (all), meaning that all functions that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the functions that are exported by the module. It can remove
+functions from the list of exported aliases, but it cannot add functions to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates an **FunctionsToExport** key with a
+value of `*` (all), meaning that all functions defined in the module are exported by the manifest.
 
 ```yaml
 Type: String[]
@@ -469,18 +530,20 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: * (all)
 Accept pipeline input: False
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -Guid
-Specifies a unique identifier for the module.
-The GUID can be used to distinguish among modules with the same name.
 
-If you omit this parameter, **New-ModuleManifest** creates a **GUID** key in the manifest and generates a GUID for the value.
+Specifies a unique identifier for the module. The GUID can be used to distinguish among modules
+with the same name.
 
-To create a new GUID in PowerShell, type "\[guid\]::NewGuid()".
+If you omit this parameter, `New-ModuleManifest` creates a **GUID** key in the manifest and
+generates a GUID for the value.
+
+To create a new GUID in Windows PowerShell, type "\[guid\]::NewGuid()".
 
 ```yaml
 Type: Guid
@@ -489,19 +552,22 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: A GUID generated for the module
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -HelpInfoUri
-Specifies the Internet address of the HelpInfo XML file for the module.
-Enter an Uniform Resource Identifier (URI) that starts with "http" or "https".
 
-The HelpInfo XML file supports the Updatable Help feature that was introduced in Windows PowerShell 3.0.
-It contains information about the location of downloadable help files for the module and the version numbers of the newest help files for each supported locale.
-For information about Updatable Help, see [about_Updatable_Help](about/about_Updatable_Help.md).
-For information about the HelpInfo XML file, see "Supporting Updatable Help" in the Microsoft Developer Network (MSDN) library.
+Specifies the Internet address of the HelpInfo XML file for the module. Enter an Uniform Resource
+Identifier (URI) that begins with "http" or "https".
+
+The HelpInfo XML file supports the Updatable Help feature that was introduced in Windows PowerShell
+3.0. It contains information about the location of downloadable help files for the module and the
+version numbers of the newest help files for each supported locale.
+
+For information about Updatable Help, see [about_Updatable_Help](./About/about_Updatable_Help.md).
+For information about the HelpInfo XML file, see [Supporting Updatable Help](/powershell/developer/module/supporting-updatable-help).
 
 This parameter was introduced in Windows PowerShell 3.0.
 
@@ -519,6 +585,8 @@ Accept wildcard characters: False
 
 ### -IconUri
 
+Specifies the URL of an icon for the module. The specified icon is displayed on the gallery web page for the module.
+
 ```yaml
 Type: Uri
 Parameter Sets: (All)
@@ -533,6 +601,8 @@ Accept wildcard characters: False
 
 ### -LicenseUri
 
+Specifies the URL of licensing terms for the module.
+
 ```yaml
 Type: Uri
 Parameter Sets: (All)
@@ -546,15 +616,15 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleList
+
 Lists all modules that are included in this module.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
 
-This key is designed to act as a module inventory.
-The modules that are listed in the value of this key are not automatically processed.
+This key is designed to act as a module inventory. The modules that are listed in the value of this
+key are not automatically processed.
 
 ```yaml
 Type: Object[]
@@ -569,10 +639,12 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleVersion
+
 Specifies the version of the module.
 
-This parameter is not required by the cmdlet, but a **ModuleVersion** key is required in the manifest.
-If you omit this parameter, **New-ModuleManifest** creates a **ModuleVersion** key with a value of "1.0".
+This parameter is not required by the cmdlet, but a **ModuleVersion** key is required in the
+manifest. If you omit this parameter, `New-ModuleManifest` creates a **ModuleVersion** key with a
+value of "1.0".
 
 ```yaml
 Type: Version
@@ -581,27 +653,32 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 1.0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -NestedModules
-Specifies script modules (.psm1) and binary modules (.dll) that are imported into the module's session state.
-The files in the **NestedModules** key run in the order in which they are listed in the value.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Specifies script modules (.psm1) and binary modules (.dll) that are imported into the module's
+session state. The files in the **NestedModules** key run in the order in which they are listed in
+the value.
+
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
 
 Typically, nested modules contain commands that the root module needs for its internal processing.
-By default, the commands in nested modules are exported from the module's session state into the caller's session state, but the root module can restrict the commands that it exports, for example, by using an Export-ModuleMember command.
+By default, the commands in nested modules are exported from the module's session state into the
+caller's session state, but the root module can restrict the commands that it exports (for example,
+by using an Export-ModuleMember command).
 
-Nested modules in the module session state are available to the root module, but they are not returned by a Get-Module command in the caller's session state.
+Nested modules in the module session state are available to the root module, but they are not
+returned by a `Get-Module` command in the caller's session state.
 
-Scripts (.ps1) that are listed in the **NestedModules** key are run in the module's session state, not in the caller's session state.
-To run a script in the caller's session state, list the script file name in the value of the **ScriptsToProcess** key in the manifest.
+Scripts (.ps1) that are listed in the **NestedModules** key are run in the module's session state,
+not in the caller's session state. To run a script in the caller's session state, list the script
+file name in the value of the **ScriptsToProcess** key in the manifest.
 
 ```yaml
 Type: Object[]
@@ -616,8 +693,9 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Indicates that this cmdlet writes the resulting module manifest to the console, in addition to creating a .psd1 file.
-By default, this cmdlet does not generate any output.
+
+Writes the resulting module manifest to the console, in addition to creating a .psd1 file. By
+default, this cmdlet does not generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -626,22 +704,26 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies the path and file name of the new module manifest.
-Enter a path and file name with a .psd1 file name extension, such as `$pshome\Modules\MyModule\MyModule.psd1`.
-This parameter is required.
 
-If you specify the path of an existing file, **New-ModuleManifest** replaces the file without warning unless the file has the read-only attribute.
+Specifies the path and file name of the new module manifest. Enter a path and file name with a
+.psd1 file name extension, such as `$pshome\Modules\MyModule\MyModule.psd1`. This parameter is
+required.
 
-The manifest should be located in the module's directory, and the manifest file name should be the same as the module directory name, but with a .psd1 file name extension.
+If you specify the path to an existing file, `New-ModuleManifest` replaces the file without
+warning unless the file has the read-only attribute.
 
-You cannot use variables, such as $pshome or $home, in response to a prompt for a **Path** parameter value.
-To use a variable, include the **Path** parameter in the command.
+The manifest should be located in the module's directory, and the manifest file name should be the
+same as the module directory name, but with a .psd1 file name extension.
+
+> [!NOTE]
+> You cannot use variables, such as `$PSHOME` or `$HOME`, in response to a prompt for a **Path**
+> parameter value. To use a variable, include the **Path** parameter in the command.
 
 ```yaml
 Type: String
@@ -649,18 +731,18 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -PowerShellHostName
-Specifies the name of the PowerShell host program that the module requires.
-Enter the name of the host program, such as `Windows PowerShell ISE Host` or `ConsoleHost`.
-Wildcard characters are not permitted.
 
-To find the name of a host program, in the program, type `$host.name`.
+Specifies the name of the PowerShell host program that the module requires. Enter the name of the
+host program, such as "Windows PowerShell ISE Host" or "ConsoleHost". Wildcards are not permitted.
+
+To find the name of a host program, in the program, type `$Host.Name`.
 
 ```yaml
 Type: String
@@ -675,8 +757,9 @@ Accept wildcard characters: False
 ```
 
 ### -PowerShellHostVersion
-Specifies the minimum version of the PowerShell host program that works with the module.
-Enter a version number, such as 1.1.
+
+Specifies the minimum version of the PowerShell host program that works with the module. Enter a
+version number, such as 1.1.
 
 ```yaml
 Type: Version
@@ -691,7 +774,8 @@ Accept wildcard characters: False
 ```
 
 ### -PowerShellVersion
-Specifies the minimum version of PowerShell that works with this module.
+
+Specifies the minimum version of Windows PowerShell that works with this module.
 For example, you can enter 3.0, 4.0, or 5.0 as the value of this parameter.
 
 ```yaml
@@ -707,6 +791,7 @@ Accept wildcard characters: False
 ```
 
 ### -PrivateData
+
 Specifies data that is passed to the module when it is imported.
 
 ```yaml
@@ -722,9 +807,9 @@ Accept wildcard characters: False
 ```
 
 ### -ProcessorArchitecture
-Specifies the processor architecture that the module requires.
-The acceptable values for this parameter are: x86, AMD64, IA64, and None.
-None indicates unknown or unspecified.
+
+Specifies the processor architecture that the module requires. Valid values are x86, AMD64, IA64, MSIL,
+and None (unknown or unspecified).
 
 ```yaml
 Type: ProcessorArchitecture
@@ -740,6 +825,7 @@ Accept wildcard characters: False
 ```
 
 ### -ProjectUri
+Specifies the URL of a web page about this project.
 
 ```yaml
 Type: Uri
@@ -769,12 +855,15 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredAssemblies
-Specifies the assembly (.dll) files that the module requires.
-Enter the assembly file names.
-PowerShell loads the specified assemblies before updating types or formats, importing nested modules, or importing the module file that is specified in the value of the **RootModule** key.
 
-Use this parameter to list all the assemblies that the module requires.
-This includes assemblies that must be loaded to update any formatting or type files that are listed in the **FormatsToProcess** or **TypesToProcess** keys, even if those assemblies are also listed as binary modules in the **NestedModules** key.
+Specifies the assembly (.dll) files that the module requires. Enter the assembly file names.
+PowerShell loads the specified assemblies before updating types or formats, importing nested
+modules, or importing the module file that is specified in the value of the **RootModule** key.
+
+Use this parameter to list all the assemblies that the module requires, including assemblies that
+must be loaded to update any formatting or type files that are listed in the **FormatsToProcess**
+or **TypesToProcess** keys, even if those assemblies are also listed as binary modules in the
+**NestedModules** key.
 
 ```yaml
 Type: String[]
@@ -789,17 +878,17 @@ Accept wildcard characters: False
 ```
 
 ### -RequiredModules
-Specifies modules that must be in the global session state.
-If the required modules are not in the global session state, PowerShell imports them.
-If the required modules are not available, the Import-Module command fails.
 
-Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion** keys.
-The hash table can also have an optional **GUID** key.
-You can combine strings and hash tables in the parameter value.
-For more information, see the examples.
+Specifies modules that must be in the global session state. If the required modules are not in the
+global session state, Windows PowerShell imports them. If the required modules are not available,
+the `Import-Module` command fails.
 
-In Windows PowerShell 2.0, **Import-Module** does not import required modules automatically.
-It just verifies that the required modules are in the global session state.
+Enter each module name as a string or as a hash table with **ModuleName** and **ModuleVersion**
+keys. The hash table can also have an optional **GUID** key. You can combine strings and hash
+tables in the parameter value. For more information, see the examples.
+
+In Windows PowerShell 2.0, `Import-Module` does not import required modules automatically. It
+just verifies that the required modules are in the global session state.
 
 ```yaml
 Type: Object[]
@@ -813,34 +902,10 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RootModule
-Specifies the primary or root file of the module.
-Enter the file name of a script (.ps1), a script module (.psm1), a module manifest (.psd1), an assembly (.dll), a cmdlet definition XML file (.cdxml), or a workflow (.xaml).
-When the module is imported, the members that are exported from the root module file are imported into the caller's session state.
-
-If a module has a manifest file and no root file has been designated in the **RootModule** key, the manifest becomes the primary file for the module, and the module becomes a manifest module (ModuleType = Manifest).
-
-To export members from .psm1 or .dll files in a module that has a manifest, the names of those files must be specified in the values of the **RootModule** or **NestedModules** keys in the manifest.
-Otherwise, their members are not exported.
-
-In Windows PowerShell 2.0, this key was called **ModuleToProcess**.
-You can use the *RootModule* parameter name or its *ModuleToProcess* alias.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: ModuleToProcess
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -ScriptsToProcess
+
 Specifies script (.ps1) files that run in the caller's session state when the module is imported.
-You can use these scripts to prepare an environment, just as you might use a logon script.
+You can use these scripts to prepare an environment, just as you might use a login script.
 
 To specify scripts that run in the module's session state, use the **NestedModules** key.
 
@@ -857,6 +922,7 @@ Accept wildcard characters: False
 ```
 
 ### -Tags
+Specifies an array of tags.
 
 ```yaml
 Type: String[]
@@ -871,10 +937,11 @@ Accept wildcard characters: False
 ```
 
 ### -TypesToProcess
+
 Specifies the type files (.ps1xml) that run when the module is imported.
 
-When you import the module, PowerShell runs the Update-TypeData cmdlet with the specified files.
-Because type files are not scoped, they affect all session states in the session.
+When you import the module, Windows PowerShell runs the `Update-TypeData` cmdlet with the specified
+files. Because type files are not scoped, they affect all session states in the session.
 
 ```yaml
 Type: String[]
@@ -889,16 +956,40 @@ Accept wildcard characters: False
 ```
 
 ### -VariablesToExport
-Specifies the variables that the module exports.
-Wildcard characters are permitted.
 
-You can use this parameter to restrict the variables that are exported by the module.
-It can remove variables from the list of exported variables, but it cannot add variables to the list.
+Specifies the variables that the module exports. Wildcards are permitted.
 
-If you omit this parameter, **New-ModuleManifest** creates a **VariablesToExport** key with a value of * (all), meaning that all variables that are exported by the module are exported by the manifest.
+You can use this parameter to restrict the variables that are exported by the module. It can remove
+variables from the list of exported variables, but it cannot add variables to the list.
+
+If you omit this parameter, `New-ModuleManifest` creates a **VariablesToExport** key with a value
+of `*` (all), meaning that all variables defined int the module are exported by the manifest.
 
 ```yaml
 Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: * (all)
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -DefaultCommandPrefix
+
+Specifies a prefix that is prepended to the nouns of all commands in the module when they are
+imported into a session. Enter a prefix string. Prefixes prevent command name conflicts in a user's
+session.
+
+Module users can override this prefix by specifying the **Prefix** parameter of the `Import-Module`
+cmdlet.
+
+This parameter is introduced in Windows PowerShell 3.0.
+
+```yaml
+Type: String
 Parameter Sets: (All)
 Aliases:
 
@@ -909,24 +1000,40 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
+### -RootModule
+
+Specifies the primary or "root" file of the module. Enter the file name of a script (.ps1), a
+script module (.psm1), a module manifest(.psd1), an assembly (.dll), a cmdlet definition XML file
+(.cdxml), or a workflow (.xaml). When the module is imported, the members that are exported from
+the root module file are imported into the caller's session state.
+
+If a module has a manifest file and no root file has been designated in the **RootModule** key, the
+manifest becomes the primary file for the module, and the module becomes a "manifest module"
+(ModuleType = Manifest).
+
+To export members from .psm1 or .dll files in a module that has a manifest, the names of those
+files must be specified in the values of the **RootModule** or **NestedModules** keys in the
+manifest. Otherwise, their members are not exported.
+
+> [!NOTE]
+> In PowerShell 2.0, this key was called **ModuleToProcess**. You can use the "RootModule" parameter
+> name or its **ModuleToProcess** alias.
 
 ```yaml
-Type: SwitchParameter
+Type: String
 Parameter Sets: (All)
-Aliases: cf
+Aliases: ModuleToProcess
 
 Required: False
 Position: Named
-Default value: False
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -941,27 +1048,44 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](./About/about_CommonParameters.md).
 
 ## INPUTS
 
 ### None
+
 You cannot pipe input to this cmdlet.
 
 ## OUTPUTS
 
 ### None or System.String
-This cmdlet does not generate any output by default.
-However, if you use the *PassThru* parameter, it generates a **System.String** object that represents the module manifest.
+
+By default, `New-ModuleManifest` does not generate any output. However, if you use the **PassThru**
+parameter, it generates a **System.String** object representing the module manifest.
 
 ## NOTES
-* Module manifests are usually optional. However, a module manifest is required to export an assembly that is installed in the global assembly cache.
-* To add or change files in the $pshome\Modules directory (%Windir%\System32\WindowsPowerShell\v1.0\Modules), start PowerShell by using the Run as administrator option.
-* In Windows PowerShell 2.0, many parameters of **New-ModuleManifest** are mandatory, even though they are not required in a module manifest. In Windows PowerShell 3.0, only the *Path* parameter is mandatory.
-* A session is an instance of the PowerShell run environment. A session can have one or more session states. By default, a session has only a global session state, but each imported module has its own session state. Session states allow the commands in a module to run without affecting the global session state.
 
-  The caller's session state is the session state into which a module is imported.
-Typically, it refers to the global session state, but when a module imports nested modules, the caller is the module and the caller's session state is the module's session state.
+Module manifests are usually optional. However, a module manifest is required to export an assembly
+that is installed in the global assembly cache.
+
+To add or change files in the `$pshome\Modules` directory, start PowerShell with the "Run as
+administrator" option.
+
+In PowerShell 2.0, many parameters of `New-ModuleManifest` are mandatory, even though they are not
+required in a module manifest. In Windows PowerShell 3.0, only the **Path** parameter is mandatory.
+
+A "session" is an instance of the PowerShell execution environment. A session can have one or more
+session states. By default, a session has only a global session state, but each imported module has
+its own session state. Session states allow the commands in a module to run without affecting the
+global session state.
+
+The "caller's session state" is the session state into which a module is imported. Typically, it
+refers to the global session state, but when a module imports nested modules, the "caller" is the
+module and the "caller's session state" is the module's session state.
 
 ## RELATED LINKS
 
@@ -976,3 +1100,5 @@ Typically, it refers to the global session state, but when a module imports nest
 [Remove-Module](Remove-Module.md)
 
 [Test-ModuleManifest](Test-ModuleManifest.md)
+
+[about_Modules](About/about_Modules.md)

--- a/reference/6/Microsoft.PowerShell.Management/Push-Location.md
+++ b/reference/6/Microsoft.PowerShell.Management/Push-Location.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Management.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Management
-ms.date: 06/09/2017
+ms.date: 01/22/2019
 online version: http://go.microsoft.com/fwlink/?LinkId=821612
 schema: 2.0.0
 title: Push-Location
@@ -27,67 +27,76 @@ Push-Location [-LiteralPath <String>] [-PassThru] [-StackName <String>] [<Common
 ```
 
 ## DESCRIPTION
-The **Push-Location** cmdlet adds, or pushes, the current location onto a location stack. A location stack basically functions like your location history. If you specify a path, this cmdlet pushes the current location onto a location stack and then changes the current location to the location specified by the path. You can use the Pop-Location cmdlet to get locations from the location stack.
 
-By default, **Push-Location** pushes the current location onto the current location stack, but you can use the *StackName* parameter to specify another location stack. If the stack does not exist, **Push-Location** creates it. The stack that is being created is named **default**.
+The `Push-Location` cmdlet adds ("pushes") the current location onto a location stack. If you
+specify a path, `Push-Location` pushes the current location onto a location stack and then changes
+the current location to the location specified by the path. You can use the `Pop-Location` cmdlet
+to get locations from the location stack.
+
+By default, the `Push-Location` cmdlet pushes the current location onto the current location stack,
+but you can use the StackName parameter to specify an alternate location stack. If the stack does
+not exist, `Push-Location` creates it.
 
 For more information about location stacks, see the Notes.
 
 ## EXAMPLES
 
-### Example 1: Change location
+### Example 1
+
+This example pushes the current location onto the default location stack and then changes the location to `C:\Windows`.
+
 ```
-PS C:\> Push-Location -Path "C:\Windows"
+PS C:\> Push-Location C:\Windows
 ```
 
-This command pushes the current location onto the default location stack and then changes the location to C:\Windows.
+### Example 2
 
-### Example 2: Change location in a named stack
+This example pushes the current location onto the RegFunction stack and changes the current location to the `HKLM:\Software\Policies` location.
+
 ```
-PS C:\> Push-Location -Path "HKLM:\Software\Policies" -StackName RegFunction
+PS C:\> Push-Location HKLM:\Software\Policies -StackName RegFunction
 ```
 
-This command pushes the current location onto the RegFunction stack and changes the current location to the HKLM:\Software\Policies location.
-You can use the **Location** cmdlets in any PowerShell drive (PSDrive).
+You can use the Location cmdlets in any PowerShell drive (PSDrive).
 
-### Example 3: Push the current location onto the default stack
-```
-PS C:\> Push-Location
-```
+### Example 3
 
 This command pushes the current location onto the default stack.
 It does not change the location.
 
-### Example 4: Create and use a named stack
 ```
-PS C:\> Push-Location ~ -StackName "Stack2"
-PS C:\Users\User01> Pop-Location -StackName "Stack2"
-PS C:\>
+PS C:\> Push-Location
 ```
+
+### Example 4 - Create and use a named stack
 
 These commands show how to create and use a named location stack.
 
-The first command pushes the current location onto a new stack named Stack2, and then changes the current location to the root directory (%USERPROFILE%), which is represented in the command by the tilde symbol (~) or $home.
-If Stack2 does not already occur in the session, **Push-Location** creates it.
-
-The second command uses **Pop-Location** to pop the original location (PS C:\\\>) from the Stack2 stack.
-Without *StackName*, **Pop-Location** would pop the location from the unnamed default stack.
-
-### Example 5: Show the current stack
 ```
-PS C:\> Get-Location -Stack
+PS C:\> Push-Location ~ -StackName Stack2
+PS C:\Users\User01> Pop-Location -StackName Stack2
+PS C:\>
 ```
 
-This commmand shows the current location stack.
+The first command pushes the current location onto a new stack named Stack2, and then changes the
+current location to the home directory, which is represented in the command by the tilde symbol (~)
+(same as `$env:USERPROFILE` or `$HOME`).
+
+If Stack2 does not already exist in the session, `Push-Location` creates it. The second command
+uses the `Pop-Location` cmdlet to pop the original location (PS C:\\\>) from the Stack2 stack.
+Without the StackName parameter, `Pop-Location` would pop the location from the unnamed default
+stack.
+
+For more information about location stacks, see the [Notes](#notes).
 
 ## PARAMETERS
 
 ### -LiteralPath
-Specifies the path of the new location.
-Unlike the *Path* parameter, the value of the *LiteralPath* parameter is used exactly as it is typed.
-No characters are interpreted as wildcard characters.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell PowerShell not to interpret any characters as escape sequences.
+
+Specifies the path to the new location. Unlike the **Path** parameter, the value of the
+**LiteralPath** parameter is used exactly as it is typed. No characters are interpreted as
+wildcards. If the path includes escape characters, enclose it in single quotation marks. Single
+quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
 
 ```yaml
 Type: String
@@ -102,8 +111,9 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Passes an object that represents the location to the pipeline.
-By default, this cmdlet does not generate any output.
+
+Passes an object representing the location to the pipeline. By default, this cmdlet does not
+generate any output.
 
 ```yaml
 Type: SwitchParameter
@@ -112,16 +122,16 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Path
-Specifies the path of the new location.
-This cmdlet your location to the location specified by this path after it adds, or pushes, the current location onto the top of the stack.
-Enter a path of any location whose provider supports this cmdlet.
-Wildcard characters are permitted.
+
+Changes your location to the location specified by this path after it adds (pushes) the current
+location onto the top of the stack. Enter a path to any location whose provider supports this
+cmdlet. Wildcards are permitted. The parameter name is optional.
 
 ```yaml
 Type: String
@@ -129,23 +139,25 @@ Parameter Sets: Path
 Aliases:
 
 Required: False
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
+Accept wildcard characters: True
 ```
 
 ### -StackName
-Specifies the location stack to which the current location is added.
-Enter a location stack name.
-If the stack does not exist, **Push-Location** creates it.
 
-Without this parameter, **Push-Location** adds the location to the current location stack.
-By default, the current location stack is the unnamed default location stack that PowerShell creates.
-To make a location stack the current location stack, use the *StackName* parameter of the Set-Location cmdlet.
-For more information about location stacks, see the Notes.
+Specifies the location stack to which the current location is added. Enter a location stack name.
+If the stack does not exist, `Push-Location` creates it.
 
-**Push-Location** cannot add a location to the unnamed default stack unless it is the current location stack.
+Without this parameter, `Push-Location` adds the location to the current location stack. By
+default, the current location stack is the unnamed default location stack that PowerShell creates.
+To make a location stack the current location stack, use the StackName parameter of the
+`Set-Location` cmdlet. For more information about location stacks, see the [Notes](#notes).
+
+> [!NOTE]
+> `Push-Location` cannot add a location to the unnamed default stack unless it is the current
+> location stack.
 
 ```yaml
 Type: String
@@ -154,40 +166,71 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: Default stack
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.String
-You can pipe a string that contains a path, but not a literal path, to this cmdlet.
+
+You can pipe a string that contains a path (but not a literal path) to `Push-Location`.
 
 ## OUTPUTS
 
-### None, System.Management.Automation.PathInfo
-This cmdlet generates a **System.Management.Automation.PathInfo** object that represents the location, if you specify the *PassThru* parameter.
-Otherwise, this cmdlet does not generate any output.
+### None or System.Management.Automation.PathInfo
+
+When you use the PassThru parameter, `Push-Location` generates a
+**System.Management.Automation.PathInfo** object that represents the location. Otherwise, this
+cmdlet does not generate any output.
 
 ## NOTES
-* A stack is a last-in, first-out list in which only the most recently added item can be accessed. You add items to a stack in the order that you use them, and then retrieve them for use in the reverse order. PowerShell lets you store provider locations in location stacks.
-* PowerShell creates an unnamed default location stack and you can create multiple named location stacks. If you do not specify a stack name, PowerShell uses the current location stack. By default, the unnamed default location is the current location stack, but you can use **Set-Location** to change the current location stack.
-* To manage location stacks, use the PowerShell **Location** cmdlets, as follows:
 
-- To add a location to a location stack, use the **Push-Location** cmdlet.
-- To get a location from a location stack, use the **Pop-Location** cmdlet.
-- To display the locations in the current location stack, use the *Stack* parameter of the **Get-Location** cmdlet.
-- To display the locations in a named location stack, use the *StackName* parameter of the **Get-Location** cmdlet.
-- To create a new location stack, use the *StackName* parameter of the **Push-Location** cmdlet. If you specify a stack that does not exist, **Push-Location** creates the stack.
-- To make a location stack the current location stack, use the *StackName* parameter of the **Set-Location** cmdlet.
-* The unnamed default location stack is fully available only when it is the current location stack. If you make a named location stack the current location stack, you can no longer use **Push-Location** or **Pop-Location** cmdlets add or get items from the default stack or use a **Get-Location** command to display the locations in the unnamed stack. To make the unnamed stack the current stack, use the *StackName* parameter of **Set-Location** with a value of $Null or an empty string ("").
-* To view more properties of the stack, use **Get-Location -Stack | Select-Object **.
-* You can also refer to **Push-Location** by its built-in alias, **pushd**. For more information, see about_Aliases.
-* **Push-Location** is designed to work with the data exposed by any provider. To list the providers available in your session, type `Get-PSProvider`. For more information, see about_Providers.
+A "stack" is a last-in, first-out list in which only the most recently added item is accessible.
+You add items to a stack in the order that you use them, and then retrieve them for use in the
+reverse order. PowerShell lets you store provider locations in location stacks.
+
+PowerShell creates an unnamed default location stack and you can create multiple named location
+stacks. If you do not specify a stack name, Windows PowerShell uses the current location stack. By
+default, the unnamed default location is the current location stack, but you can use the
+`Set-Location` cmdlet to change the current location stack.
+
+To manage location stacks, use the PowerShell Location cmdlets, as follows.
+
+- To add a location to a location stack, use the `Push-Location` cmdlet.
+- To get a location from a location stack, use the `Pop-Location` cmdlet.
+- To display the locations in the current location stack, use the **Stack** parameter of the
+  `Get-Location` cmdlet.
+
+To display the locations in a named location stack, use the **StackName** parameter of the
+`Get-Location` cmdlet.
+
+- To create a new location stack, use the StackName parameter of the `Push-Location` cmdlet. If you
+  specify a stack that does not exist, `Push-Location` creates the stack.
+- To make a location stack the current location stack, use the StackName parameter of the
+  `Set-Location` cmdlet.
+
+The unnamed default location stack is fully accessible only when it is the current location stack.
+If you make a named location stack the current location stack, you can no longer use
+`Push-Location` or `Pop-Location` cmdlets add or get items from the default stack or use
+`Get-Location` command to display the locations in the unnamed stack. To make the unnamed stack the
+current stack, use the StackName parameter of the `Set-Location` cmdlet with a value of $null or an
+empty string ("").
+
+You can also refer to `Push-Location` by its built-in alias, `pushd`. For more information, see
+[about_Aliases](../Microsoft.PowerShell.Core/About/about_Aliases.md).
+
+The `Push-Location` cmdlet is designed to work with the data exposed by any provider. To list the
+providers available in your session, type `Get-PSProvider`. For more information, see
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md).
 
 ## RELATED LINKS
 
@@ -196,3 +239,5 @@ Otherwise, this cmdlet does not generate any output.
 [Pop-Location](Pop-Location.md)
 
 [Set-Location](Set-Location.md)
+
+[about_Providers](../Microsoft.PowerShell.Core/About/about_Providers.md)


### PR DESCRIPTION
<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
This is the first of several PRs to change references to environment variables from `%variablename%` to `$env:variablename`.

Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

<!--
If the PR is fixing only a subset of document version(s), please explain why by picking appropriate items in the list below
If the PR is fixing all the document version(s), please delete the list/options below
-->
Reason(s) for not updating all version of documents
--------------------------------------------------
- [ ] The documented feature was introduced in version (list version here) of PowerShell
- [ ] This issue only shows up in version (list version(s) here) of the document
- [x] This PR partially fixes the issue, and issue #3559 tracks the remaining work
