### PR TITLE
Fix Example 7 in Select-String.md

### DIFF
--- a/reference/3.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/3.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -137,10 +137,10 @@ The CaseSensitive parameter indicates that the "M" in "Microsoft" must be capita
 ### Example 7
 
 ```powershell
-PS C:\> select-string -path process.txt -pattern idle, svchost -notmatch
+Select-String -Path process.txt -Pattern idle, svchost -NotMatch
 ```
 
-This command finds lines of text in the Process.txt file that do not include the words "idle" or "svchost".
+This command finds lines of text in the process.txt file that do not include the words "idle" or "svchost".
 
 ### Example 8
 

--- a/reference/4.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/4.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -137,10 +137,10 @@ The CaseSensitive parameter indicates that the "M" in "Microsoft" must be capita
 ### Example 7
 
 ```powershell
-PS C:\> select-string -path process.txt -pattern idle, svchost -notmatch
+Select-String -Path process.txt -Pattern idle, svchost -NotMatch
 ```
 
-This command finds lines of text in the Process.txt file that do not include the words "idle" or "svchost".
+This command finds lines of text in the process.txt file that do not include the words "idle" or "svchost".
 
 ### Example 8
 

--- a/reference/5.0/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/5.0/Microsoft.PowerShell.Utility/Select-String.md
@@ -137,10 +137,10 @@ The *CaseSensitive* parameter indicates that the "M" in "Microsoft" must be capi
 ### Example 7: Find strings that do not match a pattern
 
 ```powershell
-PS C:\> Select-String -Path "process.txt" -Pattern "idle, svchost" -NotMatch
+Select-String -Path process.txt -Pattern idle, svchost -NotMatch
 ```
 
-This command finds lines of text in the Process.txt file that do not include the words "idle" or "svchost".
+This command finds lines of text in the process.txt file that do not include the words "idle" or "svchost".
 
 ### Example 8: Find lines before and after a match
 

--- a/reference/5.1/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/5.1/Microsoft.PowerShell.Utility/Select-String.md
@@ -138,10 +138,10 @@ The *CaseSensitive* parameter indicates that the "M" in "Microsoft" must be capi
 ### Example 7: Find strings that do not match a pattern
 
 ```powershell
-PS C:\> Select-String -Path "process.txt" -Pattern "idle, svchost" -NotMatch
+Select-String -Path process.txt -Pattern idle, svchost -NotMatch
 ```
 
-This command finds lines of text in the Process.txt file that do not include the words "idle" or "svchost".
+This command finds lines of text in the process.txt file that do not include the words "idle" or "svchost".
 
 ### Example 8: Find lines before and after a match
 

--- a/reference/6/Microsoft.PowerShell.Utility/Select-String.md
+++ b/reference/6/Microsoft.PowerShell.Utility/Select-String.md
@@ -138,10 +138,10 @@ The *CaseSensitive* parameter indicates that the "M" in "Microsoft" must be capi
 ### Example 7: Find strings that do not match a pattern
 
 ```powershell
-PS C:\> Select-String -Path "process.txt" -Pattern "idle, svchost" -NotMatch
+Select-String -Path process.txt -Pattern idle, svchost -NotMatch
 ```
 
-This command finds lines of text in the Process.txt file that do not include the words "idle" or "svchost".
+This command finds lines of text in the process.txt file that do not include the words "idle" or "svchost".
 
 ### Example 8: Find lines before and after a match
 


### PR DESCRIPTION
`"idle, svchost"` is just a string. It should be an array like `idle, svchost`.

<!--
If this doc issue is for content OUTSIDE of /reference folder (such as DSC, WMF etc.), there is no need to fill this template. Please delete the template before submitting the PR.

If this doc issue is for content UNDER /reference folder, please fill out this template:
-->
Version(s) of document impacted
------------------------------
- [x] Impacts 6 document
- [x] Impacts 5.1 document
- [x] Impacts 5.0 document
- [x] Impacts 4.0 document
- [x] Impacts 3.0 document
