### PR TITLE
Related to Issue #2000. Updated Encoding parameter info for all Export-Clixml

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -1,5 +1,5 @@
 ﻿---
-ms.date:  06/09/2017
+ms.date:  1/22/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -7,10 +7,10 @@ online version:  http://go.microsoft.com/fwlink/?LinkID=113297
 external help file:  Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 title:  Export-Clixml
 ---
+
 # Export-Clixml
 
 ## SYNOPSIS
-
 Creates an XML-based representation of an object or objects and stores it in a file.
 
 ## SYNTAX
@@ -19,30 +19,31 @@ Creates an XML-based representation of an object or objects and stores it in a f
 
 ```
 Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
- [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
 
 ```
 Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
- [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The Export-Clixml cmdlet creates an XML-based representation of an object or objects and stores it in a file.
-You can then use the Import-CLIXML cmdlet to re-create the saved object based on the contents of that file.
+The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
+it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
+contents of that file.
 
-This cmdlet is similar to ConvertTo-XML, except that Export-Clixml stores the resulting XML in a file.
-ConvertTo-XML returns the XML, so you can continue to process it in Windows PowerShell.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
+a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
 
-A valuable use of Export-Clixml is to export credentials and secure strings securely as XML.
-For an example of how to do this, see Example 3 in this topic.
+A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
+an example of how to do this, see Example 3.
 
 ## EXAMPLES
 
-### Example 1
+### Example 1: Export a string to an XML file
 
 ```powershell
 "This is a test" | Export-Clixml sample.xml
@@ -50,22 +51,24 @@ For an example of how to do this, see Example 3 in this topic.
 
 This command creates an XML file that stores a representation of the string, "This is a test".
 
-### Example 2
+### Example 2: Export an object to an XML file
 
 ```powershell
 Get-Acl C:\test.txt | Export-Clixml -Path fileacl.xml
 $fileacl = Import-Clixml fileacl.xml
 ```
 
-This example shows how to export an object to an XML file and then create an object by importing the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing
+the XML from the file.
 
-The first command uses the Get-ACL cmdlet to get the security descriptor of the Test.txt file.
-It uses a pipeline operator to pass the security descriptor to Export-Clixml, which stores an XML-based representation of the object in a file named FileACL.xml.
+The first command uses the `Get-Acl` cmdlet to get the security descriptor of the Test.txt file. It
+uses a pipeline operator to pass the security descriptor to `Export-Clixml`, which stores an
+XML-based representation of the object in a file named FileACL.xml.
 
-The second command uses the Import-Clixml cmdlet to create an object from the XML in the FileACL.xml file.
-Then, it saves the object in the $FileAcl variable.
+The second command uses the `Import-Clixml` cmdlet to create an object from the XML in the
+FileACL.xml file. Then, it saves the object in the `$fileacl` variable.
 
-### Example 3
+### Example 3: Encrypt an exported credential object
 
 ```powershell
 $credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
@@ -74,27 +77,32 @@ $credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
 $credential = Import-Clixml $credxmlpath
 ```
 
-The Export-Clixml cmdlet encrypts credential objects by using the Windows Data Protection API http://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx.
+The `Export-Clixml` cmdlet encrypts credential objects by using the
+[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
 This ensures that only your user account can decrypt the contents of the credential object.
 
-In this example, given a credential that you've stored in the $credential variable by running the Get-Credential cmdlet, you can run the Export-Clixml cmdlet to save the credential to disk.In the example, the file in which the credential is stored is represented by TestScript.ps1.credential.
-Replace TestScript with the name of the script with which you are loading the credential.
+In this example, given a credential that you've stored in the `$credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
+the example, the file in which the credential is stored is represented by
+TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+loading the credential.
 
-In the second command, pipe the credential object to Export-Clixml, and save it to the path, $credxmlpath, that you specified in the first command.
+In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
+`$credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands.
-This time, you are running Import-Clixml to import the secured credential object into your script.
-This eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. This time, you
+are running `Import-Clixml` to import the secured credential object into your script. This
+eliminates the risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
 ### -Depth
 
-Specifies how many levels of contained objects are included in the XML representation.
-The default value is 2.
+Specifies how many levels of contained objects are included in the XML representation. The default
+value is 2.
 
-The default value can be overridden for the object type in the Types.ps1xml files.
-For more information, see about_Types.ps1xml.
+The default value can be overridden for the object type in the Types.ps1xml files. For more
+information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
 Type: Int32
@@ -110,9 +118,22 @@ Accept wildcard characters: False
 
 ### -Encoding
 
-Specifies the type of encoding for the target file.
-Valid values are ASCII, UTF8, UTF7, UTF32, Unicode, BigEndianUnicode, Default, and OEM.
-Unicode is the default.
+Specifies the type of encoding for the target file. The default value is **ASCII**.
+
+The acceptable values for this parameter are as follows:
+
+- **ASCII** Uses ASCII (7-bit) character set.
+- **BigEndianUnicode** Uses UTF-16 with the big-endian byte order.
+- **BigEndianUTF32** Uses UTF-32 with the big-endian byte order.
+- **Byte** Encodes a set of characters into a sequence of bytes.
+- **Default** Uses the encoding that corresponds to the system's active code page.
+- **Oem** Uses the encoding that corresponds to the system's current OEM code page.
+- **String** Same as **Unicode**.
+- **Unicode** Uses UTF-16 with the little-endian byte order.
+- **Unknown** Same as **Unicode**.
+- **UTF7** Uses UTF-7.
+- **UTF8** Uses UTF-8.
+- **UTF32** Uses UTF-32 with the little-endian byte order.
 
 ```yaml
 Type: String
@@ -121,15 +142,15 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: Unicode
+Default value: ASCII
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Force
 
-Causes the cmdlet to clear the read-only attribute of the output file if necessary.
-The cmdlet will attempt to reset the read-only attribute when the command completes.
+Causes the cmdlet to clear the read-only attribute of the output file if necessary. The cmdlet will
+attempt to reset the read-only attribute when the command completes.
 
 ```yaml
 Type: SwitchParameter
@@ -145,9 +166,8 @@ Accept wildcard characters: False
 
 ### -InputObject
 
-Specifies the object to be converted.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
-You can also pipe objects to Export-Clixml.
+Specifies the object to be converted. Enter a variable that contains the objects, or type a command
+or expression that gets the objects. You can also pipe objects to `Export-Clixml`.
 
 ```yaml
 Type: PSObject
@@ -163,8 +183,8 @@ Accept wildcard characters: False
 
 ### -NoClobber
 
-Ensures that the cmdlet does not overwrite the contents of an existing file.
-By default, if a file exists in the specified path, Export-Clixml overwrites the file without warning.
+Ensures that the cmdlet does not overwrite the contents of an existing file. By default, if a file
+exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -196,11 +216,11 @@ Accept wildcard characters: False
 
 ### -LiteralPath
 
-Specifies the path to the file where the XML representation of the object will be stored.
-Unlike **Path**, the value of the **LiteralPath** parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+Specifies the path to the file where the XML representation of the object will be stored. Unlike
+**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single
+quotation marks. Single quotation marks tell PowerShell not to interpret any characters as escape
+sequences.
 
 ```yaml
 Type: String
@@ -232,8 +252,7 @@ Accept wildcard characters: False
 
 ### -WhatIf
 
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -249,19 +268,22 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
 
-You can pipe any object to Export-Clixml.
+You can pipe any object to `Export-Clixml`.
 
 ## OUTPUTS
 
 ### System.IO.FileInfo
 
-Export-Clixml creates a file that contains the XML.
+`Export-Clixml` creates a file that contains the XML.
 
 ## NOTES
 
@@ -269,7 +291,7 @@ Export-Clixml creates a file that contains the XML.
 
 [Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
 
-[Securely Store Credentials on Disk](http://www.powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
 [ConvertTo-Html](ConvertTo-Html.md)
 

--- a/reference/4.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  1/22/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -16,78 +16,93 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ## SYNTAX
 
 ### ByPath (Default)
+
 ```
 Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
- [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
+
 ```
 Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
- [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Export-Clixml cmdlet creates an XML-based representation of an object or objects and stores it in a file.
-You can then use the Import-CLIXML cmdlet to re-create the saved object based on the contents of that file.
 
-This cmdlet is similar to ConvertTo-XML, except that Export-Clixml stores the resulting XML in a file.
-ConvertTo-XML returns the XML, so you can continue to process it in Windows PowerShell.
+The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
+it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
+contents of that file.
 
-A valuable use of Export-Clixml is to export credentials and secure strings securely as XML.
-For an example of how to do this, see Example 3 in this topic.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
+a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+
+A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
+an example of how to do this, see Example 3.
 
 ## EXAMPLES
 
-### Example 1
-```
-PS C:\> "This is a test" | export-clixml sample.xml
+### Example 1: Export a string to an XML file
+
+```powershell
+"This is a test" | Export-Clixml sample.xml
 ```
 
 This command creates an XML file that stores a representation of the string, "This is a test".
 
-### Example 2
-```
-PS C:\> get-acl C:\test.txt | export-clixml -Path fileacl.xml
-PS C:\> $fileacl = import-clixml fileacl.xml
-```
+### Example 2: Export an object to an XML file
 
-This example shows how to export an object to an XML file and then create an object by importing the XML from the file.
-
-The first command uses the Get-ACL cmdlet to get the security descriptor of the Test.txt file.
-It uses a pipeline operator to pass the security descriptor to Export-Clixml, which stores an XML-based representation of the object in a file named FileACL.xml.
-
-The second command uses the Import-Clixml cmdlet to create an object from the XML in the FileACL.xml file.
-Then, it saves the object in the $FileAcl variable.
-
-### Example 3
-```
-PS C:\> $credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-PS C:\> $credential | Export-Clixml $credPath
-PS C:\> $credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
-PS C:\> $credential = Import-Clixml $credxmlpath
+```powershell
+Get-Acl C:\test.txt | Export-Clixml -Path fileacl.xml
+$fileacl = Import-Clixml fileacl.xml
 ```
 
-The Export-Clixml cmdlet encrypts credential objects by using the Windows Data Protection API http://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx.
+This example shows how to export an object to an XML file and then create an object by importing
+the XML from the file.
+
+The first command uses the `Get-Acl` cmdlet to get the security descriptor of the Test.txt file. It
+uses a pipeline operator to pass the security descriptor to `Export-Clixml`, which stores an
+XML-based representation of the object in a file named FileACL.xml.
+
+The second command uses the `Import-Clixml` cmdlet to create an object from the XML in the
+FileACL.xml file. Then, it saves the object in the `$fileacl` variable.
+
+### Example 3: Encrypt an exported credential object
+
+```powershell
+$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
+$credential | Export-Clixml $credPath
+$credxmlpath = Join-Path (Split-Path $profile) TestScript.ps1.credential
+$credential = Import-Clixml $credxmlpath
+```
+
+The `Export-Clixml` cmdlet encrypts credential objects by using the
+[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
 This ensures that only your user account can decrypt the contents of the credential object.
 
-In this example, given a credential that you've stored in the $credential variable by running the Get-Credential cmdlet, you can run the Export-Clixml cmdlet to save the credential to disk.In the example, the file in which the credential is stored is represented by TestScript.ps1.credential.
-Replace TestScript with the name of the script with which you are loading the credential.
+In this example, given a credential that you've stored in the `$credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
+the example, the file in which the credential is stored is represented by
+TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+loading the credential.
 
-In the second command, pipe the credential object to Export-Clixml, and save it to the path, $credxmlpath, that you specified in the first command.
+In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
+`$credxmlpath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands.
-This time, you are running Import-Clixml to import the secured credential object into your script.
-This eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. This time, you
+are running `Import-Clixml` to import the secured credential object into your script. This
+eliminates the risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
 ### -Depth
-Specifies how many levels of contained objects are included in the XML representation.
-The default value is 2.
 
-The default value can be overridden for the object type in the Types.ps1xml files.
-For more information, see about_Types.ps1xml.
+Specifies how many levels of contained objects are included in the XML representation. The default
+value is 2.
+
+The default value can be overridden for the object type in the Types.ps1xml files. For more
+information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
 Type: Int32
@@ -102,9 +117,23 @@ Accept wildcard characters: False
 ```
 
 ### -Encoding
-Specifies the type of encoding for the target file.
-Valid values are ASCII, UTF8, UTF7, UTF32, Unicode, BigEndianUnicode, Default, and OEM.
-Unicode is the default.
+
+Specifies the type of encoding for the target file. The default value is **ASCII**.
+
+The acceptable values for this parameter are as follows:
+
+- **ASCII** Uses ASCII (7-bit) character set.
+- **BigEndianUnicode** Uses UTF-16 with the big-endian byte order.
+- **BigEndianUTF32** Uses UTF-32 with the big-endian byte order.
+- **Byte** Encodes a set of characters into a sequence of bytes.
+- **Default** Uses the encoding that corresponds to the system's active code page.
+- **Oem** Uses the encoding that corresponds to the system's current OEM code page.
+- **String** Same as **Unicode**.
+- **Unicode** Uses UTF-16 with the little-endian byte order.
+- **Unknown** Same as **Unicode**.
+- **UTF7** Uses UTF-7.
+- **UTF8** Uses UTF-8.
+- **UTF32** Uses UTF-32 with the little-endian byte order.
 
 ```yaml
 Type: String
@@ -113,14 +142,15 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: Unicode
+Default value: ASCII
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Force
-Causes the cmdlet to clear the read-only attribute of the output file if necessary.
-The cmdlet will attempt to reset the read-only attribute when the command completes.
+
+Causes the cmdlet to clear the read-only attribute of the output file if necessary. The cmdlet will
+attempt to reset the read-only attribute when the command completes.
 
 ```yaml
 Type: SwitchParameter
@@ -135,9 +165,9 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies the object to be converted.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
-You can also pipe objects to Export-Clixml.
+
+Specifies the object to be converted. Enter a variable that contains the objects, or type a command
+or expression that gets the objects. You can also pipe objects to `Export-Clixml`.
 
 ```yaml
 Type: PSObject
@@ -152,8 +182,9 @@ Accept wildcard characters: False
 ```
 
 ### -NoClobber
-Ensures that the cmdlet does not overwrite the contents of an existing file.
-By default, if a file exists in the specified path, Export-Clixml overwrites the file without warning.
+
+Ensures that the cmdlet does not overwrite the contents of an existing file. By default, if a file
+exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -168,6 +199,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specifies the path to the file where the XML representation of the object will be stored.
 
 ```yaml
@@ -183,11 +215,12 @@ Accept wildcard characters: False
 ```
 
 ### -LiteralPath
-Specifies the path to the file where the XML representation of the object will be stored.
-Unlike **Path**, the value of the **LiteralPath** parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+
+Specifies the path to the file where the XML representation of the object will be stored. Unlike
+**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single
+quotation marks. Single quotation marks tell PowerShell not to interpret any characters as escape
+sequences.
 
 ```yaml
 Type: String
@@ -202,6 +235,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -217,8 +251,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -233,25 +267,31 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe any object to Export-Clixml.
+
+You can pipe any object to `Export-Clixml`.
 
 ## OUTPUTS
 
 ### System.IO.FileInfo
-Export-Clixml creates a file that contains the XML.
+
+`Export-Clixml` creates a file that contains the XML.
 
 ## NOTES
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](http://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
+[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
 
-[Securely Store Credentials on Disk](http://www.powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
 [ConvertTo-Html](ConvertTo-Html.md)
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  06/09/2017
+ms.date:  1/22/2019
 schema:  2.0.0
 locale:  en-us
 keywords:  powershell,cmdlet
@@ -16,73 +16,88 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ## SYNTAX
 
 ### ByPath (Default)
+
 ```
 Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
- [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
+
 ```
 Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
- [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Export-Clixml** cmdlet creates an XML-based representation of an object or objects and stores it in a file.
-You can then use the Import-Clixml cmdlet to re-create the saved object based on the contents of that file.
 
-This cmdlet is similar to ConvertTo-Xml, except that **Export-Clixml** stores the resulting XML in a file.
-**ConvertTo-XML** returns the XML, so you can continue to process it in Windows PowerShell.
+The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
+it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
+contents of that file.
 
-A valuable use of **Export-Clixml** is to export credentials and secure strings securely as XML.
-For an example of how to do this, see Example 3.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
+a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+
+A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
+an example of how to do this, see Example 3.
 
 ## EXAMPLES
 
 ### Example 1: Export a string to an XML file
-```
-PS C:\> "This is a test" | Export-Clixml sample.xml
+
+```powershell
+"This is a test" | Export-Clixml sample.xml
 ```
 
 This command creates an XML file that stores a representation of the string, "This is a test".
 
 ### Example 2: Export an object to an XML file
+
+```powershell
+Get-Acl C:\test.txt | Export-Clixml -Path fileacl.xml
+$fileacl = Import-Clixml fileacl.xml
 ```
-PS C:\> Get-Acl C:\test.txt | Export-Clixml -Path "fileacl.xml"
-PS C:\> $Fileacl = Import-Clixml "fileacl.xml"
-```
 
-This example shows how to export an object to an XML file and then create an object by importing the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing
+the XML from the file.
 
-The first command uses the Get-Acl cmdlet to get the security descriptor of the Test.txt file.
-It uses a pipeline operator to pass the security descriptor to **Export-Clixml**, which stores an XML-based representation of the object in a file named FileACL.xml.
+The first command uses the `Get-Acl` cmdlet to get the security descriptor of the Test.txt file. It
+uses a pipeline operator to pass the security descriptor to `Export-Clixml`, which stores an
+XML-based representation of the object in a file named FileACL.xml.
 
-The second command uses the Import-Clixml cmdlet to create an object from the XML in the FileACL.xml file.
-Then, it saves the object in the $FileAcl variable.
+The second command uses the `Import-Clixml` cmdlet to create an object from the XML in the
+FileACL.xml file. Then, it saves the object in the `$FileAcl` variable.
 
 ### Example 3: Encrypt an exported credential object
-```
-PS C:\> $CredXmlPath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
-PS C:\> $credential | Export-Clixml $CredPath
-PS C:\> $CredXmlPath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
-PS C:\> $Credential = Import-Clixml $CredXmlPath
+
+```powershell
+$CredXmlPath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$credential | Export-Clixml $CredPath
+$CredXmlPath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential = Import-Clixml $CredXmlPath
 ```
 
-The **Export-Clixml** cmdlet encrypts credential objects by using the Windows Data Protection API http://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx.
+The `Export-Clixml` cmdlet encrypts credential objects by using the
+[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
 This ensures that only your user account can decrypt the contents of the credential object.
 
-In this example, given a credential that you've stored in the $Credential variable by running the Get-Credential cmdlet, you can run the **Export-Clixml** cmdlet to save the credential to disk.In the example, the file in which the credential is stored is represented by TestScript.ps1.credential.
-Replace TestScript with the name of the script with which you are loading the credential.
+In this example, given a credential that you've stored in the `$credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
+the example, the file in which the credential is stored is represented by
+TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+loading the credential.
 
-In the second command, pipe the credential object to **Export-Clixml**, and save it to the path, $CredXmlPath, that you specified in the first command.
+In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
+`$CredXmlPath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands.
-This time, you are running Import-Clixml to import the secured credential object into your script.
-This eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. This time, you
+are running `Import-Clixml` to import the secured credential object into your script. This
+eliminates the risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -98,11 +113,12 @@ Accept wildcard characters: False
 ```
 
 ### -Depth
-Specifies how many levels of contained objects are included in the XML representation.
-The default value is 2.
 
-The default value can be overridden for the object type in the Types.ps1xml files.
-For more information, see about_Types.ps1xml.
+Specifies how many levels of contained objects are included in the XML representation. The default
+value is 2.
+
+The default value can be overridden for the object type in the Types.ps1xml files. For more
+information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
 Type: Int32
@@ -117,38 +133,40 @@ Accept wildcard characters: False
 ```
 
 ### -Encoding
-Specifies the type of encoding for the target file.
-The acceptable values for this parameter are:
 
-- ASCII
-- UTF8
-- UTF7
-- UTF32
-- Unicode
-- BigEndianUnicode
-- Default
-- OEM
+Specifies the type of encoding for the target file. The default value is **ASCII**.
 
-The default value is Unicode.
+The acceptable values for this parameter are as follows:
+
+- **ASCII** Uses ASCII (7-bit) character set.
+- **BigEndianUnicode** Uses UTF-16 with the big-endian byte order.
+- **BigEndianUTF32** Uses UTF-32 with the big-endian byte order.
+- **Byte** Encodes a set of characters into a sequence of bytes.
+- **Default** Uses the encoding that corresponds to the system's active code page.
+- **Oem** Uses the encoding that corresponds to the system's current OEM code page.
+- **String** Same as **Unicode**.
+- **Unicode** Uses UTF-16 with the little-endian byte order.
+- **Unknown** Same as **Unicode**.
+- **UTF7** Uses UTF-7.
+- **UTF8** Uses UTF-8.
+- **UTF32** Uses UTF-32 with the little-endian byte order.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
-Accepted values: Unicode, UTF7, UTF8, ASCII, UTF32, BigEndianUnicode, Default, OEM
 
 Required: False
 Position: Named
-Default value: None
+Default value: ASCII
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Force
-Forces the command to run without asking for user confirmation.
 
-Causes the cmdlet to clear the read-only attribute of the output file if necessary.
-The cmdlet will attempt to reset the read-only attribute when the command completes.
+Causes the cmdlet to clear the read-only attribute of the output file if necessary. The cmdlet will
+attempt to reset the read-only attribute when the command completes.
 
 ```yaml
 Type: SwitchParameter
@@ -163,9 +181,9 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies the object to be converted.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
-You can also pipe objects to **Export-Clixml**.
+
+Specifies the object to be converted. Enter a variable that contains the objects, or type a command
+or expression that gets the objects. You can also pipe objects to `Export-Clixml`.
 
 ```yaml
 Type: PSObject
@@ -180,11 +198,12 @@ Accept wildcard characters: False
 ```
 
 ### -LiteralPath
-Specifies the path to the file where the XML representation of the object will be stored.
-Unlike *Path*, the value of the *LiteralPath* parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+
+Specifies the path to the file where the XML representation of the object will be stored. Unlike
+**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single
+quotation marks. Single quotation marks tell Windows PowerShell not to interpret any characters as
+escape sequences.
 
 ```yaml
 Type: String
@@ -199,8 +218,9 @@ Accept wildcard characters: False
 ```
 
 ### -NoClobber
-Indicates that the cmdlet does not overwrite the contents of an existing file.
-By default, if a file exists in the specified path, **Export-Clixml** overwrites the file without warning.
+
+Indicates that the cmdlet does not overwrite the contents of an existing file. By default, if a
+file exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -215,6 +235,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specifies the path to the file where the XML representation of the object will be stored.
 
 ```yaml
@@ -230,8 +251,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -246,25 +267,31 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe any object to **Export-Clixml**.
+
+You can pipe any object to `Export-Clixml`.
 
 ## OUTPUTS
 
 ### System.IO.FileInfo
-**Export-Clixml** creates a file that contains the XML.
+
+`Export-Clixml` creates a file that contains the XML.
 
 ## NOTES
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](http://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
+[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
 
-[Securely Store Credentials on Disk](http://www.powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
 [ConvertTo-Html](ConvertTo-Html.md)
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 1/22/2019
 online version: http://go.microsoft.com/fwlink/?LinkId=821767
 schema: 2.0.0
 title: Export-Clixml
@@ -17,78 +17,93 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ## SYNTAX
 
 ### ByPath (Default)
+
 ```
 Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
- [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
+
 ```
 Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
- [-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-Encoding <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Export-Clixml** cmdlet creates an XML-based representation of an object or objects and stores it in a file.
-You can then use the Import-Clixml cmdlet to re-create the saved object based on the contents of that file.
 
-This cmdlet is similar to ConvertTo-Xml, except that **Export-Clixml** stores the resulting XML in a file.
-**ConvertTo-XML** returns the XML, so you can continue to process it in Windows PowerShell.
+The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
+it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
+contents of that file.
 
-A valuable use of **Export-Clixml** is to export credentials and secure strings securely as XML.
-For an example of how to do this, see Example 3.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
+a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+
+A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
+an example of how to do this, see Example 3.
 
 ## EXAMPLES
 
 ### Example 1: Export a string to an XML file
-```
-PS C:\> "This is a test" | Export-Clixml sample.xml
+
+```powershell
+"This is a test" | Export-Clixml sample.xml
 ```
 
 This command creates an XML file that stores a representation of the string, "This is a test".
 
 ### Example 2: Export an object to an XML file
+
+```powershell
+Get-Acl C:\test.txt | Export-Clixml -Path fileacl.xml
+$fileacl = Import-Clixml fileacl.xml
 ```
-PS C:\> Get-Acl C:\test.txt | Export-Clixml -Path "fileacl.xml"
-PS C:\> $Fileacl = Import-Clixml "fileacl.xml"
-```
 
-This example shows how to export an object to an XML file and then create an object by importing the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing
+the XML from the file.
 
-The first command uses the Get-Acl cmdlet to get the security descriptor of the Test.txt file.
-It uses a pipeline operator to pass the security descriptor to **Export-Clixml**, which stores an XML-based representation of the object in a file named FileACL.xml.
+The first command uses the `Get-Acl` cmdlet to get the security descriptor of the Test.txt file. It
+uses a pipeline operator to pass the security descriptor to `Export-Clixml`, which stores an
+XML-based representation of the object in a file named FileACL.xml.
 
-The second command uses the Import-Clixml cmdlet to create an object from the XML in the FileACL.xml file.
-Then, it saves the object in the $FileAcl variable.
+The second command uses the `Import-Clixml` cmdlet to create an object from the XML in the
+FileACL.xml file. Then, it saves the object in the `$fileacl` variable.
 
 ### Example 3: Encrypt an exported credential object
-```
-PS C:\> $CredXmlPath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
-PS C:\> $credential | Export-Clixml $CredPath
-PS C:\> $CredXmlPath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
-PS C:\> $Credential = Import-Clixml $CredXmlPath
+
+```powershell
+$CredXmlPath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$credential | Export-Clixml $CredPath
+$CredXmlPath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
+$Credential = Import-Clixml $CredXmlPath
 ```
 
-The **Export-Clixml** cmdlet encrypts credential objects by using the Windows Data Protection API http://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx.
+The `Export-Clixml` cmdlet encrypts credential objects by using the
+[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
 This ensures that only your user account can decrypt the contents of the credential object.
 
-In this example, given a credential that you've stored in the $Credential variable by running the Get-Credential cmdlet, you can run the **Export-Clixml** cmdlet to save the credential to disk.In the example, the file in which the credential is stored is represented by TestScript.ps1.credential.
-Replace TestScript with the name of the script with which you are loading the credential.
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
+the example, the file in which the credential is stored is represented by
+TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+loading the credential.
 
-In the second command, pipe the credential object to **Export-Clixml**, and save it to the path, $CredXmlPath, that you specified in the first command.
+In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
+`$CredXmlPath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands.
-This time, you are running Import-Clixml to import the secured credential object into your script.
-This eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. This time, you
+are running `Import-Clixml` to import the secured credential object into your script. This
+eliminates the risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
 ### -Depth
-Specifies how many levels of contained objects are included in the XML representation.
-The default value is 2.
 
-The default value can be overridden for the object type in the Types.ps1xml files.
-For more information, see about_Types.ps1xml.
+Specifies how many levels of contained objects are included in the XML representation. The default
+value is 2.
+
+The default value can be overridden for the object type in the Types.ps1xml files. For more
+information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
 Type: Int32
@@ -97,44 +112,48 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 2
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Encoding
-Specifies the type of encoding for the target file.
-The acceptable values for this parameter are:
 
-- ASCII
-- UTF8
-- UTF7
-- UTF32
-- Unicode
-- BigEndianUnicode
-- Default
-- OEM
+Specifies the type of encoding for the target file. The default value is **ASCII**.
 
-The default value is Unicode.
+The acceptable values for this parameter are as follows:
+
+- **ASCII** Uses ASCII (7-bit) character set.
+- **BigEndianUnicode** Uses UTF-16 with the big-endian byte order.
+- **BigEndianUTF32** Uses UTF-32 with the big-endian byte order.
+- **Byte** Encodes a set of characters into a sequence of bytes.
+- **Default** Uses the encoding that corresponds to the system's active code page.
+- **Oem** Uses the encoding that corresponds to the system's current OEM code page.
+- **String** Same as **Unicode**.
+- **Unicode** Uses UTF-16 with the little-endian byte order.
+- **Unknown** Same as **Unicode**.
+- **UTF7** Uses UTF-7.
+- **UTF8** Uses UTF-8.
+- **UTF32** Uses UTF-32 with the little-endian byte order.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
-Accepted values: Unicode, UTF7, UTF8, ASCII, UTF32, BigEndianUnicode, Default, OEM
 
 Required: False
 Position: Named
-Default value: None
+Default value: ASCII
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Force
+
 Forces the command to run without asking for user confirmation.
 
-Causes the cmdlet to clear the read-only attribute of the output file if necessary.
-The cmdlet will attempt to reset the read-only attribute when the command completes.
+Causes the cmdlet to clear the read-only attribute of the output file if necessary. The cmdlet will
+attempt to reset the read-only attribute when the command completes.
 
 ```yaml
 Type: SwitchParameter
@@ -149,9 +168,9 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies the object to be converted.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
-You can also pipe objects to **Export-Clixml**.
+
+Specifies the object to be converted. Enter a variable that contains the objects, or type a command
+or expression that gets the objects. You can also pipe objects to `Export-Clixml`.
 
 ```yaml
 Type: PSObject
@@ -166,11 +185,12 @@ Accept wildcard characters: False
 ```
 
 ### -LiteralPath
-Specifies the path to the file where the XML representation of the object will be stored.
-Unlike *Path*, the value of the *LiteralPath* parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+
+Specifies the path to the file where the XML representation of the object will be stored. Unlike
+**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single
+quotation marks. Single quotation marks tell PowerShell not to interpret any characters as escape
+sequences.
 
 ```yaml
 Type: String
@@ -185,8 +205,9 @@ Accept wildcard characters: False
 ```
 
 ### -NoClobber
-Indicates that the cmdlet does not overwrite the contents of an existing file.
-By default, if a file exists in the specified path, **Export-Clixml** overwrites the file without warning.
+
+Indicates that the cmdlet does not overwrite the contents of an existing file. By default, if a
+file exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -201,6 +222,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specifies the path to the file where the XML representation of the object will be stored.
 
 ```yaml
@@ -216,6 +238,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -231,8 +254,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -247,25 +270,31 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe any object to **Export-Clixml**.
+
+You can pipe any object to `Export-Clixml`.
 
 ## OUTPUTS
 
 ### System.IO.FileInfo
-**Export-Clixml** creates a file that contains the XML.
+
+`Export-Clixml` creates a file that contains the XML.
 
 ## NOTES
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](http://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
+[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
 
-[Securely Store Credentials on Disk](http://www.powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
+[Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
 [ConvertTo-Html](ConvertTo-Html.md)
 

--- a/reference/6/Microsoft.PowerShell.Utility/Export-Clixml.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Export-Clixml.md
@@ -3,7 +3,7 @@ external help file: Microsoft.PowerShell.Commands.Utility.dll-Help.xml
 keywords: powershell,cmdlet
 locale: en-us
 Module Name: Microsoft.PowerShell.Utility
-ms.date: 06/09/2017
+ms.date: 1/22/2019
 online version: http://go.microsoft.com/fwlink/?LinkId=821767
 schema: 2.0.0
 title: Export-Clixml
@@ -17,26 +17,30 @@ Creates an XML-based representation of an object or objects and stores it in a f
 ## SYNTAX
 
 ### ByPath (Default)
+
 ```
 Export-Clixml [-Depth <Int32>] [-Path] <String> -InputObject <PSObject> [-Force] [-NoClobber]
- [-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ByLiteralPath
+
 ```
 Export-Clixml [-Depth <Int32>] -LiteralPath <String> -InputObject <PSObject> [-Force] [-NoClobber]
- [-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-Encoding <Encoding>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **Export-CliXml** cmdlet creates an XML-based representation of an object or objects and stores it in a file.
-You can then use the Import-Clixml cmdlet to re-create the saved object based on the contents of that file.
 
-This cmdlet is similar to ConvertTo-Xml, except that **Export-CliXml** stores the resulting XML in a file.
-**ConvertTo-XML** returns the XML, so you can continue to process it in PowerShell.
+The `Export-Clixml` cmdlet creates an XML-based representation of an object or objects and stores
+it in a file. You can then use the `Import-Clixml` cmdlet to recreate the saved object based on the
+contents of that file.
 
-A valuable use of **Export-CliXml** is to export credentials and secure strings securely as XML.
-For an example of how to do this, see Example 3.
+This cmdlet is similar to `ConvertTo-Xml`, except that `Export-Clixml` stores the resulting XML in
+a file. `ConvertTo-XML` returns the XML, so you can continue to process it in PowerShell.
+
+A valuable use of `Export-Clixml` is to export credentials and secure strings securely as XML. For
+an example of how to do this, see Example 3.
 
 ## EXAMPLES
 
@@ -51,47 +55,57 @@ This command creates an XML file that stores a representation of the string, "Th
 ### Example 2: Export an object to an XML file
 
 ```powershell
-Get-Acl C:\test.txt | Export-Clixml -Path "fileacl.xml"
-$Fileacl = Import-Clixml "fileacl.xml"
+Get-Acl C:\test.txt | Export-Clixml -Path fileacl.xml
+$Fileacl = Import-Clixml fileacl.xml
 ```
 
-This example shows how to export an object to an XML file and then create an object by importing the XML from the file.
+This example shows how to export an object to an XML file and then create an object by importing
+the XML from the file.
 
-The first command uses the Get-Acl cmdlet to get the security descriptor of the Test.txt file.
-It uses a pipeline operator to pass the security descriptor to **Export-Clixml**, which stores an XML-based representation of the object in a file named FileACL.xml.
+The first command uses the `Get-Acl` cmdlet to get the security descriptor of the Test.txt file. It
+uses a pipeline operator to pass the security descriptor to `Export-Clixml`, which stores an
+XML-based representation of the object in a file named FileACL.xml.
 
-The second command uses the Import-Clixml cmdlet to create an object from the XML in the FileACL.xml file.
-Then, it saves the object in the $FileAcl variable.
+The second command uses the `Import-Clixml` cmdlet to create an object from the XML in the
+FileACL.xml file. Then, it saves the object in the `$FileAcl` variable.
 
 ### Example 3: Encrypt an exported credential object
 
 ```powershell
 $CredXmlPath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
-$credential | Export-CliXml $CredPath
+$credential | Export-Clixml $CredPath
 $CredXmlPath = Join-Path (Split-Path $Profile) TestScript.ps1.credential
-$Credential = Import-CliXml $CredXmlPath
+$Credential = Import-Clixml $CredXmlPath
 ```
 
-The **Export-CliXml** cmdlet encrypts credential objects by using the [Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
-This ensures that only your user account on only that computer can decrypt the contents of the credential object. The exported CliXml file can neither be used on a different computer nor by a different user.
+The `Export-Clixml` cmdlet encrypts credential objects by using the
+[Windows Data Protection API](https://msdn.microsoft.com/library/windows/apps/xaml/hh464970.aspx).
+This ensures that only your user account on only that computer can decrypt the contents of the
+credential object. The exported CliXml file can neither be used on a different computer nor by a
+different user.
 
-In this example, given a credential that you've stored in the $Credential variable by running the Get-Credential cmdlet, you can run the **Export-CliXml** cmdlet to save the credential to disk. In the example, the file in which the credential is stored is represented by TestScript.ps1.credential.
-Replace TestScript with the name of the script with which you are loading the credential.
+In this example, given a credential that you've stored in the `$Credential` variable by running the
+`Get-Credential` cmdlet, you can run the `Export-Clixml` cmdlet to save the credential to disk. In
+the example, the file in which the credential is stored is represented by
+TestScript.ps1.credential. Replace TestScript with the name of the script with which you are
+loading the credential.
 
-In the second command, pipe the credential object to **Export-CliXml**, and save it to the path, $CredXmlPath, that you specified in the first command.
+In the second command, pipe the credential object to `Export-Clixml`, and save it to the path,
+`$CredXmlPath`, that you specified in the first command.
 
-To import the credential automatically into your script, run the final two commands.
-This time, you are running Import-Clixml to import the secured credential object into your script.
-This eliminates the risk of exposing plain-text passwords in your script.
+To import the credential automatically into your script, run the final two commands. This time, you
+are running `Import-Clixml` to import the secured credential object into your script. This
+eliminates the risk of exposing plain-text passwords in your script.
 
 ## PARAMETERS
 
 ### -Depth
-Specifies how many levels of contained objects are included in the XML representation.
-The default value is 2.
 
-The default value can be overridden for the object type in the Types.ps1xml files.
-For more information, see about_Types.ps1xml.
+Specifies how many levels of contained objects are included in the XML representation. The default
+value is 2.
+
+The default value can be overridden for the object type in the Types.ps1xml files. For more
+information, see [about_Types.ps1xml](../Microsoft.PowerShell.Core/About/about_Types.ps1xml.md).
 
 ```yaml
 Type: Int32
@@ -100,25 +114,30 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 2
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Encoding
-Specifies the type of encoding for the target file.
-The acceptable values for this parameter are:
 
-- ASCII
-- UTF8
-- UTF7
-- UTF32
-- Unicode
-- BigEndianUnicode
-- Default
-- OEM
+Specifies the type of encoding for the target file. The default value is **UTF8NoBOM**.
 
-The default value is Unicode.
+The acceptable values for this parameter are as follows:
+
+- **ASCII**: Uses the encoding for the ASCII (7-bit) character set.
+- **BigEndianUnicode**: Encodes in UTF-16 format using the big-endian byte order.
+- **Byte**: Encodes a set of characters into a sequence of bytes.
+- **Default**: Encodes using the default value: ASCII.
+- **OEM**: Uses the default encoding for MS-DOS and console programs.
+- **String**: Uses the encoding type for a string.
+- **Unicode**: Encodes in UTF-16 format using the little-endian byte order.
+- **UTF7**: Encodes in UTF-7 format.
+- **UTF8**: Encodes in UTF-8 format.
+- **UTF8BOM**: Encodes in UTF-8 format with Byte Order Mark (BOM)
+- **UF8NOBOM**: Encodes in UTF-8 format without Byte Order Mark (BOM)
+- **UTF32**:  Encodes in UTF-32 format.
+- **Unknown**: The encoding type is unknown or invalid; the data can be treated as binary.
 
 ```yaml
 Type: Encoding
@@ -127,16 +146,17 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: UTF8NoBOM
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Force
+
 Forces the command to run without asking for user confirmation.
 
-Causes the cmdlet to clear the read-only attribute of the output file if necessary.
-The cmdlet will attempt to reset the read-only attribute when the command completes.
+Causes the cmdlet to clear the read-only attribute of the output file if necessary. The cmdlet will
+attempt to reset the read-only attribute when the command completes.
 
 ```yaml
 Type: SwitchParameter
@@ -151,9 +171,9 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-Specifies the object to be converted.
-Enter a variable that contains the objects, or type a command or expression that gets the objects.
-You can also pipe objects to **Export-Clixml**.
+
+Specifies the object to be converted. Enter a variable that contains the objects, or type a command
+or expression that gets the objects. You can also pipe objects to `Export-Clixml`.
 
 ```yaml
 Type: PSObject
@@ -168,11 +188,12 @@ Accept wildcard characters: False
 ```
 
 ### -LiteralPath
-Specifies the path to the file where the XML representation of the object will be stored.
-Unlike *Path*, the value of the *LiteralPath* parameter is used exactly as it is typed.
-No characters are interpreted as wildcards.
-If the path includes escape characters, enclose it in single quotation marks.
-Single quotation marks tell Windows PowerShell not to interpret any characters as escape sequences.
+
+Specifies the path to the file where the XML representation of the object will be stored. Unlike
+**Path**, the value of the **LiteralPath** parameter is used exactly as it is typed. No characters
+are interpreted as wildcards. If the path includes escape characters, enclose it in single
+quotation marks. Single quotation marks tell PowerShell not to interpret any characters as
+escape sequences.
 
 ```yaml
 Type: String
@@ -187,8 +208,9 @@ Accept wildcard characters: False
 ```
 
 ### -NoClobber
-Indicates that the cmdlet does not overwrite the contents of an existing file.
-By default, if a file exists in the specified path, **Export-Clixml** overwrites the file without warning.
+
+Indicates that the cmdlet does not overwrite the contents of an existing file. By default, if a
+file exists in the specified path, `Export-Clixml` overwrites the file without warning.
 
 ```yaml
 Type: SwitchParameter
@@ -203,6 +225,7 @@ Accept wildcard characters: False
 ```
 
 ### -Path
+
 Specifies the path to the file where the XML representation of the object will be stored.
 
 ```yaml
@@ -218,6 +241,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -233,8 +257,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs.
-The cmdlet is not run.
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter
@@ -249,23 +273,29 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### System.Management.Automation.PSObject
-You can pipe any object to **Export-Clixml**.
+
+You can pipe any object to `Export-Clixml`.
 
 ## OUTPUTS
 
 ### System.IO.FileInfo
-**Export-Clixml** creates a file that contains the XML.
+
+`Export-Clixml` creates a file that contains the XML.
 
 ## NOTES
 
 ## RELATED LINKS
 
-[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.com/b/heyscriptingguy/archive/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems.aspx)
+[Use PowerShell to Pass Credentials to Legacy Systems](https://blogs.technet.microsoft.com/heyscriptingguy/2011/06/05/use-powershell-to-pass-credentials-to-legacy-systems/)
 
 [Securely Store Credentials on Disk](https://powershellcookbook.com/recipe/PukO/securely-store-credentials-on-disk)
 
@@ -274,7 +304,5 @@ You can pipe any object to **Export-Clixml**.
 [ConvertTo-Xml](ConvertTo-Xml.md)
 
 [Export-Csv](Export-Csv.md)
-
-[Export-Clixml](Export-Clixml.md)
 
 [Import-Clixml](Import-Clixml.md)


### PR DESCRIPTION
Related to Issue #2000 . Updated Encoding parameter info for all Export-Clixml. 

Style updates, paragraph reflows, fixed links.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [ ] Impacts 6.next document
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document

